### PR TITLE
Copy GOV.UK template into the project folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,7 @@ target/
 node_modules
 bower_components
 npm-debug.log
+app/templates/govuk
 app/templates/toolkit
 app/assets/scss/toolkit
 

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -4,12 +4,16 @@
   Sprockets-style (https://github.com/sstephenson/sprockets)
   directives to concatenate multiple Javascript files into one.
 */
+//= include ../../../node_modules/govuk_frontend_toolkit/javascripts/govuk/analytics/tracker.js
+//= include ../../../node_modules/govuk_frontend_toolkit/javascripts/govuk/analytics/google-analytics-universal-tracker.js
+//= include ../../../node_modules/govuk_frontend_toolkit/javascripts/govuk/analytics/google-analytics-classic-tracker.js
 //= include ../../../node_modules/govuk_frontend_toolkit/javascripts/vendor/polyfills/bind.js
 //= include ../../../bower_components/jquery/dist/jquery.js
 //= include ../../../bower_components/hogan/web/builds/3.0.2/hogan-3.0.2.js
 //= include ../../../bower_components/digitalmarketplace-frontend-toolkit/toolkit/javascripts/list-entry.js
 //= include ../../../bower_components/digitalmarketplace-frontend-toolkit/toolkit/javascripts/word-counter.js
 //= include ../../../node_modules/govuk_frontend_toolkit/javascripts/govuk/selection-buttons.js
+//= include _analytics.js
 //= include _selection-buttons.js
 //= include _analytics.js
 

--- a/app/templates/_base_page.html
+++ b/app/templates/_base_page.html
@@ -1,4 +1,4 @@
-{% extends "govuk_template.html" %}
+{% extends "govuk/govuk_template.html" %}
 
 {% block head %}
   {% include "_stylesheets.html" %}

--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "jquery": "1.11.2",
     "hogan": "3.0.2",
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
-    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v3.1.0",
+    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v3.1.1",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.12.0/jinja_govuk_template-0.12.0.tgz"
   }
 }

--- a/config.py
+++ b/config.py
@@ -51,8 +51,6 @@ class Config(object):
     def init_app(app):
         repo_root = os.path.abspath(os.path.dirname(__file__))
         template_folders = [
-            os.path.join(repo_root,
-                         'bower_components/govuk_template/views/layouts'),
             os.path.join(repo_root, 'app/templates')
         ]
         jinja_loader = jinja2.FileSystemLoader(template_folders)

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -5,6 +5,7 @@ var sass = require('gulp-sass');
 var filelog = require('gulp-filelog');
 var include = require('gulp-include');
 
+// Paths
 var environment;
 var repoRoot = __dirname + '/';
 var bowerRoot = repoRoot + 'bower_components';
@@ -18,14 +19,7 @@ var govukTemplateAssetsFolder = govukTemplateFolder + '/assets';
 var govukTemplateLayoutsFolder = govukTemplateFolder + '/views/layouts';
 
 // JavaScript paths
-var jsVendorFiles = [
-  govukToolkitRoot + '/javascripts/govuk/analytics/tracker.js',
-  govukToolkitRoot + '/javascripts/govuk/analytics/google-analytics-universal-tracker.js',
-  govukToolkitRoot + '/javascripts/govuk/analytics/google-analytics-classic-tracker.js',
-];
-var jsSourceFiles = [
-  assetsFolder + '/javascripts/application.js',
-];
+var jsSourceFile = assetsFolder + '/javascripts/application.js';
 var jsDistributionFolder = staticFolder + '/javascripts';
 var jsDistributionFile = 'application.js';
 
@@ -111,9 +105,7 @@ gulp.task('sass', function () {
 });
 
 gulp.task('js', function () {
-  // produce full array of JS files from vendor + local scripts
-  jsFiles = jsVendorFiles.concat(jsSourceFiles);
-  var stream = gulp.src(jsFiles)
+  var stream = gulp.src(jsSourceFile)
     .pipe(filelog('Compressing JavaScript files'))
     .pipe(include())
     .pipe(uglify(

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -13,7 +13,9 @@ var govukToolkitRoot = npmRoot + '/govuk_frontend_toolkit';
 var dmToolkitRoot = bowerRoot + '/digitalmarketplace-frontend-toolkit/toolkit';
 var assetsFolder = repoRoot + 'app/assets';
 var staticFolder = repoRoot + 'app/static';
-var govukTemplateAssetsFolder = repoRoot + 'bower_components/govuk_template/assets';
+var govukTemplateFolder = repoRoot + 'bower_components/govuk_template';
+var govukTemplateAssetsFolder = govukTemplateFolder + '/assets';
+var govukTemplateLayoutsFolder = govukTemplateFolder + '/views/layouts';
 
 // JavaScript paths
 var jsVendorFiles = [
@@ -198,6 +200,14 @@ gulp.task(
   )
 );
 
+gulp.task(
+  'copy:govuk_template',
+  copyFactory(
+    "GOV.UK template into app folder",
+    govukTemplateLayoutsFolder, 'app/templates/govuk'
+  )
+);
+
 gulp.task('watch', ['build:development'], function () {
   var jsWatcher = gulp.watch([ assetsFolder + '/**/*.js' ], ['js']);
   var cssWatcher = gulp.watch([ assetsFolder + '/**/*.scss' ], ['sass']);
@@ -228,7 +238,8 @@ gulp.task(
     'copy:dm_toolkit_assets:stylesheets',
     'copy:dm_toolkit_assets:images',
     'copy:dm_toolkit_assets:templates',
-    'copy:images'
+    'copy:images',
+    'copy:govuk_template'
   ]
 );
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,4 +1,9 @@
 #!/bin/sh
 
-npm install
-npm run frontend-build:production
+npm install 1>&2
+npm run frontend-build:production 1>&2
+
+# Non-Git paths that should be included when deploying
+echo "app/static"
+echo "app/templates/toolkit"
+echo "app/templates/govuk"

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -27,6 +27,9 @@ function display_result {
   fi
 }
 
+# Build front-end static assets
+npm run frontend-build:production
+
 pep8 .
 display_result $? 1 "Code style check"
 


### PR DESCRIPTION
This commit uses Gulp to copy the GOV.UK template HTML file into `app/templates` as part of the frontend build process.

The main reason to do this is so that we don't have to package up the `bower_components` folder when deploying to AWS.