### PR TITLE
Various UI tweaks ahead of submissions

### DIFF
--- a/app/assets/scss/_framework-application.scss
+++ b/app/assets/scss/_framework-application.scss
@@ -1,0 +1,47 @@
+.framework-application-browse-list {
+
+  .browse-list-item {
+    margin-bottom: 0;
+  }
+
+  .browse-list-item-link {
+    @include heading-24;
+    font-weight: bold;
+  }
+
+  .validation-wrapper {
+    padding-right: $gutter;
+  }
+
+  .validation-message {
+    margin-bottom: 0;
+  }
+
+}
+
+.framework-application-updates {
+
+  @include core-16;
+  margin-top: 10px;
+
+  .document-list {
+    border-top: 1px solid $border-colour;
+    margin-top: 15px;
+    padding-top: 10px;
+  }
+
+  .document-link-with-icon {
+    @include core-16;
+  }
+
+  .clarification-link {
+    font-weight: bold;
+  }
+
+}
+
+.framework-application-deadline {
+  @include core-24;
+  margin-bottom: 5px;
+  font-weight: bold;
+}

--- a/app/assets/scss/_text.scss
+++ b/app/assets/scss/_text.scss
@@ -1,4 +1,3 @@
-
 .lede {
   font-size: 100%;
   margin-bottom: 2em;

--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -45,6 +45,7 @@ $path: "/suppliers/static/images/";
 
 @import "_service-status.scss";
 @import "_return-link.scss";
+@import "_framework-application.scss";
 
 .filter-field-text {
   @include core-16;

--- a/app/templates/_proposition_header.html
+++ b/app/templates/_proposition_header.html
@@ -5,7 +5,7 @@
       <a href="/" id="proposition-name">Digital Marketplace</a>
       <ul id="proposition-links">
         {% if current_user.email_address %}
-        <li><a class="home" href="{{ url_for('main.logout') }}">Logout</a></li>
+        <li><a class="home" href="{{ url_for('main.logout') }}">Log out</a></li>
         {% else %}
         <li><a class="home" href="{{ url_for('main.render_login') }}">Supplier login</a></li>
         {% endif %}

--- a/app/templates/auth/login.html
+++ b/app/templates/auth/login.html
@@ -1,5 +1,7 @@
 {% extends "_base_page.html" %}
 
+{% block page_title %}Log in – Digital Marketplace{% endblock %}
+
 {% block main_content %}
 
 {% with messages = get_flashed_messages(with_categories=true) %}
@@ -16,13 +18,13 @@
             Accounts are locked after five failed attempts. If you think your
             account has been locked, please contact
             <a href="mailto:enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.service.gov.uk</a>.
-            
+
             {% elif message == 'password_updated' %}
             You have successfully changed your password.
-            
+
             {% elif message == 'password_not_updated' %}
             Could not update password due to an error.
-            
+
             {% else %}
             {{ message }}
             {% endif %}
@@ -74,7 +76,7 @@
 
     {% if form.password.errors %}
         <div class="validation-wrapper">
-    {% endif %}                        
+    {% endif %}
         <div class="question">
             {{ form.password.label(class="question-heading") }}
             {% if form.password.errors %}

--- a/app/templates/auth/request-password-reset.html
+++ b/app/templates/auth/request-password-reset.html
@@ -1,5 +1,7 @@
 {% extends "_base_page.html" %}
 
+{% block page_title %}Reset password – Digital Marketplace{% endblock %}
+
 {% block main_content %}
 
 {% with messages = get_flashed_messages(with_categories=true) %}
@@ -14,11 +16,11 @@
                         {% if message == 'email_sent' %}
                         If the email address you've entered is valid we'll send you a link
                         to reset your password.
-            
+
                         {% elif message == 'token_expired' %}
                         This password reset link has expired because you requested it more than
                         24 hours ago. Get a new one using the form below.
-            
+
                         {% elif message == 'token_invalid' %}
                         This password reset link is invalid. Get a new one using the form below.
 
@@ -40,9 +42,9 @@
 </p>
 
 <form autocomplete="off" action="{{ url_for('.request_password_reset') }}" method="POST" id="resetPasswordForm">
-    
+
     {{ form.hidden_tag() }}
-    
+
     {% if form.email_address.errors %}
         <div class="validation-wrapper">
     {% endif %}

--- a/app/templates/auth/reset-password.html
+++ b/app/templates/auth/reset-password.html
@@ -1,5 +1,7 @@
 {% extends "_base_page.html" %}
 
+{% block page_title %}Reset password – Digital Marketplace{% endblock %}
+
 {% block main_content %}
 
 {% if form.errors|length > 1 %}
@@ -47,7 +49,7 @@
 
     {% if form.confirm_password.errors %}
         <div class="validation-wrapper">
-    {% endif %}    
+    {% endif %}
         <div class="question">
             {{ form.confirm_password.label(class="question-heading-with-hint") }}
             <p class="hint">

--- a/app/templates/frameworks/dashboard.html
+++ b/app/templates/frameworks/dashboard.html
@@ -1,5 +1,7 @@
 {% extends "_base_page.html" %}
 
+{% block page_title %}Apply to G-Cloud 7 – Digital Marketplace{% endblock %}
+
 {% block breadcrumb %}
   {%
     with items = [
@@ -9,10 +11,7 @@
       },
       {
         "link": url_for(".dashboard"),
-        "label": current_user.supplier_name,
-      },
-      {
-        "label": "Apply for G-Cloud 7"
+        "label": "Your account",
       }
     ]
   %}
@@ -24,24 +23,58 @@
   <div class="grid-row">
     <div class="column-two-thirds">
       {% with
-         heading = "Apply to G-Cloud 7"
+         heading = "Apply to G-Cloud 7",
+         smaller = True,
+         with_breadcrumb = True
       %}
         {% include "toolkit/page-heading.html" %}
       {% endwith %}
     </div>
   </div>
 
-  {% with
-     items = [
-      {
-        "title": "Make supplier declaration",
-        "body": "You must do this to supply services on the Digital Marketplace",
-        "link": url_for(".framework_supplier_declaration"),
-      }
-     ]
-  %}
-    {% include "toolkit/browse-list.html" %}
-  {% endwith %}
+  <div class="grid-row">
+    <div class="column-two-thirds framework-application-browse-list">
+      <div class="validation-wrapper">
+        <h2 class="framework-application-deadline">
+          0 services will be submitted on 2 October 2015
+        </h2>
+        <p>
+
+        </p>
+        <p class="validation-message">
+          Supplier declaration must be completed to submit services
+        </p>
+      </div>
+      {% with
+         items = [
+          {
+            "title": "Make supplier declaration",
+            "body": "You must do this to supply services on the Digital Marketplace",
+            "link": url_for(".framework_supplier_declaration"),
+          }
+         ]
+      %}
+        {% include "toolkit/browse-list.html" %}
+      {% endwith %}
+    </div>
+    <div class="column-one-third framework-application-updates">
+      <p>
+        <a href="#" class="clarification-link">Read updates or ask clarification questions</a>
+      </p>
+      {%
+        with
+        items = [
+          {
+            "file_type": "ZIP",
+            "link": "#",
+            "title": "Download supplier pack"
+          }
+        ]
+      %}
+        {% include "toolkit/documents.html" %}
+      {% endwith %}
+    </div>
+  </div>
 
   <div class="grid-row">
     <div class="column-one-whole">

--- a/app/templates/frameworks/declaration.html
+++ b/app/templates/frameworks/declaration.html
@@ -9,11 +9,11 @@
       },
       {
         "link": url_for(".dashboard"),
-        "label": current_user.supplier_name,
+        "label": "Your account",
       },
       {
         "link": url_for(".framework_dashboard"),
-        "label": "Apply for G-Cloud 7",
+        "label": "Apply to G-Cloud 7",
       }
     ]
   %}
@@ -60,7 +60,7 @@
          name = form.registration_number.name,
          value = form.registration_number.data or ""
       %}
-        {% include "toolkit/forms/textbox.html" %}       
+        {% include "toolkit/forms/textbox.html" %}
       {% endwith %}
 
       {% with

--- a/app/templates/services/create_new_draft_service.html
+++ b/app/templates/services/create_new_draft_service.html
@@ -1,5 +1,7 @@
 {% extends "_base_page.html" %}
 
+{% block page_title %}Create service – Digital Marketplace{% endblock %}
+
 {% block breadcrumb %}
   {%
     with items = breadcrumbs

--- a/app/templates/services/edit_section.html
+++ b/app/templates/services/edit_section.html
@@ -1,6 +1,8 @@
 {% extends "_base_page.html" %}
 {% import "macros/toolkit_forms.html" as forms %}
 
+{% block page_title %}{{ section.name }} – Digital Marketplace{% endblock %}
+
 {% block breadcrumb %}
   {%
     with items = [

--- a/app/templates/services/list_services.html
+++ b/app/templates/services/list_services.html
@@ -1,5 +1,7 @@
 {% extends "_base_page.html" %}
 
+{% block page_title %}Current services – Digital Marketplace{% endblock %}
+
 {% block breadcrumb %}
   {%
     with items = [

--- a/app/templates/services/service.html
+++ b/app/templates/services/service.html
@@ -1,6 +1,8 @@
 {% extends "_base_page.html" %}
 {% import 'macros/answers.html' as answers %}
 
+{% block page_title %}{{service_data['serviceName']}} – Digital Marketplace{% endblock %}
+
 {% block breadcrumb %}
   {%
     with items = [

--- a/app/templates/services/service_submission.html
+++ b/app/templates/services/service_submission.html
@@ -1,6 +1,8 @@
 {% extends "_base_page.html" %}
 {% import 'macros/answers.html' as answers %}
 
+{% block page_title %}{{service_data['serviceName']}} – Digital Marketplace{% endblock %}
+
 {% block breadcrumb %}
   {%
     with items = [

--- a/app/templates/suppliers/dashboard.html
+++ b/app/templates/suppliers/dashboard.html
@@ -1,5 +1,7 @@
 {% extends "_base_page.html" %}
 
+{% block page_title %}{{current_user.supplier_name}} – Digital Marketplace{% endblock %}
+
 {% block breadcrumb %}
   {%
     with items = [

--- a/app/templates/suppliers/edit_supplier.html
+++ b/app/templates/suppliers/edit_supplier.html
@@ -1,6 +1,8 @@
 {% extends "_base_page.html" %}
 {% import "macros/forms.html" as forms %}
 
+{% block page_title %}Edit {{current_user.supplier_name}} – Digital Marketplace{% endblock %}
+
 {% block breadcrumb %}
   {%
     with items = [

--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "jquery": "1.11.2",
     "hogan": "3.0.2",
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
-    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v5.2.0",
+    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#5.3.1",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.12.0/jinja_govuk_template-0.12.0.tgz",
     "digital-marketplace-ssp-content": "git://github.com/alphagov/digital-marketplace-ssp-content#15fcaeab5b24893a04bece14a56ff2fa425e5633"
   }


### PR DESCRIPTION
This pull request:
- rationalises breadcrumbs based on observations in the lab (mostly replacing _supplier name_ with _your account_)
- adds page `<title>`s to pages that didn't have them
- adds some extra UI elements to the 'Apply to G-Cloud 7' page, without hooking them up to any functionality (or any references to real dates!)

Before | After
--- | ---
![image](https://cloud.githubusercontent.com/assets/355079/8525460/e94d1fce-23f8-11e5-9388-9511715a9c70.png) | ![image](https://cloud.githubusercontent.com/assets/355079/8524930/ef8af3be-23f5-11e5-9c4d-11ac648ed6ec.png)

