### PR TITLE
Set version in config.

### DIFF
--- a/app/status/views.py
+++ b/app/status/views.py
@@ -2,25 +2,26 @@ from flask import jsonify, current_app
 
 from . import status
 from .. import data_api_client
-from dmutils.status import get_version_label, get_flags
+from dmutils.status import get_flags
 
 
 @status.route('/_status')
 def status():
 
     api_status = data_api_client.get_status()
+    version = current_app.config['VERSION']
 
     if api_status['status'] == "ok":
         return jsonify(
             status="ok",
-            version=get_version_label(),
+            version=version,
             api_status=api_status,
             flags=get_flags(current_app)
         )
 
     return jsonify(
         status="error",
-        version=get_version_label(),
+        version=version,
         api_status=api_status,
         message="Error connecting to the (Data) API.",
         flags=get_flags(current_app)

--- a/config.py
+++ b/config.py
@@ -1,11 +1,13 @@
 import os
 import jinja2
-from dmutils.status import enabled_since
-
-basedir = os.path.abspath(os.path.dirname(__file__))
+from dmutils.status import enabled_since, get_version_label
 
 
 class Config(object):
+
+    VERSION = get_version_label(
+        os.path.abspath(os.path.dirname(__file__))
+    )
     SESSION_COOKIE_NAME = 'dm_session'
     SESSION_COOKIE_PATH = '/'
     SESSION_COOKIE_HTTPONLY = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ Flask-Login==0.2.11
 Flask-Script==2.0.5
 Flask-WTF==0.11
 git+https://github.com/pcraig3/Flask-FeatureFlags.git@master#egg=Flask-FeatureFlags==0.6-dev
-git+https://github.com/alphagov/digitalmarketplace-utils.git@0.19.0#egg=digitalmarketplace-utils==0.19.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@0.20.0#egg=digitalmarketplace-utils==0.20.0
 
 mandrill==1.0.57
 


### PR DESCRIPTION
Instead of reading the file each time in the /_status endpoint, we can just initialise it when the app starts and then reference it later.
Removed `basedir` variable because it wasn't being used anywhere.

Depends on [open pull request in digitalmarketplace-utils](https://github.com/alphagov/digitalmarketplace-utils/pull/53)