### PR TITLE
Stop relying on presence of bower_components

### DIFF
--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -11,7 +11,7 @@ from dmutils.presenters import Presenters
 
 content = ContentLoader(
     "app/section_order.yml",
-    "bower_components/digital-marketplace-ssp-content/g6/"
+    "app/content/g6/"
 )
 presenters = Presenters()
 


### PR DESCRIPTION
Previously, the content was sourced from the `bower_components` folder. It is now copied to `app/content`, and `bower_components` is no longer packaged when deploying to AWS.