### PR TITLE
Fail the build if SASS doesn't compile

### DIFF
--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -1,3 +1,5 @@
+@import "doesnt_exist.scss"
+
 @import "_phase_banner.scss";
 @import "_grid_layout.scss";
 @import "_typography.scss";

--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -1,5 +1,3 @@
-@import "doesnt_exist.scss"
-
 @import "_phase_banner.scss";
 @import "_grid_layout.scss";
 @import "_typography.scss";

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -68,6 +68,14 @@ var uglifyOptions = {
   }
 };
 
+var logErrorAndExit = function logErrorAndExit(err) {
+
+  // coloured text: https://coderwall.com/p/yphywg/printing-colorful-text-in-terminal-when-run-node-js-script
+  console.log('\x1b[41m\x1b[37m  Error: ' + err.message + '\x1b[0m');
+  process.exit(1);
+
+};
+
 gulp.task('clean', function (cb) {
   var fileTypes = [];
   var complete = function (fileType) {
@@ -92,10 +100,9 @@ gulp.task('clean', function (cb) {
 gulp.task('sass', function () {
   var stream = gulp.src(cssSourceGlob)
     .pipe(filelog('Compressing SCSS files'))
-    .pipe(sass(sassOptions[environment]))
-    .on('error', function (err) {
-      console.log(err.message);
-    })
+    .pipe(
+      sass(sassOptions[environment]))
+        .on('error', logErrorAndExit)
     .pipe(gulp.dest(cssDistributionFolder));
 
   stream.on('end', function () {

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -27,11 +27,11 @@ function display_result {
   fi
 }
 
-# Build front-end static assets
-npm run frontend-build:production
+npm run --silent frontend-build:production
+display_result $? 1 "Build of front end static assets"
 
 pep8 .
-display_result $? 1 "Code style check"
+display_result $? 2 "Code style check"
 
 nosetests -v -s --with-doctest
-display_result $? 2 "Unit tests"
+display_result $? 3 "Unit tests"


### PR DESCRIPTION
We have had problems with builds going through and getting deployed without any stylesheets.

This commit addresses that issue by causing `./scripts/run_tests.sh` to fail if the SASS compilation doesn't complete.

This means that problems will be picked up locally or on Travis before they reach deployment.

--

### Running this…
![1](https://cloud.githubusercontent.com/assets/355079/8147990/2cb78f56-127e-11e5-8bbc-5d29dd5d67b1.png)

### …now results if this, if you've made a mistake
![2](https://cloud.githubusercontent.com/assets/355079/8147994/3f993c3c-127e-11e5-9f21-9a87439652fa.png)

### …or this if everything is OK
![3](https://cloud.githubusercontent.com/assets/355079/8147995/4b2d1c80-127e-11e5-893a-9fd4aacb8b6d.png)

### [Example of Travis failing a build because of a problem with the SASS](https://travis-ci.org/alphagov/digitalmarketplace-supplier-frontend/jobs/66830545)
