### PR TITLE
Remove ability for Suppliers to edit status of their Services.

### DIFF
--- a/app/main/services.py
+++ b/app/main/services.py
@@ -28,6 +28,8 @@ def dashboard():
 @main.route('/services/<string:service_id>', methods=['GET'])
 @login_required
 def services(service_id):
+    abort(404)
+
     service = data_api_client.get_service(service_id).get('services')
 
     if not _is_service_associated_with_supplier(service):
@@ -51,6 +53,8 @@ def services(service_id):
 @main.route('/services/<string:service_id>', methods=['POST'])
 @login_required
 def update_service_status(service_id):
+    abort(404)
+
     service = data_api_client.get_service(service_id).get('services')
 
     if not _is_service_associated_with_supplier(service):

--- a/app/templates/services/dashboard.html
+++ b/app/templates/services/dashboard.html
@@ -68,11 +68,6 @@
             {{ service.status|title }}
           {% endif %}
         </td>
-        <td class="summary-item-action-field">
-          <a href="{{ url_for('.services', service_id=service.id) }}">
-            {{ 'Details' if service.status == 'disabled' else 'Edit' }}
-          </a>
-        </td>
       </tr>
     {% else %}
       <h2 class="summary-item-heading first-summary-item-heading">

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -126,53 +126,10 @@ class TestDashboardLogin(BaseApplicationTest):
                      '?next=%2Fsuppliers%2F')
 
 
-class TestServicesLogin(BaseApplicationTest):
-    def test_should_show_dashboard_if_logged_in(self):
-        with self.app.test_client():
-            data_api_client.authenticate_user = Mock(
-                return_value=(self.user(123, "email@email.com", 1234, 'name')))
-
-            data_api_client.get_user = Mock(
-                return_value=(self.user(123, "email@email.com", 1234, 'name')))
-
-            data_api_client.get_service = Mock(
-                return_value={'services': {
-                    'serviceName': 'Service name 123',
-                    'status': 'published',
-                    'id': '123',
-                    'frameworkName': 'G-Cloud 6',
-                    'supplierId': 1234
-                }})
-
-            self.client.post("/suppliers/login", data={
-                'email_address': 'valid@email.com',
-                'password': '1234567890'
-            })
-
-            res = self.client.get('/suppliers/services/123')
-
-            assert_equal(res.status_code, 200)
-
-            assert_true(
-                self.strip_all_whitespace('<p class="context">Edit</p>')
-                in self.strip_all_whitespace(res.get_data(as_text=True))
-            )
-            assert_true(
-                'Service name 123' in res.get_data(as_text=True)
-            )
-
-    def test_should_redirect_to_login_if_not_logged_in(self):
-        res = self.client.get("/suppliers/services/123")
-        assert_equal(res.status_code, 302)
-        assert_equal(res.location,
-                     'http://localhost/suppliers/login'
-                     '?next=%2Fsuppliers%2Fservices%2F123')
-
-
 @mock.patch('app.main.services.data_api_client')
 class TestSupplierUpdateService(BaseApplicationTest):
 
-    def _add_user_and_service(
+    def _login(
             self,
             data_api_client,
             service_status="published",
@@ -212,36 +169,41 @@ class TestSupplierUpdateService(BaseApplicationTest):
 
     def _post_status_updates(
             self,
-            service_should_be_modifiable=True
+            service_should_be_modifiable=True,
+            failing_status_code=400
     ):
-        expected_status_code = 302 if service_should_be_modifiable else 400
+        expected_status_code = \
+            302 if service_should_be_modifiable else failing_status_code
 
         # Should work if service not removed/disabled or another supplier's
         self._post_status_update('private', expected_status_code)
         self._post_status_update('public', expected_status_code)
 
         # Database statuses should not work
-        self._post_status_update('published', 400)
-        self._post_status_update('enabled', 400)
+        self._post_status_update('published', failing_status_code)
+        self._post_status_update('enabled', failing_status_code)
 
         # Removing a service should be impossible
-        self._post_status_update('removed', 400)
-        self._post_status_update('disabled', 400)
+        self._post_status_update('removed', failing_status_code)
+        self._post_status_update('disabled', failing_status_code)
 
         # non-statuses should not work
-        self._post_status_update('orange', 400)
-        self._post_status_update('banana', 400)
+        self._post_status_update('orange', failing_status_code)
+        self._post_status_update('banana', failing_status_code)
 
-    def test_should_view_public_service_with_correct_input_checked(
+    def xtest_should_view_public_service_with_correct_input_checked(
             self, data_api_client
     ):
-        self._add_user_and_service(
+        self._login(
             data_api_client,
             service_status='published'
         )
 
         res = self.client.get('/suppliers/services/123')
         assert_equal(res.status_code, 200)
+        assert_true(
+            'Service name 123' in res.get_data(as_text=True)
+        )
 
         # check that 'public' is selected.
         assert_true(
@@ -257,16 +219,19 @@ class TestSupplierUpdateService(BaseApplicationTest):
             service_should_be_modifiable=True
         )
 
-    def test_should_view_private_service_with_correct_input_checked(
+    def xtest_should_view_private_service_with_correct_input_checked(
             self, data_api_client
     ):
-        self._add_user_and_service(
+        self._login(
             data_api_client,
             service_status='enabled'
         )
 
         res = self.client.get('/suppliers/services/123')
         assert_equal(res.status_code, 200)
+        assert_true(
+            'Service name 123' in res.get_data(as_text=True)
+        )
 
         # check that 'public' is not selected.
         assert_false(
@@ -282,16 +247,19 @@ class TestSupplierUpdateService(BaseApplicationTest):
             service_should_be_modifiable=True
         )
 
-    def test_should_view_disabled_service_with_removed_message(
+    def xtest_should_view_disabled_service_with_removed_message(
             self, data_api_client
     ):
-        self._add_user_and_service(
+        self._login(
             data_api_client,
             service_status='disabled'
         )
 
         res = self.client.get('/suppliers/services/123')
         assert_equal(res.status_code, 200)
+        assert_true(
+            'Service name 123' in res.get_data(as_text=True)
+        )
 
         assert_true(
             'This service has been removed'
@@ -302,8 +270,10 @@ class TestSupplierUpdateService(BaseApplicationTest):
             service_should_be_modifiable=False
         )
 
-    def test_should_not_view_other_suppliers_services(self, data_api_client):
-        self._add_user_and_service(
+    def xtest_should_not_view_other_suppliers_services(
+            self, data_api_client
+    ):
+        self._login(
             data_api_client,
             service_status='published',
             service_belongs_to_user=False
@@ -313,6 +283,33 @@ class TestSupplierUpdateService(BaseApplicationTest):
         assert_equal(res.status_code, 404)
 
         # Should all be 404 if service doesn't belong to supplier
-        self._post_status_update('public', 404)
-        self._post_status_update('published', 404)
-        self._post_status_update('watermelon', 404)
+        self._post_status_updates(
+            service_should_be_modifiable=False,
+            failing_status_code=404
+        )
+
+    # Remove this test (and re-enable the others) once suppliers can edit their services' statuses  # noqa
+    def test_should_not_view_or_post_to_service(
+            self, data_api_client
+    ):
+        self._login(
+            data_api_client
+        )
+
+        res = self.client.get('/suppliers/services/123')
+        assert_equal(res.status_code, 404)
+        assert_false(
+            'Service name 123' in res.get_data(as_text=True)
+        )
+
+        self._post_status_updates(
+            service_should_be_modifiable=False,
+            failing_status_code=404
+        )
+
+    def test_should_redirect_to_login_if_not_logged_in(self, data_api_client):
+        res = self.client.get("/suppliers/services/123")
+        assert_equal(res.status_code, 302)
+        assert_equal(res.location,
+                     'http://localhost/suppliers/login'
+                     '?next=%2Fsuppliers%2Fservices%2F123')

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -44,7 +44,8 @@ class TestDashboardContent(BaseApplicationTest):
             assert_true("SaaaaaaaS" in res.get_data(as_text=True))
             assert_true("G-Cloud 1" in res.get_data(as_text=True))
 
-    def test_shows_services_edit_button_with_id_on_dashboard(self):
+    # remove 'x' once suppliers can edit their services' statuses again
+    def xtest_shows_services_edit_button_with_id_on_dashboard(self):
         with self.app.test_client():
             self.login()
 

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -191,6 +191,7 @@ class TestSupplierUpdateService(BaseApplicationTest):
         self._post_status_update('orange', failing_status_code)
         self._post_status_update('banana', failing_status_code)
 
+    # remove 'x' once suppliers can edit their services' statuses again
     def xtest_should_view_public_service_with_correct_input_checked(
             self, data_api_client
     ):
@@ -219,6 +220,7 @@ class TestSupplierUpdateService(BaseApplicationTest):
             service_should_be_modifiable=True
         )
 
+    # remove 'x' once suppliers can edit their services' statuses again
     def xtest_should_view_private_service_with_correct_input_checked(
             self, data_api_client
     ):
@@ -247,6 +249,7 @@ class TestSupplierUpdateService(BaseApplicationTest):
             service_should_be_modifiable=True
         )
 
+    # remove 'x' once suppliers can edit their services' statuses again
     def xtest_should_view_disabled_service_with_removed_message(
             self, data_api_client
     ):
@@ -270,6 +273,7 @@ class TestSupplierUpdateService(BaseApplicationTest):
             service_should_be_modifiable=False
         )
 
+    # remove 'x' once suppliers can edit their services' statuses again
     def xtest_should_not_view_other_suppliers_services(
             self, data_api_client
     ):


### PR DESCRIPTION
After talking with Cath and Nicole today, it was felt that giving Suppliers the ability to make their Services 'private' wasn't really valuable.  
The contention was that Suppliers would see the 'Edit' link and -- thinking it would allow them to edit all of the fields -- become disappointed when all they would actually be able to do would be remove Services from public view.

Solution was to:
* Remove 'Edit'  / 'Details' links on the Supplier dashboard
* Disable routes to view/change a Service's status in the app
* Refactor the tests


[>> Story on Pivotal](https://www.pivotaltracker.com/story/show/94826380)

***

### New Dashboard

![screen shot 2015-05-18 at 15 03 53](https://cloud.githubusercontent.com/assets/2454380/7682461/1d1be8f8-fd70-11e4-8034-413781b61f6c.png)
