### PR TITLE
[#97502388] Service updates: Respond to validation errors returned by the API

### DIFF
--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -159,15 +159,18 @@ def update_section(service_id, section):
         except HTTPError as e:
             errors_map = {}
             for error in e.response.json()['error'].keys():
-                id = existing_service_content.get_question(error)['id']
-                errors_map[id] = \
-                    {
-                    'input_name': error,
-                    'question': existing_service_content
-                        .get_question(error)['question'],
-                    'message': existing_service_content
-                        .get_question(error)['validations'][-1]['message']
-                    }
+                if error == '_form':
+                    abort(400, "Submitted data was not in a valid format")
+                else:
+                    id = existing_service_content.get_question(error)['id']
+                    errors_map[id] = \
+                        {
+                        'input_name': error,
+                        'question': existing_service_content
+                            .get_question(error)['question'],
+                        'message': existing_service_content
+                            .get_question(error)['validations'][-1]['message']
+                        }
 
             return render_template(
                 "services/edit_section.html",

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -157,6 +157,17 @@ def update_section(service_id, section):
                 "user",
                 "supplier app")
         except HTTPError as e:
+            errors_map = {}
+            for error in e.response.json()['error'].keys():
+                id = existing_service_content.get_question(error)['id']
+                errors_map[id] = {
+                    'input_name': error,
+                    'question': existing_service_content
+                    .get_question(error)['question'],
+                    'message': existing_service_content
+                    .get_question(error)['validations'][-1]['message']
+                }
+
             return render_template(
                 "services/edit_section.html",
                 section=content.get_section(section),
@@ -164,7 +175,7 @@ def update_section(service_id, section):
                 service_id=service_id,
                 post_to=".update_section",
                 return_to=".edit_service",
-                error=e.message,
+                errors=errors_map,
                 **main.config['BASE_TEMPLATE_DATA']
             )
 

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -160,13 +160,14 @@ def update_section(service_id, section):
             errors_map = {}
             for error in e.response.json()['error'].keys():
                 id = existing_service_content.get_question(error)['id']
-                errors_map[id] = {
+                errors_map[id] = \
+                    {
                     'input_name': error,
                     'question': existing_service_content
-                    .get_question(error)['question'],
+                        .get_question(error)['question'],
                     'message': existing_service_content
-                    .get_question(error)['validations'][-1]['message']
-                }
+                        .get_question(error)['validations'][-1]['message']
+                    }
 
             return render_template(
                 "services/edit_section.html",

--- a/app/templates/macros/toolkit_forms.html
+++ b/app/templates/macros/toolkit_forms.html
@@ -4,7 +4,7 @@
     question=question_content.question,
     name=question_content.id,
     value=service_data[question_content.id],
-    error=errors.get(question_content.id)['message'] or None
+    error=errors.get(question_content.id)['message']
   %}
     {% include "toolkit/forms/textbox.html" %}
   {% endwith %}
@@ -17,8 +17,8 @@
     name=question_content.id,
     value=service_data[question_content.id],
     large=True,
-    max_length_in_words=question_content["maxLengthInWords"] or False,
-    error=errors.get(question_content.id)['message'] or None
+    max_length_in_words=question_content["maxLengthInWords"],
+    error=errors.get(question_content.id)['message']
   %}
     {% include "toolkit/forms/textbox.html" %}
   {% endwith %}
@@ -32,7 +32,7 @@
     question=question_content.question,
     id=question_content.id,
     hint=question_content.hint,
-    error=errors.get(question_content.id)['message'] or None
+    error=errors.get(question_content.id)['message']
   %}
     {% include "toolkit/forms/list-entry.html" %}
   {% endwith %}
@@ -46,7 +46,7 @@
     hint=question_content.hint,
     options=question_content.options,
     type='checkbox',
-    error=errors.get(question_content.id)['message'] or None
+    error=errors.get(question_content.id)['message']
   %}
     {% include "toolkit/forms/selection-buttons.html" %}
   {% endwith %}
@@ -60,7 +60,7 @@
     hint=question_content.hint,
     options=question_content.options,
     type='radio',
-    error=errors.get(question_content.id)['message'] or None
+    error=errors.get(question_content.id)['message']
   %}
     {% include "toolkit/forms/selection-buttons.html" %}
   {% endwith %}
@@ -73,7 +73,7 @@
     id=question_content.id,
     hint=question_content.hint,
     type='boolean',
-    error=errors.get(question_content.id)['message'] or None
+    error=errors.get(question_content.id)['message']
   %}
     {% include "toolkit/forms/selection-buttons.html" %}
   {% endwith %}
@@ -86,7 +86,7 @@
     hint=question_content.hint,
     name=question_content.id,
     value=service_data[question_content.id],
-    error=errors.get(question_content.id)['message'] or None
+    error=errors.get(question_content.id)['message']
   %}
     {% include "toolkit/forms/upload.html" %}
   {% endwith %}
@@ -99,7 +99,7 @@
     question=question_content.question,
     id=question_content.id,
     hint=question_content.hint,
-    error=errors.get(question_content.id)['message'] or None
+    error=errors.get(question_content.id)['message']
   %}
     {% include "toolkit/forms/textbox.html" %}
   {% endwith %}

--- a/app/templates/macros/toolkit_forms.html
+++ b/app/templates/macros/toolkit_forms.html
@@ -4,7 +4,7 @@
     question=question_content.question,
     name=question_content.id,
     value=service_data[question_content.id],
-    error=errors.get(question_content.id) or None
+    error=errors.get(question_content.id)['message'] or None
   %}
     {% include "toolkit/forms/textbox.html" %}
   {% endwith %}
@@ -17,7 +17,8 @@
     name=question_content.id,
     value=service_data[question_content.id],
     large=True,
-    max_length_in_words=question_content["maxLengthInWords"] or False
+    max_length_in_words=question_content["maxLengthInWords"] or False,
+    error=errors.get(question_content.id)['message'] or None
   %}
     {% include "toolkit/forms/textbox.html" %}
   {% endwith %}
@@ -30,7 +31,8 @@
     number_of_items=10,
     question=question_content.question,
     id=question_content.id,
-    hint=question_content.hint
+    hint=question_content.hint,
+    error=errors.get(question_content.id)['message'] or None
   %}
     {% include "toolkit/forms/list-entry.html" %}
   {% endwith %}
@@ -43,7 +45,8 @@
     id=question_content.id,
     hint=question_content.hint,
     options=question_content.options,
-    type='checkbox'
+    type='checkbox',
+    error=errors.get(question_content.id)['message'] or None
   %}
     {% include "toolkit/forms/selection-buttons.html" %}
   {% endwith %}
@@ -56,7 +59,8 @@
     id=question_content.id,
     hint=question_content.hint,
     options=question_content.options,
-    type='radio'
+    type='radio',
+    error=errors.get(question_content.id)['message'] or None
   %}
     {% include "toolkit/forms/selection-buttons.html" %}
   {% endwith %}
@@ -68,7 +72,8 @@
     question=question_content.question,
     id=question_content.id,
     hint=question_content.hint,
-    type='boolean'
+    type='boolean',
+    error=errors.get(question_content.id)['message'] or None
   %}
     {% include "toolkit/forms/selection-buttons.html" %}
   {% endwith %}
@@ -80,7 +85,8 @@
     question=question_content.question,
     hint=question_content.hint,
     name=question_content.id,
-    value=service_data[question_content.id]
+    value=service_data[question_content.id],
+    error=errors.get(question_content.id)['message'] or None
   %}
     {% include "toolkit/forms/upload.html" %}
   {% endwith %}
@@ -92,7 +98,8 @@
     value=service_data[question_content.id],
     question=question_content.question,
     id=question_content.id,
-    hint=question_content.hint
+    hint=question_content.hint,
+    error=errors.get(question_content.id)['message'] or None
   %}
     {% include "toolkit/forms/textbox.html" %}
   {% endwith %}

--- a/app/templates/services/edit_section.html
+++ b/app/templates/services/edit_section.html
@@ -27,13 +27,15 @@
 {% endblock %}
 
 {% block main_content %}
+
+  {% if errors %}
+    {% with errors = errors.values() %}
+      {% include 'toolkit/forms/validation.html' %}
+    {% endwith %}
+  {% endif %}
+
   <div class="grid-row">
     <div class="column-two-thirds">
-      {% if errors %}
-        {% with errors = errors.values() %}
-          {% include 'toolkit/forms/validation.html' %}
-        {% endwith %}
-      {% endif %}
 
       {% with
         heading = section.name,

--- a/app/templates/services/edit_section.html
+++ b/app/templates/services/edit_section.html
@@ -29,9 +29,8 @@
 {% block main_content %}
   <div class="grid-row">
     <div class="column-two-thirds">
-
-      {% if error %}
-        {% with lede = error %}
+      {% if errors %}
+        {% with errors = errors.values() %}
           {% include 'toolkit/forms/validation.html' %}
         {% endwith %}
       {% endif %}
@@ -48,7 +47,11 @@
   <form method="post" action="{{ url_for(post_to, service_id=service_id, section=section.id) }}">
 
     {% for question in section.questions %}
-      {{ forms[question.type](question, service_data, {}) }}
+      {% if errors and errors[question.id] %}
+        {{ forms[question.type](question, service_data, errors) }}
+      {% else %}
+        {{ forms[question.type](question, service_data, {}) }}
+      {% endif %}
     {% endfor %}
 
     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />


### PR DESCRIPTION
**NOTE**: This requires validation error responses from the API, which are added in this pull request: https://github.com/alphagov/digitalmarketplace-api/pull/159

This prevents updates with validation errors from being saved, and displays validation errors on the form.

In-line messages are no properly mapped to all possible validation errors - it could be easily done for this small set of fields, but it will be better to harmonise with the messaging mechanism used for SSP flow once it exists.

For now the validation message shown is the last in the list of `validations` for the question in SSP content.

There seems to be some issue with the width of the "Edit service" form - @quis can you help with that at all?


![screen shot 2015-06-29 at 15 03 15](https://cloud.githubusercontent.com/assets/6525554/8409552/84b8762c-1e70-11e5-806c-f9575b439740.png)
