### PR TITLE
Fix reset password flow

### DIFF
--- a/app/main/forms/auth_forms.py
+++ b/app/main/forms/auth_forms.py
@@ -21,11 +21,6 @@ class ResetPasswordForm(Form):
 
 
 class ChangePasswordForm(Form):
-    email_address = HiddenField('Email address', validators=[
-        DataRequired(message="Email can not be empty"),
-        Email(message="Please enter a valid email address")
-    ])
-    user_id = HiddenField('User ID')
     password = PasswordField('Password', validators=[
         DataRequired(message="Please enter a new password"),
         Length(min=10,

--- a/app/templates/auth/reset-password.html
+++ b/app/templates/auth/reset-password.html
@@ -19,7 +19,7 @@
     <h1>Reset password</h1>
 </header>
 <p class="lede">
-    Reset password for {{ form.email_address.data }}
+    Reset password for {{ email_address }}
 </p>
 
 <form action="{{ url_for('.update_password', token=token) }}" method="POST">
@@ -31,11 +31,9 @@
     {% endif %}
         <div class="question">
             {{ form.password.label(class="question-heading-with-hint") }}
-            {% if form.email_address %}
             <p class="hint">
               Must be between 10 and 50 characters
             </p>
-            {% endif %}
             {% if form.password.errors %}
             <p class="validation-message" id="error-password-textbox">
                 {% for error in form.password.errors %}{{ error }}{% endfor %}

--- a/tests/app/main/test_login.py
+++ b/tests/app/main/test_login.py
@@ -132,66 +132,66 @@ class TestResetPassword(BaseApplicationTest):
         )
 
     def test_password_should_not_be_empty(self):
-        res = self.client.post("/suppliers/reset-password/token", data={
-            'user_id': 123,
-            'email_address': 'email@email.com',
-            'password': '',
-            'confirm_password': ''
-        })
-        assert_equal(res.status_code, 400)
-        assert_true(
-            NEW_PASSWORD_EMPTY_ERROR in res.get_data(as_text=True)
-        )
-        assert_true(
-            NEW_PASSWORD_CONFIRM_EMPTY_ERROR in res.get_data(as_text=True)
-        )
+        with self.app.app_context():
+            url = helpers.email.generate_reset_url(123, 'email@email.com')
+            res = self.client.post(url, data={
+                'password': '',
+                'confirm_password': ''
+            })
+            assert_equal(res.status_code, 400)
+            assert_true(
+                NEW_PASSWORD_EMPTY_ERROR in res.get_data(as_text=True)
+            )
+            assert_true(
+                NEW_PASSWORD_CONFIRM_EMPTY_ERROR in res.get_data(as_text=True)
+            )
 
     def test_password_should_be_over_ten_chars_long(self):
-        res = self.client.post("/suppliers/reset-password/token", data={
-            'user_id': 123,
-            'email_address': 'email@email.com',
-            'password': '123456789',
-            'confirm_password': '123456789'
-        })
-        assert_equal(res.status_code, 400)
-        assert_true(
-            PASSWORD_INVALID_ERROR in res.get_data(as_text=True)
-        )
+        with self.app.app_context():
+            url = helpers.email.generate_reset_url(123, 'email@email.com')
+            res = self.client.post(url, data={
+                'password': '123456789',
+                'confirm_password': '123456789'
+            })
+            assert_equal(res.status_code, 400)
+            assert_true(
+                PASSWORD_INVALID_ERROR in res.get_data(as_text=True)
+            )
 
     def test_password_should_be_under_51_chars_long(self):
-        res = self.client.post("/suppliers/reset-password/token", data={
-            'user_id': 123,
-            'email_address': 'email@email.com',
-            'password':
-                '123456789012345678901234567890123456789012345678901',
-            'confirm_password':
-                '123456789012345678901234567890123456789012345678901'
-        })
-        assert_equal(res.status_code, 400)
-        assert_true(
-            PASSWORD_INVALID_ERROR in res.get_data(as_text=True)
-        )
+        with self.app.app_context():
+            url = helpers.email.generate_reset_url(123, 'email@email.com')
+            res = self.client.post(url, data={
+                'password':
+                    '123456789012345678901234567890123456789012345678901',
+                'confirm_password':
+                    '123456789012345678901234567890123456789012345678901'
+            })
+            assert_equal(res.status_code, 400)
+            assert_true(
+                PASSWORD_INVALID_ERROR in res.get_data(as_text=True)
+            )
 
     def test_passwords_should_match(self):
-        res = self.client.post("/suppliers/reset-password/token", data={
-            'user_id': 123,
-            'email_address': 'email@email.com',
-            'password': '1234567890',
-            'confirm_password': '0123456789'
-        })
-        assert_equal(res.status_code, 400)
-        assert_true(
-            PASSWORD_MISMATCH_ERROR in res.get_data(as_text=True)
-        )
+        with self.app.app_context():
+            url = helpers.email.generate_reset_url(123, 'email@email.com')
+            res = self.client.post(url, data={
+                'password': '1234567890',
+                'confirm_password': '0123456789'
+            })
+            assert_equal(res.status_code, 400)
+            assert_true(
+                PASSWORD_MISMATCH_ERROR in res.get_data(as_text=True)
+            )
 
     def test_redirect_to_login_page_on_success(self):
         data_api_client.update_user_password = Mock()
-        res = self.client.post("/suppliers/reset-password/token", data={
-            'user_id': 123,
-            'email_address': 'email@email.com',
-            'password': '1234567890',
-            'confirm_password': '1234567890'
-        })
-        assert_equal(res.status_code, 302)
-        assert_equal(res.location,
-                     'http://localhost/suppliers/login')
+        with self.app.app_context():
+            url = helpers.email.generate_reset_url(123, 'email@email.com')
+            res = self.client.post(url, data={
+                'password': '1234567890',
+                'confirm_password': '1234567890'
+            })
+            assert_equal(res.status_code, 302)
+            assert_equal(res.location,
+                         'http://localhost/suppliers/login')


### PR DESCRIPTION
The reset-password form was wrongly including the email address and user ID as hidden form fields.  They are now only encoded in the token, so that it can't be hacked.