### PR TITLE
Name things more clearly in Gulpfile

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -12,6 +12,7 @@ var bowerRoot = repoRoot + 'bower_components';
 var npmRoot = repoRoot + 'node_modules';
 var govukToolkitRoot = npmRoot + '/govuk_frontend_toolkit';
 var dmToolkitRoot = bowerRoot + '/digitalmarketplace-frontend-toolkit/toolkit';
+var sspContentRoot = bowerRoot + '/digital-marketplace-ssp-content';
 var assetsFolder = repoRoot + 'app/assets';
 var staticFolder = repoRoot + 'app/static';
 var govukTemplateFolder = repoRoot + 'bower_components/govuk_template';
@@ -121,15 +122,15 @@ gulp.task('js', function () {
   return stream;
 });
 
-function copyFactory(what, base, destination) {
+function copyFactory(resourceName, sourceFolder, targetFolder) {
 
   return function() {
 
     return gulp
-      .src(base + "/**/*", { base: base })
-      .pipe(gulp.dest(destination))
+      .src(sourceFolder + "/**/*", { base: sourceFolder })
+      .pipe(gulp.dest(targetFolder))
       .on('end', function () {
-        console.log('📂  Copied ' + what);
+        console.log('📂  Copied ' + resourceName);
       });
 
   };
@@ -140,7 +141,8 @@ gulp.task(
   'copy:template_assets:stylesheets',
   copyFactory(
     "GOV.UK template stylesheets",
-    govukTemplateAssetsFolder + '/stylesheets', staticFolder + '/stylesheets'
+    govukTemplateAssetsFolder + '/stylesheets',
+    staticFolder + '/stylesheets'
   )
 );
 
@@ -148,7 +150,8 @@ gulp.task(
   'copy:template_assets:images',
   copyFactory(
     "GOV.UK template images",
-    govukTemplateAssetsFolder + '/images', staticFolder + '/images'
+    govukTemplateAssetsFolder + '/images',
+    staticFolder + '/images'
   )
 );
 
@@ -156,7 +159,8 @@ gulp.task(
   'copy:template_assets:javascripts',
   copyFactory(
     'GOV.UK template Javascript files',
-    govukTemplateAssetsFolder + '/javascripts', staticFolder + '/javascripts'
+    govukTemplateAssetsFolder + '/javascripts',
+    staticFolder + '/javascripts'
   )
 );
 
@@ -164,7 +168,8 @@ gulp.task(
   'copy:dm_toolkit_assets:stylesheets',
   copyFactory(
     "stylesheets from the Digital Marketplace frontend toolkit",
-    dmToolkitRoot + '/scss', 'app/assets/scss/toolkit'
+    dmToolkitRoot + '/scss',
+    'app/assets/scss/toolkit'
   )
 );
 
@@ -172,7 +177,8 @@ gulp.task(
   'copy:dm_toolkit_assets:images',
   copyFactory(
     "images from the Digital Marketplace frontend toolkit",
-    dmToolkitRoot + '/images', staticFolder + '/images'
+    dmToolkitRoot + '/images',
+    staticFolder + '/images'
   )
 );
 
@@ -180,7 +186,8 @@ gulp.task(
   'copy:dm_toolkit_assets:templates',
   copyFactory(
     "templates from the Digital Marketplace frontend toolkit",
-    dmToolkitRoot + '/templates', 'app/templates/toolkit'
+    dmToolkitRoot + '/templates',
+    'app/templates/toolkit'
   )
 );
 
@@ -188,7 +195,8 @@ gulp.task(
   'copy:images',
   copyFactory(
     "image assets from app to static folder",
-    assetsFolder + '/images', staticFolder + '/images'
+    assetsFolder + '/images',
+    staticFolder + '/images'
   )
 );
 
@@ -196,7 +204,16 @@ gulp.task(
   'copy:govuk_template',
   copyFactory(
     "GOV.UK template into app folder",
-    govukTemplateLayoutsFolder, 'app/templates/govuk'
+    govukTemplateLayoutsFolder,
+    'app/templates/govuk'
+  )
+);
+
+gulp.task(
+  'copy:ssp_content',
+  copyFactory(
+    "content YAML into app folder",
+    sspContentRoot, 'app/content'
   )
 );
 
@@ -224,6 +241,7 @@ gulp.task('set_environment_to_production', function (cb) {
 gulp.task(
   'copy',
   [
+    'copy:ssp_content',
     'copy:template_assets:images',
     'copy:template_assets:stylesheets',
     'copy:template_assets:javascripts',


### PR DESCRIPTION
This copies the Gulpfile from [the admin frontend](https://github.com/alphagov/digitalmarketplace-admin-frontend/pull/67) to keep all the Gulping synchronized.