### PR TITLE
[# 97631008] Add draft documents S3 and prune config

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ Create a virtual environment
 Set the required environment variables (for dev use local API instance if you 
 have it running):
 ```
-export DM_API_URL=http://localhost:5000
-export DM_SUPPLIER_FRONTEND_API_AUTH_TOKEN=<auth_token>
+export DM_DATA_API_URL=http://localhost:5000
+export DM_DATA_API_AUTH_TOKEN=<auth_token>
 ```
 
 ### Activate the virtual environment

--- a/app/main/helpers/email.py
+++ b/app/main/helpers/email.py
@@ -9,7 +9,7 @@ from .. import main
 
 def send_password_email(user_id, email_address):
     try:
-        mandrill_client = mandrill.Mandrill(main.config['MANDRILL_API_KEY'])
+        mandrill_client = mandrill.Mandrill(main.config['DM_MANDRILL_API_KEY'])
         url = generate_reset_url(user_id, email_address)
         body = render_template("emails/reset_password_email.html", url=url)
         message = {'html': body,

--- a/config.py
+++ b/config.py
@@ -13,15 +13,10 @@ class Config(object):
     SESSION_COOKIE_HTTPONLY = True
     SESSION_COOKIE_SECURE = True
     WTF_CSRF_ENABLED = True
-    DM_API_URL = None
-    DM_API_AUTH_TOKEN = None
     DM_DATA_API_URL = None
     DM_DATA_API_AUTH_TOKEN = None
     DM_G7_DRAFT_DOCUMENTS_BUCKET = None
     DEBUG = False
-
-    API_URL = os.getenv('DM_API_URL')
-    API_AUTH_TOKEN = os.getenv('DM_SUPPLIER_FRONTEND_API_AUTH_TOKEN')
 
     MANDRILL_API_KEY = os.getenv('DM_MANDRILL_API_KEY')
     RESET_PASSWORD_EMAIL_NAME = 'Digital Marketplace Admin'
@@ -65,8 +60,6 @@ class Test(Config):
     DM_LOG_LEVEL = 'CRITICAL'
     DM_API_AUTH_TOKEN = 'test'
     DM_API_URL = 'http://localhost'
-    DM_DATA_API_URL = os.getenv('DM_DATA_API_URL')
-    DM_DATA_API_AUTH_TOKEN = os.getenv('DM_DATA_API_AUTH_TOKEN')
     WTF_CSRF_ENABLED = False
     SERVER_NAME = 'localhost'
 

--- a/config.py
+++ b/config.py
@@ -17,6 +17,7 @@ class Config(object):
     DM_API_AUTH_TOKEN = None
     DM_DATA_API_URL = None
     DM_DATA_API_AUTH_TOKEN = None
+    DM_G7_DRAFT_DOCUMENTS_BUCKET = None
     DEBUG = False
 
     API_URL = os.getenv('DM_API_URL')

--- a/config.py
+++ b/config.py
@@ -15,10 +15,10 @@ class Config(object):
     WTF_CSRF_ENABLED = True
     DM_DATA_API_URL = None
     DM_DATA_API_AUTH_TOKEN = None
+    DM_MANDRILL_API_KEY = None
     DM_G7_DRAFT_DOCUMENTS_BUCKET = None
     DEBUG = False
 
-    MANDRILL_API_KEY = os.getenv('DM_MANDRILL_API_KEY')
     RESET_PASSWORD_EMAIL_NAME = 'Digital Marketplace Admin'
     RESET_PASSWORD_EMAIL_FROM = 'enquiries@digitalmarketplace.service.gov.uk'
     RESET_PASSWORD_EMAIL_SUBJECT = 'Reset your Digital Marketplace password'


### PR DESCRIPTION
This adds an environment variable for the S3 bucket we want to use for uploading draft documents. It does not actually do any uploading yet because that will use the existing S3 upload from dmutils.

When adding the config I noticed a few old configs that could be cleaned up as well.