### PR TITLE
Make dashboard handle supplier with no services

### DIFF
--- a/app/templates/suppliers/dashboard.html
+++ b/app/templates/suppliers/dashboard.html
@@ -24,14 +24,13 @@
       {% endwith %}
     </div>
   </div>
-
   <div class="grid-row">
     <div class="column-one-whole">
-      <h2 class="summary-item-heading">Services</h2>
+      <h2 class="summary-item-heading">Current services</h2>
+      {% if supplier.service_counts %}
       <p class="summary-item-top-level-action">
         <a href="{{ url_for('.list_services') }}">View</a>
       </p>
-      {% if supplier.service_counts %}
       <table class="summary-item-body">
         <thead></thead>
         <tbody class="summary-item-body">
@@ -47,6 +46,10 @@
           {% endfor %}
         </tbody>
       </table>
+      {% else %}
+      <p class="hint summary-item-no-content">
+        You don't have any services on the Digital Marketplace
+      </p>
       {% endif %}
     </div>
   </div>

--- a/tests/app/main/test_suppliers.py
+++ b/tests/app/main/test_suppliers.py
@@ -20,7 +20,11 @@ def get_supplier(*args, **kwargs):
             "city": "Supplierville",
             "country": "Supplierland",
             "postcode": "11 AB",
-        }]
+        }],
+        "service_counts": {
+            "G-Cloud 6": 12,
+            "G-Cloud 5": 34
+        }
     }}
 
 


### PR DESCRIPTION
This commit does two things:
- changes 'Services' to 'Current services', to make it clear that this is not where G-Cloud 7 services will appear
- adds a message for the case where a supplier doesn't have any current services (preferable to hiding this section entirely because it shows where new services will, eventually, appear)

### No services
![image](https://cloud.githubusercontent.com/assets/355079/8473928/e717c29c-20a4-11e5-83a9-f0438536a034.png)

### Some services
![image](https://cloud.githubusercontent.com/assets/355079/8473935/f0f69eb4-20a4-11e5-8914-2965258a83dd.png)
