### PR TITLE
[#94292928] Integrate custom proxy fix

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -3,8 +3,7 @@ import re
 from flask import Flask
 from flask_login import LoginManager
 from flask._compat import string_types
-from werkzeug.contrib.fixers import ProxyFix
-from dmutils import apiclient, logging, config
+from dmutils import apiclient, logging, config, proxy_fix
 
 from config import configs
 from .model import User
@@ -17,7 +16,6 @@ def create_app(config_name):
     application = Flask(__name__,
                         static_folder='static/',
                         static_url_path=configs[config_name].STATIC_URL_PATH)
-    application.wsgi_app = ProxyFix(application.wsgi_app)
     application.config.from_object(configs[config_name])
     configs[config_name].init_app(application)
     config.init_app(application)
@@ -25,6 +23,7 @@ def create_app(config_name):
     from .main import main as main_blueprint
     from .status import status as status_blueprint
 
+    proxy_fix.init_app(application)
     login_manager.init_app(application)
     logging.init_app(application)
     data_api_client.init_app(application)

--- a/config.py
+++ b/config.py
@@ -69,6 +69,7 @@ class Development(Config):
 class Live(Config):
     DEBUG = False
     SESSION_COOKIE_SECURE = True
+    DM_HTTP_PROTO = 'https'
 
 
 configs = {

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ Flask==0.10.1
 Flask-Login==0.2.11
 Flask-Script==2.0.5
 Flask-WTF==0.11
--e git+https://github.com/alphagov/digitalmarketplace-utils.git@0.10.2#egg=digitalmarketplace-utils
+git+https://github.com/alphagov/digitalmarketplace-utils.git@0.12.0#egg=digitalmarketplace-utils==0.12.0
 
 mandrill==1.0.57
 


### PR DESCRIPTION
AWS ELBs set the X-Forwarded-Proto to HTTP if they're configured port
80 -> 80. Because the apps are now internal and served over HTTP we lose
the X-Forwarded-Proto that is sent by Nginx. This change allows the HTTP
protocol to be configured per environment while still making use of
flasks ProxyFix middleware.