### PR TITLE
Pull out `_status` error handling into dmutils

### DIFF
--- a/app/status/utils.py
+++ b/app/status/utils.py
@@ -1,6 +1,4 @@
 import os
-# from requests.exceptions import ConnectionError
-from dmutils.apiclient import ConnectionError
 
 
 def get_version_label():
@@ -11,18 +9,3 @@ def get_version_label():
             return f.read().strip()
     except IOError:
         return None
-
-
-def return_response_from_api_status_call(api_status_call):
-
-    try:
-        return api_status_call()
-
-    except ConnectionError:
-        pass
-
-    return None
-
-
-def return_json_or_none(response):
-    return None if response is None else response.json()

--- a/app/status/views.py
+++ b/app/status/views.py
@@ -1,4 +1,4 @@
-from flask import jsonify, current_app
+from flask import jsonify
 
 from . import status
 from . import utils
@@ -8,32 +8,18 @@ from .. import data_api_client
 @status.route('/_status')
 def status():
 
-    api_response = utils.return_response_from_api_status_call(
-        data_api_client.get_status
-    )
+    api_status = data_api_client.get_status()
 
-    apis_with_errors = []
-
-    if api_response is None or api_response.status_code != 200:
-        apis_with_errors.append("(Data) API")
-
-    # if no errors found, return everything
-    if not apis_with_errors:
+    if api_status['status'] == "ok":
         return jsonify(
             status="ok",
             version=utils.get_version_label(),
-            api_status=api_response.json(),
+            api_status=api_status,
         )
-
-    message = "Error connecting to the {}.".format(
-        " and the ".join(apis_with_errors)
-    )
-
-    current_app.logger.error(message)
 
     return jsonify(
         status="error",
         version=utils.get_version_label(),
-        api_status=utils.return_json_or_none(api_response),
-        message=message,
+        api_status=api_status,
+        message="Error connecting to the (Data) API.",
     ), 500

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ Flask==0.10.1
 Flask-Login==0.2.11
 Flask-Script==2.0.5
 Flask-WTF==0.11
--e git+https://github.com/alphagov/digitalmarketplace-utils.git@0.5.0#egg=digitalmarketplace-utils
+-e git+https://github.com/alphagov/digitalmarketplace-utils.git@0.6.0#egg=digitalmarketplace-utils
 
 mandrill==1.0.57
 

--- a/tests/app/status/test_status.py
+++ b/tests/app/status/test_status.py
@@ -1,29 +1,17 @@
 import json
 from ..helpers import BaseApplicationTest
-from requests import Response
 
 import mock
 from nose.tools import assert_equal, assert_in
 
 
 class TestStatus(BaseApplicationTest):
-    def setup(self):
-        super(TestStatus, self).setup()
 
-        self._api_response = mock.patch(
-            'app.status.utils.return_response_from_api_status_call',
-        ).start()
-
-    def teardown(self):
-        self._api_response.stop()
-
-    def test_status_ok(self):
-        api_response = Response()
-        api_response.status_code = 200
-        api_response._content = json.dumps({
-            'status': 'ok'
-        }).encode('utf-8')
-        self._api_response.return_value = api_response
+    @mock.patch('app.status.views.data_api_client')
+    def test_status_ok(self, data_api_client):
+        data_api_client.get_status.return_value = {
+            "status": "ok"
+        }
 
         status_response = self.client.get('/_status')
         assert_equal(200, status_response.status_code)
@@ -34,13 +22,14 @@ class TestStatus(BaseApplicationTest):
         assert_equal(
             "ok", "{}".format(json_data['api_status']['status']))
 
-    def test_status_api_responses_return_500(self):
-        api_response = Response()
-        api_response.status_code = 500
-        api_response._content = json.dumps({
-            'status': 'error'
-        }).encode('utf-8')
-        self._api_response.return_value = api_response
+    @mock.patch('app.status.views.data_api_client')
+    def test_status_error(self, data_api_client):
+
+        data_api_client.get_status.return_value = {
+            'status': 'error',
+            'app_version': None,
+            'message': 'Cannot connect to (Data) API'
+        }
 
         status_response = self.client.get('/_status')
         assert_equal(500, status_response.status_code)
@@ -52,15 +41,3 @@ class TestStatus(BaseApplicationTest):
             "error", "{}".format(json_data['api_status']['status']))
         assert_in(
             "Error connecting to", "{}".format(json_data['message']))
-
-    def test_status_api_responses_are_none(self):
-        self._api_response.return_value = None
-
-        status_response = self.client.get('/_status')
-        assert_equal(500, status_response.status_code)
-
-        json_data = json.loads(status_response.get_data().decode('utf-8'))
-        assert_equal(
-            "error", "{}".format(json_data['status']))
-        assert_equal(None, json_data['api_status'])
-        assert_in("Error connecting to", "{}".format(json_data['message']))


### PR DESCRIPTION
API Client now handles exceptions and errors, meaning that _status routes for our frontend apps need less logic.  Removed the try/catch stuff.

Also updated dmutils tag.