### PR TITLE
Ensure cookie page uses local cookie page

### DIFF
--- a/app/templates/_cookie_message.html
+++ b/app/templates/_cookie_message.html
@@ -1,2 +1,2 @@
-<p>GOV.UK uses cookies to make the site simpler. <a href="https://www.gov.uk/help/cookies">Find out more about cookies</a></p>
+<p>GOV.UK uses cookies to make the site simpler. <a href="/cookies">Find out more about cookies</a></p>
 

--- a/tests/app/test_application.py
+++ b/tests/app/test_application.py
@@ -63,3 +63,11 @@ class TestApplication(BaseApplicationTest):
         res = self.client.get('/suppliers/login')
         assert 200 == res.status_code
         assert 'DENY', res.headers['X-Frame-Options']
+
+    def test_should_use_local_cookie_page_on_cookie_message(self):
+        res = self.client.get('/suppliers/login')
+        assert_equal(200, res.status_code)
+        assert_true(
+            '<p>GOV.UK uses cookies to make the site simpler. <a href="/cookies">Find out more about cookies</a></p>'
+            in res.get_data(as_text=True)
+        )


### PR DESCRIPTION
- seen cookie message pointed to GOV.UK
- changed to use /cookies
- note on local builds this will not work as cookie pages served from buyer app