### PR TITLE
Use templates from the Digital Marketplace frontend toolkit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,7 @@ node_modules
 bower_components
 npm-debug.log
 app/templates/toolkit
+app/assets/scss/toolkit
 
 # Front end generated assets
 app/static

--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,7 @@ target/
 node_modules
 bower_components
 npm-debug.log
+app/templates/toolkit
 
 # Front end generated assets
 app/static

--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -18,22 +18,22 @@ $path: "/suppliers/static/images/";
   margin-bottom: $gutter * 2;
 }
 
-@import "_digital-marketplace-colours.scss";
-@import "_grids.scss";
-@import "_buttons.scss";
-@import "_breadcrumb.scss";
-@import "_footer.scss";
-@import "_page-headings.scss";
-@import "search/_search-result.scss";
-@import "_notification-banners.scss";
-@import "_service-id.scss";
-@import "_text.scss";
-@import "forms/_questions.scss";
-@import "forms/_summary.scss";
-@import "forms/_hint.scss";
-@import "forms/_selection-buttons.scss";
-@import "forms/_textboxes.scss";
-@import "forms/_validation.scss";
+@import "toolkit/_digital-marketplace-colours.scss";
+@import "toolkit/_grids.scss";
+@import "toolkit/_buttons.scss";
+@import "toolkit/_breadcrumb.scss";
+@import "toolkit/_footer.scss";
+@import "toolkit/_page-headings.scss";
+@import "toolkit/search/_search-result.scss";
+@import "toolkit/_notification-banners.scss";
+@import "toolkit/_service-id.scss";
+@import "toolkit/_text.scss";
+@import "toolkit/forms/_questions.scss";
+@import "toolkit/forms/_summary.scss";
+@import "toolkit/forms/_hint.scss";
+@import "toolkit/forms/_selection-buttons.scss";
+@import "toolkit/forms/_textboxes.scss";
+@import "toolkit/forms/_validation.scss";
 
 @import "_service-status.scss";
 @import "_return-link.scss";

--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -19,21 +19,22 @@ $path: "/suppliers/static/images/";
 }
 
 @import "toolkit/_digital-marketplace-colours.scss";
-@import "toolkit/_grids.scss";
 @import "toolkit/_buttons.scss";
 @import "toolkit/_breadcrumb.scss";
-@import "toolkit/_footer.scss";
 @import "toolkit/_page-headings.scss";
 @import "toolkit/search/_search-result.scss";
 @import "toolkit/_notification-banners.scss";
 @import "toolkit/_service-id.scss";
-@import "toolkit/_text.scss";
 @import "toolkit/forms/_questions.scss";
 @import "toolkit/forms/_summary.scss";
 @import "toolkit/forms/_hint.scss";
 @import "toolkit/forms/_selection-buttons.scss";
 @import "toolkit/forms/_textboxes.scss";
 @import "toolkit/forms/_validation.scss";
+
+@import "_text.scss";
+@import "_grids.scss";
+@import "_footer.scss";
 
 @import "_service-status.scss";
 @import "_return-link.scss";

--- a/app/templates/services/dashboard.html
+++ b/app/templates/services/dashboard.html
@@ -20,10 +20,12 @@
   {% endif %}
   <div class="grid-row">
     <div class="column-two-thirds">
-      <header class="page-heading page-heading-with-context">
-        <p class="context">{{ current_user.email_address }}</p>
-        <h1>{{ current_user.supplier_name }}</h1>
-      </header>
+      {% with
+        context = current_user.email_address,
+        heading = current_user.supplier_name
+      %}
+        {% include 'toolkit/page-heading.html' %}
+      {% endwith %}
     </div>
   </div>
   <table class="summary-item-body">

--- a/application.py
+++ b/application.py
@@ -7,6 +7,12 @@ from flask.ext.script import Manager, Server
 application = create_app(
     os.getenv('DM_ENVIRONMENT') or 'development'
 )
+application.jinja_options = {
+    'extensions': [
+        'jinja2.ext.with_'
+    ]
+}
+
 manager = Manager(application)
 manager.add_command("runserver", Server(
     os.getenv('DM_HOST') or '127.0.0.1', port=5003))

--- a/bower.json
+++ b/bower.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "jquery": "1.11.2",
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
-    "digitalmarketplace_frontend_toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v3.0.0",
+    "digitalmarketplace_frontend_toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v3.1.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.12.0/jinja_govuk_template-0.12.0.tgz"
   }
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -81,7 +81,7 @@ gulp.task('clean', function (cb) {
   var logOutputFor = function (fileType) {
     return function (err, paths) {
       if (paths !== undefined) {
-        console.log('Deleted the following ' + fileType + ' files:\n', paths.join('\n'));
+        console.log('💥  Deleted the following ' + fileType + ' files:\n', paths.join('\n'));
       }
       complete(fileType);
     };
@@ -101,7 +101,7 @@ gulp.task('sass', function () {
     .pipe(gulp.dest(cssDistributionFolder));
 
   stream.on('end', function () {
-    console.log('Compressed CSS saved as .css files in ' + cssDistributionFolder)
+    console.log('💾  Compressed CSS saved as .css files in ' + cssDistributionFolder);
   });
 
   return stream;
@@ -119,95 +119,81 @@ gulp.task('js', function () {
     .pipe(gulp.dest(jsDistributionFolder));
 
   stream.on('end', function () {
-    console.log('Compressed JavaScript saved as ' + jsDistributionFolder + '/' + jsDistributionFile)
+    console.log('💾 Compressed JavaScript saved as ' + jsDistributionFolder + '/' + jsDistributionFile);
   });
 
   return stream;
 });
 
-gulp.task('copy_template_assets:stylesheets', function () {
-  stream = gulp.src(govukTemplateAssetsFolder + '/stylesheets/**/*', { base : govukTemplateAssetsFolder + '/stylesheets' })
-    .pipe(gulp.dest(staticFolder + '/stylesheets'))
+function copyFactory(what, base, destination) {
 
-  stream.on('end', function () {
-    console.log('Copied CSS assets from the govuk template');
-  });
+  return function() {
 
-  return stream;
-});
+    return gulp
+      .src(base + "/**/*", { base: base })
+      .pipe(gulp.dest(destination))
+      .on('end', function () {
+        console.log('📂  Copied ' + what);
+      });
 
-gulp.task('copy_template_assets:images', function () {
-  stream = gulp.src(govukTemplateAssetsFolder + '/images/**/*', { base : govukTemplateAssetsFolder + '/images' })
-    .pipe(gulp.dest(staticFolder + '/images'))
+  };
 
-  stream.on('end', function () {
-    console.log('Copied image assets from the govuk template');
-  });
+}
 
-  return stream;
-});
+gulp.task(
+  'copy:template_assets:stylesheets',
+  copyFactory(
+    "GOV.UK template stylesheets",
+    govukTemplateAssetsFolder + '/stylesheets', staticFolder + '/stylesheets'
+  )
+);
 
-gulp.task('copy_template_assets:javascripts', function () {
-  stream = gulp.src(govukTemplateAssetsFolder + '/javascripts/**/*', { base : govukTemplateAssetsFolder + '/javascripts' })
-    .pipe(gulp.dest(staticFolder + '/javascripts'))
+gulp.task(
+  'copy:template_assets:images',
+  copyFactory(
+    "GOV.UK template images",
+    govukTemplateAssetsFolder + '/images', staticFolder + '/images'
+  )
+);
 
-  stream.on('end', function () {
-    console.log('Copied JS assets from the govuk template');
-  });
+gulp.task(
+  'copy:template_assets:javascripts',
+  copyFactory(
+    'GOV.UK template Javascript files',
+    govukTemplateAssetsFolder + '/javascripts', staticFolder + '/javascripts'
+  )
+);
 
-  return stream;
-});
+gulp.task(
+  'copy:dm_toolkit_assets:images',
+  copyFactory(
+    "images from the Digital Marketplace frontend toolkit",
+    dmToolkitRoot + '/images', staticFolder + '/images'
+  )
+);
 
-gulp.task('copy_dm_toolkit_assets:images', function () {
-  stream = gulp.src(dmToolkitRoot + '/images/**/*', { base : dmToolkitRoot + '/images' })
-    .pipe(gulp.dest(staticFolder + '/images'))
+gulp.task(
+  'copy:dm_toolkit_assets:templates',
+  copyFactory(
+    "templates from the Digital Marketplace frontend toolkit",
+    dmToolkitRoot + '/templates', 'app/templates/toolkit'
+  )
+);
 
-  stream.on('end', function () {
-    console.log('Copied image assets from the digital marketplace front-end toolkit');
-  });
-
-  return stream;
-});
-
-gulp.task('copy_dm_toolkit_assets:templates', function () {
-  stream = gulp.src(dmToolkitRoot + '/templates/**/*', { base : dmToolkitRoot + '/templates' })
-    .pipe(gulp.dest('app/templates/toolkit'));
-
-  stream.on('end', function () {
-    console.log('Copied templates from the digital marketplace front-end toolkit');
-  });
-
-  return stream;
-});
-
-gulp.task('copy_template_assets', [
-  'copy_template_assets:stylesheets',
-  'copy_template_assets:images',
-  'copy_template_assets:javascripts'
-]);
-
-gulp.task('copy:images', function () {
-  stream = gulp.src(assetsFolder + '/images/**/*', { base : assetsFolder + '/images' })
-    .pipe(gulp.dest(staticFolder + '/images'));
-
-  stream.on('end', function () {
-    console.log('Copied image assets into static folder');
-  });
-
-  return stream;
-});
-
-gulp.task('copy_dm_toolkit_assets', [
-  'copy_dm_toolkit_assets:images',
-  'copy_dm_toolkit_assets:templates'
-]);
+gulp.task(
+  'copy:images',
+  copyFactory(
+    "image assets from app to static folder",
+    assetsFolder + '/images', staticFolder + '/images'
+  )
+);
 
 gulp.task('watch', ['build:development'], function () {
   var jsWatcher = gulp.watch([ assetsFolder + '/**/*.js' ], ['js']);
   var cssWatcher = gulp.watch([ assetsFolder + '/**/*.scss' ], ['sass']);
   var notice = function (event) {
     console.log('File ' + event.path + ' was ' + event.type + ' running tasks...');
-  }
+  };
 
   cssWatcher.on('change', notice);
   jsWatcher.on('change', notice);
@@ -223,18 +209,24 @@ gulp.task('set_environment_to_production', function (cb) {
   cb();
 });
 
-gulp.task('copy_and_compile', ['sass', 'js', 'copy_template_assets', 'copy_dm_toolkit_assets']);
+gulp.task(
+  'copy_and_compile',
+  [
+    'copy:template_assets:images',
+    'copy:template_assets:stylesheets',
+    'copy:template_assets:javascripts',
+    'copy:dm_toolkit_assets:images',
+    'copy:dm_toolkit_assets:templates',
+    'copy:images',
+    'sass',
+    'js'
+  ]
+);
 
 gulp.task('build:development', ['set_environment_to_development', 'clean'], function () {
-  gulp.start('sass', 'js');
-  gulp.start('copy:images');
-  gulp.start('copy_template_assets');
-  gulp.start('copy_dm_toolkit_assets');
+  gulp.start('copy_and_compile');
 });
 
 gulp.task('build:production', ['set_environment_to_production', 'clean'], function () {
-  gulp.start('sass', 'js');
-  gulp.start('copy:images');
-  gulp.start('copy_template_assets');
-  gulp.start('copy_dm_toolkit_assets');
+  gulp.start('copy_and_compile');
 });

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -169,6 +169,17 @@ gulp.task('copy_dm_toolkit_assets:images', function () {
   return stream;
 });
 
+gulp.task('copy_dm_toolkit_assets:templates', function () {
+  stream = gulp.src(dmToolkitRoot + '/templates/**/*', { base : dmToolkitRoot + '/templates' })
+    .pipe(gulp.dest('app/templates/toolkit'));
+
+  stream.on('end', function () {
+    console.log('Copied templates from the digital marketplace front-end toolkit');
+  });
+
+  return stream;
+});
+
 gulp.task('copy_template_assets', [
   'copy_template_assets:stylesheets',
   'copy_template_assets:images',
@@ -177,7 +188,7 @@ gulp.task('copy_template_assets', [
 
 gulp.task('copy:images', function () {
   stream = gulp.src(assetsFolder + '/images/**/*', { base : assetsFolder + '/images' })
-    .pipe(gulp.dest(staticFolder + '/images'))
+    .pipe(gulp.dest(staticFolder + '/images'));
 
   stream.on('end', function () {
     console.log('Copied image assets into static folder');
@@ -186,7 +197,10 @@ gulp.task('copy:images', function () {
   return stream;
 });
 
-gulp.task('copy_dm_toolkit_assets', ['copy_dm_toolkit_assets:images']);
+gulp.task('copy_dm_toolkit_assets', [
+  'copy_dm_toolkit_assets:images',
+  'copy_dm_toolkit_assets:templates'
+]);
 
 gulp.task('watch', ['build:development'], function () {
   var jsWatcher = gulp.watch([ assetsFolder + '/**/*.js' ], ['js']);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -38,7 +38,6 @@ var sassOptions = {
     includePaths: [
       assetsFolder + '/scss',
       govukToolkitRoot + '/stylesheets',
-      dmToolkitRoot + '/scss'
     ],
     sourceComments: true,
     errLogToConsole: true
@@ -49,7 +48,6 @@ var sassOptions = {
     includePaths: [
       assetsFolder + '/scss',
       govukToolkitRoot + '/stylesheets',
-      dmToolkitRoot + '/scss'
     ],
   },
 };
@@ -165,6 +163,14 @@ gulp.task(
 );
 
 gulp.task(
+  'copy:dm_toolkit_assets:stylesheets',
+  copyFactory(
+    "stylesheets from the Digital Marketplace frontend toolkit",
+    dmToolkitRoot + '/scss', 'app/assets/scss/toolkit'
+  )
+);
+
+gulp.task(
   'copy:dm_toolkit_assets:images',
   copyFactory(
     "images from the Digital Marketplace frontend toolkit",
@@ -215,6 +221,7 @@ gulp.task(
     'copy:template_assets:images',
     'copy:template_assets:stylesheets',
     'copy:template_assets:javascripts',
+    'copy:dm_toolkit_assets:stylesheets',
     'copy:dm_toolkit_assets:images',
     'copy:dm_toolkit_assets:templates',
     'copy:images',

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -27,7 +27,7 @@ var jsDistributionFolder = staticFolder + '/javascripts';
 var jsDistributionFile = 'application.js';
 
 // CSS paths
-var cssSourceGlob = assetsFolder + '/scss/**/*.scss';
+var cssSourceGlob = assetsFolder + '/scss/application*.scss';
 var cssDistributionFolder = staticFolder + '/stylesheets';
 
 // Configuration
@@ -37,6 +37,7 @@ var sassOptions = {
     lineNumbers: true,
     includePaths: [
       assetsFolder + '/scss',
+      dmToolkitRoot + '/scss',
       govukToolkitRoot + '/stylesheets',
     ],
     sourceComments: true,
@@ -47,6 +48,7 @@ var sassOptions = {
     lineNumbers: true,
     includePaths: [
       assetsFolder + '/scss',
+      dmToolkitRoot + '/scss',
       govukToolkitRoot + '/stylesheets',
     ],
   },

--- a/package.json
+++ b/package.json
@@ -6,20 +6,20 @@
   "engine": "node >= 0.10.0",
   "dependencies": {
     "bower": "1.3.12",
+    "del": "1.1.1",
     "govuk_frontend_toolkit": "3.5.1",
     "gulp": "3.8.7",
+    "gulp-filelog": "0.4.1",
     "gulp-include": "1.1.1",
-    "gulp-uglifyjs": "0.6.0",
-    "del": "1.1.1",
     "gulp-sass": "1.3.3",
     "gulp-shell": "0.2.9",
-    "gulp-filelog" : "0.4.1"
+    "gulp-uglifyjs": "0.6.0"
   },
   "scripts": {
     "frontend-install": "./node_modules/bower/bin/bower install",
-    "frontend-build:development" : "./node_modules/gulp/bin/gulp.js build:development",
-    "frontend-build:production" : "./node_modules/gulp/bin/gulp.js build:production",
-    "frontend-build:watch" : "./node_modules/gulp/bin/gulp.js watch",
+    "frontend-build:development": "./node_modules/gulp/bin/gulp.js build:development",
+    "frontend-build:production": "./node_modules/gulp/bin/gulp.js build:production",
+    "frontend-build:watch": "./node_modules/gulp/bin/gulp.js watch",
     "postinstall": "./node_modules/bower/bin/bower install"
   }
 }


### PR DESCRIPTION
This pull request gives the app the ability to use templates from the Digital Marketplace frontend toolkit.

![image](https://cloud.githubusercontent.com/assets/355079/8061891/e576e522-0ec4-11e5-8551-d3c20fc48b95.png)
![image](https://cloud.githubusercontent.com/assets/355079/8061933/04c02a06-0ec5-11e5-9816-f1f6eeb3149b.png)

--

Dependency management is handled by Bower (for now).

The template files are copied into the `app/templates/` folder (and I've done some refactoring of how we copy files with Gulp).

Using the templates required turning on [Jinja's with extension](jinja.pocoo.org/docs/dev/extensions/#with-extension).

One example (using the `page-heading` design pattern) is implemented on the dashboard page.