### PR TITLE
Tag buyer apps with analytics tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
 install:
   - pip install -r requirements_for_test.txt
   - npm install
+  - npm run frontend-build:production
 script:
   - ./scripts/run_tests.sh
 notifications:

--- a/app/assets/javascripts/_analytics.js
+++ b/app/assets/javascripts/_analytics.js
@@ -1,0 +1,10 @@
+(function() {
+  "use strict";
+  GOVUK.Tracker.load();
+  var cookieDomain = (document.domain === 'www.beta.digitalmarketplace.service.gov.uk') ? '.digitalmarketplace.service.gov.uk' : document.domain;
+  GOVUK.analytics = new GOVUK.Tracker({
+    universalId: 'UA-49258698-3',
+    cookieDomain: cookieDomain
+  });
+  GOVUK.analytics.trackPageview();
+})();

--- a/bower.json
+++ b/bower.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "jquery": "1.11.2",
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
-    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v3.0.0",
+    "digitalmarketplace_frontend_toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v3.0.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.12.0/jinja_govuk_template-0.12.0.tgz"
   }
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -2,16 +2,17 @@ var gulp = require('gulp');
 var uglify = require('gulp-uglifyjs');
 var deleteFiles = require('del');
 var sass = require('gulp-sass');
-var include = require('gulp-include');
+var filelog = require('gulp-filelog');
 
 var environment;
 var repoRoot = __dirname + '/';
-var govukToolkitSCSS = repoRoot + 'node_modules/govuk_frontend_toolkit/stylesheets';
-var dmToolkitSCSS = repoRoot + 'bower_components/digitalmarketplace-frontend-toolkit/toolkit/scss';
+var bowerRoot = repoRoot + 'bower_components';
+var npmRoot = repoRoot + 'node_modules';
+var govukToolkitRoot = npmRoot + '/govuk_frontend_toolkit';
+var dmToolkitRoot = bowerRoot + '/digitalmarketplace_frontend_toolkit/toolkit';
 var assetsFolder = repoRoot + 'app/assets';
 var staticFolder = repoRoot + 'app/static';
 var govukTemplateAssetsFolder = repoRoot + 'bower_components/govuk_template/assets';
-var dmToolkitAssetsFolder = repoRoot + 'bower_components/digitalmarketplace-frontend-toolkit/toolkit/';
 
 // JavaScript paths
 var jsVendorFiles = [
@@ -33,13 +34,22 @@ var sassOptions = {
   development: {
     outputStyle: 'expanded',
     lineNumbers: true,
-    includePaths: [govukToolkitSCSS, dmToolkitSCSS],
-    sourceComments: true
+    includePaths: [
+      assetsFolder + '/scss',
+      govukToolkitRoot + '/stylesheets',
+      dmToolkitRoot + '/scss'
+    ],
+    sourceComments: true,
+    errLogToConsole: true
   },
   production: {
     outputStyle: 'compressed',
     lineNumbers: true,
-    includePaths: [govukToolkitSCSS, dmToolkitSCSS]
+    includePaths: [
+      assetsFolder + '/scss',
+      govukToolkitRoot + '/stylesheets',
+      dmToolkitRoot + '/scss'
+    ],
   },
 };
 
@@ -51,26 +61,38 @@ var uglifyOptions = {
       semicolons: true,
       comments: true,
       indent_level: 2
-    }
+    },
+    compress: false
   },
   production: {
     mangle: true
   }
 };
 
-gulp.task('clean', function () {
+gulp.task('clean', function (cb) {
+  var fileTypes = [];
+  var complete = function (fileType) {
+    fileTypes.push(fileType);
+    if (fileTypes.length == 2) {
+      cb();
+    }
+  };
   var logOutputFor = function (fileType) {
     return function (err, paths) {
-      console.log('Deleted the following ' + fileType + ' files:\n', paths.join('\n'));
+      if (paths !== undefined) {
+        console.log('Deleted the following ' + fileType + ' files:\n', paths.join('\n'));
+      }
+      complete(fileType);
     };
   };
 
-  deleteFiles(jsDistributionFolder + '/*.js', logOutputFor('JavaScript'));
-  deleteFiles(cssDistributionFolder + '/*.css', logOutputFor('CSS'));
+  deleteFiles(jsDistributionFolder + '/**/*', logOutputFor('JavaScript'));
+  deleteFiles(cssDistributionFolder + '/**/*', logOutputFor('CSS'));
 });
 
 gulp.task('sass', function () {
   var stream = gulp.src(cssSourceGlob)
+    .pipe(filelog('Compressing SCSS files'))
     .pipe(sass(sassOptions[environment]))
     .on('error', function (err) {
       console.log(err.message);
@@ -78,7 +100,7 @@ gulp.task('sass', function () {
     .pipe(gulp.dest(cssDistributionFolder));
 
   stream.on('end', function () {
-    console.log('Compressed CSS saved as .css files in ' + cssDistributionFolder);
+    console.log('Compressed CSS saved as .css files in ' + cssDistributionFolder)
   });
 
   return stream;
@@ -88,7 +110,7 @@ gulp.task('js', function () {
   // produce full array of JS files from vendor + local scripts
   jsFiles = jsVendorFiles.concat(jsSourceFiles);
   var stream = gulp.src(jsFiles)
-    .pipe(include())
+    .pipe(filelog('Compressing JavaScript files'))
     .pipe(uglify(
       jsDistributionFile,
       uglifyOptions[environment]
@@ -103,52 +125,101 @@ gulp.task('js', function () {
 });
 
 gulp.task('copy_template_assets:stylesheets', function () {
-  return gulp.src(govukTemplateAssetsFolder + '/stylesheets/**/*', { base : govukTemplateAssetsFolder + '/stylesheets' })
+  stream = gulp.src(govukTemplateAssetsFolder + '/stylesheets/**/*', { base : govukTemplateAssetsFolder + '/stylesheets' })
     .pipe(gulp.dest(staticFolder + '/stylesheets'))
+
+  stream.on('end', function () {
+    console.log('Copied CSS assets from the govuk template');
+  });
+
+  return stream;
 });
 
 gulp.task('copy_template_assets:images', function () {
-  return gulp.src(govukTemplateAssetsFolder + '/images/**/*', { base : govukTemplateAssetsFolder + '/images' })
+  stream = gulp.src(govukTemplateAssetsFolder + '/images/**/*', { base : govukTemplateAssetsFolder + '/images' })
     .pipe(gulp.dest(staticFolder + '/images'))
+
+  stream.on('end', function () {
+    console.log('Copied image assets from the govuk template');
+  });
+
+  return stream;
 });
 
 gulp.task('copy_template_assets:javascripts', function () {
-  return gulp.src(govukTemplateAssetsFolder + '/javascripts/**/*', { base : govukTemplateAssetsFolder + '/javascripts' })
+  stream = gulp.src(govukTemplateAssetsFolder + '/javascripts/**/*', { base : govukTemplateAssetsFolder + '/javascripts' })
     .pipe(gulp.dest(staticFolder + '/javascripts'))
+
+  stream.on('end', function () {
+    console.log('Copied JS assets from the govuk template');
+  });
+
+  return stream;
 });
 
-gulp.task('copy_template_assets', function () {
-   gulp.start('copy_template_assets:stylesheets');
-   gulp.start('copy_template_assets:images');
-   gulp.start('copy_template_assets:javascripts');
+gulp.task('copy_dm_toolkit_assets:images', function () {
+  stream = gulp.src(dmToolkitRoot + '/images/**/*', { base : dmToolkitRoot + '/images' })
+    .pipe(gulp.dest(staticFolder + '/images'))
+
+  stream.on('end', function () {
+    console.log('Copied image assets from the digital marketplace front-end toolkit');
+  });
+
+  return stream;
 });
+
+gulp.task('copy_template_assets', [
+  'copy_template_assets:stylesheets',
+  'copy_template_assets:images',
+  'copy_template_assets:javascripts'
+]);
+
+gulp.task('copy:images', function () {
+  stream = gulp.src(assetsFolder + '/images/**/*', { base : assetsFolder + '/images' })
+    .pipe(gulp.dest(staticFolder + '/images'))
+
+  stream.on('end', function () {
+    console.log('Copied image assets into static folder');
+  });
+
+  return stream;
+});
+
+gulp.task('copy_dm_toolkit_assets', ['copy_dm_toolkit_assets:images']);
 
 gulp.task('watch', ['build:development'], function () {
   var jsWatcher = gulp.watch([ assetsFolder + '/**/*.js' ], ['js']);
   var cssWatcher = gulp.watch([ assetsFolder + '/**/*.scss' ], ['sass']);
   var notice = function (event) {
     console.log('File ' + event.path + ' was ' + event.type + ' running tasks...');
-  };
+  }
 
   cssWatcher.on('change', notice);
   jsWatcher.on('change', notice);
 });
 
-gulp.task('copy_toolkit_assets:images', function () {
-  return gulp.src(dmToolkitAssetsFolder + '/images/**/*', { base : dmToolkitAssetsFolder + '/images' })
-    .pipe(gulp.dest(staticFolder + '/images'));
-});
-
-gulp.task('build:development', ['clean'], function () {
+gulp.task('set_environment_to_development', function (cb) {
   environment = 'development';
-  gulp.start('sass', 'js');
-  gulp.start('copy_template_assets');
-  gulp.start('copy_toolkit_assets:images');
+  cb();
 });
 
-gulp.task('build:production', ['clean'], function () {
+gulp.task('set_environment_to_production', function (cb) {
   environment = 'production';
+  cb();
+});
+
+gulp.task('copy_and_compile', ['sass', 'js', 'copy_template_assets', 'copy_dm_toolkit_assets']);
+
+gulp.task('build:development', ['set_environment_to_development', 'clean'], function () {
   gulp.start('sass', 'js');
+  gulp.start('copy:images');
   gulp.start('copy_template_assets');
-  gulp.start('copy_toolkit_assets:images');
+  gulp.start('copy_dm_toolkit_assets');
+});
+
+gulp.task('build:production', ['set_environment_to_production', 'clean'], function () {
+  gulp.start('sass', 'js');
+  gulp.start('copy:images');
+  gulp.start('copy_template_assets');
+  gulp.start('copy_dm_toolkit_assets');
 });

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -16,11 +16,12 @@ var govukTemplateAssetsFolder = repoRoot + 'bower_components/govuk_template/asse
 
 // JavaScript paths
 var jsVendorFiles = [
-  assetsFolder + '/javascripts/vendor/jquery-1.11.0.js',
-  assetsFolder + '/javascripts/vendor/hogan-3.0.2.min.js'
+  govukToolkitRoot + '/javascripts/govuk/analytics/tracker.js',
+  govukToolkitRoot + '/javascripts/govuk/analytics/google-analytics-universal-tracker.js',
+  govukToolkitRoot + '/javascripts/govuk/analytics/google-analytics-classic-tracker.js',
 ];
 var jsSourceFiles = [
-  assetsFolder + '/javascripts/application.js'
+  assetsFolder + '/javascripts/_analytics.js',
 ];
 var jsDistributionFolder = staticFolder + '/javascripts';
 var jsDistributionFile = 'application.js';

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "gulp-uglifyjs": "0.6.0",
     "del": "1.1.1",
     "gulp-sass": "1.3.3",
-    "gulp-shell": "0.2.9"
+    "gulp-shell": "0.2.9",
+    "gulp-filelog" : "0.4.1"
   },
   "scripts": {
     "frontend-install": "./node_modules/bower/bin/bower install",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "engine": "node >= 0.10.0",
   "dependencies": {
     "bower": "1.3.12",
-    "govuk_frontend_toolkit": "3.1.0",
+    "govuk_frontend_toolkit": "3.5.1",
     "gulp": "3.8.7",
     "gulp-include": "1.1.1",
     "gulp-uglifyjs": "0.6.0",

--- a/tests/app/main/test_application.py
+++ b/tests/app/main/test_application.py
@@ -1,0 +1,15 @@
+import mock
+from nose.tools import assert_equal, assert_true
+from ..helpers import BaseApplicationTest
+
+
+class TestApplication(BaseApplicationTest):
+    def setup(self):
+        super(TestApplication, self).setup()
+
+    def test_analytics_code_should_be_in_javascript(self):
+        res = self.client.get('/suppliers/static/javascripts/application.js')
+        assert_equal(200, res.status_code)
+        assert_true(
+            'GOVUK.analytics.trackPageview'
+            in res.get_data(as_text=True))


### PR DESCRIPTION
Part two of this story to add the tags to both buyer and supplier apps
(paired with https://github.com/alphagov/digitalmarketplace-buyer-frontend/pull/59):

https://www.pivotaltracker.com/story/show/94570480

Uses the new Google Analytics API from the govuk front-end toolkit:

https://github.com/alphagov/govuk_frontend_toolkit/blob/master/docs/analytics.md