### PR TITLE
Pass pathname to `get_version_label` in dmutils

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ Flask-Login==0.2.11
 Flask-Script==2.0.5
 Flask-WTF==0.11
 git+https://github.com/pcraig3/Flask-FeatureFlags.git@master#egg=Flask-FeatureFlags==0.6-dev
-git+https://github.com/alphagov/digitalmarketplace-utils.git@0.18.0#egg=digitalmarketplace-utils==0.18.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@0.19.0#egg=digitalmarketplace-utils==0.19.0
 
 mandrill==1.0.57
 


### PR DESCRIPTION
`get_version_label` in dmutils tries to call the wrong file because it's looking for a local path. 
Refactored so that each app passes its path as a parameter to `get_version_label` in dmutils.  

Should work, but currently breaking until pending pull request in [digitalmarketplace-utils](https://github.com/alphagov/digitalmarketplace-utils/pull/51) gets merged.