### PR TITLE
Disable autocomplete on logins.

### DIFF
--- a/app/templates/auth/login.html
+++ b/app/templates/auth/login.html
@@ -47,7 +47,7 @@
     <h1>Supplier login</h1>
 </header>
 
-<form action="{{ url_for('.process_login', next=next) }}" method="POST">
+<form autocomplete="off" action="{{ url_for('.process_login', next=next) }}" method="POST">
 
     {{ form.hidden_tag() }}
 
@@ -64,7 +64,7 @@
                 {% for error in form.email_address.errors %}{{ error }}{% endfor %}
             </p>
             {% endif %}
-            {{ form.email_address(class="text-box") }}
+            {{ form.email_address(class="text-box", autocomplete="off") }}
         </div>
     {% if form.email_address.errors %}
         </div>
@@ -80,7 +80,7 @@
                 {% for error in form.password.errors %}{{ error }}{% endfor %}
             </p>
             {% endif %}
-            {{ form.password(class="text-box") }}
+            {{ form.password(class="text-box", autocomplete="off") }}
         </div>
     {% if form.password.errors %}
         </div>

--- a/app/templates/auth/request-password-reset.html
+++ b/app/templates/auth/request-password-reset.html
@@ -41,7 +41,7 @@
     password. Password reset links are only valid for 24 hours.
 </p>
 
-<form action="{{ url_for('.request_password_reset') }}" method="POST" id="resetPasswordForm">
+<form autocomplete="off" action="{{ url_for('.request_password_reset') }}" method="POST" id="resetPasswordForm">
     
     {{ form.hidden_tag() }}
     
@@ -58,7 +58,7 @@
                 {% for error in form.email_address.errors %}{{ error }}{% endfor %}
             </p>
             {% endif %}
-            {{ form.email_address(class="text-box") }}
+            {{ form.email_address(class="text-box", autocomplete="off") }}
         </div>
     {% if form.email_address.errors %}
         </div>

--- a/app/templates/auth/reset-password.html
+++ b/app/templates/auth/reset-password.html
@@ -22,7 +22,7 @@
     Reset password for {{ email_address }}
 </p>
 
-<form action="{{ url_for('.update_password', token=token) }}" method="POST">
+<form autocomplete="off" action="{{ url_for('.update_password', token=token) }}" method="POST">
 
     {{ form.hidden_tag() }}
 
@@ -39,7 +39,7 @@
                 {% for error in form.password.errors %}{{ error }}{% endfor %}
             </p>
             {% endif %}
-            {{ form.password(class="text-box") }}
+            {{ form.password(class="text-box", autocomplete="off") }}
         </div>
     {% if form.password.errors %}
         </div>
@@ -58,7 +58,7 @@
                 {% for error in form.confirm_password.errors %}{{ error }}{% endfor %}
             </p>
             {% endif %}
-            {{ form.confirm_password(class="text-box") }}
+            {{ form.confirm_password(class="text-box", autocomplete="off") }}
         </div>
     {% if form.confirm_password.errors %}
         </div>

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -3,3 +3,4 @@ nose==1.3.6
 pep8==1.5.7
 requests-mock==0.6.0
 mock==1.0.1
+lxml==3.4.4


### PR DESCRIPTION
Login forms and (non-hidden) input elements belonging to them are checked for `autocomplete=off` attribute, which, somewhat intuitively, prevents browsers from autofilling their content.

Demoed to Martyn and I'll have to do the same thing for the Admin App, so let me know if you have any suggestions for improvements before I do the other one.

[>> Comment ("5.21 disable autocomplete on logins") in story on Pivotal](https://www.pivotaltracker.com/story/show/96550136)