### PR TITLE
Edit existing service

### DIFF
--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -112,11 +112,16 @@ def update_service_status(service_id):
 @login_required
 @flask_featureflags.is_active_feature('EDIT_SERVICE_PAGE')
 def edit_section(service_id, section):
-    service_data = data_api_client.get_service(service_id)['services']
+
+    service = data_api_client.get_service(service_id)['services']
+
+    if not _is_service_associated_with_supplier(service):
+        abort(404)
+
     return render_template(
         "services/edit_section.html",
-        section=content.get_section_filtered_by(section, service_data),
-        service_data=service_data,
+        section=content.get_section_filtered_by(section, service),
+        service_data=service,
         service_id=service_id,
         **main.config['BASE_TEMPLATE_DATA']
     )

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -149,13 +149,9 @@ def update_section(service_id, section):
     for key in request.form:
         item_as_list = request.form.getlist(key)
         list_types = ['list', 'checkboxes', 'pricing']
-        print("============================")
-        print(key)
-        print(content.get_question(key))
-        print(content.get_question(key).get("type"))
-        print("============================")
         if (
             key != 'csrf_token' and
+            # 'type' in content.get_question(key) and
             content.get_question(key)['type'] in list_types
         ):
             posted_data[key] = item_as_list
@@ -168,9 +164,16 @@ def update_section(service_id, section):
                 "user",
                 "supplier app")
         except HTTPError as e:
-            return e.message
+            return render_template(
+                "services/edit_section.html",
+                section=content.get_section(section),
+                service_data=service_data,
+                service_id=service_id,
+                error=e.message,
+                **main.config['BASE_TEMPLATE_DATA']
+            )
 
-    return "Ohai"
+    return redirect(url_for(".edit_service", service_id=service_id))
 
 
 def _is_service_associated_with_supplier(service):

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -107,6 +107,16 @@ def update_service_status(service_id):
     )
 
 
+@main.route(
+    '/services/<string:service_id>/edit/<string:section>',
+    methods=['GET']
+)
+@login_required
+@flask_featureflags.is_active_feature('EDIT_SERVICE_PAGE')
+def edit_section(service_id, section):
+    return "hey"
+
+
 def _is_service_associated_with_supplier(service):
 
     return service.get('supplierId') == current_user.supplier_id

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -43,17 +43,11 @@ def edit_service(service_id):
         abort(404)
 
     template_data = main.config['BASE_TEMPLATE_DATA']
-
-    presented_service_data = {}
-    for key, value in service.items():
-        presented_service_data[key] = presenters.present(
-            value, content.get_question(key)
-        )
-
+    content.filter(service)
     return render_template(
         "services/service.html",
         service_id=service_id,
-        service_data=presented_service_data,
+        service_data=presenters.present_all(service, content),
         sections=content.sections,
         **template_data), 200
 

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -151,7 +151,6 @@ def update_section(service_id, section):
         list_types = ['list', 'checkboxes', 'pricing']
         if (
             key != 'csrf_token' and
-            # 'type' in content.get_question(key) and
             content.get_question(key)['type'] in list_types
         ):
             posted_data[key] = item_as_list

--- a/app/section_order.yml
+++ b/app/section_order.yml
@@ -6,13 +6,13 @@
     - lot
 -
   name: Description
-  editable: false
+  editable: edit
   questions:
     - serviceName
     - serviceSummary
 -
   name: Features and benefits
-  editable: false
+  editable: edit
   questions:
     - serviceFeatures
     - serviceBenefits

--- a/app/templates/macros/toolkit_forms.html
+++ b/app/templates/macros/toolkit_forms.html
@@ -16,7 +16,8 @@
     question=question_content.question,
     name=question_content.id,
     value=service_data[question_content.id],
-    large=True
+    large=True,
+    max_length_in_words=question_content["maxLengthInWords"] or False
   %}
     {% include "toolkit/forms/textbox.html" %}
   {% endwith %}
@@ -31,7 +32,6 @@
     id=question_content.id,
     hint=question_content.hint
   %}
-    {{question_content.id}}
     {% include "toolkit/forms/list-entry.html" %}
   {% endwith %}
 {%- endmacro %}

--- a/app/templates/macros/toolkit_forms.html
+++ b/app/templates/macros/toolkit_forms.html
@@ -1,0 +1,37 @@
+{% macro text(question_content, service_data, errors) -%}
+  {%
+    with
+    question=question_content.question,
+    name=question_content.id,
+    value=service_data[question_content.id],
+    error=errors.get(question_content.id) or None
+  %}
+    {% include "toolkit/forms/textbox.html" %}
+  {% endwith %}
+{%- endmacro %}
+
+{% macro textbox_large(question_content, service_data, errors) -%}
+  {%
+    with
+    question=question_content.question,
+    name=question_content.id,
+    value=service_data[question_content.id],
+    large=True
+  %}
+    {% include "toolkit/forms/textbox.html" %}
+  {% endwith %}
+{%- endmacro %}
+
+{% macro list(question_content, service_data, errors) -%}
+  {%
+    with
+    values=service_data[question_content.id],
+    number_of_items=10,
+    question=question_content.question,
+    id=question_content.id,
+    hint=question_content.hint
+  %}
+    {{question_content.id}}
+    {% include "toolkit/forms/list-entry.html" %}
+  {% endwith %}
+{%- endmacro %}

--- a/app/templates/services/edit_section.html
+++ b/app/templates/services/edit_section.html
@@ -15,6 +15,10 @@
       {
         "link": url_for(".list_services"),
         "label": "Services"
+      },
+      {
+        "link": url_for(".edit_service", service_id=service_id),
+        "label": service_data["serviceName"]
       }
     ]
   %}
@@ -25,13 +29,20 @@
 {% block main_content %}
   <div class="grid-row">
     <div class="column-two-thirds">
+
+      {% if error %}
+        {% with lede = error %}
+          {% include 'toolkit/forms/validation.html' %}
+        {% endwith %}
+      {% endif %}
+
       {% with
-        context = service_data["serviceName"],
         heading = section.name,
         smaller = true
       %}
         {% include 'toolkit/page-heading.html' %}
       {% endwith %}
+
     </div>
   </div>
   <form method="post" action="{{ url_for(".update_section", service_id=service_id, section=section.id) }}">

--- a/app/templates/services/edit_section.html
+++ b/app/templates/services/edit_section.html
@@ -1,0 +1,55 @@
+{% extends "_base_page.html" %}
+{% import "macros/toolkit_forms.html" as forms %}
+
+{% block breadcrumb %}
+  {%
+    with items = [
+      {
+        "link": "/",
+        "label": "Digital Marketplace"
+      },
+      {
+        "link": url_for(".dashboard"),
+        "label": current_user.supplier_name
+      },
+      {
+        "link": url_for(".list_services"),
+        "label": "Services"
+      }
+    ]
+  %}
+    {% include "toolkit/breadcrumb.html" %}
+  {% endwith %}
+{% endblock %}
+
+{% block main_content %}
+  <div class="grid-row">
+    <div class="column-two-thirds">
+      {% with
+        context = service_data["serviceName"],
+        heading = section.name,
+        smaller = true
+      %}
+        {% include 'toolkit/page-heading.html' %}
+      {% endwith %}
+    </div>
+  </div>
+  <form method="post" action="{{ url_for(".update_section", service_id=service_id, section=section.id) }}">
+
+    {% for question in section.questions %}
+      {{ forms[question.type](question, service_data, {}) }}
+    {% endfor %}
+
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+
+    {%
+      with
+      label="Save and return to service",
+      type="save"
+    %}
+      {% include "toolkit/button.html" %}
+    {% endwith %}
+    <a href="{{ url_for(".edit_service", service_id=service_id) }}">Return to service</a>
+
+  </form>
+{% endblock %}

--- a/app/templates/services/service.html
+++ b/app/templates/services/service.html
@@ -11,6 +11,10 @@
       {
         "link": url_for(".dashboard"),
         "label": current_user.supplier_name
+      },
+      {
+        "link": url_for(".list_services"),
+        "label": "Services"
       }
     ]
   %}
@@ -44,35 +48,31 @@
     </div>
     <div class="column-one-whole">
       {% for section in sections %}
-        {% if service_data['lot']|lower in section['depends_on_lots'] %}
-          <h2 class="summary-item-heading">
-            {{section.name}}
-          </h2>
-          {% if section.editable %}
-            <p class="summary-item-top-level-action">
-              <a href="#">Edit</a>
-            </p>
-          {% endif %}
-          <table class="summary-item-body">
-            <thead class="summary-item-field-headings">
-              <tr>
-                <th>Service attribute name</th><th>Service attribute</th>
-              </tr>
-            </thead>
-            <tbody class="summary-item-body">
-              {% for question in section.questions %}
-                {% if service_data['lot']|lower in question['depends_on_lots'] %}
-                  <tr class="summary-item-row">
-                    <td class="summary-item-field-name">{{ question.question }}</td>
-                    <td class="summary-item-field-content">
-                      {{ answers[question.type](service_data[question.id]) }}
-                    </td>
-                  </tr>
-                {% endif %}
-              {% endfor %}
-            </tbody>
-          </table>
+        <h2 class="summary-item-heading">
+          {{section.name}}
+        </h2>
+        {% if section.editable %}
+          <p class="summary-item-top-level-action">
+            <a href="#">Edit</a>
+          </p>
         {% endif %}
+        <table class="summary-item-body">
+          <thead class="summary-item-field-headings">
+            <tr>
+              <th>Service attribute name</th><th>Service attribute</th>
+            </tr>
+          </thead>
+          <tbody class="summary-item-body">
+            {% for question in section.questions %}
+              <tr class="summary-item-row">
+                <td class="summary-item-field-name">{{ question.question }}</td>
+                <td class="summary-item-field-content">
+                  {{ answers[question.type](service_data[question.id]) }}
+                </td>
+              </tr>
+            {% endfor %}
+          </tbody>
+        </table>
       {% endfor %}
     </div>
   </div>

--- a/app/templates/services/service.html
+++ b/app/templates/services/service.html
@@ -53,7 +53,7 @@
         </h2>
         {% if section.editable %}
           <p class="summary-item-top-level-action">
-            <a href="#">Edit</a>
+            <a href="{{ url_for('.edit_section', service_id=service_id, section=section.id ) }}">Edit</a>
           </p>
         {% endif %}
         <table class="summary-item-body">

--- a/bower.json
+++ b/bower.json
@@ -5,8 +5,8 @@
     "jquery": "1.11.2",
     "hogan": "3.0.2",
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
-    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v3.1.1",
+    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v5.0.1",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.12.0/jinja_govuk_template-0.12.0.tgz",
-    "digital-marketplace-ssp-content": "git://github.com/alphagov/digital-marketplace-ssp-content#973f540"
+    "digital-marketplace-ssp-content": "git://github.com/alphagov/digital-marketplace-ssp-content#ac4876c9eed4fc97132a280feb54cc88ae4b747e"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "jquery": "1.11.2",
     "hogan": "3.0.2",
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
-    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v5.0.1",
+    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v5.0.2",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.12.0/jinja_govuk_template-0.12.0.tgz",
     "digital-marketplace-ssp-content": "git://github.com/alphagov/digital-marketplace-ssp-content#ac4876c9eed4fc97132a280feb54cc88ae4b747e"
   }

--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "jquery": "1.11.2",
     "hogan": "3.0.2",
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
-    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v5.0.2",
+    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v5.0.3",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.12.0/jinja_govuk_template-0.12.0.tgz",
     "digital-marketplace-ssp-content": "git://github.com/alphagov/digital-marketplace-ssp-content#ac4876c9eed4fc97132a280feb54cc88ae4b747e"
   }

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ Flask==0.10.1
 Flask-Login==0.2.11
 Flask-Script==2.0.5
 Flask-WTF==0.11
-git+https://github.com/alphagov/digitalmarketplace-utils.git@0.23.0#egg=digitalmarketplace-utils==0.23.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@1.0.2#egg=digitalmarketplace-utils==1.0.2
 
 mandrill==1.0.57
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ Flask==0.10.1
 Flask-Login==0.2.11
 Flask-Script==2.0.5
 Flask-WTF==0.11
-git+https://github.com/alphagov/digitalmarketplace-utils.git@1.0.2#egg=digitalmarketplace-utils==1.0.2
+git+https://github.com/alphagov/digitalmarketplace-utils.git@1.0.3#egg=digitalmarketplace-utils==1.0.3
 
 mandrill==1.0.57
 

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -32,7 +32,7 @@ class TestListServices(BaseApplicationTest):
                     'serviceName': 'Service name 123',
                     'status': 'published',
                     'id': '123',
-                    'lot': 'SaaaaaaaS',
+                    'lot': 'SaaS',
                     'frameworkName': 'G-Cloud 1'
                 }]}
             )
@@ -42,7 +42,7 @@ class TestListServices(BaseApplicationTest):
             data_api_client.find_services.assert_called_once_with(
                 supplier_id=1234)
             assert_true("Service name 123" in res.get_data(as_text=True))
-            assert_true("SaaaaaaaS" in res.get_data(as_text=True))
+            assert_true("SaaS" in res.get_data(as_text=True))
             assert_true("G-Cloud 1" in res.get_data(as_text=True))
 
     @mock.patch('app.main.views.services.data_api_client')


### PR DESCRIPTION
_Fulfills [95430642](https://www.pivotaltracker.com/story/show/95430642)_

![image](https://cloud.githubusercontent.com/assets/355079/8228620/462cf6b0-15a8-11e5-9dc1-2ea36d5acd71.png)

This pull request, [using the new dmutils features](https://github.com/alphagov/digitalmarketplace-supplier-frontend/pull/71) and templates from the toolkit:
- adds a `GET` endpoint for `/services/<id>/edit/<section>`
- renders form fields with prefilled values for the above four questions, using templates from the toolkit
- adds a `POST` endpoint for the same, which takes the edited values and
  - if the API returns successfully redirects back to the service summary page
  - if the API returns an error then it will be displayed back to the user

It doesn't, yet, do any per-field validation of edits.