### PR TITLE
Make use of new dmutils features

### DIFF
--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -43,17 +43,11 @@ def edit_service(service_id):
         abort(404)
 
     template_data = main.config['BASE_TEMPLATE_DATA']
-
-    presented_service_data = {}
-    for key, value in service.items():
-        presented_service_data[key] = presenters.present(
-            value, content.get_question(key)
-        )
-
+    content.filter(service)
     return render_template(
         "services/service.html",
         service_id=service_id,
-        service_data=presented_service_data,
+        service_data=presenters.present_all(service, content),
         sections=content.sections,
         **template_data), 200
 

--- a/app/templates/services/service.html
+++ b/app/templates/services/service.html
@@ -11,6 +11,10 @@
       {
         "link": url_for(".dashboard"),
         "label": current_user.supplier_name
+      },
+      {
+        "link": url_for(".list_services"),
+        "label": "Services"
       }
     ]
   %}
@@ -44,35 +48,31 @@
     </div>
     <div class="column-one-whole">
       {% for section in sections %}
-        {% if service_data['lot']|lower in section['depends_on_lots'] %}
-          <h2 class="summary-item-heading">
-            {{section.name}}
-          </h2>
-          {% if section.editable %}
-            <p class="summary-item-top-level-action">
-              <a href="#">Edit</a>
-            </p>
-          {% endif %}
-          <table class="summary-item-body">
-            <thead class="summary-item-field-headings">
-              <tr>
-                <th>Service attribute name</th><th>Service attribute</th>
-              </tr>
-            </thead>
-            <tbody class="summary-item-body">
-              {% for question in section.questions %}
-                {% if service_data['lot']|lower in question['depends_on_lots'] %}
-                  <tr class="summary-item-row">
-                    <td class="summary-item-field-name">{{ question.question }}</td>
-                    <td class="summary-item-field-content">
-                      {{ answers[question.type](service_data[question.id]) }}
-                    </td>
-                  </tr>
-                {% endif %}
-              {% endfor %}
-            </tbody>
-          </table>
+        <h2 class="summary-item-heading">
+          {{section.name}}
+        </h2>
+        {% if section.editable %}
+          <p class="summary-item-top-level-action">
+            <a href="#">Edit</a>
+          </p>
         {% endif %}
+        <table class="summary-item-body">
+          <thead class="summary-item-field-headings">
+            <tr>
+              <th>Service attribute name</th><th>Service attribute</th>
+            </tr>
+          </thead>
+          <tbody class="summary-item-body">
+            {% for question in section.questions %}
+              <tr class="summary-item-row">
+                <td class="summary-item-field-name">{{ question.question }}</td>
+                <td class="summary-item-field-content">
+                  {{ answers[question.type](service_data[question.id]) }}
+                </td>
+              </tr>
+            {% endfor %}
+          </tbody>
+        </table>
       {% endfor %}
     </div>
   </div>

--- a/bower.json
+++ b/bower.json
@@ -5,8 +5,8 @@
     "jquery": "1.11.2",
     "hogan": "3.0.2",
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
-    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v3.1.1",
+    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v5.0.1",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.12.0/jinja_govuk_template-0.12.0.tgz",
-    "digital-marketplace-ssp-content": "git://github.com/alphagov/digital-marketplace-ssp-content#973f540"
+    "digital-marketplace-ssp-content": "git://github.com/alphagov/digital-marketplace-ssp-content#ac4876c9eed4fc97132a280feb54cc88ae4b747e"
   }
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ Flask==0.10.1
 Flask-Login==0.2.11
 Flask-Script==2.0.5
 Flask-WTF==0.11
-git+https://github.com/alphagov/digitalmarketplace-utils.git@0.23.0#egg=digitalmarketplace-utils==0.23.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@1.0.2#egg=digitalmarketplace-utils==1.0.2
 
 mandrill==1.0.57
 

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -32,7 +32,7 @@ class TestListServices(BaseApplicationTest):
                     'serviceName': 'Service name 123',
                     'status': 'published',
                     'id': '123',
-                    'lot': 'SaaaaaaaS',
+                    'lot': 'SaaS',
                     'frameworkName': 'G-Cloud 1'
                 }]}
             )
@@ -42,7 +42,7 @@ class TestListServices(BaseApplicationTest):
             data_api_client.find_services.assert_called_once_with(
                 supplier_id=1234)
             assert_true("Service name 123" in res.get_data(as_text=True))
-            assert_true("SaaaaaaaS" in res.get_data(as_text=True))
+            assert_true("SaaS" in res.get_data(as_text=True))
             assert_true("G-Cloud 1" in res.get_data(as_text=True))
 
     @mock.patch('app.main.views.services.data_api_client')


### PR DESCRIPTION
Namely:

- Add present_all method to presenters
  https://github.com/alphagov/digitalmarketplace-utils/pull/61

- Make content loader handle dependencies…
  https://github.com/alphagov/digitalmarketplace-utils/pull/62

…which means that the app can update to the latest content structure, as changed in: https://github.com/alphagov/digital-marketplace-ssp-content/pull/42

This commit also makes use, wherever possible, of the templates from the toolkit, rather than local templates.