### PR TITLE
Deny third-party sites from embedding in an iframe

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ Flask==0.10.1
 Flask-Login==0.2.11
 Flask-Script==2.0.5
 Flask-WTF==0.11
-git+https://github.com/alphagov/digitalmarketplace-utils.git@0.21.0#egg=digitalmarketplace-utils==0.21.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@0.23.0#egg=digitalmarketplace-utils==0.23.0
 
 mandrill==1.0.57
 

--- a/tests/app/main/test_login.py
+++ b/tests/app/main/test_login.py
@@ -34,6 +34,7 @@ class TestLogin(BaseApplicationTest):
         assert_equal(res.status_code, 302)
         assert_equal(res.location, 'http://localhost/suppliers')
         assert_in('Secure;', res.headers['Set-Cookie'])
+        assert_in('DENY', res.headers['X-Frame-Options'])
 
     def test_ok_next_url_redirects_on_login(self):
         data_api_client.authenticate_user = Mock(

--- a/tests/app/main/test_login.py
+++ b/tests/app/main/test_login.py
@@ -34,7 +34,6 @@ class TestLogin(BaseApplicationTest):
         assert_equal(res.status_code, 302)
         assert_equal(res.location, 'http://localhost/suppliers')
         assert_in('Secure;', res.headers['Set-Cookie'])
-        assert_in('DENY', res.headers['X-Frame-Options'])
 
     def test_ok_next_url_redirects_on_login(self):
         data_api_client.authenticate_user = Mock(

--- a/tests/app/test_application.py
+++ b/tests/app/test_application.py
@@ -49,3 +49,8 @@ class TestApplication(BaseApplicationTest):
             assert_true(
                 "Try again later."
                 in res.get_data(as_text=True))
+
+    def test_header_xframeoptions_set_to_deny(self):
+        res = self.client.get('/suppliers/login')
+        assert 200 == res.status_code
+        assert 'DENY', res.headers['X-Frame-Options']


### PR DESCRIPTION
Upgrading to new verison of dmutils which initiates each app with the `X-Frame-Options` header set to `DENY`.
Also added test to confirm.