### PR TITLE
Put validation errors in the right order

### DIFF
--- a/app/templates/auth/reset-password.html
+++ b/app/templates/auth/reset-password.html
@@ -7,7 +7,7 @@
         <h3 class="validation-masthead-heading" id="validation-masthead-heading">
             There was a problem with your answer to the following questions
         </h3>
-        {% for field_name, field_errors in form.errors|dictsort if field_errors %}
+        {% for field_name, field_errors in form.errors|dictsort|reverse if field_errors %}
         {% for error in field_errors %}
         <a href="#example-textbox" class="validation-masthead-link">{{ form[field_name].label }}</a>
         {% endfor %}


### PR DESCRIPTION
Fixes this bug: https://www.pivotaltracker.com/story/show/96536526

Previously if there were errors on both fields (i.e. "Password" and "Confirm password") the messages were in the wrong order (alphabetical ordering made them the opposite way round from on the page).  By reversing the alphabetical ordering we can guarantee that two errors will be displayed in the same order as the fields on the page.