### PR TITLE
Use correct analytics properties for live/other

### DIFF
--- a/app/assets/javascripts/_analytics.js
+++ b/app/assets/javascripts/_analytics.js
@@ -2,8 +2,9 @@
   "use strict";
   GOVUK.Tracker.load();
   var cookieDomain = (document.domain === 'www.beta.digitalmarketplace.service.gov.uk') ? '.digitalmarketplace.service.gov.uk' : document.domain;
+  var property = (document.domain === 'www.digitalmarketplace.service.gov.uk') ? 'UA-49258698-1' : 'UA-49258698-3';
   GOVUK.analytics = new GOVUK.Tracker({
-    universalId: 'UA-49258698-3',
+    universalId: property,
     cookieDomain: cookieDomain
   });
   GOVUK.analytics.trackPageview();


### PR DESCRIPTION
This commit makes the app select different Google analytics properties to track
against depending on which domain the user is browsing.

This will ensure continuity of analytics when we switch the DNS.

Sister of https://github.com/alphagov/digitalmarketplace-buyer-frontend/pull/101