### PR TITLE
Bump DM utils to 0.10.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ Flask==0.10.1
 Flask-Login==0.2.11
 Flask-Script==2.0.5
 Flask-WTF==0.11
--e git+https://github.com/alphagov/digitalmarketplace-utils.git@0.7.0#egg=digitalmarketplace-utils
+-e git+https://github.com/alphagov/digitalmarketplace-utils.git@0.10.2#egg=digitalmarketplace-utils
 
 mandrill==1.0.57
 


### PR DESCRIPTION
https://github.com/alphagov/digitalmarketplace-utils/compare/0.7.0...0.10.2

Changes are mostly bug fixes or for the buyers app.