### PR TITLE
Enabled supplier service edits in Live

### DIFF
--- a/config.py
+++ b/config.py
@@ -85,6 +85,7 @@ class Live(Config):
     DEBUG = False
     DM_HTTP_PROTO = 'https'
 
+    FEATURE_FLAGS_EDIT_SERVICE_PAGE = enabled_since('2015-07-02')
     FEATURE_FLAGS_SUPPLIER_DASHBOARD = enabled_since('2015-06-18')
 
 


### PR DESCRIPTION
Requested by Cath for preview, but is turned on for all live
environemnts. We'll need to go through the list of feature flags as
part of the go-live plan.