### PR TITLE
Require new version of digitalmarketplace-utils

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,7 @@ Flask==0.10.1
 Flask-Login==0.2.11
 Flask-Script==2.0.5
 Flask-WTF==0.11
-git+https://github.com/pcraig3/Flask-FeatureFlags.git@master#egg=Flask-FeatureFlags==0.6-dev
-git+https://github.com/alphagov/digitalmarketplace-utils.git@0.20.0#egg=digitalmarketplace-utils==0.20.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@0.21.0#egg=digitalmarketplace-utils==0.21.0
 
 mandrill==1.0.57
 


### PR DESCRIPTION
New version of digitalmarketplace-utils requires FeatureFlags in a more normal fashion and so we can lose the dependency on a custom forked FeatureFlags repo.