### PR TITLE
[#97631142] Validate required questions per page

### DIFF
--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -144,8 +144,7 @@ def update_section(service_id, section_id):
     if section is None:
         abort(404)
 
-    posted_data = _get_formatted_section_data()
-    posted_data = _filter_keys(posted_data, get_section_questions(section))
+    posted_data = _get_formatted_section_data(section)
 
     try:
         data_api_client.update_service(
@@ -348,8 +347,7 @@ def update_section_submission(service_id, section_id):
     if section is None:
         abort(404)
 
-    posted_data = _get_formatted_section_data()
-    posted_data = _filter_keys(posted_data, get_section_questions(section))
+    posted_data = _get_formatted_section_data(section)
     posted_data['page_questions'] = get_section_questions(section)
 
     try:
@@ -413,13 +411,13 @@ def _is_boolean_type(key):
     return new_service_content.get_question(key)['type'] == 'boolean'
 
 
-def _get_formatted_section_data():
+def _get_formatted_section_data(section):
     section_data = dict(
         list(request.form.items()) + list(request.files.items())
     )
-    section_data.pop('csrf_token', None)
+    section_data = _filter_keys(section_data, get_section_questions(section))
     # Turn responses which have multiple parts into lists and booleans into booleans
-    for key in request.form:
+    for key in section_data:
         if _is_list_type(key):
             section_data[key] = request.form.getlist(key)
         elif _is_boolean_type(key):

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -262,7 +262,7 @@ def create_new_draft_service():
         url_for(
             ".edit_service_submission",
             service_id=draft_service.get('id'),
-            section=content.get_next_editable_section_id()
+            section_id=content.get_next_editable_section_id()
         )
     )
 
@@ -310,13 +310,10 @@ def view_service_submission(service_id):
         **main.config['BASE_TEMPLATE_DATA']), 200
 
 
-@main.route(
-    '/submission/services/<string:service_id>/edit/<string:section>',
-    methods=['GET']
-)
+@main.route('/submission/services/<string:service_id>/edit/<string:section_id>', methods=['GET'])
 @login_required
 @flask_featureflags.is_active_feature('GCLOUD7_OPEN')
-def edit_service_submission(service_id, section):
+def edit_service_submission(service_id, section_id):
     try:
         draft = data_api_client.get_draft_service(service_id)['services']
     except HTTPError as e:
@@ -359,7 +356,7 @@ def update_section_submission(service_id, section_id):
         abort(404)
 
     content = new_service_content.get_builder().filter(draft)
-    section = content.get_section(section)
+    section = content.get_section(section_id)
     if section is None:
         abort(404)
 
@@ -391,7 +388,7 @@ def update_section_submission(service_id, section_id):
     next_section = content.get_next_editable_section_id(section_id)
 
     if next_section and not return_to_summary:
-        return redirect(url_for(".edit_service_submission", service_id=service_id, section=next_section))
+        return redirect(url_for(".edit_service_submission", service_id=service_id, section_id=next_section))
     else:
         return redirect(url_for(".view_service_submission", service_id=service_id))
 

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -412,9 +412,7 @@ def _is_boolean_type(key):
 
 
 def _get_formatted_section_data(section):
-    section_data = dict(
-        list(request.form.items()) + list(request.files.items())
-    )
+    section_data = dict(list(request.form.items()))
     section_data = _filter_keys(section_data, get_section_questions(section))
     # Turn responses which have multiple parts into lists and booleans into booleans
     for key in section_data:

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -146,7 +146,7 @@ def update_section(service_id, section_id):
         abort(404)
 
     posted_data = _get_formatted_section_data()
-    del posted_data['page_questions']
+    posted_data = _filter_keys(posted_data, get_section_questions(section))
 
     try:
         data_api_client.update_service(
@@ -352,6 +352,7 @@ def update_section_submission(service_id, section_id):
         abort(404)
 
     posted_data = _get_formatted_section_data()
+    posted_data = _filter_keys(posted_data, get_section_questions(section) + ['page_questions'])
 
     try:
         data_api_client.update_draft_service(
@@ -433,6 +434,16 @@ def _get_formatted_section_data():
         elif key == 'page_questions':
             section_data[key] = section_data[key].split('|')
     return section_data
+
+
+def _filter_keys(data, keys):
+    """Return a dictionary filtered by a list of keys
+
+    >>> _filter_keys({'a': 1, 'b': 2}, ['a'])
+    {'a': 1}
+    """
+    key_set = set(keys) & set(data.keys())
+    return {key: data[key] for key in key_set}
 
 
 def _update_service_status(service, error_message=None):

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -102,8 +102,10 @@ def update_service_status(service_id):
 @login_required
 @flask_featureflags.is_active_feature('EDIT_SERVICE_PAGE')
 def edit_section(service_id, section):
-
-    service = data_api_client.get_service(service_id)['services']
+    service = data_api_client.get_service(service_id)
+    if service is None:
+        abort(404)
+    service = service['services']
 
     if not _is_service_associated_with_supplier(service):
         abort(404)
@@ -137,7 +139,10 @@ def get_section_questions(section):
 @login_required
 @flask_featureflags.is_active_feature('EDIT_SERVICE_PAGE')
 def update_section(service_id, section):
-    service = data_api_client.get_service(service_id).get('services')
+    service = data_api_client.get_service(service_id)
+    if service is None:
+        abort(404)
+    service = service['services']
 
     if not _is_service_associated_with_supplier(service):
         abort(404)
@@ -289,8 +294,10 @@ def copy_draft_service(service_id):
 @login_required
 @flask_featureflags.is_active_feature('GCLOUD7_OPEN')
 def view_service_submission(service_id):
-
-    draft = data_api_client.get_draft_service(service_id).get('services')
+    try:
+        draft = data_api_client.get_draft_service(service_id)['services']
+    except HTTPError as e:
+        abort(e.status_code)
 
     if not _is_service_associated_with_supplier(draft):
         abort(404)
@@ -312,8 +319,10 @@ def view_service_submission(service_id):
 @login_required
 @flask_featureflags.is_active_feature('GCLOUD7_OPEN')
 def edit_service_submission(service_id, section):
-
-    draft = data_api_client.get_draft_service(service_id).get('services')
+    try:
+        draft = data_api_client.get_draft_service(service_id)['services']
+    except HTTPError as e:
+        abort(e.status_code)
 
     if not _is_service_associated_with_supplier(draft):
         abort(404)
@@ -343,7 +352,10 @@ def edit_service_submission(service_id, section):
 @login_required
 @flask_featureflags.is_active_feature('GCLOUD7_OPEN')
 def update_section_submission(service_id, section):
-    draft = data_api_client.get_draft_service(service_id).get('services')
+    try:
+        draft = data_api_client.get_draft_service(service_id)['services']
+    except HTTPError as e:
+        abort(e.status_code)
 
     if not _is_service_associated_with_supplier(draft):
         abort(404)

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -94,13 +94,10 @@ def update_service_status(service_id):
     )
 
 
-@main.route(
-    '/services/<string:service_id>/edit/<string:section>',
-    methods=['GET']
-)
+@main.route('/services/<string:service_id>/edit/<string:section_id>', methods=['GET'])
 @login_required
 @flask_featureflags.is_active_feature('EDIT_SERVICE_PAGE')
-def edit_section(service_id, section):
+def edit_section(service_id, section_id):
     service = data_api_client.get_service(service_id)
     if service is None:
         abort(404)
@@ -110,7 +107,7 @@ def edit_section(service_id, section):
         abort(404)
 
     content = existing_service_content.get_builder().filter(service)
-    section = content.get_section(section)
+    section = content.get_section(section_id)
     if section is None:
         abort(404)
 
@@ -131,13 +128,10 @@ def get_section_questions(section):
     return [question['id'] for question in section['questions']]
 
 
-@main.route(
-    '/services/<string:service_id>/edit/<string:section>',
-    methods=['POST']
-)
+@main.route('/services/<string:service_id>/edit/<string:section_id>', methods=['POST'])
 @login_required
 @flask_featureflags.is_active_feature('EDIT_SERVICE_PAGE')
-def update_section(service_id, section):
+def update_section(service_id, section_id):
     service = data_api_client.get_service(service_id)
     if service is None:
         abort(404)
@@ -147,7 +141,7 @@ def update_section(service_id, section):
         abort(404)
 
     content = existing_service_content.get_builder().filter(service)
-    section = content.get_section(section)
+    section = content.get_section(section_id)
     if section is None:
         abort(404)
 
@@ -340,10 +334,7 @@ def edit_service_submission(service_id, section_id):
     )
 
 
-@main.route(
-    '/submission/services/<string:service_id>/edit/<string:section_id>',
-    methods=['POST']
-)
+@main.route('/submission/services/<string:service_id>/edit/<string:section_id>', methods=['POST'])
 @login_required
 @flask_featureflags.is_active_feature('GCLOUD7_OPEN')
 def update_section_submission(service_id, section_id):

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -394,7 +394,7 @@ def _is_service_modifiable(service):
 
 def _get_error_message(error, message_key, content):
     validations_list = filter(
-        lambda(x): x['name'] == message_key,
+        lambda x: x['name'] == message_key,
         content.get_question(error)['validations']
     )
     validation_message = validations_list[0]['message'] \
@@ -420,9 +420,9 @@ def _get_formatted_section_data():
         ):
             section_data[key] = item_as_list
         elif (
-                            key != 'csrf_token' and
-                            key != 'page_questions' and
-                        new_service_content.get_question(key)['type'] == 'boolean'
+            key != 'csrf_token' and
+            key != 'page_questions' and
+            new_service_content.get_question(key)['type'] == 'boolean'
         ):
             section_data[key] = convert_to_boolean(section_data[key])
 

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -109,11 +109,14 @@ def edit_section(service_id, section):
         abort(404)
 
     content = existing_service_content.get_builder().filter(service)
+    section = content.get_section(section)
+    if section is None:
+        abort(404)
 
     return render_template(
         "services/edit_section.html",
-        section=content.get_section(section),
-        page_questions='|'.join(get_section_questions(content.get_section(section))),
+        section=section,
+        page_questions='|'.join(get_section_questions(section)),
         service_data=service,
         service_id=service_id,
         return_to=".edit_service",
@@ -124,10 +127,7 @@ def edit_section(service_id, section):
 
 
 def get_section_questions(section):
-    questions = []
-    for question in section.get('questions', None):
-        questions.append(question.get('id', None))
-    return questions
+    return [question['id'] for question in section['questions']]
 
 
 @main.route(
@@ -143,6 +143,9 @@ def update_section(service_id, section):
         abort(404)
 
     content = existing_service_content.get_builder().filter(service)
+    section = content.get_section(section)
+    if section is None:
+        abort(404)
 
     posted_data = _get_formatted_section_data()
     posted_data.pop('page_questions')
@@ -160,8 +163,8 @@ def update_section(service_id, section):
                 posted_data['serviceName'] = service.get('serviceName', '')
             return render_template(
                 "services/edit_section.html",
-                section=content.get_section(section),
-                page_questions='|'.join(get_section_questions(content.get_section(section))),
+                section=section,
+                page_questions='|'.join(get_section_questions(section)),
                 service_data=posted_data,
                 service_id=service_id,
                 return_to=".edit_service",
@@ -316,11 +319,14 @@ def edit_service_submission(service_id, section):
         abort(404)
 
     content = new_service_content.get_builder().filter(draft)
+    section = content.get_section(section)
+    if section is None:
+        abort(404)
 
     return render_template(
         "services/edit_section.html",
-        section=content.get_section(section),
-        page_questions='|'.join(get_section_questions(content.get_section(section))),
+        section=section,
+        page_questions='|'.join(get_section_questions(section)),
         service_data=draft,
         service_id=service_id,
         dashboard=".framework_dashboard",
@@ -343,6 +349,10 @@ def update_section_submission(service_id, section):
         abort(404)
 
     content = new_service_content.get_builder().filter(draft)
+    section = content.get_section(section)
+    if section is None:
+        abort(404)
+
     posted_data = _get_formatted_section_data()
 
     if posted_data:
@@ -357,8 +367,8 @@ def update_section_submission(service_id, section):
                 posted_data['serviceName'] = draft.get('serviceName', '')
             return render_template(
                 "services/edit_section.html",
-                section=content.get_section(section),
-                page_questions='|'.join(get_section_questions(content.get_section(section))),
+                section=section,
+                page_questions='|'.join(get_section_questions(section)),
                 service_data=posted_data,
                 service_id=service_id,
                 return_to=".view_service_submission",

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -114,7 +114,6 @@ def edit_section(service_id, section_id):
     return render_template(
         "services/edit_section.html",
         section=section,
-        page_questions='|'.join(get_section_questions(section)),
         service_data=service,
         service_id=service_id,
         return_to=".edit_service",
@@ -161,7 +160,6 @@ def update_section(service_id, section_id):
         return render_template(
             "services/edit_section.html",
             section=section,
-            page_questions='|'.join(get_section_questions(section)),
             service_data=posted_data,
             service_id=service_id,
             return_to=".edit_service",
@@ -324,7 +322,6 @@ def edit_service_submission(service_id, section_id):
     return render_template(
         "services/edit_section.html",
         section=section,
-        page_questions='|'.join(get_section_questions(section)),
         service_data=draft,
         service_id=service_id,
         dashboard=".framework_dashboard",
@@ -352,7 +349,8 @@ def update_section_submission(service_id, section_id):
         abort(404)
 
     posted_data = _get_formatted_section_data()
-    posted_data = _filter_keys(posted_data, get_section_questions(section) + ['page_questions'])
+    posted_data = _filter_keys(posted_data, get_section_questions(section))
+    posted_data['page_questions'] = get_section_questions(section)
 
     try:
         data_api_client.update_draft_service(
@@ -366,7 +364,6 @@ def update_section_submission(service_id, section_id):
         return render_template(
             "services/edit_section.html",
             section=section,
-            page_questions='|'.join(get_section_questions(section)),
             service_data=posted_data,
             service_id=service_id,
             return_to=".view_service_submission",
@@ -406,8 +403,6 @@ def _get_error_message(error, message_key, content):
 
 def _is_list_type(key):
     """Return True if a given key is a list type"""
-    if key in ['csrf_token', 'page_questions']:
-        return False
     if key == 'serviceTypes':
         return True
     return new_service_content.get_question(key)['type'] in ['list', 'checkbox', 'pricing']
@@ -415,8 +410,6 @@ def _is_list_type(key):
 
 def _is_boolean_type(key):
     """Return True if a given key is a boolean type"""
-    if key in ['csrf_token', 'page_questions']:
-        return False
     return new_service_content.get_question(key)['type'] == 'boolean'
 
 
@@ -431,8 +424,6 @@ def _get_formatted_section_data():
             section_data[key] = request.form.getlist(key)
         elif _is_boolean_type(key):
             section_data[key] = convert_to_boolean(section_data[key])
-        elif key == 'page_questions':
-            section_data[key] = section_data[key].split('|')
     return section_data
 
 

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -113,7 +113,7 @@ def edit_section(service_id, section):
     return render_template(
         "services/edit_section.html",
         section=content.get_section(section),
-        page_questions=get_section_questions(content.get_section(section)),
+        page_questions='|'.join(get_section_questions(content.get_section(section))),
         service_data=service,
         service_id=service_id,
         return_to=".edit_service",
@@ -161,7 +161,7 @@ def update_section(service_id, section):
             return render_template(
                 "services/edit_section.html",
                 section=content.get_section(section),
-                page_questions=get_section_questions(content.get_section(section)),
+                page_questions='|'.join(get_section_questions(content.get_section(section))),
                 service_data=posted_data,
                 service_id=service_id,
                 return_to=".edit_service",
@@ -320,7 +320,7 @@ def edit_service_submission(service_id, section):
     return render_template(
         "services/edit_section.html",
         section=content.get_section(section),
-        page_questions=get_section_questions(content.get_section(section)),
+        page_questions='|'.join(get_section_questions(content.get_section(section))),
         service_data=draft,
         service_id=service_id,
         dashboard=".framework_dashboard",
@@ -358,7 +358,7 @@ def update_section_submission(service_id, section):
             return render_template(
                 "services/edit_section.html",
                 section=content.get_section(section),
-                page_questions=get_section_questions(content.get_section(section)),
+                page_questions='|'.join(get_section_questions(content.get_section(section))),
                 service_data=posted_data,
                 service_id=service_id,
                 return_to=".view_service_submission",
@@ -425,7 +425,8 @@ def _get_formatted_section_data():
             new_service_content.get_question(key)['type'] == 'boolean'
         ):
             section_data[key] = convert_to_boolean(section_data[key])
-
+        elif (key == 'page_questions'):
+            section_data[key] = section_data[key].split('|')
     return section_data
 
 

--- a/app/templates/macros/toolkit_forms.html
+++ b/app/templates/macros/toolkit_forms.html
@@ -112,3 +112,18 @@
     {% include "toolkit/forms/textbox.html" %}
   {% endwith %}
 {%- endmacro %}
+
+{% macro percentage(question_content, service_data, errors) -%}
+  {%
+    with
+    unit_in_full="percent",
+    unit_position="after",
+    unit="%",
+    question=question_content.question,
+    name=question_content.id,
+    value=service_data[question_content.id],
+    error=errors.get(question_content.id)['message']
+  %}
+    {% include "toolkit/forms/textbox.html" %}
+  {% endwith %}
+{%- endmacro %}

--- a/app/templates/services/edit_section.html
+++ b/app/templates/services/edit_section.html
@@ -59,7 +59,6 @@
     {% endfor %}
 
     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
-    <input type="hidden" name="page_questions" value="{{ page_questions }}" />
     {% if request.args.get('return_to_summary') or "suppliers/submission/" not in request.url %}
       {%
         with

--- a/app/templates/services/edit_section.html
+++ b/app/templates/services/edit_section.html
@@ -15,8 +15,8 @@
         "label": current_user.supplier_name
       },
       {
-        "link": url_for(".list_services"),
-        "label": "Services"
+        "link": url_for(dashboard),
+        "label": dash_label
       },
       {
         "link": url_for(return_to, service_id=service_id),
@@ -59,6 +59,7 @@
     {% endfor %}
 
     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+    <input type="hidden" name="page_questions" value="{{ page_questions }}" />
     {% if request.args.get('return_to_summary') or "suppliers/submission/" not in request.url %}
       {%
         with

--- a/app/templates/services/service_submission.html
+++ b/app/templates/services/service_submission.html
@@ -40,7 +40,7 @@
       {% for section in sections %}
         {{ summary.heading(section.name) }}
         {% if section.editable %}
-          {{ summary.top_link("Edit", url_for(".edit_service_submission", service_id=service_id, section=section.id)) }}
+          {{ summary.top_link("Edit", url_for(".edit_service_submission", service_id=service_id, section_id=section.id)) }}
         {% endif %}
         {% call(question) summary.list_table(
           section.questions,

--- a/app/templates/services/service_submission.html
+++ b/app/templates/services/service_submission.html
@@ -15,8 +15,8 @@
         "label": current_user.supplier_name
       },
       {
-        "link": url_for(".list_services"),
-        "label": "Services"
+        "link": url_for(".framework_dashboard"),
+        "label": "Apply to G-Cloud 7"
       }
     ]
   %}

--- a/bower.json
+++ b/bower.json
@@ -7,6 +7,6 @@
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
     "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v8.1.1",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.14.1/jinja_govuk_template-0.14.1.tgz",
-    "digital-marketplace-ssp-content": "git://github.com/alphagov/digital-marketplace-ssp-content#15fcaeab5b24893a04bece14a56ff2fa425e5633"
+    "digital-marketplace-ssp-content": "git://github.com/alphagov/digitalmarketplace-ssp-content#c1150946db3f145a686d491eb216d4a7e55dd321"
   }
 }

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -462,7 +462,7 @@ class TestCreateDraftService(BaseApplicationTest):
 
     def test_post_create_draft_service_without_lot_selected_fails(self, request):
         request.form.get.return_value = None
-        self._test_post_create_service(if_error_expected=True)
+        self._test_post_create_draft_service(if_error_expected=True)
 
 
 @mock.patch('app.main.views.services.data_api_client')

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -545,6 +545,51 @@ class TestEditDraftService(BaseApplicationTest):
             )
             assert_equal(404, res.status_code)
 
+    def test_update_redirects_to_next_editable_section(self):
+        with mock.patch('app.main.views.services.data_api_client') as data_api_client:
+            data_api_client.get_draft_service.return_value = self.empty_draft
+            data_api_client.update_draft_service.return_value = None
+
+            res = self.client.post(
+                '/suppliers/submission/services/1/edit/service_description',
+                data={
+                    'page_questions': '',
+                })
+
+            assert_equal(302, res.status_code)
+            assert_equal('http://localhost/suppliers/submission/services/1/edit/service_definition',
+                         res.headers['Location'])
+
+    def test_update_redirects_to_edit_submission_if_no_next_editable_section(self):
+        with mock.patch('app.main.views.services.data_api_client') as data_api_client:
+            data_api_client.get_draft_service.return_value = self.empty_draft
+            data_api_client.update_draft_service.return_value = None
+
+            res = self.client.post(
+                '/suppliers/submission/services/1/edit/certifications',
+                data={
+                    'page_questions': '',
+                })
+
+            assert_equal(302, res.status_code)
+            assert_equal('http://localhost/suppliers/submission/services/1',
+                         res.headers['Location'])
+
+    def test_update_redirects_to_edit_submission_if_return_to_summary(self):
+        with mock.patch('app.main.views.services.data_api_client') as data_api_client:
+            data_api_client.get_draft_service.return_value = self.empty_draft
+            data_api_client.update_draft_service.return_value = None
+
+            res = self.client.post(
+                '/suppliers/submission/services/1/edit/service_description?return_to_summary=1',
+                data={
+                    'page_questions': '',
+                })
+
+            assert_equal(302, res.status_code)
+            assert_equal('http://localhost/suppliers/submission/services/1',
+                         res.headers['Location'])
+
     def test_update_with_answer_required_error(self):
         with mock.patch('app.main.views.services.data_api_client') as data_api_client:
             data_api_client.get_draft_service.return_value = self.empty_draft

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -284,6 +284,43 @@ class TestSupplierUpdateService(BaseApplicationTest):
 
 
 @mock.patch('app.main.views.services.request')
+class TestEditService(BaseApplicationTest):
+
+    empty_service = {
+        'services': {
+            'serviceName': 'Service name 123',
+            'status': 'published',
+            'id': '123',
+            'frameworkName': 'G-Cloud 6',
+            'supplierId': 1234,
+            'supplierName': 'We supply any',
+            'lot': 'SCS',
+        }
+    }
+
+    def setup(self):
+        super(TestEditService, self).setup()
+        with self.app.test_client():
+            self.login()
+
+    def test_edit_non_existent_section_returns_404(self, request):
+        with mock.patch('app.main.views.services.data_api_client') as data_api_client:
+            data_api_client.get_service.return_value = self.empty_service
+            res = self.client.get(
+                '/suppliers/services/1/edit/invalid_section'
+            )
+            assert_equal(404, res.status_code)
+
+    def test_update_non_existent_section_returns_404(self, request):
+        with mock.patch('app.main.views.services.data_api_client') as data_api_client:
+            data_api_client.get_service.return_value = self.empty_service
+            res = self.client.post(
+                '/suppliers/services/1/edit/invalid_section'
+            )
+            assert_equal(404, res.status_code)
+
+
+@mock.patch('app.main.views.services.request')
 class TestCreateDraftService(BaseApplicationTest):
 
     def setup(self):
@@ -438,7 +475,23 @@ class TestEditDraftService(BaseApplicationTest):
             res = self.client.get(
                 '/suppliers/submission/services/1/edit/service_description'
             )
-            assert_true(
-                '<input type="hidden" name="page_questions" value="serviceName|serviceSummary" />'
-                in res.get_data(as_text=True)
+            assert_in(
+                '<input type="hidden" name="page_questions" value="serviceName|serviceSummary" />',
+                res.get_data(as_text=True)
             )
+
+    def test_edit_non_existent_draft_section_returns_404(self, request):
+        with mock.patch('app.main.views.services.data_api_client') as data_api_client:
+            data_api_client.get_draft_service.return_value = self.empty_draft
+            res = self.client.get(
+                '/suppliers/submission/services/1/edit/invalid_section'
+            )
+            assert_equal(404, res.status_code)
+
+    def test_update_non_existent_draft_section_returns_404(self, request):
+        with mock.patch('app.main.views.services.data_api_client') as data_api_client:
+            data_api_client.get_draft_service.return_value = self.empty_draft
+            res = self.client.post(
+                '/suppliers/submission/services/1/edit/invalid_section'
+            )
+            assert_equal(404, res.status_code)

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -303,24 +303,12 @@ class TestEditService(BaseApplicationTest):
         with self.app.test_client():
             self.login()
 
-    def test_edit_section_contains_hidden_page_questions(self):
-        with mock.patch('app.main.views.services.data_api_client') as data_api_client:
-            data_api_client.get_service.return_value = self.empty_service
-            res = self.client.get('/suppliers/services/1/edit/description')
-
-            assert_equal(res.status_code, 200)
-            document = html.fromstring(res.get_data(as_text=True))
-            assert_equal(
-                'serviceName|serviceSummary',
-                document.xpath('//input[@name="page_questions"]/@value')[0])
-
     def test_questions_for_this_section_can_be_changed(self):
         with mock.patch('app.main.views.services.data_api_client') as data_api_client:
             data_api_client.get_service.return_value = self.empty_service
             res = self.client.post(
                 '/suppliers/services/1/edit/description',
                 data={
-                    'page_questions': '',
                     'serviceName': 'The service',
                     'serviceSummary': 'This is the service',
                 })
@@ -336,7 +324,6 @@ class TestEditService(BaseApplicationTest):
             res = self.client.post(
                 '/suppliers/services/1/edit/description',
                 data={
-                    'page_questions': '',
                     'serviceFeatures': '',
                 })
 
@@ -367,9 +354,7 @@ class TestEditService(BaseApplicationTest):
                 {'serviceSummary': 'answer_required'})
             res = self.client.post(
                 '/suppliers/services/1/edit/description',
-                data={
-                    'page_questions': '',
-                })
+                data={})
 
             assert_equal(res.status_code, 200)
             document = html.fromstring(res.get_data(as_text=True))
@@ -385,9 +370,7 @@ class TestEditService(BaseApplicationTest):
                 {'serviceSummary': 'under_50_words'})
             res = self.client.post(
                 '/suppliers/services/1/edit/description',
-                data={
-                    'page_questions': '',
-                })
+                data={})
 
             assert_equal(res.status_code, 200)
             document = html.fromstring(res.get_data(as_text=True))
@@ -549,24 +532,12 @@ class TestEditDraftService(BaseApplicationTest):
         with self.app.test_client():
             self.login()
 
-    def test_edit_draft_section_contains_hidden_page_questions(self):
-        with mock.patch('app.main.views.services.data_api_client') as data_api_client:
-            data_api_client.get_draft_service.return_value = self.empty_draft
-            res = self.client.get('/suppliers/submission/services/1/edit/service_description')
-
-            assert_equal(res.status_code, 200)
-            document = html.fromstring(res.get_data(as_text=True))
-            assert_equal(
-                'serviceName|serviceSummary',
-                document.xpath('//input[@name="page_questions"]/@value')[0])
-
     def test_questions_for_this_section_can_be_changed(self):
         with mock.patch('app.main.views.services.data_api_client') as data_api_client:
             data_api_client.get_draft_service.return_value = self.empty_draft
             res = self.client.post(
                 '/suppliers/submission/services/1/edit/service_description',
                 data={
-                    'page_questions': '',
                     'serviceName': 'The service',
                     'serviceSummary': 'This is the service',
                 })
@@ -575,7 +546,7 @@ class TestEditDraftService(BaseApplicationTest):
             data_api_client.update_draft_service.assert_called_once_with(
                 '1',
                 {'serviceName': 'The service', 'serviceSummary': 'This is the service',
-                 'page_questions': ['']},
+                 'page_questions': ['serviceName', 'serviceSummary']},
                 'email@email.com')
 
     def test_only_questions_for_this_section_can_be_changed(self):
@@ -584,13 +555,12 @@ class TestEditDraftService(BaseApplicationTest):
             res = self.client.post(
                 '/suppliers/submission/services/1/edit/service_description',
                 data={
-                    'page_questions': '',
                     'serviceFeatures': '',
                 })
 
             assert_equal(res.status_code, 302)
             data_api_client.update_draft_service.assert_called_once_with(
-                '1', {'page_questions': ['']}, 'email@email.com')
+                '1', {'page_questions': ['serviceName', 'serviceSummary']}, 'email@email.com')
 
     def test_edit_non_existent_draft_service_returns_404(self):
         with mock.patch('app.main.views.services.data_api_client') as data_api_client:
@@ -614,9 +584,7 @@ class TestEditDraftService(BaseApplicationTest):
 
             res = self.client.post(
                 '/suppliers/submission/services/1/edit/service_description',
-                data={
-                    'page_questions': '',
-                })
+                data={})
 
             assert_equal(302, res.status_code)
             assert_equal('http://localhost/suppliers/submission/services/1/edit/service_definition',
@@ -629,9 +597,7 @@ class TestEditDraftService(BaseApplicationTest):
 
             res = self.client.post(
                 '/suppliers/submission/services/1/edit/certifications',
-                data={
-                    'page_questions': '',
-                })
+                data={})
 
             assert_equal(302, res.status_code)
             assert_equal('http://localhost/suppliers/submission/services/1',
@@ -644,9 +610,7 @@ class TestEditDraftService(BaseApplicationTest):
 
             res = self.client.post(
                 '/suppliers/submission/services/1/edit/service_description?return_to_summary=1',
-                data={
-                    'page_questions': '',
-                })
+                data={})
 
             assert_equal(302, res.status_code)
             assert_equal('http://localhost/suppliers/submission/services/1',
@@ -660,9 +624,7 @@ class TestEditDraftService(BaseApplicationTest):
                 {'serviceSummary': 'answer_required'})
             res = self.client.post(
                 '/suppliers/submission/services/1/edit/service_description',
-                data={
-                    'page_questions': '',
-                })
+                data={})
 
             assert_equal(res.status_code, 200)
             document = html.fromstring(res.get_data(as_text=True))
@@ -678,9 +640,7 @@ class TestEditDraftService(BaseApplicationTest):
                 {'serviceSummary': 'under_50_words'})
             res = self.client.post(
                 '/suppliers/submission/services/1/edit/service_description',
-                data={
-                    'page_questions': '',
-                })
+                data={})
 
             assert_equal(res.status_code, 200)
             document = html.fromstring(res.get_data(as_text=True))

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -314,6 +314,36 @@ class TestEditService(BaseApplicationTest):
                 'serviceName|serviceSummary',
                 document.xpath('//input[@name="page_questions"]/@value')[0])
 
+    def test_questions_for_this_section_can_be_changed(self):
+        with mock.patch('app.main.views.services.data_api_client') as data_api_client:
+            data_api_client.get_service.return_value = self.empty_service
+            res = self.client.post(
+                '/suppliers/services/1/edit/description',
+                data={
+                    'page_questions': '',
+                    'serviceName': 'The service',
+                    'serviceSummary': 'This is the service',
+                })
+
+            assert_equal(res.status_code, 302)
+            data_api_client.update_service.assert_called_once_with(
+                '1', {'serviceName': 'The service', 'serviceSummary': 'This is the service'},
+                'email@email.com', 'supplier app')
+
+    def test_only_questions_for_this_section_can_be_changed(self):
+        with mock.patch('app.main.views.services.data_api_client') as data_api_client:
+            data_api_client.get_service.return_value = self.empty_service
+            res = self.client.post(
+                '/suppliers/services/1/edit/description',
+                data={
+                    'page_questions': '',
+                    'serviceFeatures': '',
+                })
+
+            assert_equal(res.status_code, 302)
+            data_api_client.update_service.assert_called_one_with(
+                '1', dict(), 'email@email.com', 'supplier app')
+
     def test_edit_non_existent_service_returns_404(self):
         with mock.patch('app.main.views.services.data_api_client') as data_api_client:
             data_api_client.get_service.return_value = None
@@ -529,6 +559,38 @@ class TestEditDraftService(BaseApplicationTest):
             assert_equal(
                 'serviceName|serviceSummary',
                 document.xpath('//input[@name="page_questions"]/@value')[0])
+
+    def test_questions_for_this_section_can_be_changed(self):
+        with mock.patch('app.main.views.services.data_api_client') as data_api_client:
+            data_api_client.get_draft_service.return_value = self.empty_draft
+            res = self.client.post(
+                '/suppliers/submission/services/1/edit/service_description',
+                data={
+                    'page_questions': '',
+                    'serviceName': 'The service',
+                    'serviceSummary': 'This is the service',
+                })
+
+            assert_equal(res.status_code, 302)
+            data_api_client.update_draft_service.assert_called_once_with(
+                '1',
+                {'serviceName': 'The service', 'serviceSummary': 'This is the service',
+                 'page_questions': ['']},
+                'email@email.com')
+
+    def test_only_questions_for_this_section_can_be_changed(self):
+        with mock.patch('app.main.views.services.data_api_client') as data_api_client:
+            data_api_client.get_draft_service.return_value = self.empty_draft
+            res = self.client.post(
+                '/suppliers/submission/services/1/edit/service_description',
+                data={
+                    'page_questions': '',
+                    'serviceFeatures': '',
+                })
+
+            assert_equal(res.status_code, 302)
+            data_api_client.update_draft_service.assert_called_once_with(
+                '1', {'page_questions': ['']}, 'email@email.com')
 
     def test_edit_non_existent_draft_service_returns_404(self):
         with mock.patch('app.main.views.services.data_api_client') as data_api_client:

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -315,6 +315,13 @@ class TestEditService(BaseApplicationTest):
                 'serviceName|serviceSummary',
                 document.xpath('//input[@name="page_questions"]/@value')[0])
 
+    def test_edit_non_existent_service_returns_404(self, request):
+        with mock.patch('app.main.views.services.data_api_client') as data_api_client:
+            data_api_client.get_service.return_value = None
+            res = self.client.get('/suppliers/services/1/edit/description')
+
+            assert_equal(res.status_code, 404)
+
     def test_edit_non_existent_section_returns_404(self, request):
         with mock.patch('app.main.views.services.data_api_client') as data_api_client:
             data_api_client.get_service.return_value = self.empty_service
@@ -322,6 +329,13 @@ class TestEditService(BaseApplicationTest):
                 '/suppliers/services/1/edit/invalid_section'
             )
             assert_equal(404, res.status_code)
+
+    def test_update_non_existent_service_returns_404(self, request):
+        with mock.patch('app.main.views.services.data_api_client') as data_api_client:
+            data_api_client.get_service.return_value = None
+            res = self.client.post('/suppliers/services/1/edit/description')
+
+            assert_equal(res.status_code, 404)
 
     def test_update_non_existent_section_returns_404(self, request):
         with mock.patch('app.main.views.services.data_api_client') as data_api_client:
@@ -492,6 +506,13 @@ class TestEditDraftService(BaseApplicationTest):
                 'serviceName|serviceSummary',
                 document.xpath('//input[@name="page_questions"]/@value')[0])
 
+    def test_edit_non_existent_draft_service_returns_404(self, request):
+        with mock.patch('app.main.views.services.data_api_client') as data_api_client:
+            data_api_client.get_draft_service.side_effect = HTTPError(mock.Mock(status_code=404))
+            res = self.client.get('/suppliers/submission/services/1/edit/service_description')
+
+            assert_equal(res.status_code, 404)
+
     def test_edit_non_existent_draft_section_returns_404(self, request):
         with mock.patch('app.main.views.services.data_api_client') as data_api_client:
             data_api_client.get_draft_service.return_value = self.empty_draft
@@ -499,6 +520,13 @@ class TestEditDraftService(BaseApplicationTest):
                 '/suppliers/submission/services/1/edit/invalid_section'
             )
             assert_equal(404, res.status_code)
+
+    def test_update_non_existent_draft_service_returns_404(self, request):
+        with mock.patch('app.main.views.services.data_api_client') as data_api_client:
+            data_api_client.get_draft_service.side_effect = HTTPError(mock.Mock(status_code=404))
+            res = self.client.post('/suppliers/submission/services/1/edit/service_description')
+
+            assert_equal(res.status_code, 404)
 
     def test_update_non_existent_draft_section_returns_404(self, request):
         with mock.patch('app.main.views.services.data_api_client') as data_api_client:


### PR DESCRIPTION
See: https://www.pivotaltracker.com/story/show/97631142

This adds a hidden field to `edit section` pages that lists all the questions on the page.  This way the API can check if there were required fields on the page that have not been submitted with the form, and if so return a validation error for the page.

It also adds a `percentage` macro to display the percentage box for the "service uptime" question.
