### PR TITLE
Update links to CCS

### DIFF
--- a/app/templates/_footer_categories.html
+++ b/app/templates/_footer_categories.html
@@ -27,7 +27,7 @@
         <a href="/digital-services/framework">Digital Services framework</a>
       </li>
       <li>
-        <a href="https://ccs.cabinetoffice.gov.uk">Crown Commercial Service</a>
+        <a href="https://www.gov.uk/government/organisations/crown-commercial-service">Crown Commercial Service</a>
       </li>
     </ul>
   </div>


### PR DESCRIPTION
Crown Commercial Service's (CCS) website has transitioned to GOV.UK, and
uses Bouncer - a GOV.UK project - to redirect users from the old URL to the
new GOV.UK one. In this instance, Bouncer responds to requests for
https://ccs.cabinetoffice.gov.uk by sending a HTTP 301 in the response to
send users to
https://www.gov.uk/government/organisations/crown-commercial-service.

One thing that Bouncer explicitly doesn't do is hold SSL/TLS certificates
for domains external to GOV.UK, because that adds additional burden on to
the whole notion of URL redirection. As such, users will get an SSL
certificate error when they click the link to go to the CCS website in the
Digital Marketplace because the SSL certificate presented is for GOV.UK, not
the Common Name of the host header value - ccs.cabinetoffice.gov.uk.

Fixes URLs to avoid this.