### PR TITLE
Refactor the framework summary HTML

### DIFF
--- a/app/assets/scss/_framework-application.scss
+++ b/app/assets/scss/_framework-application.scss
@@ -1,47 +1,22 @@
-.framework-application-browse-list {
+.framework-deadline {
+  padding-left: $gutter-half;
+  border-left: solid 5px $error-colour;
+  margin-bottom: $gutter;
 
-  .browse-list-item {
+  .framework-notification {
+    color: $error-colour;
+  }
+}
+
+.framework-declaration {
+  margin-bottom: $gutter;
+
+  @include media(tablet) {
     margin-bottom: 0;
   }
 
-  .browse-list-item-link {
+  h3 {
     @include heading-24;
     font-weight: bold;
   }
-
-  .validation-wrapper {
-    padding-right: $gutter;
-  }
-
-  .validation-message {
-    margin-bottom: 0;
-  }
-
-}
-
-.framework-application-updates {
-
-  @include core-16;
-  margin-top: 10px;
-
-  .document-list {
-    border-top: 1px solid $border-colour;
-    margin-top: 15px;
-    padding-top: 10px;
-  }
-
-  .document-link-with-icon {
-    @include core-16;
-  }
-
-  .clarification-link {
-    font-weight: bold;
-  }
-
-}
-
-.framework-application-deadline {
-  @include core-24;
-  margin-bottom: 5px;
-  font-weight: bold;
 }

--- a/app/assets/scss/_framework-application.scss
+++ b/app/assets/scss/_framework-application.scss
@@ -14,9 +14,4 @@
   @include media(tablet) {
     margin-bottom: 0;
   }
-
-  h3 {
-    @include heading-24;
-    font-weight: bold;
-  }
 }

--- a/app/templates/frameworks/dashboard.html
+++ b/app/templates/frameworks/dashboard.html
@@ -42,10 +42,10 @@
         </p>
       </div>
       <div class="framework-declaration">
-        <h3>
+        <h3 class="browse-list-item-link">
           <a href='{{ url_for('.framework_supplier_declaration') }}'>Make supplier declaration</a>
         </h3>
-        <p>
+        <p class="browse-list-item-body">
           Legal declaration required to supply G-Cloud 7 services
         </p>
       </div>

--- a/app/templates/frameworks/dashboard.html
+++ b/app/templates/frameworks/dashboard.html
@@ -20,44 +20,37 @@
 {% endblock %}
 
 {% block main_content %}
-  <div class="grid-row">
-    <div class="column-two-thirds">
-      {% with
-         heading = "Apply to G-Cloud 7",
-         smaller = True,
-         with_breadcrumb = True
-      %}
-        {% include "toolkit/page-heading.html" %}
-      {% endwith %}
-    </div>
-  </div>
+  {% with
+     heading = "Apply to G-Cloud 7",
+     smaller = True,
+     with_breadcrumb = True
+  %}
+    {% include "toolkit/page-heading.html" %}
+  {% endwith %}
 
   <div class="grid-row">
-    <div class="column-two-thirds framework-application-browse-list">
-      <div class="validation-wrapper">
-        <h2 class="framework-application-deadline">
-          0 services will be submitted on 2 October 2015
+    <div class="column-two-thirds ">
+      <div class="framework-deadline">
+        <h2 id="framework-deadline">
+          Deadline 2 October 2015
         </h2>
         <p>
-
+          0 services will be submitted
         </p>
-        <p class="validation-message">
-          Supplier declaration must be completed to submit services
+        <p class="framework-notification">
+          <strong>No services will be submitted if supplier declaration is incomplete</strong>
         </p>
       </div>
-      {% with
-         items = [
-          {
-            "title": "Make supplier declaration",
-            "body": "You must do this to supply services on the Digital Marketplace",
-            "link": url_for(".framework_supplier_declaration"),
-          }
-         ]
-      %}
-        {% include "toolkit/browse-list.html" %}
-      {% endwith %}
+      <div class="framework-declaration">
+        <h3>
+          <a href='{{ url_for('.framework_supplier_declaration') }}'>Make supplier declaration</a>
+        </h3>
+        <p>
+          Legal declaration required to supply G-Cloud 7 services
+        </p>
+      </div>
     </div>
-    <div class="column-one-third framework-application-updates">
+    <aside role="complementary" class="column-one-third framework-help">
       <p>
         <a href="#" class="clarification-link">Read updates or ask clarification questions</a>
       </p>
@@ -73,7 +66,7 @@
       %}
         {% include "toolkit/documents.html" %}
       {% endwith %}
-    </div>
+    </aside>
   </div>
 
   <div class="grid-row">


### PR DESCRIPTION
The intention of this is to add the following semantics:

- the help section being identified as content [tangental](http://www.w3.org/TR/html5/sections.html#the-aside-element) to that in the main block
- the information about the need for a declaration being its own section
- emphasis around the need for a declaration

It also breaks the information about the deadline into 2 lines to allow its date to sit on it's own.

![framework_dashboard](https://cloud.githubusercontent.com/assets/87140/8618857/05dae1d0-270a-11e5-9b9d-605f2b4a7a86.png)
