### PR TITLE
Put all service attributes in the manifest for new services

### DIFF
--- a/app/new_service_manifest.yml
+++ b/app/new_service_manifest.yml
@@ -45,7 +45,7 @@
     - termsAndConditionsDocumentURL
 -
   name: Support
-  editable: true
+  editable: True
   questions:
     - supportTypes
     - supportForThirdParties
@@ -53,7 +53,202 @@
     - supportResponseTime
     - incidentEscalation
 -
+  name: Open standards
+  editable: True
+  questions:
+    - openStandardsSupported
+-
+  name: Onboarding and offboarding
+  editable: True
+  questions:
+    - serviceOnboarding
+    - serviceOffboarding
+-
+  name: Analytics
+  editable: True
+  questions:
+    - analyticsAvailable
+-
+  name: Cloud features
+  editable: True
+  questions:
+    - elasticCloud
+    - guaranteedResources
+    - persistentStorage
+-
+  name: Provisioning
+  editable: True
+  questions:
+    - selfServiceProvisioning
+    - provisioningTime
+    - deprovisioningTime
+-
+  name: Open source
+  editable: True
+  questions:
+    - openSource
+-
+  name: Code libraries
+  editable: True
+  questions:
+    - codeLibraryLanguages
+-
+  name: API access
+  editable: True
+  questions:
+    - apiAccess
+    - apiType
+-
+  name: Networks and connectivity
+  editable: True
+  questions:
+    - networksConnected
+-
+  name: Access
+  editable: True
+  questions:
+    - supportedBrowsers
+    - offlineWorking
+    - supportedDevices
+-
   name: Certifications
-  editable: true
+  editable: True
   questions:
     - vendorCertifications
+-
+  name: Identity standards
+  editable: True
+  questions:
+    - identityStandards
+-
+  name: Data storage
+  editable: True
+  questions:
+    - datacentresEUCode
+    - datacentresSpecifyLocation
+    - datacentreTier
+    - dataBackupRecovery
+    - dataExtractionRemoval
+-
+  name: Data-in-transit protection
+  editable: True
+  questions:
+    - dataProtectionBetweenUserAndService
+    - dataProtectionWithinService
+    - dataProtectionBetweenServices
+-
+  name: Asset protection and resilience
+  editable: True
+  questions:
+    - datacentreLocations
+    - dataManagementLocations
+    - legalJurisdiction
+    - datacentreProtectionDisclosure
+    - dataAtRestProtections
+    - dataSecureDeletion
+    - dataStorageMediaDisposal
+    - dataSecureEquipmentDisposal
+    - dataRedundantEquipmentAccountsRevoked
+    - serviceAvailabilityPercentage
+-
+  name: Separation between consumers
+  editable: True
+  questions:
+    - cloudDeploymentModel
+    - otherConsumers
+    - servicesSeparation
+    - servicesManagementSeparation
+-
+  name: Governance
+  editable: True
+  questions:
+    - governanceFramework
+-
+  name: Configuration and change management
+  editable: True
+  questions:
+    - configurationTracking
+    - changeImpactAssessment
+-
+  name: Vulnerabilility management
+  editable: True
+  questions:
+    - vulnerabilityAssessment
+    - vulnerabilityMonitoring
+    - vulnerabilityMitigationPrioritisation
+    - vulnerabilityTracking
+    - vulnerabilityTimescales
+-
+  name: Event monitoring
+  editable: True
+  questions:
+    - eventMonitoring
+-
+  name: Incident management
+  editable: True
+  questions:
+    - incidentManagementProcess
+    - incidentManagementReporting
+    - incidentDefinitionPublished
+-
+  name: Personnel security
+  editable: True
+  questions:
+    - personnelSecurityChecks
+-
+  name: Secure development
+  editable: True
+  questions:
+    - secureDevelopment
+    - secureDesign
+    - secureConfigurationManagement
+-
+  name: Supply-chain security
+  editable: True
+  questions:
+    - thirdPartyDataSharingInformation
+    - thirdPartySecurityRequirements
+    - thirdPartyRiskAssessment
+    - thirdPartyComplianceMonitoring
+    - hardwareSoftwareVerification
+-
+  name: Authentication of consumers
+  editable: True
+  questions:
+    - userAuthenticateManagement
+    - userAuthenticateSupport
+-
+  name: Separation and access control within management interfaces
+  editable: True
+  questions:
+    - userAccessControlManagement
+    - restrictAdministratorPermissions
+    - managementInterfaceProtection
+-
+  name: Identity and authentication
+  editable: True
+  questions:
+    - identityAuthenticationControls
+-
+  name: External interface protection
+  editable: True
+  questions:
+    - onboardingGuidance
+    - interconnectionMethods
+-
+  name: Secure service administration
+  editable: True
+  questions:
+    - serviceManagementModel
+-
+  name: Audit information provision to consumers
+  editable: True
+  questions:
+    - auditInformationProvided
+-
+  name: Secure use of the service by the customer
+  editable: True
+  questions:
+    - deviceAccessMethod
+    - serviceConfigurationGuidance
+    - trainingProvided

--- a/app/templates/macros/answers.html
+++ b/app/templates/macros/answers.html
@@ -64,3 +64,8 @@
     {{ value.0 }}
   {% endif %}
 {%- endmacro %}
+
+
+{% macro percentage(value='') -%}
+  {{ value }}%
+{%- endmacro %}

--- a/bower.json
+++ b/bower.json
@@ -7,6 +7,6 @@
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
     "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v5.1.2",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.12.0/jinja_govuk_template-0.12.0.tgz",
-    "digital-marketplace-ssp-content": "git://github.com/alphagov/digital-marketplace-ssp-content#blah"
+    "digital-marketplace-ssp-content": "git://github.com/alphagov/digital-marketplace-ssp-content#15fcaeab5b24893a04bece14a56ff2fa425e5633"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -7,6 +7,6 @@
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
     "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v5.1.2",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.12.0/jinja_govuk_template-0.12.0.tgz",
-    "digital-marketplace-ssp-content": "git://github.com/alphagov/digital-marketplace-ssp-content#10c8055868daf085b5bc8870b8d352a0c43695d2"
+    "digital-marketplace-ssp-content": "git://github.com/alphagov/digital-marketplace-ssp-content#blah"
   }
 }


### PR DESCRIPTION
This pull request:
- matches [the order and groupings used in the Grails app](https://github.gds/gds/digitalmarketplace-frontend/blob/c7a901c6cd9b7c53db21b4dbe3b6717c62e1e7b4/grails-app/views/marketplace/listing/_G6Listing.gsp) for displaying services
- does just enough to stop the above throwing template exceptions when viewing a service

--

It does not:
- display all the service data perfectly (it especially has trouble with questions that have an assurance component)
- do any integration with the draft services stuff

--

![gov uk - the best place to find government services and information copy](https://cloud.githubusercontent.com/assets/355079/8407990/171124e0-1e64-11e5-93cc-88eac17079c5.png)
![longcat](https://cloud.githubusercontent.com/assets/355079/8408012/4184e950-1e64-11e5-8758-ac84d9c0ca3d.jpg)
