### PR TITLE
[#97275278] Enable supplier dashboard

### DIFF
--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -33,7 +33,7 @@ def dashboard():
 
 @main.route('/edit', methods=['GET'])
 @login_required
-@flask_featureflags.is_active_feature('SUPPLIER_DASHBOARD')
+@flask_featureflags.is_active_feature('EDIT_SUPPLIER_PAGE')
 def edit_supplier(supplier_form=None, contact_form=None, error=None):
     template_data = main.config['BASE_TEMPLATE_DATA']
 
@@ -65,7 +65,7 @@ def edit_supplier(supplier_form=None, contact_form=None, error=None):
 
 @main.route('/edit', methods=['POST'])
 @login_required
-@flask_featureflags.is_active_feature('SUPPLIER_DASHBOARD')
+@flask_featureflags.is_active_feature('EDIT_SUPPLIER_PAGE')
 def update_supplier():
     # FieldList expects post parameter keys to have number suffixes
     # (eg client-0, client-1 ...), which is incompatible with how

--- a/app/templates/suppliers/dashboard.html
+++ b/app/templates/suppliers/dashboard.html
@@ -37,9 +37,11 @@
   <div class="grid-row">
     <div class="column-one-whole">
       <h2 class="summary-item-heading">Supplier information</h2>
+      {% if 'EDIT_SUPPLIER_PAGE' is active_feature %}
       <p class="summary-item-top-level-action">
         <a href="{{ url_for('.edit_supplier') }}">Edit</a>
       </p>
+      {% endif %}
       <table class="summary-item-body">
         <thead></thead>
           <tbody class="summary-item-body">

--- a/config.py
+++ b/config.py
@@ -38,8 +38,10 @@ class Config(object):
 
     # Feature Flags
     RAISE_ERROR_ON_MISSING_FEATURES = True
+
     FEATURE_FLAGS_EDIT_SERVICE_PAGE = False
     FEATURE_FLAGS_SUPPLIER_DASHBOARD = False
+    FEATURE_FLAGS_EDIT_SUPPLIER_PAGE = False
 
     # Logging
     DM_LOG_LEVEL = 'DEBUG'
@@ -69,6 +71,7 @@ class Test(Config):
 
     FEATURE_FLAGS_EDIT_SERVICE_PAGE = enabled_since('2015-06-03')
     FEATURE_FLAGS_SUPPLIER_DASHBOARD = enabled_since('2015-06-10')
+    FEATURE_FLAGS_EDIT_SUPPLIER_PAGE = enabled_since('2015-06-18')
 
 
 class Development(Config):
@@ -78,6 +81,7 @@ class Development(Config):
     # Dates not formatted like YYYY-(0)M-(0)D will fail
     FEATURE_FLAGS_EDIT_SERVICE_PAGE = enabled_since('2015-06-03')
     FEATURE_FLAGS_SUPPLIER_DASHBOARD = enabled_since('2015-06-10')
+    FEATURE_FLAGS_EDIT_SUPPLIER_PAGE = enabled_since('2015-06-18')
 
 
 class Live(Config):

--- a/config.py
+++ b/config.py
@@ -84,6 +84,8 @@ class Live(Config):
     DEBUG = False
     DM_HTTP_PROTO = 'https'
 
+    FEATURE_FLAGS_SUPPLIER_DASHBOARD = enabled_since('2015-06-18')
+
 
 configs = {
     'development': Development,


### PR DESCRIPTION
[#97275278](https://www.pivotaltracker.com/story/show/97275278)

Enables dashboard edit in preview, staging and production.

### Add a separate feature flag for editing supplier details
Hides the "Edit" button next to the "Supplier information" and disables the /suppliers/edit page.