### PR TITLE
Make link to service relative to environment

### DIFF
--- a/app/templates/services/list_services.html
+++ b/app/templates/services/list_services.html
@@ -63,7 +63,7 @@
     {% for service in services %}
       <tr class="summary-item-row">
         <td class="summary-item-field-name-wider">
-          <a href="https://www.digitalmarketplace.service.gov.uk/service/{{ service.id.lower() }}">
+          <a href="/g-cloud/services/{{ service.id.lower() }}">
             {{ service.serviceName }}
           </a>
         </td>


### PR DESCRIPTION
Currently the "view service" link in the admin app always points at live. It should be relative to the environment that the app is being used it (so that it can be tested).

Actual: https://www.digitalmarketplace.service.gov.uk/service/5126395806089216

Expected: https://preview.development.digitalmarketplace.service.gov.uk/service/5126395806089216

Similar to: https://www.pivotaltracker.com/story/show/94162812