### PR TITLE
Deny third-party sites embedding ours in an iframe

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -53,6 +53,11 @@ def create_app(config_name):
         session.permanent = True
         session.modified = True
 
+    @application.after_request
+    def add_header(response):
+        response.headers['X-Frame-Options'] = 'DENY'
+        return response
+
     return application
 
 

--- a/tests/app/main/test_login.py
+++ b/tests/app/main/test_login.py
@@ -34,6 +34,7 @@ class TestLogin(BaseApplicationTest):
         assert_equal(res.status_code, 302)
         assert_equal(res.location, 'http://localhost/suppliers')
         assert_in('Secure;', res.headers['Set-Cookie'])
+        assert_in('DENY', res.headers['X-Frame-Options'])
 
     def test_ok_next_url_redirects_on_login(self):
         data_api_client.authenticate_user = Mock(


### PR DESCRIPTION
Added an `X-Frame-Options` line in our header which denies embedding our site in an iframe by other sites.
All very well and good for this app, but we'll also have to duplicate the code in other apps we want to share this behaviour.
Things to consider:
- We *could* set this at the server level if we wanted to make
this change more uniform.
- The alphagov/whitehall team have set their public-facing headers
for their content to `ALLOWALL`, but @minglis says we're not going
to allow this at present.
https://github.com/alphagov/whitehall/commit/9f8c7ccd1fdf7695e66b1340cb6b89ca0e134f9a