### PR TITLE
Added ignore dependencies option to status

### DIFF
--- a/app/status/views.py
+++ b/app/status/views.py
@@ -1,4 +1,4 @@
-from flask import jsonify, current_app
+from flask import jsonify, current_app, request
 
 from . import status
 from .. import data_api_client
@@ -7,6 +7,11 @@ from dmutils.status import get_flags
 
 @status.route('/_status')
 def status():
+
+    if 'ignore-dependencies' in request.args:
+        return jsonify(
+            status="ok",
+        ), 200
 
     api_status = data_api_client.get_status()
     version = current_app.config['VERSION']

--- a/tests/app/status/test_status.py
+++ b/tests/app/status/test_status.py
@@ -2,10 +2,16 @@ import json
 from ..helpers import BaseApplicationTest
 
 import mock
-from nose.tools import assert_equal, assert_in
+from nose.tools import assert_equal, assert_in, assert_false
 
 
 class TestStatus(BaseApplicationTest):
+
+    @mock.patch('app.status.views.data_api_client')
+    def test_should_return_200_from_elb_status_check(self, data_api_client):
+        status_response = self.client.get('/suppliers/_status?ignore-dependencies')
+        assert_equal(200, status_response.status_code)
+        assert_false(data_api_client.called)
 
     @mock.patch('app.status.views.data_api_client')
     def test_status_ok(self, data_api_client):


### PR DESCRIPTION
This is too alllow a check simply on the status of this app without hitting it's dependecies

- supply query param of ignore-dependencies

    /_status?ignore-dependencies

And the app will return a simply 200 JSON response. Allows us to use this with amazon load balancers, without impacting DB/Search performance on the periodic checks.