### PR TITLE
Update GOV.UK template

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,7 @@
     "hogan": "3.0.2",
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
     "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v6.0.0",
-    "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.12.0/jinja_govuk_template-0.12.0.tgz",
+    "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.14.0/jinja_govuk_template-0.14.0.tgz",
     "digital-marketplace-ssp-content": "git://github.com/alphagov/digital-marketplace-ssp-content#15fcaeab5b24893a04bece14a56ff2fa425e5633"
   }
 }


### PR DESCRIPTION
Doing a check of footer links discovered an unnecessary redirect, which was fixed here: https://github.com/alphagov/govuk_template/commit/091f855551923733c9e7df11f0eb66660653fa79

This commit updates the version of GOV.UK template we use to bring in this fix.

Full change list: https://github.com/alphagov/govuk_template/compare/v0.12.0%E2%80%A6v0.14.0