### PR TITLE
Error pages

### DIFF
--- a/app/templates/errors/404.html
+++ b/app/templates/errors/404.html
@@ -6,5 +6,12 @@
   <h1>Page could not be found</h1>
 </header>
 
+<p>
+    Check you've entered the correct web address or start again on the Digital Marketplace homepage.
+</p>
+<p>
+    If you can't find what you're looking for, contact us at <a href="mailto:enquiries@digitalmarketplace.service.gov.uk?subject=Digital%20Marketplace%20feedback" title="Please send feedback to enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.service.gov.uk</a>
+</p>
+
 
 {% endblock %}

--- a/app/templates/errors/500.html
+++ b/app/templates/errors/500.html
@@ -1,9 +1,10 @@
-{% extends "_base_page.html" %}
-
-{% block main_content %}
 
 <header class="page-heading-smaller">
-  <h1>An error has occurred</h1>
+  <h1>Sorry, we're experiencing technical difficulties</h1>
 </header>
 
-{% endblock %}
+<p>
+    Try again later.
+</p>
+
+

--- a/app/templates/errors/500.html
+++ b/app/templates/errors/500.html
@@ -1,3 +1,6 @@
+{% extends "_base_page.html" %}
+
+{% block main_content %}
 
 <header class="page-heading-smaller">
   <h1>Sorry, we're experiencing technical difficulties</h1>
@@ -8,3 +11,4 @@
 </p>
 
 
+{% endblock %}

--- a/tests/app/helpers.py
+++ b/tests/app/helpers.py
@@ -1,7 +1,9 @@
 import re
+from mock import Mock
 from app import create_app
 from werkzeug.http import parse_cookie
 from app.model import User
+from app import data_api_client
 
 
 class BaseApplicationTest(object):
@@ -48,3 +50,20 @@ class BaseApplicationTest(object):
                 }
             ]
         }
+
+    def login(self):
+        data_api_client.authenticate_user = Mock(
+            return_value=(self.user(
+                123, "email@email.com", 1234, 'Supplier Name')))
+
+        data_api_client.get_user = Mock(
+            return_value=(self.user(
+                123, "email@email.com", 1234, 'Supplier Name')))
+
+        self.client.post("/suppliers/login", data={
+            'email_address': 'valid@email.com',
+            'password': '1234567890'
+        })
+
+        data_api_client.authenticate_user.assert_called_once_with(
+            "valid@email.com", "1234567890")

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -1,5 +1,5 @@
-from mock import Mock
 import mock
+from mock import Mock
 from app import data_api_client
 from nose.tools import assert_equal, assert_true, assert_false
 from tests.app.helpers import BaseApplicationTest
@@ -62,23 +62,6 @@ class TestDashboardContent(BaseApplicationTest):
                 supplier_id=1234)
             assert_true(
                 "/suppliers/services/123" in res.get_data(as_text=True))
-
-    def login(self):
-        data_api_client.authenticate_user = Mock(
-            return_value=(self.user(
-                123, "email@email.com", 1234, 'Supplier Name')))
-
-        data_api_client.get_user = Mock(
-            return_value=(self.user(
-                123, "email@email.com", 1234, 'Supplier Name')))
-
-        self.client.post("/suppliers/login", data={
-            'email_address': 'valid@email.com',
-            'password': '1234567890'
-        })
-
-        data_api_client.authenticate_user.assert_called_once_with(
-            "valid@email.com", "1234567890")
 
 
 class TestDashboardLogin(BaseApplicationTest):

--- a/tests/app/test_application.py
+++ b/tests/app/test_application.py
@@ -1,13 +1,51 @@
+# coding=utf-8
+
+import mock
+from mock import Mock
+from nose.tools import assert_equal, assert_true
+from app import data_api_client
+from requests import ConnectionError
 from .helpers import BaseApplicationTest
 
 
 class TestApplication(BaseApplicationTest):
-
-    def test_404(self):
-        response = self.client.get('/not-found')
-        assert 404 == response.status_code
+    def setup(self):
+        super(TestApplication, self).setup()
 
     def test_url_with_non_canonical_trailing_slash(self):
         response = self.client.get('/suppliers/')
         assert 301 == response.status_code
         assert "http://localhost/suppliers" == response.location
+
+    def test_404(self):
+        res = self.client.get('/service/1234')
+        assert_equal(404, res.status_code)
+        assert_true(
+            "Check you've entered the correct web "
+            "address or start again on the Digital Marketplace homepage."
+            in res.get_data(as_text=True))
+        assert_true(
+            "If you can't find what you're looking for, contact us at "
+            "<a href=\"mailto:enquiries@digitalmarketplace.service.gov.uk?"
+            "subject=Digital%20Marketplace%20feedback\" title=\"Please "
+            "send feedback to enquiries@digitalmarketplace.service.gov.uk\">"
+            "enquiries@digitalmarketplace.service.gov.uk</a>"
+            in res.get_data(as_text=True))
+
+    def test_500(self):
+        with self.app.test_client():
+            self.login()
+
+            data_api_client.get_service = Mock(
+                side_effect=ConnectionError('API is down')
+            )
+            self.app.config['DEBUG'] = False
+
+            res = self.client.get('/suppliers/services/12345')
+            assert_equal(500, res.status_code)
+            assert_true(
+                "Sorry, we're experiencing technical difficulties"
+                in res.get_data(as_text=True))
+            assert_true(
+                "Try again later."
+                in res.get_data(as_text=True))


### PR DESCRIPTION
Bringing the error pages into line with those on the buyer app.

- Please note there is an issue currently where API errors cause an internal server error to be displayed NOT the error template.

- This is because whilst rendering a template Flask-Login tries to confirm the user - fails (API error) and throws an error - preventing the template rendering.

- Propose we merge this (as this issue is preexisting) and I'll add a story to fix in another way.