### PR TITLE
Show log-in for logged-out users and log-out for logged-in users

### DIFF
--- a/app/templates/_proposition_header.html
+++ b/app/templates/_proposition_header.html
@@ -4,7 +4,11 @@
     <nav id="proposition-menu">
       <a href="/" id="proposition-name">Digital Marketplace</a>
       <ul id="proposition-links">
+        {% if current_user.email_address %}
         <li><a class="home" href="{{ url_for('main.logout') }}">Logout</a></li>
+        {% else %}
+        <li><a class="home" href="{{ url_for('main.render_login') }}">Supplier login</a></li>
+        {% endif %}
       </ul>
     </nav>
   </div>


### PR DESCRIPTION
Currently "Logout" link is shown on all pages, whether or not there is any user logged in.

This only shows "Logout" if there is a user logged in, or the "Supplier login" link (same as the buyer app) otherwise.