### PR TITLE
Make service link relative

### DIFF
--- a/app/templates/services/dashboard.html
+++ b/app/templates/services/dashboard.html
@@ -33,9 +33,7 @@
     {% for service in services %}
     <tr class="summary-item-row">
         <td class="summary-item-field-name">
-            <a href="https://www.digitalmarketplace.service.gov.uk/service/{{ service.id.lower() }}">
-                {{ service.serviceName }}
-            </a>
+            <a href="/service/{{ service.id.lower() }}">{{ service.serviceName }}</a>
         </td>
         <td class="summary-item-field-content">
             {{ service.frameworkName}}


### PR DESCRIPTION
On the dashboard, make the services link relative so that it points to
the correct environment.

Fixes: [94162812](https://www.pivotaltracker.com/story/show/94162812)