### PR TITLE
Swap out HTML service status update form for toolkit-generated form.

### DIFF
--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -42,31 +42,7 @@ def edit_service(service_id):
     if not _is_service_associated_with_supplier(service):
         abort(404)
 
-    question = {
-        'question': 'Choose service status',
-        'hint': 'Private services don\'t appear in search results '
-                'and don\'t have a URL',
-        'name': 'status',
-        'type': 'radio',
-        'inline': True,
-        'options': [
-            {
-                'checked': service['status'] == 'published',
-                'label': 'Public'
-            },
-            {
-                'checked': service['status'] == 'enabled',
-                'label': 'Private'
-            }
-        ]
-    }
-
-    return render_template(
-        "services/service.html",
-        service_id=service_id,
-        service_data=presenters.present_all(service, content),
-        sections=content.get_sections_filtered_by(service),
-        **dict(question, **main.config['BASE_TEMPLATE_DATA'])), 200
+    return _update_service_status(service)
 
 
 # Might have to change the route if we're generalizing this to update
@@ -80,7 +56,7 @@ def update_service_status(service_id):
         abort(404)
 
     if not _is_service_modifiable(service):
-        return _update_service_status_error(
+        return _update_service_status(
             service,
             "Sorry, but this service isn't modifiable."
         )
@@ -96,7 +72,7 @@ def update_service_status(service_id):
     if status in translate_frontend_to_api.keys():
         status = translate_frontend_to_api[status]
     else:
-        return _update_service_status_error(
+        return _update_service_status(
             service,
             "Sorry, but '{}' is not a valid status.".format(status)
         )
@@ -109,7 +85,7 @@ def update_service_status(service_id):
 
     except APIError:
 
-        return _update_service_status_error(
+        return _update_service_status(
             service,
             "Sorry, there's been a problem updating the status."
         )
@@ -204,12 +180,34 @@ def _is_service_modifiable(service):
     return service.get('status') != 'disabled'
 
 
-def _update_service_status_error(service, error_message):
+def _update_service_status(service, error_message=None):
+
     template_data = main.config['BASE_TEMPLATE_DATA']
+    status_code = 400 if error_message else 200
+
+    question = {
+        'question': 'Choose service status',
+        'hint': 'Private services don\'t appear in search results '
+                'and don\'t have a URL',
+        'name': 'status',
+        'type': 'radio',
+        'inline': True,
+        'options': [
+            {
+                'checked': service['status'] == 'published',
+                'label': 'Public'
+            },
+            {
+                'checked': service['status'] == 'enabled',
+                'label': 'Private'
+            }
+        ]
+    }
 
     return render_template(
         "services/service.html",
         service_id=service.get('id'),
-        service_data=service,
+        service_data=presenters.present_all(service, content),
+        sections=content.get_sections_filtered_by(service),
         error=error_message,
-        **template_data), 400
+        **dict(question, **template_data)), status_code

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -42,12 +42,31 @@ def edit_service(service_id):
     if not _is_service_associated_with_supplier(service):
         abort(404)
 
+    question = {
+        'question': 'Choose service status',
+        'hint': 'Private services don\'t appear in search results '
+                'and don\'t have a URL',
+        'name': 'status',
+        'type': 'radio',
+        'inline': True,
+        'options': [
+            {
+                'checked': service['status'] == 'published',
+                'label': 'Public'
+            },
+            {
+                'checked': service['status'] == 'enabled',
+                'label': 'Private'
+            }
+        ]
+    }
+
     return render_template(
         "services/service.html",
         service_id=service_id,
         service_data=presenters.present_all(service, content),
         sections=content.get_sections_filtered_by(service),
-        **main.config['BASE_TEMPLATE_DATA']), 200
+        **dict(question, **main.config['BASE_TEMPLATE_DATA'])), 200
 
 
 # Might have to change the route if we're generalizing this to update
@@ -67,7 +86,7 @@ def update_service_status(service_id):
         )
 
     # Value should be either public or private
-    status = request.form['service_status']
+    status = request.form.get('status', '').lower()
 
     translate_frontend_to_api = {
         'public': 'published',

--- a/app/templates/services/_edit-status.html
+++ b/app/templates/services/_edit-status.html
@@ -1,23 +1,7 @@
 {% if service_data.status != 'disabled' %}
   <form action="{{ url_for('.update_service_status', service_id=service_id ) }}" method="POST">
     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
-    <fieldset class="question">
-      <legend class="question-heading question-heading-with-hint ">
-        Choose service status
-      </legend>
-      <p class="hint">
-        Private services don't appear in search results and don't have a
-        <acronym title="Uniform resource locator">URL</acronym>
-      </p>
-      <label class="selection-button selection-button-boolean">
-        <input type="radio" name="service_status" id="service_status_published" value="public" {% if service_data['status'] == 'published' %}checked="checked"{% endif %} />
-        Public
-      </label>
-      <label class="selection-button  selection-button-boolean">
-        <input type="radio" name="service_status" id="service_status_private" value="private" {% if service_data['status'] == 'enabled' %}checked="checked"{% endif %} />
-        Private
-      </label>
-    </fieldset>
+      {% include "toolkit/forms/selection-buttons.html" %}
     <button type="submit" class="button-save">Save and return</button>
   </form>
 {% endif %}

--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "jquery": "1.11.2",
     "hogan": "3.0.2",
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
-    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v5.0.3",
+    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v5.1.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.12.0/jinja_govuk_template-0.12.0.tgz",
     "digital-marketplace-ssp-content": "git://github.com/alphagov/digital-marketplace-ssp-content#ac4876c9eed4fc97132a280feb54cc88ae4b747e"
   }

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -149,7 +149,7 @@ class TestSupplierUpdateService(BaseApplicationTest):
             self, status, expected_status_code):
 
         res = self.client.post('/suppliers/services/123', data={
-            'service_status': status,
+            'status': status,
         })
         assert_equal(res.status_code, expected_status_code)
 
@@ -193,11 +193,11 @@ class TestSupplierUpdateService(BaseApplicationTest):
 
         # check that 'public' is selected.
         assert_true(
-            '<input type="radio" name="service_status" id="service_status_published" value="public" checked="checked"'  # noqa
+            '<input type="radio" name="status" id="status-1" value="Public" checked="checked"'  # noqa
             in res.get_data(as_text=True)
         )
         assert_false(
-            '<input type="radio" name="service_status" id="service_status_private" value="private" checked="checked"'  # noqa
+            '<input type="radio" name="status" id="status-2" value="Private" checked="checked"'  # noqa
             in res.get_data(as_text=True)
         )
 
@@ -221,11 +221,11 @@ class TestSupplierUpdateService(BaseApplicationTest):
 
         # check that 'public' is not selected.
         assert_false(
-            '<input type="radio" name="service_status" id="service_status_published" value="public" checked="checked"'  # noqa
+            '<input type="radio" name="status" id="status-1" value="Public" checked="checked"'  # noqa
             in res.get_data(as_text=True)
         )
         assert_true(
-            '<input type="radio" name="service_status" id="service_status_private" value="private" checked="checked"'  # noqa
+            '<input type="radio" name="status" id="status-2" value="Private" checked="checked"'  # noqa
             in res.get_data(as_text=True)
         )
 


### PR DESCRIPTION
Our public/private service status update form was just plain HTML, which meant that it risked becoming outdated as the toolkit evolved.
Also changed the `service_status` name to `status` as it would appear in the JSON response for a service.

Also resolved a bug where if you caused an error while trying to update your status, you wouldn't get the correct page back. 