### PR TITLE
[#97275662] Create SCS draft services

### DIFF
--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -115,7 +115,6 @@ def edit_section(service_id, section):
         section=content.get_section(section),
         service_data=service,
         service_id=service_id,
-        post_to=".update_section",
         return_to=".edit_service",
         **main.config['BASE_TEMPLATE_DATA']
     )
@@ -179,7 +178,6 @@ def update_section(service_id, section):
                 section=content.get_section(section),
                 service_data=posted_data,
                 service_id=service_id,
-                post_to=".update_section",
                 return_to=".edit_service",
                 errors=errors_map,
                 **main.config['BASE_TEMPLATE_DATA']
@@ -315,7 +313,6 @@ def edit_service_submission(service_id, section):
         section=content.get_section(section),
         service_data=draft,
         service_id=service_id,
-        post_to=".update_section_submission",
         return_to=".view_service_submission",
         **main.config['BASE_TEMPLATE_DATA']
     )
@@ -372,8 +369,7 @@ def update_section_submission(service_id, section):
                 section=content.get_section(section),
                 service_data=posted_data,
                 service_id=service_id,
-                post_to=".update_section_submission",
-                return_to=".edit_service_submission",
+                return_to=".view_service_submission",
                 errors=errors_map,
                 **main.config['BASE_TEMPLATE_DATA']
             )

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -417,13 +417,12 @@ def _update_service_status(service, error_message=None):
         'name': 'status',
         'type': 'radio',
         'inline': True,
+        'value': "Public" if service['status'] == 'published' else "Private",
         'options': [
             {
-                'checked': service['status'] == 'published',
                 'label': 'Public'
             },
             {
-                'checked': service['status'] == 'enabled',
                 'label': 'Private'
             }
         ]

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -187,7 +187,7 @@ def update_section(service_id, section):
 
 @main.route('/submission/services/<string:service_id>', methods=['GET'])
 @login_required
-@flask_featureflags.is_active_feature('EDIT_SERVICE_PAGE')
+@flask_featureflags.is_active_feature('GCLOUD7_OPEN')
 def view_service_submission(service_id):
     service = data_api_client.get_draft_service(service_id).get('services')
 
@@ -209,7 +209,7 @@ def view_service_submission(service_id):
     methods=['GET']
 )
 @login_required
-@flask_featureflags.is_active_feature('EDIT_SERVICE_PAGE')
+@flask_featureflags.is_active_feature('GCLOUD7_OPEN')
 def edit_service_submission(service_id, section):
 
     service = data_api_client.get_draft_service(service_id).get('services')
@@ -235,7 +235,7 @@ def edit_service_submission(service_id, section):
     methods=['POST']
 )
 @login_required
-@flask_featureflags.is_active_feature('EDIT_SERVICE_PAGE')
+@flask_featureflags.is_active_feature('GCLOUD7_OPEN')
 def update_section_submission(service_id, section):
 
     service = data_api_client.get_draft_service(service_id).get('services')
@@ -262,7 +262,7 @@ def update_section_submission(service_id, section):
 
 @main.route('/submission/g-cloud-7/create', methods=['GET'])
 @login_required
-@flask_featureflags.is_active_feature('CREATE_SERVICE_PAGE')
+@flask_featureflags.is_active_feature('GCLOUD7_OPEN')
 def start_new_draft_service():
     """
     Page to kick off creation of a new (G7) service.
@@ -307,7 +307,7 @@ def start_new_draft_service():
 
 @main.route('/submission/g-cloud-7/create', methods=['POST'])
 @login_required
-@flask_featureflags.is_active_feature('CREATE_SERVICE_PAGE')
+@flask_featureflags.is_active_feature('GCLOUD7_OPEN')
 def create_new_draft_service():
     """
     Hits up the data API to create a new draft (G7) service.

--- a/app/new_service_manifest.yml
+++ b/app/new_service_manifest.yml
@@ -18,7 +18,7 @@
   name: Service type
   editable: true
   questions:
-    - serviceTypesSCS
+    - serviceTypes
 -
   name: Features and benefits
   editable: true

--- a/app/templates/macros/toolkit_forms.html
+++ b/app/templates/macros/toolkit_forms.html
@@ -30,6 +30,7 @@
     name=question_content.id,
     number_of_items=10,
     question=question_content.question,
+    values=service_data[question_content.id],
     id=question_content.id,
     hint=question_content.hint,
     error=errors.get(question_content.id)['message']
@@ -43,6 +44,7 @@
     with
     name=question_content.id,
     question=question_content.question,
+    value=service_data[question_content.id],
     id=question_content.id,
     hint=question_content.hint,
     options=question_content.options,
@@ -58,6 +60,7 @@
     with
     name=question_content.id,
     question=question_content.question,
+    value=service_data[question_content.id],
     id=question_content.id,
     hint=question_content.hint,
     options=question_content.options,
@@ -73,6 +76,7 @@
     with
     name=question_content.id,
     question=question_content.question,
+    value=service_data[question_content.id],
     id=question_content.id,
     hint=question_content.hint,
     type='boolean',

--- a/app/templates/macros/toolkit_forms.html
+++ b/app/templates/macros/toolkit_forms.html
@@ -27,7 +27,7 @@
 {% macro list(question_content, service_data, errors) -%}
   {%
     with
-    values=service_data[question_content.id],
+    name=question_content.id,
     number_of_items=10,
     question=question_content.question,
     id=question_content.id,
@@ -41,6 +41,7 @@
 {% macro checkboxes(question_content, service_data, errors) -%}
   {%
     with
+    name=question_content.id,
     question=question_content.question,
     id=question_content.id,
     hint=question_content.hint,
@@ -55,6 +56,7 @@
 {% macro radios(question_content, service_data, errors) -%}
   {%
     with
+    name=question_content.id,
     question=question_content.question,
     id=question_content.id,
     hint=question_content.hint,
@@ -69,6 +71,7 @@
 {% macro boolean(question_content, service_data, errors) -%}
   {%
     with
+    name=question_content.id,
     question=question_content.question,
     id=question_content.id,
     hint=question_content.hint,
@@ -95,6 +98,7 @@
 {% macro pricing(question_content, service_data, errors) -%}
   {%
     with
+    name=question_content.id,
     value=service_data[question_content.id],
     question=question_content.question,
     id=question_content.id,

--- a/app/templates/services/edit_section.html
+++ b/app/templates/services/edit_section.html
@@ -19,8 +19,8 @@
         "label": "Services"
       },
       {
-        "link": url_for(".edit_service", service_id=service_id),
-        "label": service_data["serviceName"]
+        "link": url_for(return_to, service_id=service_id),
+        "label": service_data["serviceName"] or 'New service'
       }
     ]
   %}

--- a/app/templates/services/edit_section.html
+++ b/app/templates/services/edit_section.html
@@ -19,7 +19,7 @@
         "label": "Services"
       },
       {
-        "link": url_for(return_to, service_id=service_id, section=section if section),
+        "link": url_for(return_to, service_id=service_id),
         "label": service_data["serviceName"] or 'New service'
       }
     ]
@@ -48,7 +48,7 @@
 
     </div>
   </div>
-  <form method="post" action="{{ url_for(post_to, service_id=service_id, section=section.id) }}">
+  <form method="post" action="">
 
     {% for question in section.questions %}
       {% if errors and errors[question.id] %}
@@ -59,15 +59,25 @@
     {% endfor %}
 
     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
-
-    {%
-      with
-      label="Save and return to service",
-      type="save"
-    %}
+    {% if request.args.get('return_to_summary') or "suppliers/submission/" not in request.url %}
+      {%
+        with
+        label="Save and return to service",
+        type="save"
+      %}
       {% include "toolkit/button.html" %}
-    {% endwith %}
-    <a href="{{ url_for(return_to, service_id=service_id, section=section if section) }}">Return to service</a>
+      {% endwith %}
+    {% else %}
+      {%
+        with
+        label="Save and continue",
+        type="save"
+      %}
+      {% include "toolkit/button.html" %}
+      {% endwith %}
+    {% endif %}
+    
+    <a href="{{ url_for(return_to, service_id=service_id) }}">Return to service</a>
 
   </form>
 {% endblock %}

--- a/app/templates/services/edit_section.html
+++ b/app/templates/services/edit_section.html
@@ -19,7 +19,7 @@
         "label": "Services"
       },
       {
-        "link": url_for(return_to, service_id=service_id),
+        "link": url_for(return_to, service_id=service_id, section=section if section),
         "label": service_data["serviceName"] or 'New service'
       }
     ]
@@ -67,7 +67,7 @@
     %}
       {% include "toolkit/button.html" %}
     {% endwith %}
-    <a href="{{ url_for(return_to, service_id=service_id) }}">Return to service</a>
+    <a href="{{ url_for(return_to, service_id=service_id, section=section if section) }}">Return to service</a>
 
   </form>
 {% endblock %}

--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "jquery": "1.11.2",
     "hogan": "3.0.2",
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
-    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#5.3.1",
+    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v6.0.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.12.0/jinja_govuk_template-0.12.0.tgz",
     "digital-marketplace-ssp-content": "git://github.com/alphagov/digital-marketplace-ssp-content#15fcaeab5b24893a04bece14a56ff2fa425e5633"
   }

--- a/config.py
+++ b/config.py
@@ -39,7 +39,6 @@ class Config(object):
     FEATURE_FLAGS_SUPPLIER_DASHBOARD = False
     FEATURE_FLAGS_EDIT_SUPPLIER_PAGE = False
     FEATURE_FLAGS_GCLOUD7_OPEN = False
-    FEATURE_FLAGS_CREATE_SERVICE_PAGE = False
 
     # Logging
     DM_LOG_LEVEL = 'DEBUG'
@@ -69,7 +68,6 @@ class Test(Config):
     FEATURE_FLAGS_SUPPLIER_DASHBOARD = enabled_since('2015-06-10')
     FEATURE_FLAGS_EDIT_SUPPLIER_PAGE = enabled_since('2015-06-18')
     FEATURE_FLAGS_GCLOUD7_OPEN = enabled_since('2015-06-18')
-    FEATURE_FLAGS_CREATE_SERVICE_PAGE = enabled_since('2015-06-18')
 
 
 class Development(Config):
@@ -81,7 +79,6 @@ class Development(Config):
     FEATURE_FLAGS_SUPPLIER_DASHBOARD = enabled_since('2015-06-10')
     FEATURE_FLAGS_EDIT_SUPPLIER_PAGE = enabled_since('2015-06-18')
     FEATURE_FLAGS_GCLOUD7_OPEN = enabled_since('2015-06-18')
-    FEATURE_FLAGS_CREATE_SERVICE_PAGE = enabled_since('2015-06-18')
 
 
 class Live(Config):


### PR DESCRIPTION
NOTE: This depends on code in the following two pull-requests to work: https://github.com/alphagov/digitalmarketplace-api/pull/166 and https://github.com/alphagov/digitalmarketplace-frontend-toolkit/pull/99

It will need an update to the frontend toolkit version number, once the toolkit PR has been merged.

This pull-request is another step on the way to completion of: https://www.pivotaltracker.com/story/show/97275662 and https://www.pivotaltracker.com/story/show/96551096

What this PR does:
* move all service creation endpoints under the single feature flag GCLOUD7_OPEN
* starting from `/suppliers/submission/g-cloud-7/create` you can choose Lot 4 (SCS) and it will create a new draft service for the logged-in supplier.
* You can add details for each of the pages right through the flow up to the Pricing page, which does not work yet.
* At the pricing page click "return to service" and you can go back into the flow from the next page (T&Cs) up to the end.
* Leave file upload questions blank.
* Values are saved and pre-populated if you return to edit the pages again.
* Values are displayed on the draft summary page.

What this does not do:
* Handle file uploads.
* Have a "drafts" dashboard (the breadcrumb in `edit_section.html` will need to change once this exists).
* Have any links from the main supplier app into the draft creation flow.