### PR TITLE
[WIP] Prevent unwanted reuse of password reset tokens.

### DIFF
--- a/app/main/helpers/email.py
+++ b/app/main/helpers/email.py
@@ -1,6 +1,7 @@
 from flask import url_for, current_app, render_template
 import mandrill
 from itsdangerous import URLSafeTimedSerializer
+from datetime import datetime
 
 from .. import main
 
@@ -49,5 +50,12 @@ def decode_email(token):
     ts = URLSafeTimedSerializer(main.config["SECRET_KEY"])
     decoded = ts.loads(token,
                        salt=main.config["RESET_PASSWORD_SALT"],
-                       max_age=86400)
+                       max_age=86400, return_timestamp=True)
     return decoded
+
+
+def token_created_before_password_last_changed(token_timestamp, user):
+
+        password_last_changed = datetime.strptime(
+            user['users']['passwordChangedAt'], '%a, %d %b %Y %H:%M:%S %Z')
+        return token_timestamp < password_last_changed

--- a/app/main/views/login.py
+++ b/app/main/views/login.py
@@ -167,7 +167,7 @@ def decode_password_reset_token(token):
             "Error changing password: "
             + "Token generated earlier than password was last changed."
         )
-        flash('token_used', 'error')
+        flash('token_invalid', 'error')
         return None
 
     return decoded

--- a/app/templates/auth/request-password-reset.html
+++ b/app/templates/auth/request-password-reset.html
@@ -24,10 +24,6 @@
                         This password reset link is invalid.
                         You can generate a new one using the form below.
 
-                        {% elif message == 'token_used' %}
-                        Password has been changed since this reset link was requested.
-                        You can generate a new one using the form below.
-
                         {% else %}
                         {{ message }}
                         {% endif %}

--- a/app/templates/auth/request-password-reset.html
+++ b/app/templates/auth/request-password-reset.html
@@ -16,13 +16,17 @@
                         be sent an email containing a link to reset your password.
             
                         {% elif message == 'token_expired' %}
-                        The token supplied has expired. Password reset links are only
+                        This password reset link has expired. Password reset links are only
                         valid for 24 hours. You can generate a new one using the form
                         below.
             
                         {% elif message == 'token_invalid' %}
-                        The token supplied was invalid. You can generate a new one
-                        using the form below.
+                        This password reset link is invalid.
+                        You can generate a new one using the form below.
+
+                        {% elif message == 'token_used' %}
+                        Password has been changed since this reset link was requested.
+                        You can generate a new one using the form below.
 
                         {% else %}
                         {{ message }}

--- a/tests/app/helpers.py
+++ b/tests/app/helpers.py
@@ -2,8 +2,8 @@ import re
 from mock import Mock
 from app import create_app
 from werkzeug.http import parse_cookie
-from app.model import User
 from app import data_api_client
+from datetime import datetime, timedelta
 
 
 class BaseApplicationTest(object):
@@ -20,7 +20,14 @@ class BaseApplicationTest(object):
         return None
 
     @staticmethod
-    def user(id, email_address, supplier_id, supplier_name):
+    def user(id, email_address, supplier_id, supplier_name,
+             is_token_valid=True):
+
+        hours_offset = -1 if is_token_valid else 1
+        date = datetime.now() + timedelta(hours=hours_offset)
+        # will be formatted like 'Mon, 15 Jun 2015 00:00:00 GMT'
+        password_changed_at = date.strftime('%a, %d %b %Y %H:%M:%S GMT')
+
         return {
             "users": {
                 "id": id,
@@ -28,7 +35,8 @@ class BaseApplicationTest(object):
                 "supplier": {
                     "supplierId": supplier_id,
                     "name": supplier_name,
-                }
+                },
+                'passwordChangedAt': password_changed_at
             }
         }
 

--- a/tests/app/main/test_login.py
+++ b/tests/app/main/test_login.py
@@ -17,7 +17,7 @@ NEW_PASSWORD_EMPTY_ERROR = "Please enter a new password"
 NEW_PASSWORD_CONFIRM_EMPTY_ERROR = "Please confirm your new password"
 
 TOKEN_CREATED_BEFORE_PASSWORD_LAST_CHANGED_ERROR = \
-    'Password has been changed since this reset link was requested.'
+    'This password reset link is invalid.'
 
 
 class TestLogin(BaseApplicationTest):

--- a/tests/app/main/test_login.py
+++ b/tests/app/main/test_login.py
@@ -303,7 +303,14 @@ class TestLoginFormsNotAutofillable(BaseApplicationTest):
             "Reset password"
         )
 
-    def test_reset_password_form_and_inputs_not_autofillable(self):
+    @mock.patch('app.main.views.login.data_api_client')
+    def test_reset_password_form_and_inputs_not_autofillable(
+            self, data_api_client
+    ):
+        data_api_client.get_user.return_value = self.user(
+            123, "email@email.com", 1234, 'email'
+        )
+
         with self.app.app_context():
             url = helpers.email.generate_reset_url(123, "email@email.com")
 


### PR DESCRIPTION
Password reset tokens, once issued, would be valid for 24 hours.
This meant that all generated tokens could be used for the full 24 period without discrimination.
Added some logic to disallow tokens that were created _before_ a user's password was last changed.
Also created a new method that isolates token verification logic.

Also also replaced calls to `Mock` with `mock.patched` objects for our login tests because apparently that's a better way to go.

[>> Task ("Password reset tokens can be used multiple times") in story on Pivotal](https://www.pivotaltracker.com/story/show/96550136)