### PR TITLE
[WIP] Add 'Apply to G-Cloud 7…' link

### DIFF
--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -207,7 +207,7 @@ def start_new_draft_service():
             "label": "Your account"
         },
         {
-            "link": "/suppliers/submission/g-cloud-7",
+            "link": url_for(".framework_dashboard"),
             "label": "Apply to G-Cloud 7"
         }
     ]

--- a/app/templates/frameworks/dashboard.html
+++ b/app/templates/frameworks/dashboard.html
@@ -80,7 +80,7 @@
     <div class="column-one-whole">
       <h2 class="summary-item-heading">Services</h2>
       <p class="summary-item-top-level-action">
-        <a href="#">Add a service</a>
+        <a href="{{ url_for('.start_new_draft_service') }}">Add a service</a>
       </p>
       <table class="summary-item-body">
         <thead></thead>

--- a/app/templates/suppliers/dashboard.html
+++ b/app/templates/suppliers/dashboard.html
@@ -28,6 +28,20 @@
   </div>
   <div class="grid-row">
     <div class="column-one-whole">
+
+      {% if 'GCLOUD7_OPEN' is active_feature %}
+        {%
+          with
+          items = [{
+            "title": "Apply to become a G-Cloud 7 supplier and add services",
+            "link": url_for(".framework_dashboard"),
+            "body": "G-Cloud 7 is open for applications until 1 October 2015"
+          }]
+        %}
+          {% include "toolkit/browse-list.html" %}
+        {% endwith %}
+      {% endif %}
+
       <h2 class="summary-item-heading">Current services</h2>
       {% if supplier.service_counts %}
       <p class="summary-item-top-level-action">


### PR DESCRIPTION
**This pull request is based off #89. It will need rebasing against master once #89 is merged.**

This adds a link to the supplier's homepage when the framework is open.

The type size of the link is a touch too big, but there's some rationalisation of the browse list pattern to be done at a later date.

![image](https://cloud.githubusercontent.com/assets/355079/8543270/9b596552-2493-11e5-85d1-6c8d1ab543d8.png)

--

It also adds links between the _Apply to G-Cloud 7_ page and the _Add service_ page.
