### PR TITLE
Remove SESSION_COOKIE_DOMAIN

### DIFF
--- a/config.py
+++ b/config.py
@@ -66,7 +66,6 @@ class Development(Config):
 
 
 class Live(Config):
-    SESSION_COOKIE_DOMAIN = 'www.digitalmarketplace.service.gov.uk'
     DEBUG = False
     SESSION_COOKIE_SECURE = True
 


### PR DESCRIPTION
This is in an attempt to get login working. Flask should use the host
name instead.