### PR TITLE
Make URLs for assets cache-proof

### DIFF
--- a/app/templates/_javascripts.html
+++ b/app/templates/_javascripts.html
@@ -1,1 +1,1 @@
-<script type="text/javascript" src="{{ asset_path }}javascripts/application.js"></script>
+<script type="text/javascript" src="{{ asset_path }}javascripts/application.js?{{ asset_fingerprints['js'] }}"></script>

--- a/app/templates/_stylesheets.html
+++ b/app/templates/_stylesheets.html
@@ -1,14 +1,12 @@
 <!--[if gt IE 8]><!-->
-  <link type="text/css" rel="stylesheet" media="screen" href="{{ asset_path }}stylesheets/application.css" />
+  <link type="text/css" rel="stylesheet" media="screen" href="{{ asset_path }}stylesheets/application.css?{{ asset_fingerprints['css'] }}" />
 <!--<![endif]-->
 <!--[if IE 6]>
-  <link type="text/css" rel="stylesheet" media="screen" href="{{ asset_path }}stylesheets/application-ie6.css" />
+  <link type="text/css" rel="stylesheet" media="screen" href="{{ asset_path }}stylesheets/application-ie6.css?{{ asset_fingerprints['css'] }}" />
 <![endif]-->
 <!--[if IE 7]>
-  <link type="text/css" rel="stylesheet" media="screen" href="{{ asset_path }}stylesheets/application-ie7.css" />
+  <link type="text/css" rel="stylesheet" media="screen" href="{{ asset_path }}stylesheets/application-ie7.css?{{ asset_fingerprints['css'] }}" />
 <![endif]-->
 <!--[if IE 8]>
-  <link type="text/css" rel="stylesheet" media="screen" href="{{ asset_path }}stylesheets/application-ie8.css" />
+  <link type="text/css" rel="stylesheet" media="screen" href="{{ asset_path }}stylesheets/application-ie8.css?{{ asset_fingerprints['css'] }}" />
 <![endif]-->
-
-

--- a/config.py
+++ b/config.py
@@ -1,6 +1,15 @@
 import os
+import hashlib
 import jinja2
 from dmutils.status import enabled_since, get_version_label
+
+
+def get_asset_fingerprint(asset_file_path):
+    hasher = hashlib.md5()
+    with open(asset_file_path, 'rb') as asset_file:
+        buf = asset_file.read()
+        hasher.update(buf)
+    return hasher.hexdigest()
 
 
 class Config(object):
@@ -29,7 +38,11 @@ class Config(object):
     ASSET_PATH = STATIC_URL_PATH + '/'
     BASE_TEMPLATE_DATA = {
         'asset_path': ASSET_PATH,
-        'header_class': 'with-proposition'
+        'header_class': 'with-proposition',
+        "asset_fingerprints": {
+            "css": get_asset_fingerprint("app/static/stylesheets/application.css"),
+            "js": get_asset_fingerprint("app/static/javascripts/application.js")
+        }
     }
 
     # Feature Flags


### PR DESCRIPTION
This commit adds a query string to assets URLs which is generated from a hash of the file contents. When asset files are changed they will now be served from a different URL, which means they wont be loaded from browser cache.

This is similar to how GOV.UK template adds its version number as a querystring parameter for its assets, and matches how the buyer app does it too.

Addresses [98936730](https://www.pivotaltracker.com/story/show/98936730)