### PR TITLE
Remove DM_HOST variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,12 @@ not already been set:
 ./scripts/run_app.sh
 ```
 
+To set the host the app will run on, use the `h` flag:
+
+```
+./scripts/run_app.sh -h '0.0.0.0'
+```
+
 More generally, the command to start the server is:
 
 ```

--- a/README.md
+++ b/README.md
@@ -92,7 +92,8 @@ not already been set:
 ./scripts/run_app.sh
 ```
 
-To set the host the app will run on, use the `h` flag:
+The script is a wrapper around `python application.py runserver` so all the options available there
+can also be sent in. For example, to set the host:
 
 ```
 ./scripts/run_app.sh -h '0.0.0.0'

--- a/README.md
+++ b/README.md
@@ -92,12 +92,6 @@ not already been set:
 ./scripts/run_app.sh
 ```
 
-If you want the app to be available on the network, you need to set the `DM_HOST` environment variable to '0.0.0.0':
-
-```
-DM_HOST='0.0.0.0' ./scripts/run_app.sh
-```
-
 More generally, the command to start the server is:
 
 ```

--- a/application.py
+++ b/application.py
@@ -8,8 +8,7 @@ application = create_app(
     os.getenv('DM_ENVIRONMENT') or 'development'
 )
 manager = Manager(application)
-manager.add_command("runserver", Server(
-    os.getenv('DM_HOST') or '127.0.0.1', port=5003))
+manager.add_command("runserver", Server(port=5003))
 
 if __name__ == '__main__':
     manager.run()

--- a/scripts/run_app.sh
+++ b/scripts/run_app.sh
@@ -1,14 +1,5 @@
 #!/bin/bash
 
-while getopts "h:" OPTION; do
-  case $OPTION in
-    h )
-      HOST=$OPTARG
-      ;;
-  esac
-done
-shift $(($OPTIND-1))
-
 if [ -n "$VIRTUAL_ENV" ]; then
   echo "Already in virtual environment $VIRTUAL_ENV"
 else
@@ -25,9 +16,4 @@ export DM_PASSWORD_SECRET_KEY=${DM_PASSWORD_SECRET_KEY:=verySecretKey}
 echo "Environment variables in use:"
 env | grep DM_
 
-if [ -z "$HOST" ]
-then
-  python application.py runserver
-else
-  python application.py runserver -h $HOST
-fi
+python application.py runserver $@

--- a/scripts/run_app.sh
+++ b/scripts/run_app.sh
@@ -1,4 +1,14 @@
 #!/bin/bash
+
+while getopts "h:" OPTION; do
+  case $OPTION in
+    h )
+      HOST=$OPTARG
+      ;;
+  esac
+done
+shift $(($OPTIND-1))
+
 if [ -n "$VIRTUAL_ENV" ]; then
   echo "Already in virtual environment $VIRTUAL_ENV"
 else
@@ -15,4 +25,9 @@ export DM_PASSWORD_SECRET_KEY=${DM_PASSWORD_SECRET_KEY:=verySecretKey}
 echo "Environment variables in use:"
 env | grep DM_
 
-python application.py runserver
+if [ -z "$HOST" ]
+then
+  python application.py runserver
+else
+  python application.py runserver -h $HOST
+fi


### PR DESCRIPTION
It's not needed as explained in alphagov/digitalmarketplace-buyer-frontend#74 but it's useful to be able to specify the host when running the `scripts/run_app.sh` script so this also adds that.