### PR TITLE
Sync secure cookie config with admin app

### DIFF
--- a/config.py
+++ b/config.py
@@ -11,7 +11,7 @@ class Config(object):
     SESSION_COOKIE_NAME = 'dm_session'
     SESSION_COOKIE_PATH = '/'
     SESSION_COOKIE_HTTPONLY = True
-    SESSION_COOKIE_SECURE = False
+    SESSION_COOKIE_SECURE = True
     WTF_CSRF_ENABLED = True
     DM_API_URL = None
     DM_API_AUTH_TOKEN = None
@@ -75,6 +75,7 @@ class Test(Config):
 
 class Development(Config):
     DEBUG = True
+    SESSION_COOKIE_SECURE = False
 
     # Dates not formatted like YYYY-(0)M-(0)D will fail
     FEATURE_FLAGS_EDIT_SERVICE_PAGE = enabled_since('2015-06-03')
@@ -83,7 +84,6 @@ class Development(Config):
 
 class Live(Config):
     DEBUG = False
-    SESSION_COOKIE_SECURE = True
     DM_HTTP_PROTO = 'https'
 
 

--- a/tests/app/main/test_login.py
+++ b/tests/app/main/test_login.py
@@ -1,5 +1,5 @@
 from app.main import helpers
-from nose.tools import assert_equal, assert_true, assert_is_not_none
+from nose.tools import assert_equal, assert_true, assert_is_not_none, assert_in
 from ..helpers import BaseApplicationTest
 from mock import Mock
 from app import data_api_client
@@ -33,6 +33,7 @@ class TestLogin(BaseApplicationTest):
         })
         assert_equal(res.status_code, 302)
         assert_equal(res.location, 'http://localhost/suppliers')
+        assert_in('Secure;', res.headers['Set-Cookie'])
 
     def test_should_have_cookie_on_redirect(self):
         with self.app.app_context():


### PR DESCRIPTION
Instead of having our secure cookies set to `False` and then explicitly set as `True` in a Live environment, it's better to assume secure cookies and explicitly unset them where needed.  
This is how it's been done [in the admin app](https://github.com/alphagov/digitalmarketplace-admin-frontend/pull/66/files), at any rate.
Also added a test to confirm secure cookies are enabled.