### PR TITLE
Add framework service counts to the supplier dashboard

### DIFF
--- a/app/templates/suppliers/dashboard.html
+++ b/app/templates/suppliers/dashboard.html
@@ -29,7 +29,7 @@
     <div class="column-one-whole">
       <h2 class="summary-item-heading">Services</h2>
       <p class="summary-item-top-level-action">
-        <a href="{{ url_for('.list_services') }}">Edit</a>
+        <a href="{{ url_for('.list_services') }}">View</a>
       </p>
       {% if supplier.service_counts %}
       <table class="summary-item-body">

--- a/app/templates/suppliers/dashboard.html
+++ b/app/templates/suppliers/dashboard.html
@@ -31,6 +31,23 @@
       <p class="summary-item-top-level-action">
         <a href="{{ url_for('.list_services') }}">Edit</a>
       </p>
+      {% if supplier.service_counts %}
+      <table class="summary-item-body">
+        <thead></thead>
+        <tbody class="summary-item-body">
+          {% for framework, service_count in supplier.service_counts|dictsort %}
+          <tr class="summary-item-row">
+            <td class="summary-item-field-name">
+              {{ framework }}
+            </td>
+            <td class="summary-item-field-content">
+              {{ service_count }} service{{ "s" if service_count > 1 }}
+            </td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+      {% endif %}
     </div>
   </div>
 


### PR DESCRIPTION
[#97275278](https://www.pivotaltracker.com/story/show/97275278)

Requires alphagov/digitalmarketplace-api#150 

Displays the service counts as reported by the API.
There are no framework dates since we don't return them from the API yet

![screen shot 2015-06-18 at 16 11 22](https://cloud.githubusercontent.com/assets/246664/8235657/0a0ce32e-15db-11e5-8da2-b76e175f5eab.png)

G-Cloud 7 "now open" block will be a part of @robyoung's pull request.