### PR TITLE
Make `url_for` use the correct scheme (http/https)

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -3,6 +3,7 @@ import re
 from flask import Flask
 from flask_login import LoginManager
 from flask._compat import string_types
+from werkzeug.contrib.fixers import ProxyFix
 from dmutils import apiclient, logging, config
 
 from config import configs
@@ -16,7 +17,7 @@ def create_app(config_name):
     application = Flask(__name__,
                         static_folder='static/',
                         static_url_path=configs[config_name].STATIC_URL_PATH)
-
+    application.wsgi_app = ProxyFix(application.wsgi_app)
     application.config.from_object(configs[config_name])
     configs[config_name].init_app(application)
     config.init_app(application)

--- a/app/main/helpers/email.py
+++ b/app/main/helpers/email.py
@@ -37,7 +37,6 @@ def send_password_email(user_id, email_address):
 
 
 def generate_reset_url(user_id, email_address):
-    encoded_string = str(user_id) + " " + email_address
     ts = URLSafeTimedSerializer(main.config["SECRET_KEY"])
     token = ts.dumps({"user": user_id, "email": email_address},
                      salt=main.config["RESET_PASSWORD_SALT"])


### PR DESCRIPTION
Addresses this bug: https://www.pivotaltracker.com/story/show/94091430

By adding ProxyFix the headers are correctly passed through to the app, so that it will know
if the original request was from an http or https context.

This is the same way it is done in the data API project for generating URLs.