### PR TITLE
Fix http status monitoring

### DIFF
--- a/.ebextensions/apache_log.config
+++ b/.ebextensions/apache_log.config
@@ -1,0 +1,8 @@
+files:
+  "/etc/httpd/conf.d/custom_log.conf":
+    mode: "000644"
+    owner: root
+    group: root
+    content: |
+      LogFormat "apache-access supplier-frontend \"%{DM-Request-ID}i\" %h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" cloudwatchlogs
+      CustomLog logs/cwl_access_log cloudwatchlogs

--- a/.ebextensions/cwl-logs-apache-access.config
+++ b/.ebextensions/cwl-logs-apache-access.config
@@ -28,15 +28,15 @@
 Mappings:
   CWLogs:
     AccessLogs:
-      LogFile: "/var/log/httpd/access_log"
+      LogFile: "/var/log/httpd/cwl_access_log"
       TimestampFormat: "%d/%b/%Y:%H:%M:%S %z"
       LogGroupName: {"Fn::GetOptionSetting": {"OptionName": "LogGroupName"}}
       ApplicationName: {"Fn::GetOptionSetting": {"OptionName": "ApplicationName"}}
     FilterPatterns:
-      Http4xxMetricFilter: "[..., status=4*, size, referer, agent]"  
-      HttpNon4xxMetricFilter: "[..., status!=4*, size, referer, agent]"
-      Http5xxMetricFilter: "[..., status=5*, size, referer, agent]"  
-      HttpNon5xxMetricFilter: "[..., status!=5*, size, referer, agent]"  
+      Http4xxMetricFilter: "[type=apache-access, app=supplier-frontend, ..., status=4*, size, referer, agent]"
+      HttpNon4xxMetricFilter: "[type=apache-access, app=supplier-frontend, ..., status!=4*, size, referer, agent]"
+      Http5xxMetricFilter: "[type=apache-access, app=supplier-frontend, ..., status=5*, size, referer, agent]"
+      HttpNon5xxMetricFilter: "[type=apache-access, app=supplier-frontend, ..., status!=5*, size, referer, agent]"
 
 
 Outputs:
@@ -128,7 +128,15 @@ Resources :
     Type : "AWS::CloudWatch::Alarm"
     DependsOn : AWSEBCWLHttpNon5xxMetricFilter
     Properties :
-      AlarmDescription: "Application is returning too many 5xx responses (count too high)."
+      AlarmDescription:
+        "Fn::Join":
+          - ""
+          -
+            - "The supplier frontend is returning too many 5xx responses.\n"
+            - "Stage and environment: "
+            - {"Fn::FindInMap": ["CWLogs", "AccessLogs", "LogGroupName"]}
+            - "\n"
+            - "Manual link: https://github.gds/pages/gds/digitalmarketplace-manual/alerts.html#5xx-error-rate"
       MetricName: CWLHttp5xx
       Namespace: {"Fn::Join":["/", ["ElasticBeanstalk", {"Ref":"AWSEBEnvironmentName"}]]}
       Statistic: Sum
@@ -149,7 +157,15 @@ Resources :
     Type : "AWS::CloudWatch::Alarm"
     DependsOn : AWSEBCWLHttpNon4xxMetricFilter
     Properties :
-      AlarmDescription: "Application is returning too many 4xx responses (percentage too high)."
+      AlarmDescription:
+        "Fn::Join":
+          - ""
+          -
+            - "The supplier frontend is returning too high a proportion of 4xx responses.\n"
+            - "Stage and environment: "
+            - {"Fn::FindInMap": ["CWLogs", "AccessLogs", "LogGroupName"]}
+            - "\n"
+            - "Manual link: https://github.gds/pages/gds/digitalmarketplace-manual/alerts.html#4xx-error-rate"
       MetricName: CWLHttp4xx
       Namespace: {"Fn::Join":["/", ["ElasticBeanstalk", {"Ref":"AWSEBEnvironmentName"}]]}
       Statistic: Average

--- a/.ebextensions/cwl-logs-application.config
+++ b/.ebextensions/cwl-logs-application.config
@@ -8,8 +8,9 @@ Mappings:
       LogGroupName: {"Fn::GetOptionSetting": {"OptionName": "LogGroupName"}}
       ApplicationName: {"Fn::GetOptionSetting": {"OptionName": "ApplicationName"}}
     FilterPatterns:
-      ResetEmailSentMetricFilter: "[asctime, app_name, name, level, request_id, message = *login.reset-email.sent*, ...]"
-      ResetEmailInvalidEmailMetricFilter: "[asctime, app_name, name, level, request_id, message = *login.reset-email.invalid-email*, ...]"
+      LoginFailure: "[asctime, app_name=supplier-frontend, name, level, request_id, message = *login.fail*, ...]"
+      ResetEmailSentMetricFilter: "[asctime, app_name=supplier-frontend, name, level, request_id, message = *login.reset-email.sent*, ...]"
+      ResetEmailInvalidEmailMetricFilter: "[asctime, app_name=supplier-frontend, name, level, request_id, message = *login.reset-email.invalid-email*, ...]"
 
 Resources:
   AWSEBAutoScalingGroup:
@@ -36,6 +37,19 @@ Resources:
               mode  : "000400"
               owner : root
               group : root
+  
+  #################################
+  ## Cloudwatch Logs Metric Filters
+  
+  AWSEBLoginFailureMetricFilter:
+    Type : "AWS::Logs::MetricFilter"
+    Properties :
+      LogGroupName: {"Fn::FindInMap":["CWLogs", "AccessLogs", "LogGroupName"]}
+      FilterPattern : {"Fn::FindInMap":["CWLogs", "FilterPatterns", "LoginFailure"]}
+      MetricTransformations :
+        - MetricValue : 1
+          MetricNamespace: {"Fn::Join":["/", ["ElasticBeanstalk", {"Ref":"AWSEBEnvironmentName"}]]}
+          MetricName : LoginFailure
 
   AWSEBCWLResetEmailSentMetricFilter:
     Type: "AWS::Logs::MetricFilter"
@@ -56,6 +70,38 @@ Resources:
         - MetricValue: 1
           MetricNamespace: {"Fn::Join": ["/", ["DigitalMarketplace", {"Fn::FindInMap": ["CWLogs", "ApplicationLogs", "LogGroupName"]}]]}
           MetricName: {"Fn::Join": ["/", [{"Fn::FindInMap": ["CWLogs", "ApplicationLogs", "ApplicationName"]}, "ResetEmailInvalidEmail"]]}
+
+  ###############################
+  ## Alarms
+
+  AWSEBLoginFailureCountAlarm:
+    Type: "AWS::CloudWatch::Alarm"
+    DependsOn: AWSEBLoginFailureMetricFilter
+    Properties:
+      AlarmDescription:
+        "Fn::Join":
+          - ""
+          -
+            - "There have been too many failed logins on the supplier app.\n"
+            - "Application: supplier-frontend\n"
+            - "Stage and environment: "
+            - {"Fn::FindInMap": ["CWLogs", "ApplicationLogs", "LogGroupName"]}
+            - "\nManual link: https://github.gds/pages/gds/digitalmarketplace-manual/alerts.html#login-failures"
+      MetricName: LoginFailure
+      Namespace: {"Fn::Join":["/", ["ElasticBeanstalk", {"Ref":"AWSEBEnvironmentName"}]]}
+      Statistic: Sum
+      Period: 60
+      EvaluationPeriods: 5
+      Threshold: 10
+      ComparisonOperator: GreaterThanThreshold
+      AlarmActions:
+        - "Fn::If":
+            - SNSTopicExists
+            - "Fn::FindInMap":
+                - AWSEBOptions
+                - options
+                - EBSNSTopicArn
+            - { "Ref" : "AWS::NoValue" }
 
 container_commands:
   # Cannot reference cloud formation variables here


### PR DESCRIPTION
Create a new Apache access log with type and application information in
so that we can distinguish where a log message has come from. The
CloudWatch metric filters are applied to all messages in a log group and
seeing as we put all our log streams in the same group so that we can
easily search over them this means our alarms do not work properly.

This change also updates the alarm descriptions to be a bit more
helpful. They now say which application and environment the alarm came
from and link to the manual explaining what should be done.

This adds an alarm that fires if there are more than 10 failed logins in
a 5 minute period. This may not be ideal but after discussion @minglis
and I decided that this would be good enough as first stab.
