### PR TITLE
[#97631082] Use specific serviceTypes for SaaS, IaaS, SCS

### DIFF
--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -340,6 +340,7 @@ def update_section_submission(service_id, section):
         item_as_list = request.form.getlist(key)
         list_types = ['list', 'checkboxes', 'pricing']
         if (
+            key == 'serviceTypes' or
             key != 'csrf_token' and
             new_service_content.get_question(key)['type'] in list_types
         ):

--- a/app/new_service_manifest.yml
+++ b/app/new_service_manifest.yml
@@ -18,7 +18,17 @@
   name: Service type
   editable: true
   questions:
-    - serviceTypes
+    - serviceTypesIaaS
+-
+  name: Service type
+  editable: true
+  questions:
+    - serviceTypesSaaS
+-
+  name: Service type
+  editable: true
+  questions:
+    - serviceTypesSCS
 -
   name: Features and benefits
   editable: true

--- a/app/new_service_manifest.yml
+++ b/app/new_service_manifest.yml
@@ -19,15 +19,7 @@
   editable: true
   questions:
     - serviceTypesIaaS
--
-  name: Service type
-  editable: true
-  questions:
     - serviceTypesSaaS
--
-  name: Service type
-  editable: true
-  questions:
     - serviceTypesSCS
 -
   name: Features and benefits


### PR DESCRIPTION
Now we have more than one possible lot we need to use the specific `serviceTypes` for each lot.

Once this and the corresponding API pull-request is merged we'll be able to create drafts for any lot and work through the flow up as far as questions with assurance, which will not validate yet (as the assurance questions don't yet exist on the pages).