### PR TITLE
Edit supplier and contact information page

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -3,14 +3,18 @@ import re
 from flask import Flask, request, redirect
 from flask_login import LoginManager
 from flask._compat import string_types
+from flask_wtf.csrf import CsrfProtect
+
 from dmutils import apiclient, init_app, flask_featureflags
 
 from config import configs
 from .model import User
 
+
 data_api_client = apiclient.DataAPIClient()
 login_manager = LoginManager()
 feature_flags = flask_featureflags.FeatureFlag()
+csrf = CsrfProtect()
 
 
 def create_app(config_name):
@@ -35,6 +39,8 @@ def create_app(config_name):
                                    url_prefix='/suppliers')
     login_manager.login_view = 'main.render_login'
     main_blueprint.config = application.config.copy()
+
+    csrf.init_app(application)
 
     @application.before_request
     def remove_trailing_slash():

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -6,8 +6,13 @@
 */
 //= include ../../../node_modules/govuk_frontend_toolkit/javascripts/vendor/polyfills/bind.js
 //= include ../../../bower_components/jquery/dist/jquery.js
+//= include ../../../bower_components/hogan/web/builds/3.0.2/hogan-3.0.2.js
+//= include ../../../bower_components/digitalmarketplace-frontend-toolkit/toolkit/javascripts/list-entry.js
+//= include ../../../bower_components/digitalmarketplace-frontend-toolkit/toolkit/javascripts/word-counter.js
 //= include ../../../node_modules/govuk_frontend_toolkit/javascripts/govuk/selection-buttons.js
 //= include _selection-buttons.js
+//= include _analytics.js
+
 (function(GOVUK, GDM) {
 
   "use strict";

--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -6,6 +6,10 @@
 // Path to assets for use with file-url()
 $path: "/suppliers/static/images/";
 
+// Digital Marketplace front end toolkit components
+@import "forms/word-counter";
+@import "forms/list-entry";
+
 @import "_reset.scss";
 
 #wrapper {

--- a/app/main/__init__.py
+++ b/app/main/__init__.py
@@ -3,4 +3,4 @@ from flask import Blueprint
 main = Blueprint('main', __name__)
 
 from . import errors
-from .views import services, login
+from .views import services, suppliers, login

--- a/app/main/__init__.py
+++ b/app/main/__init__.py
@@ -2,4 +2,5 @@ from flask import Blueprint
 
 main = Blueprint('main', __name__)
 
-from . import errors, services, login
+from . import errors
+from .views import services, login

--- a/app/main/errors.py
+++ b/app/main/errors.py
@@ -12,3 +12,9 @@ def page_not_found(e):
 def exception(e):
     template_data = main.config['BASE_TEMPLATE_DATA']
     return render_template("errors/500.html", **template_data), 500
+
+
+@main.app_errorhandler(503)
+def service_unavailable(e):
+    template_data = main.config['BASE_TEMPLATE_DATA']
+    return render_template("errors/500.html", **template_data), 503

--- a/app/main/forms/suppliers.py
+++ b/app/main/forms/suppliers.py
@@ -1,10 +1,26 @@
 from flask.ext.wtf import Form
 from wtforms import IntegerField, StringField, FieldList
-from wtforms.validators import DataRequired, Email
+from wtforms.validators import DataRequired, Email, ValidationError
+
+
+def word_length(limit=None, message=None):
+    message = message or 'Must not be more than %d words'
+    message = message % limit
+
+    def _length(form, field):
+        if not field.data or not limit:
+            return field
+
+        if len(field.data.split()) > limit:
+            raise ValidationError(message)
+
+    return _length
 
 
 class EditSupplierForm(Form):
-    description = StringField()
+    description = StringField('Supplier summary', validators=[
+        word_length(50, 'Your summary must not be more than %d words')
+    ])
     clients = FieldList(StringField(), max_entries=10)
 
 

--- a/app/main/forms/suppliers.py
+++ b/app/main/forms/suppliers.py
@@ -21,7 +21,11 @@ class EditSupplierForm(Form):
     description = StringField('Supplier summary', validators=[
         word_length(50, 'Your summary must not be more than %d words')
     ])
-    clients = FieldList(StringField(), max_entries=10)
+    clients = FieldList(StringField())
+
+    def validate_clients(form, field):
+        if len(field.data) > 10:
+            raise ValidationError('You must have 10 or fewer clients')
 
 
 class EditContactInformationForm(Form):

--- a/app/main/forms/suppliers.py
+++ b/app/main/forms/suppliers.py
@@ -1,0 +1,28 @@
+from flask.ext.wtf import Form
+from wtforms import IntegerField, StringField, FieldList
+from wtforms.validators import DataRequired, Email
+
+
+class EditSupplierForm(Form):
+    description = StringField()
+    clients = FieldList(StringField(), max_entries=10)
+
+
+class EditContactInformationForm(Form):
+    id = IntegerField()
+    address1 = StringField('Business address')
+    address2 = StringField('Business address')
+    city = StringField('Town or city')
+    country = StringField()
+    postcode = StringField(validators=[
+        DataRequired(message="Postcode can not be empty"),
+    ])
+    website = StringField()
+    phoneNumber = StringField('Phone number')
+    email = StringField('Email address', validators=[
+        DataRequired(message="Email can not be empty"),
+        Email(message="Please enter a valid email address")
+    ])
+    contactName = StringField('Contact name', validators=[
+        DataRequired(message="Contact name can not be empty"),
+    ])

--- a/app/main/views/login.py
+++ b/app/main/views/login.py
@@ -4,12 +4,11 @@ from itsdangerous import BadSignature, SignatureExpired
 from flask import current_app, flash, redirect, render_template, url_for
 from flask_login import logout_user, login_user
 
-from . import main
-from .forms.auth_forms \
-    import LoginForm, ResetPasswordForm, ChangePasswordForm
-from .. import data_api_client
-from ..model import User
-from .helpers import email
+from .. import main
+from ..forms.auth_forms import LoginForm, ResetPasswordForm, ChangePasswordForm
+from ... import data_api_client
+from ...model import User
+from ..helpers import email
 
 
 @main.route('/login', methods=["GET"])

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -8,16 +8,16 @@ from ... import data_api_client, flask_featureflags
 from dmutils.apiclient import APIError
 
 
-@main.route('')
+@main.route('/services')
 @login_required
-def dashboard():
+def list_services():
     template_data = main.config['BASE_TEMPLATE_DATA']
     suppliers_services = data_api_client.find_services(
         supplier_id=current_user.supplier_id
     )
 
     return render_template(
-        "services/dashboard.html",
+        "services/list_services.html",
         services=suppliers_services["services"],
         updated_service_id=request.args.get('updated_service_id'),
         updated_service_name=request.args.get('updated_service_name'),
@@ -28,7 +28,7 @@ def dashboard():
 @main.route('/services/<string:service_id>', methods=['GET'])
 @login_required
 @flask_featureflags.is_active_feature('EDIT_SERVICE_PAGE')
-def services(service_id):
+def edit_service(service_id):
     service = data_api_client.get_service(service_id).get('services')
 
     if not _is_service_associated_with_supplier(service):
@@ -95,7 +95,7 @@ def update_service_status(service_id):
 
     updated_service = updated_service.get("services")
     return redirect(
-        url_for(".dashboard",
+        url_for(".list_services",
                 updated_service_id=updated_service.get("id"),
                 updated_service_name=updated_service.get("serviceName"),
                 updated_service_status=updated_service.get("status")

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -3,8 +3,8 @@ import re
 from flask_login import login_required, current_user
 from flask import render_template, request, redirect, url_for, abort
 
-from app.main import main
-from .. import data_api_client, flask_featureflags
+from ...main import main
+from ... import data_api_client, flask_featureflags
 from dmutils.apiclient import APIError
 
 

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -2,6 +2,7 @@ from flask import render_template, request, redirect, url_for, abort
 from flask_login import login_required, current_user
 
 from dmutils.apiclient import APIError
+from dmutils import flask_featureflags
 
 from ...main import main
 from ... import data_api_client
@@ -10,6 +11,8 @@ from ..forms.suppliers import EditSupplierForm, EditContactInformationForm
 
 @main.route('')
 @login_required
+@flask_featureflags.is_active_feature('SUPPLIER_DASHBOARD',
+                                      redirect='.list_services')
 def dashboard():
     template_data = main.config['BASE_TEMPLATE_DATA']
 
@@ -30,6 +33,7 @@ def dashboard():
 
 @main.route('/edit', methods=['GET'])
 @login_required
+@flask_featureflags.is_active_feature('SUPPLIER_DASHBOARD')
 def edit_supplier(supplier_form=None, contact_form=None, error=None):
     template_data = main.config['BASE_TEMPLATE_DATA']
 
@@ -61,6 +65,7 @@ def edit_supplier(supplier_form=None, contact_form=None, error=None):
 
 @main.route('/edit', methods=['POST'])
 @login_required
+@flask_featureflags.is_active_feature('SUPPLIER_DASHBOARD')
 def update_supplier():
     # FieldList expects post parameter keys to have number suffixes
     # (eg client-0, client-1 ...), which is incompatible with how

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -25,3 +25,54 @@ def dashboard():
         supplier=supplier,
         **template_data
     ), 200
+
+
+@main.route('/edit', methods=['GET'])
+@login_required
+def edit_supplier(error=None):
+    template_data = main.config['BASE_TEMPLATE_DATA']
+
+    try:
+        supplier = data_api_client.get_supplier(
+            current_user.supplier_id
+        )['suppliers']
+        supplier['contact'] = supplier['contactInformation'][0]
+    except APIError as e:
+        abort(e.status_code)
+
+    return render_template(
+        "suppliers/edit_supplier.html",
+        supplier=supplier,
+        error=error,
+        **template_data
+    ), 200
+
+
+@main.route('/edit', methods=['POST'])
+@login_required
+def update_supplier():
+    try:
+        data_api_client.update_supplier(
+            current_user.supplier_id,
+            {
+                "description": request.form['description'],
+                "clients": request.form.getlist('clients'),
+            },
+            current_user.email_address,
+            "Update supplier info"
+        )
+
+        data_api_client.update_contact_information(
+            current_user.supplier_id,
+            request.form['contactId'],
+            {k: request.form[k] for k in [
+                "address1", "address2", "city", "country", "postcode",
+                "website", "phoneNumber", "email", "contactName",
+            ]},
+            current_user.email_address,
+            "Update supplier info"
+        )
+    except APIError as e:
+        return edit_supplier(error=e.message)
+
+    return redirect(url_for(".dashboard"))

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -1,0 +1,27 @@
+from flask import render_template, request, redirect, url_for, abort
+from flask_login import login_required, current_user
+
+from dmutils.apiclient import APIError
+
+from ...main import main
+from ... import data_api_client
+
+
+@main.route('')
+@login_required
+def dashboard():
+    template_data = main.config['BASE_TEMPLATE_DATA']
+
+    try:
+        supplier = data_api_client.get_supplier(
+            current_user.supplier_id
+        )['suppliers']
+        supplier['contact'] = supplier['contactInformation'][0]
+    except APIError as e:
+        abort(e.status_code)
+
+    return render_template(
+        "suppliers/dashboard.html",
+        supplier=supplier,
+        **template_data
+    ), 200

--- a/app/templates/macros/forms.html
+++ b/app/templates/macros/forms.html
@@ -1,0 +1,13 @@
+{% macro text_input(name, label, value='', hint='') -%}
+  <div class="question">
+    <label for="{{ name }}-text-box" class="question-heading{% if hint %}-with-hint{% endif %}">
+      {{ label }}
+    </label>
+    {% if hint %}
+      <p class="hint box-label">
+        {{ hint }}
+      </p>
+    {% endif %}
+    <input type="text" class="text-box" name="{{ name }}" id="{{ name }}-text-box" value="{{ value }}" />
+  </div>
+{%- endmacro %}

--- a/app/templates/macros/forms.html
+++ b/app/templates/macros/forms.html
@@ -1,13 +1,79 @@
-{% macro text_input(name, label, value='', hint='') -%}
-  <div class="question">
-    <label for="{{ name }}-text-box" class="question-heading{% if hint %}-with-hint{% endif %}">
-      {{ label }}
-    </label>
-    {% if hint %}
-      <p class="hint box-label">
-        {{ hint }}
-      </p>
+{% macro question_input(name, label, value='', hint='', errors=None) -%}
+  {{ _question_header(name, label, hint, errors) }}
+    <input type="text" class="text-box" name="{{ name }}" id="{{ name }}-input" value="{{ value }}" />
+  {{ _question_footer(name, label, hint, errors) }}
+{%- endmacro %}
+
+
+{% macro input(name, value='', errors=None, type='text') -%}
+  {{ field_errors(name, errors) }}
+  <input type="{{ type }}" class="text-box" name="{{ name }}" id="{{ name }}-input" value="{{ value }}" />
+{%- endmacro %}
+
+
+{% macro question_textarea(name, label, value='', hint='', errors=None, words=None) -%}
+  {{ _question_header(name, label, hint, errors) }}
+    {% if words %}
+    <div class="word-count">
+      <textarea class="text-box text-box-large" name="{{ name }}" id="{{ name }}-input" data-max-length-in-words="{{ words }}">{{ value }}</textarea>
+    </div>
+    {% else %}
+    <textarea class="text-box text-box-large" name="{{ name }}" id="{{ name }}-input">{{ value }}</textarea>
     {% endif %}
-    <input type="text" class="text-box" name="{{ name }}" id="{{ name }}-text-box" value="{{ value }}" />
+  {{ _question_footer(name, label, hint, errors) }}
+{%- endmacro %}
+
+
+{% macro question_list_entry(name, label, value='', hint='', errors=None, item_name='', count=10) -%}
+  {{ _question_header(name, label, hint, errors) }}
+    <div class="input-list" id="{{ name }}" data-list-item-name="{{ item_name }}">
+    {% for index in range(count) %}
+      <div class="list-entry">
+        <label for="{{ name }}-input-{{ index }}" class="text-box-number-label">
+          <span class="visuallyhidden">{{ item_name }} number </span>{{ index + 1 }}.
+        </label>
+        <input type="text" name="{{ name }}-{{ index }}" id="{{ name }}-input-{{ index }}" class="text-box" value="{{ value[index] }}" />
+      </div>
+    {% endfor %}
+    </div>
+  {{ _question_footer(name, label, hint, errors) }}
+{%- endmacro %}
+
+
+{% macro field_label(name, label, hint='') -%}
+  <label id="{{ name }}-label" for="{{ name }}-input" class="question-heading{% if hint %}-with-hint{% endif %}">
+    {{ label }}
+  </label>
+  {% if hint %}
+    <p class="hint box-label">
+      {{ hint }}
+    </p>
+  {% endif %}
+{%- endmacro %}
+
+
+{% macro field_errors(name, errors=None) -%}
+  {% if errors %}
+  <p class="validation-message" id="{{ name }}-errors">
+      {% for error in errors %}{{ error }}{% endfor %}
+  </p>
+  {% endif %}
+{%- endmacro %}
+
+
+{% macro _question_header(name, label, hint='', errors=None) -%}
+  {% if errors %}
+  <div class="validation-wrapper">
+  {% endif %}
+  <div class="question">
+    {{ field_label(name, label, hint) }}
+    {{ field_errors(name, errors) }}
+{%- endmacro %}
+
+
+{% macro _question_footer(name, label, hint='', errors=None) -%}
   </div>
+  {% if errors %}
+  </div>
+  {% endif %}
 {%- endmacro %}

--- a/app/templates/services/list_services.html
+++ b/app/templates/services/list_services.html
@@ -2,7 +2,12 @@
 {% from 'macros/_breadcrumbs.html' import breadcrumb %}
 
 {% block breadcrumb %}
-  {{ breadcrumb() }}
+  {{ breadcrumb([
+    {
+      "link": url_for(".dashboard"),
+      "text": current_user.supplier_name
+    }
+  ]) }}
 {% endblock %}
 
 {% block main_content %}
@@ -72,7 +77,7 @@
         </td>
         {% if 'EDIT_SERVICE_PAGE' is active_feature %}
         <td class="summary-item-action-field">
-          <a href="{{ url_for('.services', service_id=service.id) }}">
+          <a href="{{ url_for('.edit_service', service_id=service.id) }}">
             {{ 'Details' if service.status == 'disabled' else 'Edit' }}
           </a>
         </td>

--- a/app/templates/services/service.html
+++ b/app/templates/services/service.html
@@ -30,6 +30,7 @@
         {% endif %}
         {% if service_data.status != 'disabled' %}
       <form action="{{ url_for('.update_service_status', service_id=service_data['id'] ) }}" method="POST">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
         <fieldset class="question">
           <legend class="question-heading question-heading-with-hint ">
             Choose service status

--- a/app/templates/suppliers/dashboard.html
+++ b/app/templates/suppliers/dashboard.html
@@ -8,10 +8,12 @@
 {% block main_content %}
   <div class="grid-row">
     <div class="column-two-thirds">
-      <header class="page-heading page-heading-with-context">
-        <p class="context">{{ current_user.email_address }}</p>
-        <h1>{{ current_user.supplier_name }}</h1>
-      </header>
+      {% with
+        context = current_user.email_address,
+        heading = current_user.supplier_name
+      %}
+        {% include 'toolkit/page-heading.html' %}
+      {% endwith %}
     </div>
   </div>
 

--- a/app/templates/suppliers/dashboard.html
+++ b/app/templates/suppliers/dashboard.html
@@ -47,7 +47,7 @@
                 {% endfor %}
                 </ul>
                 {% else %}
-                  <span class="hint summary-item-no-content"> — </p>
+                  <span class="hint summary-item-no-content">None entered</p>
                 {% endif %}
               </td>
             </tr>

--- a/app/templates/suppliers/dashboard.html
+++ b/app/templates/suppliers/dashboard.html
@@ -16,81 +16,87 @@
   </div>
 
   <div class="grid-row">
-    <h2 class="summary-item-heading">Services</h2>
-    <p class="summary-item-top-level-action">
-      <a href="{{ url_for('.list_services') }}">Edit</a>
-    </p>
+    <div class="column-one-whole">
+      <h2 class="summary-item-heading">Services</h2>
+      <p class="summary-item-top-level-action">
+        <a href="{{ url_for('.list_services') }}">Edit</a>
+      </p>
+    </div>
   </div>
 
   <div class="grid-row">
-    <h2 class="summary-item-heading">Supplier information</h2>
-    <p class="summary-item-top-level-action">
-      <a href="">Edit</a>
-    </p>
-    <table class="summary-item-body">
-      <thead></thead>
-        <tbody class="summary-item-body">
-          <tr class="summary-item-row">
-            <td class="summary-item-field-name">Supplier summary</td>
-            <td class="summary-item-field-content">{{ supplier.description }}</td>
-          </tr>
-          <tr class="summary-item-row">
-            <td class="summary-item-field-name">Clients</td>
-            <td class="summary-item-field-content">
-              {% if supplier.clients %}
-              <ul>
-              {% for client in supplier.clients %}
-                <li>{{ client }}</li>
-              {% endfor %}
-              </ul>
-              {% else %}
-                <span class="hint summary-item-no-content"> — </p>
-              {% endif %}
-            </td>
-          </tr>
-          <tr class="summary-item-row">
-            <td class="summary-item-field-name">Contact name</td>
-            <td class="summary-item-field-content">{{ supplier.contact.contactName }}</td>
-          </tr>
-          <tr class="summary-item-row">
-            <td class="summary-item-field-name">Website</td>
-            <td class="summary-item-field-content">{{ supplier.contact.website }}</td>
-          </tr>
-          <tr class="summary-item-row">
-            <td class="summary-item-field-name">Email address</td>
-            <td class="summary-item-field-content">{{ supplier.contact.email }}</td>
-          </tr>
-          <tr class="summary-item-row">
-            <td class="summary-item-field-name">Phone number</td>
-            <td class="summary-item-field-content">{{ supplier.contact.phoneNumber }}</td>
-          </tr>
-          <tr class="summary-item-row">
-            <td class="summary-item-field-name">Address</td>
-            <td class="summary-item-field-content">
-              <address>
-                {{ supplier.contact.address1 }}<br>
-                {{ supplier.contact.address2}}<br>
-                {{ supplier.contact.city }}<br>
-                {{ supplier.contact.country }}<br>
-                {{ supplier.contact.postcode }}<br>
-              </address>
-            </td>
-          </tr>
-        </tbody>
-    </table>
+    <div class="column-one-whole">
+      <h2 class="summary-item-heading">Supplier information</h2>
+      <p class="summary-item-top-level-action">
+        <a href="{{ url_for('.edit_supplier') }}">Edit</a>
+      </p>
+      <table class="summary-item-body">
+        <thead></thead>
+          <tbody class="summary-item-body">
+            <tr class="summary-item-row">
+              <td class="summary-item-field-name">Supplier summary</td>
+              <td class="summary-item-field-content">{{ supplier.description }}</td>
+            </tr>
+            <tr class="summary-item-row">
+              <td class="summary-item-field-name">Clients</td>
+              <td class="summary-item-field-content">
+                {% if supplier.clients %}
+                <ul>
+                {% for client in supplier.clients %}
+                  <li>{{ client }}</li>
+                {% endfor %}
+                </ul>
+                {% else %}
+                  <span class="hint summary-item-no-content"> — </p>
+                {% endif %}
+              </td>
+            </tr>
+            <tr class="summary-item-row">
+              <td class="summary-item-field-name">Contact name</td>
+              <td class="summary-item-field-content">{{ supplier.contact.contactName }}</td>
+            </tr>
+            <tr class="summary-item-row">
+              <td class="summary-item-field-name">Website</td>
+              <td class="summary-item-field-content">{{ supplier.contact.website }}</td>
+            </tr>
+            <tr class="summary-item-row">
+              <td class="summary-item-field-name">Email address</td>
+              <td class="summary-item-field-content">{{ supplier.contact.email }}</td>
+            </tr>
+            <tr class="summary-item-row">
+              <td class="summary-item-field-name">Phone number</td>
+              <td class="summary-item-field-content">{{ supplier.contact.phoneNumber }}</td>
+            </tr>
+            <tr class="summary-item-row">
+              <td class="summary-item-field-name">Address</td>
+              <td class="summary-item-field-content">
+                <address>
+                  {{ supplier.contact.address1 }}<br>
+                  {{ supplier.contact.address2}}<br>
+                  {{ supplier.contact.city }}<br>
+                  {{ supplier.contact.country }}<br>
+                  {{ supplier.contact.postcode }}<br>
+                </address>
+              </td>
+            </tr>
+          </tbody>
+      </table>
+    </div>
   </div>
 
   <div class="grid-row">
-    <h2 class="summary-item-heading">Account information</h2>
-    <table class="summary-item-body">
-      <thead></thead>
-        <tbody>
-          <tr class="summary-item-row">
-            <td class="summary-item-field-name">Email address</td>
-            <td class="summary-item-field-content">{{ current_user.email_address }}</td>
-          </tr>
-        </tbody>
-    </table>
+    <div class="column-one-whole">
+      <h2 class="summary-item-heading">Account information</h2>
+      <table class="summary-item-body">
+        <thead></thead>
+          <tbody>
+            <tr class="summary-item-row">
+              <td class="summary-item-field-name">Email address</td>
+              <td class="summary-item-field-content">{{ current_user.email_address }}</td>
+            </tr>
+          </tbody>
+      </table>
+    </div>
   </div>
 
 {% endblock %}

--- a/app/templates/suppliers/dashboard.html
+++ b/app/templates/suppliers/dashboard.html
@@ -1,0 +1,96 @@
+{% extends "_base_page.html" %}
+{% from "macros/_breadcrumbs.html" import breadcrumb %}
+
+{% block breadcrumb %}
+  {{ breadcrumb() }}
+{% endblock %}
+
+{% block main_content %}
+  <div class="grid-row">
+    <div class="column-two-thirds">
+      <header class="page-heading page-heading-with-context">
+        <p class="context">{{ current_user.email_address }}</p>
+        <h1>{{ current_user.supplier_name }}</h1>
+      </header>
+    </div>
+  </div>
+
+  <div class="grid-row">
+    <h2 class="summary-item-heading">Services</h2>
+    <p class="summary-item-top-level-action">
+      <a href="" class="edit-dashboard">Edit</a>
+    </p>
+  </div>
+
+  <div class="grid-row">
+    <h2 class="summary-item-heading">Supplier information</h2>
+    <p class="summary-item-top-level-action">
+      <a href="" class="edit-dashboard">Edit</a>
+    </p>
+    <table class="summary-item-body">
+      <thead></thead>
+        <tbody class="summary-item-body">
+          <tr class="summary-item-row">
+            <td class="summary-item-field-name">Supplier summary</td>
+            <td class="summary-item-field-content">{{ supplier.description }}</td>
+          </tr>
+          <tr class="summary-item-row">
+            <td class="summary-item-field-name">Clients</td>
+            <td class="summary-item-field-content">
+              {% if supplier.clients %}
+              <ul>
+              {% for client in supplier.clients %}
+                <li>{{ client }}</li>
+              {% endfor %}
+              </ul>
+              {% else %}
+                <span class="hint summary-item-no-content"> — </p>
+              {% endif %}
+            </td>
+          </tr>
+          <tr class="summary-item-row">
+            <td class="summary-item-field-name">Contact name</td>
+            <td class="summary-item-field-content">{{ supplier.contact.contactName }}</td>
+          </tr>
+          <tr class="summary-item-row">
+            <td class="summary-item-field-name">Website</td>
+            <td class="summary-item-field-content">{{ supplier.contact.website }}</td>
+          </tr>
+          <tr class="summary-item-row">
+            <td class="summary-item-field-name">Email address</td>
+            <td class="summary-item-field-content">{{ supplier.contact.email }}</td>
+          </tr>
+          <tr class="summary-item-row">
+            <td class="summary-item-field-name">Phone number</td>
+            <td class="summary-item-field-content">{{ supplier.contact.phoneNumber }}</td>
+          </tr>
+          <tr class="summary-item-row">
+            <td class="summary-item-field-name">Address</td>
+            <td class="summary-item-field-content">
+              <address>
+                {{ supplier.contact.address1 }}<br>
+                {{ supplier.contact.address2}}<br>
+                {{ supplier.contact.city }}<br>
+                {{ supplier.contact.country }}<br>
+                {{ supplier.contact.postcode }}<br>
+              </address>
+            </td>
+          </tr>
+        </tbody>
+    </table>
+  </div>
+
+  <div class="grid-row">
+    <h2 class="summary-item-heading">Account information</h2>
+    <table class="summary-item-body">
+      <thead></thead>
+        <tbody>
+          <tr class="summary-item-row">
+            <td class="summary-item-field-name">Email address</td>
+            <td class="summary-item-field-content">{{ current_user.email_address }}</td>
+          </tr>
+        </tbody>
+    </table>
+  </div>
+
+{% endblock %}

--- a/app/templates/suppliers/dashboard.html
+++ b/app/templates/suppliers/dashboard.html
@@ -18,14 +18,14 @@
   <div class="grid-row">
     <h2 class="summary-item-heading">Services</h2>
     <p class="summary-item-top-level-action">
-      <a href="" class="edit-dashboard">Edit</a>
+      <a href="{{ url_for('.list_services') }}">Edit</a>
     </p>
   </div>
 
   <div class="grid-row">
     <h2 class="summary-item-heading">Supplier information</h2>
     <p class="summary-item-top-level-action">
-      <a href="" class="edit-dashboard">Edit</a>
+      <a href="">Edit</a>
     </p>
     <table class="summary-item-body">
       <thead></thead>

--- a/app/templates/suppliers/edit_supplier.html
+++ b/app/templates/suppliers/edit_supplier.html
@@ -1,0 +1,98 @@
+{% extends "_base_page.html" %}
+
+{% import "macros/forms.html" as forms %}
+{% from "macros/_breadcrumbs.html" import breadcrumb %}
+
+{% block breadcrumb %}
+  {{ breadcrumb([
+    {
+      "link": url_for(".dashboard"),
+      "text": current_user.supplier_name
+    }
+  ]) }}
+{% endblock %}
+
+{% block main_content %}
+  <div class="grid-row">
+    <div class="column-one-whole">
+      <div class="page-heading">
+        <p class="context">Edit supplier information</p>
+        <h1>{{ supplier.name }}</h1>
+      </div>
+    </div>
+  </div>
+
+  {% if error %}
+  <div class="validation-masthead" aria-labelledby="validation-masthead-heading">
+    <h3 class="validation-masthead-heading" id="validation-masthead-heading">
+      {{ error }}
+    </h3>
+  </div>
+  {% endif %}
+
+  <form action="" method="post" enctype="multipart/form-data">
+
+  <div class="grid-row">
+    <div class="column-one-whole">
+      <div class="question">
+        <label for="description-text-box" class="question-heading-with-hint">
+          Supplier summary
+        </label>
+        <p class="hint box-label">
+          200 words max
+        </p>
+        <div class="word-count">
+          <textarea class="text-box text-box-large" name="description" id="description-text-box" data-max-length-in-words="200">{{ supplier.description }}</textarea>
+        </div>
+      </div>
+
+      <div class="question">
+        <label for="clients" class="question-heading-with-hint">
+          Clients
+        </label>
+        <p class="hint box-label">
+          1 client per box, max 10 clients
+        </p>
+        <div class="input-list" id="clients" data-list-item-name="client">
+        {% for index in range(1,11) %}
+          <div class="list-entry">
+            <label for="clients-{{ index }}" class="text-box-number-label">
+              <span class="visuallyhidden">client number </span>{{ index }}.
+            </label>
+            <input type="text" name="clients" id="clients-{{ index }}" class="text-box" value="{{ supplier.clients[index - 1] }}" />
+          </div>
+        {% endfor %}
+        </div>
+      </div>
+
+      {{ forms.text_input('contactName', 'Contact name', supplier.contact.contactName, 'Primary contact') }}
+      {{ forms.text_input('website', 'Website', supplier.contact.website) }}
+      {{ forms.text_input('email', 'Email address', supplier.contact.email) }}
+      {{ forms.text_input('phoneNumber', 'Phone number', supplier.contact.phoneNumber) }}
+
+      <div class="question">
+        <label class="question-heading-with-hint">
+          Business address
+        </label>
+        <input name="contactId" type="hidden" value="{{ supplier.contact.id }}" />
+        <div class="box-label">Building and street</div>
+        <input name="address1" id="address1-text-box" class="text-box" value="{{ supplier.contact.address1 }}" />
+        <input name="address2" id="address2-text-box" class="text-box" value="{{ supplier.contact.address2 }}" />
+        <div class="box-label">Town or city</div>
+        <input name="city" id="city-text-box" class="text-box" value="{{ supplier.contact.city }}" />
+        <div class="box-label">Country</div>
+        <input name="country" id="country-text-box" class="text-box" value="{{ supplier.contact.country }}" />
+        <div class="box-label">Postcode</div>
+        <input name="postcode" id="postcode-text-box" class="text-box" value="{{ supplier.contact.postcode }}" />
+      </div>
+
+    </div>
+  </div>
+
+  <button class="button-save" type="submit">Save and return</button>
+  <p>
+    <a href="{{ url_for('.dashboard') }}">Return without saving</a>
+  </p>
+  </form>
+
+{% endblock %}

--- a/app/templates/suppliers/edit_supplier.html
+++ b/app/templates/suppliers/edit_supplier.html
@@ -15,10 +15,12 @@
 {% block main_content %}
   <div class="grid-row">
     <div class="column-one-whole">
-      <div class="page-heading">
-        <p class="context">Edit supplier information</p>
-        <h1>{{ current_user.supplier_name }}</h1>
-      </div>
+      {% with
+        context = "Edit supplier information",
+        heading = current_user.supplier_name
+      %}
+        {% include 'toolkit/page-heading.html' %}
+      {% endwith %}
     </div>
   </div>
 

--- a/app/templates/suppliers/edit_supplier.html
+++ b/app/templates/suppliers/edit_supplier.html
@@ -17,7 +17,7 @@
     <div class="column-one-whole">
       <div class="page-heading">
         <p class="context">Edit supplier information</p>
-        <h1>{{ supplier.name }}</h1>
+        <h1>{{ current_user.supplier_name }}</h1>
       </div>
     </div>
   </div>
@@ -29,61 +29,54 @@
     </h3>
   </div>
   {% endif %}
+  {% if supplier_form.errors or contact_form.errors %}
+      <div class="validation-masthead" aria-labelledby="validation-masthead-heading">
+          <h3 class="validation-masthead-heading" id="validation-masthead-heading">
+              There was a problem with your answer to the following questions
+          </h3>
+          {% for field_name, field_errors in supplier_form.errors|dictsort %}
+            {% for error in field_errors %}
+              <a href="#{{ field_name }}-label" class="validation-masthead-link">{{ supplier_form[field_name].label }}</a>
+            {% endfor %}
+          {% endfor %}
 
-  <form action="" method="post" enctype="multipart/form-data">
+          {% for field_name, field_errors in contact_form.errors|dictsort %}
+            {% for error in field_errors %}
+            <a href="#contact_{{ field_name }}-label" class="validation-masthead-link">{{ contact_form[field_name].label }}</a>
+            {% endfor %}
+          {% endfor %}
+      </div>
+  {% endif %}
+
+  <form action="{{ url_for('.update_supplier') }}" method="post" enctype="multipart/form-data">
+
+  <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
 
   <div class="grid-row">
     <div class="column-one-whole">
-      <div class="question">
-        <label for="description-text-box" class="question-heading-with-hint">
-          Supplier summary
-        </label>
-        <p class="hint box-label">
-          200 words max
-        </p>
-        <div class="word-count">
-          <textarea class="text-box text-box-large" name="description" id="description-text-box" data-max-length-in-words="200">{{ supplier.description }}</textarea>
-        </div>
-      </div>
+      {{ forms.question_textarea('description', 'Supplier summary', supplier_form.description.data, '50 words max', errors=supplier_form.description.errors, words=50) }}
 
-      <div class="question">
-        <label for="clients" class="question-heading-with-hint">
-          Clients
-        </label>
-        <p class="hint box-label">
-          1 client per box, max 10 clients
-        </p>
-        <div class="input-list" id="clients" data-list-item-name="client">
-        {% for index in range(1,11) %}
-          <div class="list-entry">
-            <label for="clients-{{ index }}" class="text-box-number-label">
-              <span class="visuallyhidden">client number </span>{{ index }}.
-            </label>
-            <input type="text" name="clients" id="clients-{{ index }}" class="text-box" value="{{ supplier.clients[index - 1] }}" />
-          </div>
-        {% endfor %}
-        </div>
-      </div>
+      {{ forms.question_list_entry('clients', 'Clients', supplier_form.clients.data, '1 client per box, max 10 clients', errors=supplier_form.clients.errors, item_name='client', count=10) }}
 
-      {{ forms.text_input('contactName', 'Contact name', supplier.contact.contactName, 'Primary contact') }}
-      {{ forms.text_input('website', 'Website', supplier.contact.website) }}
-      {{ forms.text_input('email', 'Email address', supplier.contact.email) }}
-      {{ forms.text_input('phoneNumber', 'Phone number', supplier.contact.phoneNumber) }}
+      {{ forms.question_input('contact_contactName', 'Contact name', contact_form.contactName.data, 'Primary contact', errors=contact_form.contactName.errors) }}
+      {{ forms.question_input('contact_website', 'Website', contact_form.website.data, errors=contact_form.website.errors) }}
+      {{ forms.question_input('contact_email', 'Email address', contact_form.email.data, errors=contact_form.email.errors) }}
+      {{ forms.question_input('contact_phoneNumber', 'Phone number', contact_form.phoneNumber.data, errors=contact_form.phoneNumber.errors) }}
 
       <div class="question">
         <label class="question-heading-with-hint">
           Business address
         </label>
-        <input name="contactId" type="hidden" value="{{ supplier.contact.id }}" />
-        <div class="box-label">Building and street</div>
-        <input name="address1" id="address1-text-box" class="text-box" value="{{ supplier.contact.address1 }}" />
-        <input name="address2" id="address2-text-box" class="text-box" value="{{ supplier.contact.address2 }}" />
-        <div class="box-label">Town or city</div>
-        <input name="city" id="city-text-box" class="text-box" value="{{ supplier.contact.city }}" />
-        <div class="box-label">Country</div>
-        <input name="country" id="country-text-box" class="text-box" value="{{ supplier.contact.country }}" />
-        <div class="box-label">Postcode</div>
-        <input name="postcode" id="postcode-text-box" class="text-box" value="{{ supplier.contact.postcode }}" />
+        {{ forms.input('contact_id', contact_form.id.data, type='hidden') }}
+        <div class="box-label" id="address1-label">Building and street</div>
+        {{ forms.input('contact_address1', contact_form.address1.data, errors=contact_form.address1.errors) }}
+        {{ forms.input('contact_address2', contact_form.address2.data, errors=contact_form.address2.errors) }}
+        <div class="box-label" id="city-label">Town or city</div>
+        {{ forms.input('contact_city', contact_form.city.data, errors=contact_form.city.errors) }}
+        <div class="box-label" id="country-label">Country</div>
+        {{ forms.input('contact_country', contact_form.country.data, errors=contact_form.country.errors) }}
+        <div class="box-label" id="postcode-label">Postcode</div>
+        {{ forms.input('contact_postcode', contact_form.postcode.data, errors=contact_form.postcode.errors) }}
       </div>
 
     </div>

--- a/bower.json
+++ b/bower.json
@@ -3,8 +3,9 @@
   "version": "0.0.1",
   "dependencies": {
     "jquery": "1.11.2",
+    "hogan": "3.0.2",
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
-    "digitalmarketplace_frontend_toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v3.1.0",
+    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v3.1.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.12.0/jinja_govuk_template-0.12.0.tgz"
   }
 }

--- a/config.py
+++ b/config.py
@@ -39,6 +39,7 @@ class Config(object):
     # Feature Flags
     RAISE_ERROR_ON_MISSING_FEATURES = True
     FEATURE_FLAGS_EDIT_SERVICE_PAGE = False
+    FEATURE_FLAGS_SUPPLIER_DASHBOARD = False
 
     # Logging
     DM_LOG_LEVEL = 'DEBUG'
@@ -69,6 +70,7 @@ class Test(Config):
     SERVER_NAME = 'localhost'
 
     FEATURE_FLAGS_EDIT_SERVICE_PAGE = enabled_since('2015-06-03')
+    FEATURE_FLAGS_SUPPLIER_DASHBOARD = enabled_since('2015-06-10')
 
 
 class Development(Config):
@@ -76,6 +78,7 @@ class Development(Config):
 
     # Dates not formatted like YYYY-(0)M-(0)D will fail
     FEATURE_FLAGS_EDIT_SERVICE_PAGE = enabled_since('2015-06-03')
+    FEATURE_FLAGS_SUPPLIER_DASHBOARD = enabled_since('2015-06-10')
 
 
 class Live(Config):

--- a/config.py
+++ b/config.py
@@ -26,7 +26,7 @@ class Config(object):
     RESET_PASSWORD_EMAIL_NAME = 'Digital Marketplace Admin'
     RESET_PASSWORD_EMAIL_FROM = 'enquiries@digitalmarketplace.service.gov.uk'
     RESET_PASSWORD_EMAIL_SUBJECT = 'Reset your Digital Marketplace password'
-    SECRET_KEY = os.getenv('DM_PASSWORD_SECRET_KEY', "not_very_secret")
+    SECRET_KEY = os.getenv('DM_PASSWORD_SECRET_KEY')
     RESET_PASSWORD_SALT = 'ResetPasswordSalt'
 
     STATIC_URL_PATH = '/suppliers/static'

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -3,13 +3,14 @@ var uglify = require('gulp-uglifyjs');
 var deleteFiles = require('del');
 var sass = require('gulp-sass');
 var filelog = require('gulp-filelog');
+var include = require('gulp-include');
 
 var environment;
 var repoRoot = __dirname + '/';
 var bowerRoot = repoRoot + 'bower_components';
 var npmRoot = repoRoot + 'node_modules';
 var govukToolkitRoot = npmRoot + '/govuk_frontend_toolkit';
-var dmToolkitRoot = bowerRoot + '/digitalmarketplace_frontend_toolkit/toolkit';
+var dmToolkitRoot = bowerRoot + '/digitalmarketplace-frontend-toolkit/toolkit';
 var assetsFolder = repoRoot + 'app/assets';
 var staticFolder = repoRoot + 'app/static';
 var govukTemplateAssetsFolder = repoRoot + 'bower_components/govuk_template/assets';
@@ -21,7 +22,7 @@ var jsVendorFiles = [
   govukToolkitRoot + '/javascripts/govuk/analytics/google-analytics-classic-tracker.js',
 ];
 var jsSourceFiles = [
-  assetsFolder + '/javascripts/_analytics.js',
+  assetsFolder + '/javascripts/application.js',
 ];
 var jsDistributionFolder = staticFolder + '/javascripts';
 var jsDistributionFile = 'application.js';
@@ -112,6 +113,7 @@ gulp.task('js', function () {
   jsFiles = jsVendorFiles.concat(jsSourceFiles);
   var stream = gulp.src(jsFiles)
     .pipe(filelog('Compressing JavaScript files'))
+    .pipe(include())
     .pipe(uglify(
       jsDistributionFile,
       uglifyOptions[environment]

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -1,12 +1,12 @@
 import mock
 from mock import Mock
-from app import data_api_client
 from nose.tools import assert_equal, assert_true, assert_false
 from tests.app.helpers import BaseApplicationTest
 
 
-class TestDashboardContent(BaseApplicationTest):
-    def test_shows_no_services_message(self):
+class TestListServices(BaseApplicationTest):
+    @mock.patch('app.main.views.services.data_api_client')
+    def test_shows_no_services_message(self, data_api_client):
         with self.app.test_client():
             self.login()
 
@@ -22,7 +22,8 @@ class TestDashboardContent(BaseApplicationTest):
             assert_true("You don't have any services"
                         in res.get_data(as_text=True))
 
-    def test_shows_services_on_dashboard(self):
+    @mock.patch('app.main.views.services.data_api_client')
+    def test_shows_services_list(self, data_api_client):
         with self.app.test_client():
             self.login()
 
@@ -44,7 +45,8 @@ class TestDashboardContent(BaseApplicationTest):
             assert_true("SaaaaaaaS" in res.get_data(as_text=True))
             assert_true("G-Cloud 1" in res.get_data(as_text=True))
 
-    def test_shows_services_edit_button_with_id_on_dashboard(self):
+    @mock.patch('app.main.views.services.data_api_client')
+    def test_shows_services_edit_button_with_id(self, data_api_client):
         with self.app.test_client():
             self.login()
 
@@ -64,8 +66,9 @@ class TestDashboardContent(BaseApplicationTest):
                 "/suppliers/services/123" in res.get_data(as_text=True))
 
 
-class TestDashboardLogin(BaseApplicationTest):
-    def test_should_show_dashboard_if_logged_in(self):
+class TestListServicesLogin(BaseApplicationTest):
+    @mock.patch('app.main.views.services.data_api_client')
+    def test_should_show_services_list_if_logged_in(self, data_api_client):
         with self.app.test_client():
             data_api_client.authenticate_user = Mock(
                 return_value=(self.user(
@@ -102,11 +105,11 @@ class TestDashboardLogin(BaseApplicationTest):
             )
 
     def test_should_redirect_to_login_if_not_logged_in(self):
-        res = self.client.get("/suppliers")
+        res = self.client.get("/suppliers/services")
         assert_equal(res.status_code, 302)
         assert_equal(res.location,
                      'http://localhost/suppliers/login'
-                     '?next=%2Fsuppliers')
+                     '?next=%2Fsuppliers%2Fservices')
 
 
 @mock.patch('app.main.services.data_api_client')

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -15,7 +15,7 @@ class TestDashboardContent(BaseApplicationTest):
                     "services": []
                 })
 
-            res = self.client.get('/suppliers')
+            res = self.client.get('/suppliers/services')
             assert_equal(res.status_code, 200)
             data_api_client.find_services.assert_called_once_with(
                 supplier_id=1234)
@@ -36,7 +36,7 @@ class TestDashboardContent(BaseApplicationTest):
                 }]}
             )
 
-            res = self.client.get('/suppliers')
+            res = self.client.get('/suppliers/services')
             assert_equal(res.status_code, 200)
             data_api_client.find_services.assert_called_once_with(
                 supplier_id=1234)
@@ -56,7 +56,7 @@ class TestDashboardContent(BaseApplicationTest):
                 }]}
             )
 
-            res = self.client.get('/suppliers')
+            res = self.client.get('/suppliers/services')
             assert_equal(res.status_code, 200)
             data_api_client.find_services.assert_called_once_with(
                 supplier_id=1234)
@@ -88,7 +88,7 @@ class TestDashboardLogin(BaseApplicationTest):
                 'password': '1234567890'
             })
 
-            res = self.client.get('/suppliers')
+            res = self.client.get('/suppliers/services')
 
             assert_equal(res.status_code, 200)
 

--- a/tests/app/main/test_suppliers.py
+++ b/tests/app/main/test_suppliers.py
@@ -1,0 +1,224 @@
+import mock
+from mock import Mock
+from nose.tools import assert_equal, assert_true, assert_in, assert_false
+from tests.app.helpers import BaseApplicationTest
+
+
+def get_supplier(*args, **kwargs):
+    return {"suppliers": {
+        "id": 1234,
+        "description": "Supplier Description",
+        "clients": ["Client One", "Client Two"],
+        "contactInformation": [{
+            "id": 2,
+            "website": "supplier.dmdev",
+            "email": "supplier@user.dmdev",
+            "contactName": "Supplier Person",
+            "phoneNumber": "0800123123",
+            "address1": "1 Street",
+            "address2": "2 Building",
+            "city": "Supplierville",
+            "country": "Supplierland",
+            "postcode": "11 AB",
+        }]
+    }}
+
+
+class TestSuppliersDashboard(BaseApplicationTest):
+    @mock.patch("app.main.views.suppliers.data_api_client")
+    def test_shows_supplier_info(self, data_api_client):
+        data_api_client.get_supplier.side_effect = get_supplier
+        with self.app.test_client():
+            self.login()
+
+            res = self.client.get("/suppliers")
+            assert_equal(res.status_code, 200)
+
+            data_api_client.get_supplier.assert_called_once_with(1234)
+
+            resp_data = res.get_data(as_text=True)
+
+            assert_in("Supplier Description", resp_data)
+            assert_in("Client One", resp_data)
+            assert_in("Client Two", resp_data)
+
+            assert_in("1 Street", resp_data)
+            assert_in("2 Building", resp_data)
+            assert_in("supplier.dmdev", resp_data)
+            assert_in("supplier@user.dmdev", resp_data)
+            assert_in("Supplier Person", resp_data)
+            assert_in("0800123123", resp_data)
+            assert_in("Supplierville", resp_data)
+            assert_in("Supplierland", resp_data)
+            assert_in("11 AB", resp_data)
+
+    @mock.patch("app.main.views.suppliers.data_api_client")
+    def test_shows_edit_buttons(self, data_api_client):
+        data_api_client.get_supplier.side_effect = get_supplier
+        with self.app.test_client():
+            self.login()
+
+            res = self.client.get("/suppliers")
+            assert_equal(res.status_code, 200)
+
+            assert_true("/suppliers/edit" in res.get_data(as_text=True))
+            assert_true("/suppliers/services" in res.get_data(as_text=True))
+
+
+class TestSupplierDashboardLogin(BaseApplicationTest):
+    @mock.patch("app.main.views.suppliers.data_api_client")
+    def test_should_show_supplier_dashboard_logged_in(self, data_api_client):
+        with self.app.test_client():
+            data_api_client.authenticate_user = Mock(
+                return_value=(self.user(
+                    123, "email@email.com", 1234, "Supplier Name")))
+
+            data_api_client.get_user = Mock(
+                return_value=(self.user(
+                    123, "email@email.com", 1234, "Supplier Name")))
+
+            data_api_client.get_supplier = Mock(side_effect=get_supplier)
+
+            self.client.post("/suppliers/login", data={
+                "email_address": "valid@email.com",
+                "password": "1234567890"
+            })
+
+            res = self.client.get("/suppliers")
+
+            assert_equal(res.status_code, 200)
+
+            assert_true(
+                self.strip_all_whitespace("<h1>Supplier Name</h1>")
+                in self.strip_all_whitespace(res.get_data(as_text=True))
+            )
+            assert_true(
+                self.strip_all_whitespace("email@email.com")
+                in self.strip_all_whitespace(res.get_data(as_text=True))
+            )
+
+    def test_should_redirect_to_login_if_not_logged_in(self):
+        res = self.client.get("/suppliers")
+        assert_equal(res.status_code, 302)
+        assert_equal(res.location,
+                     "http://localhost/suppliers/login"
+                     "?next=%2Fsuppliers")
+
+
+@mock.patch("app.main.suppliers.data_api_client")
+class TestSupplierUpdate(BaseApplicationTest):
+
+    def _login(self, data_api_client):
+
+        data_api_client.authenticate_user.return_value = self.user(
+            123, "email@email.com", 1234, "name"
+        )
+
+        data_api_client.get_user.return_value = self.user(
+            123, "email@email.com", 1234, "name"
+        )
+
+        data_api_client.get_supplier.side_effect = get_supplier
+
+        self.client.post("/suppliers/login", data={
+            "email_address": "email@email.com",
+            "password": "1234567890"
+        })
+
+    def post_supplier_edit(self, data=None, **kwargs):
+        if data is None:
+            data = {
+                "description": "New Description",
+                "clients": ["ClientA", "ClientB"],
+                "contact_id": 2,
+                "contact_email": "supplier@user.dmdev",
+                "contact_website": "supplier.dmdev",
+                "contact_contactName": "Supplier Person",
+                "contact_phoneNumber": "0800123123",
+                "contact_address1": "1 Street",
+                "contact_address2": "2 Building",
+                "contact_city": "Supplierville",
+                "contact_country": "Supplierland",
+                "contact_postcode": "11 AB",
+            }
+        data.update(kwargs)
+        res = self.client.post("/suppliers/edit", data=data)
+        return res.status_code, res.get_data(as_text=True)
+
+    def test_update_all_supplier_fields(self, data_api_client):
+        self._login(data_api_client)
+
+        status, resp = self.post_supplier_edit()
+
+        assert_equal(status, 302)
+
+        data_api_client.update_supplier.assert_called_once_with(
+            1234,
+            {
+                'clients': [u'ClientA', u'ClientB'],
+                'description': u'New Description'
+            },
+            'email@email.com'
+        )
+        data_api_client.update_contact_information.assert_called_once_with(
+            1234, 2,
+            {
+                'website': u'supplier.dmdev',
+                'city': u'Supplierville',
+                'country': u'Supplierland',
+                'address1': u'1 Street',
+                'address2': u'2 Building',
+                'email': u'supplier@user.dmdev',
+                'phoneNumber': u'0800123123',
+                'postcode': u'11 AB',
+                'contactName': u'Supplier Person',
+                'id': 2
+            },
+            'email@email.com'
+        )
+
+    def test_missing_required_supplier_fields(self, data_api_client):
+        self._login(data_api_client)
+
+        status, resp = self.post_supplier_edit({
+            "description": "New Description",
+            "clients": ["ClientA", "", "ClientB"],
+            "contact_id": 2,
+            "contact_website": "supplier.dmdev",
+            "contact_contactName": "Supplier Person",
+            "contact_phoneNumber": "0800123123",
+            "contact_address1": "1 Street",
+            "contact_address2": "2 Building",
+            "contact_city": "Supplierville",
+            "contact_country": u"Supplierland",
+            "contact_postcode": "11 AB",
+        })
+
+        assert_equal(status, 200)
+        assert_in('Email can not be empty', resp)
+
+        assert_false(data_api_client.update_supplier.called)
+        assert_false(
+            data_api_client.update_contact_information.called
+        )
+
+        assert_in("New Description", resp)
+        assert_in('value="ClientA"', resp)
+        assert_in('value="ClientB"', resp)
+        assert_in('value="2"', resp)
+        assert_in('value="supplier.dmdev"', resp)
+        assert_in('value="Supplier Person"', resp)
+        assert_in('value="0800123123"', resp)
+        assert_in('value="1 Street"', resp)
+        assert_in('value="2 Building"', resp)
+        assert_in('value="Supplierville"', resp)
+        assert_in('value="Supplierland"', resp)
+        assert_in('value="11 AB"', resp)
+
+    def test_should_redirect_to_login_if_not_logged_in(self, data_api_client):
+        res = self.client.get("/suppliers/edit")
+        assert_equal(res.status_code, 302)
+        assert_equal(
+            res.location,
+            "http://localhost/suppliers/login?next=%2Fsuppliers%2Fedit"
+        )

--- a/tests/app/main/test_suppliers.py
+++ b/tests/app/main/test_suppliers.py
@@ -215,6 +215,31 @@ class TestSupplierUpdate(BaseApplicationTest):
         assert_in('value="Supplierland"', resp)
         assert_in('value="11 AB"', resp)
 
+    def test_description_below_word_length(self, data_api_client):
+        self._login(data_api_client)
+
+        status, resp = self.post_supplier_edit(
+            description="DESCR " * 49
+        )
+
+        assert_equal(status, 302)
+
+        assert_true(data_api_client.update_supplier.called)
+        assert_true(data_api_client.update_contact_information.called)
+
+    def test_description_above_word_length(self, data_api_client):
+        self._login(data_api_client)
+
+        status, resp = self.post_supplier_edit(
+            description="DESCR " * 51
+        )
+
+        assert_equal(status, 200)
+        assert_in('must not be more than 50', resp)
+
+        assert_false(data_api_client.update_supplier.called)
+        assert_false(data_api_client.update_contact_information.called)
+
     def test_should_redirect_to_login_if_not_logged_in(self, data_api_client):
         res = self.client.get("/suppliers/edit")
         assert_equal(res.status_code, 302)

--- a/tests/app/main/test_suppliers.py
+++ b/tests/app/main/test_suppliers.py
@@ -240,6 +240,16 @@ class TestSupplierUpdate(BaseApplicationTest):
         assert_false(data_api_client.update_supplier.called)
         assert_false(data_api_client.update_contact_information.called)
 
+    def test_clients_above_limit(self, data_api_client):
+        self._login(data_api_client)
+
+        status, resp = self.post_supplier_edit(
+            clients=["", "A Client"] * 11
+        )
+
+        assert_equal(status, 200)
+        assert_in('You must have 10 or fewer clients', resp)
+
     def test_should_redirect_to_login_if_not_logged_in(self, data_api_client):
         res = self.client.get("/suppliers/edit")
         assert_equal(res.status_code, 302)

--- a/tests/app/test_application.py
+++ b/tests/app/test_application.py
@@ -32,7 +32,7 @@ class TestApplication(BaseApplicationTest):
             "enquiries@digitalmarketplace.service.gov.uk</a>"
             in res.get_data(as_text=True))
 
-    def test_500(self):
+    def test_503(self):
         with self.app.test_client():
             self.login()
 
@@ -42,7 +42,7 @@ class TestApplication(BaseApplicationTest):
             self.app.config['DEBUG'] = False
 
             res = self.client.get('/suppliers')
-            assert_equal(500, res.status_code)
+            assert_equal(503, res.status_code)
             assert_true(
                 "Sorry, we're experiencing technical difficulties"
                 in res.get_data(as_text=True))


### PR DESCRIPTION
Pivotal: [#95432162](https://www.pivotaltracker.com/story/show/95432162)

### Add supplier dashboard view and template (`/suppliers`)
Includes supplier and account information and links to service list and supplier info edit pages.

There's no service counts since API doesn't return them with supplier data yet.

![screen shot 2015-06-08 at 16 01 30](https://cloud.githubusercontent.com/assets/246664/8038094/6ef1f7b4-0df9-11e5-918a-8a3d1e1475e4.png)

### Move supplier services list to /suppliers/services
Renames services.dashboard view and template to list_services.
Adds a breadcrumb link to the new supplier dashboard.

### Add supplier info edit page (`/suppliers/edit`)
Allows editing supplier and main contact details. There's no validation apart from form field limits, data is sent to the API and the response "error" message is displayed if the request fails or returns 400.

Things that are missing compared to dm-prototype design: last edit date, since it's not returned by the API yet
![screen shot 2015-06-08 at 16 01 42](https://cloud.githubusercontent.com/assets/246664/8038176/dbb9c296-0df9-11e5-8ffe-46221da75619.png)

### Remove SECRET_KEY default value from app config
Missing SECERET_KEY env variable should always prevent the app from working, otherwise errors in production configuration can mean the app is silently using the default value, which is unsafe.

### Enable CSRF protection for all app endpoints
Flask-WTF will automatically store a CSRF token in the user session and require that each POST request contains a matching value in the submitted form data. Forms still need to either explicitly define
the CSRF token field or mark the view as csrf.exempt.

### Add forms for supplier and contact information
Forms allow us to validate basic field requirements before making a request to the API, since the API doesn't return per-field errors at the moment.

Supplier and contact information have separate forms, since they require separate API requests to save the data and might end up with separate views in the future.

### Use forms for editing supplier and contact information
Forms are populated with data from API response or the previous form submits. Only editable fields are populated.

Form classes are not used for HTML rendering. Instead, input fields are created by Jinja macros and only use data and errors values from the Form field objects.

Contact information form fields are prefixed with `contact_` to avoid possible field name clashes and adding a prefix to the hidden contact `id` field.

Submitted form with errors:
![screen shot 2015-06-08 at 16 02 42](https://cloud.githubusercontent.com/assets/246664/8038231/37a8df38-0dfa-11e5-9a00-74dc0684bfb3.png)
