### PR TITLE
Add breadcrumbs to supplier app

### DIFF
--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -4,7 +4,7 @@
 @import "_url-helpers.scss";
 
 // Path to assets for use with file-url()
-$path: "/static/images/";
+$path: "/suppliers/static/images/";
 
 #wrapper {
   @extend %site-width-container;

--- a/app/templates/macros/_breadcrumbs.html
+++ b/app/templates/macros/_breadcrumbs.html
@@ -1,0 +1,22 @@
+{% macro breadcrumb(crumbs = []) -%}
+  <div id="global-breadcrumb">
+    <nav>
+      <ol>
+        <li>
+          <a href="/" alt="Back to home">Digital Marketplace</a>
+        </li>
+        {% for crumb in crumbs %}
+          {% if crumb.link is defined %}
+            <li>
+              <a href="{{ crumb.link }}">{{ crumb.text }}</a>
+            </li>
+          {% else %}
+            <li>
+              {{ crumb.text }}
+            </li>
+          {% endif %}
+        {% endfor %}
+      </ol>
+    </nav>
+  </div>
+{% endmacro -%}

--- a/app/templates/services/dashboard.html
+++ b/app/templates/services/dashboard.html
@@ -1,4 +1,10 @@
 {% extends "_base_page.html" %}
+{% from 'macros/_breadcrumbs.html' import breadcrumb %}
+
+{% block breadcrumb %}
+  {{ breadcrumb([
+  ]) }}
+{% endblock %}
 
 {% block main_content %}
 

--- a/app/templates/services/services.html
+++ b/app/templates/services/services.html
@@ -1,24 +1,20 @@
 {% extends "_base_page.html" %}
-
+{% from 'macros/_breadcrumbs.html' import breadcrumb %}
+{% block breadcrumb %}
+  {{ breadcrumb([
+    {
+      "link": url_for(".dashboard"),
+      "text": "Company name"
+    }
+  ]) }}
+{% endblock %}
 {% block main_content %}
-<header class="page-heading">
-    <h1>Service</h1>
-</header>
-
-<header class="page-heading-smaller">
+  <header class="page-heading-smaller">
     <p class="context">
-        Service Details for {{ service_id }}
+      Edit
     </p>
-
-    <h1>Some stuff about the service</h1>
-</header>
-
-
-<header class="page-heading-smaller">
-    <p class="context">
-        <a href="{{ url_for('.dashboard') }}">Dashboard</a>
-    </p>
-</header>
-
-
+    <h1>
+      Service name {{ service_id }}
+    </h1>
+  </header>
 {% endblock %}

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -10,6 +10,7 @@ var dmToolkitSCSS = repoRoot + 'bower_components/digitalmarketplace-frontend-too
 var assetsFolder = repoRoot + 'app/assets';
 var staticFolder = repoRoot + 'app/static';
 var govukTemplateAssetsFolder = repoRoot + 'bower_components/govuk_template/assets';
+var dmToolkitAssetsFolder = repoRoot + 'bower_components/digitalmarketplace-frontend-toolkit/toolkit/';
 
 // JavaScript paths
 var jsVendorFiles = [
@@ -121,6 +122,11 @@ gulp.task('copy_template_assets', function () {
    gulp.start('copy_template_assets:javascripts');
 });
 
+gulp.task('copy_toolkit_assets:images', function () {
+  return gulp.src(dmToolkitAssetsFolder + '/images/**/*', { base : dmToolkitAssetsFolder + '/images' })
+    .pipe(gulp.dest(staticFolder + '/images'));
+});
+
 gulp.task('watch', ['build:development'], function () {
   var jsWatcher = gulp.watch([ assetsFolder + '/**/*.js' ], ['js']);
   var cssWatcher = gulp.watch([ assetsFolder + '/**/*.scss' ], ['sass']);
@@ -136,10 +142,12 @@ gulp.task('build:development', ['clean'], function () {
   environment = 'development';
   gulp.start('sass', 'js');
   gulp.start('copy_template_assets');
+  gulp.start('copy_toolkit_assets:images');
 });
 
 gulp.task('build:production', ['clean'], function () {
   environment = 'production';
   gulp.start('sass', 'js');
   gulp.start('copy_template_assets');
+  gulp.start('copy_toolkit_assets:images');
 });

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -119,11 +119,11 @@ class TestServicesLogin(BaseApplicationTest):
             assert_equal(res.status_code, 200)
 
             assert_true(
-                self.strip_all_whitespace('<h1>Service</h1>')
+                self.strip_all_whitespace('<p class="context">Edit</p>')
                 in self.strip_all_whitespace(res.get_data(as_text=True))
             )
             assert_true(
-                'Service Details for 123' in res.get_data(as_text=True)
+                'Service name 123' in res.get_data(as_text=True)
             )
 
     def test_should_redirect_to_login_if_not_logged_in(self):


### PR DESCRIPTION
This commit adds our standard breadcrumbs, with placeholder text where the real data is not yet available in the app.

![image](https://cloud.githubusercontent.com/assets/355079/7513364/7b7d3faa-f4ab-11e4-880d-42cfc7995061.png)
