### PR TITLE
Add G7 drafts list with "Make a copy" button

### DIFF
--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -15,8 +15,18 @@ from ..forms.frameworks import G7SelectionQuestions
 def framework_dashboard():
     template_data = main.config['BASE_TEMPLATE_DATA']
 
+    try:
+        drafts = data_api_client.find_draft_services(
+            current_user.supplier_id,
+            framework='g-cloud-7'
+        )['services']
+
+    except APIError as e:
+        abort(e.status_code)
+
     return render_template(
         "frameworks/dashboard.html",
+        drafts=drafts,
         **template_data
     ), 200
 

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -273,6 +273,27 @@ def create_new_draft_service():
     )
 
 
+@main.route('/submission/services/<string:service_id>/copy', methods=['POST'])
+@login_required
+@flask_featureflags.is_active_feature('GCLOUD7_OPEN')
+def copy_draft_service(service_id):
+    draft = data_api_client.get_draft_service(service_id).get('services')
+
+    if not _is_service_associated_with_supplier(draft):
+        abort(404)
+
+    try:
+        data_api_client.copy_draft_service(
+            service_id,
+            current_user.email_address
+        )
+
+    except APIError as e:
+        abort(e.status_code)
+
+    return redirect(url_for(".framework_dashboard"))
+
+
 @main.route('/submission/services/<string:service_id>', methods=['GET'])
 @login_required
 @flask_featureflags.is_active_feature('GCLOUD7_OPEN')

--- a/app/templates/frameworks/dashboard.html
+++ b/app/templates/frameworks/dashboard.html
@@ -76,20 +76,24 @@
 
   <div class="grid-row">
     <div class="column-one-whole">
-      <h2 class="summary-item-heading">Services</h2>
-      <p class="summary-item-top-level-action">
-        <a href="{{ url_for('.start_new_draft_service') }}">Add a service</a>
-      </p>
-      <table class="summary-item-body">
-        <thead></thead>
-        <tbody class="summary-item-body">
-          <tr class="summary-item-row">
-            <td class="summary-item-field-name">
-              <span class="hint">You haven't added any services yet.</span>
-            </td>
-          </tr>
-        </tbody>
-      </table>
+      {% import "toolkit/summary-table.html" as summary %}
+      {{ summary.heading("Draft services") }}
+      {{ summary.top_link("Add a service", url_for(".start_new_draft_service")) }}
+      {% call(draft) summary.list_table(
+        drafts,
+        caption="Draft services",
+        empty_message="You haven't added any services yet.",
+        field_headings=["Service name", "Lot", summary.hidden_field_heading("Make a copy")],
+        field_headings_visible=False
+      ) %}
+        {% call summary.row() %}
+          {{ summary.service_link(draft.serviceName,
+                                  url_for(".view_service_submission", service_id=draft.id)) }}
+          {{ summary.text(draft.lot) }}
+          {{ summary.button(text="Make a copy",
+                             action=url_for('.copy_draft_service', service_id=draft.id)) }}
+        {% endcall %}
+      {% endcall %}
     </div>
   </div>
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ Flask==0.10.1
 Flask-Login==0.2.11
 Flask-Script==2.0.5
 Flask-WTF==0.11
-git+https://github.com/alphagov/digitalmarketplace-utils.git@3.5.2#egg=digitalmarketplace-utils==3.5.2
+git+https://github.com/alphagov/digitalmarketplace-utils.git@3.6.0#egg=digitalmarketplace-utils==3.6.0
 
 mandrill==1.0.57
 

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -2,14 +2,14 @@ from nose.tools import assert_equal
 import mock
 from mock import Mock
 from lxml import html
-from lxml import etree
 from dmutils.apiclient import APIError
 
 from ..helpers import BaseApplicationTest
 
 
+@mock.patch('app.main.views.frameworks.data_api_client')
 class TestFrameworksDashboard(BaseApplicationTest):
-    def test_shows(self):
+    def test_shows(self, data_api_client):
         with self.app.test_client():
             self.login()
 

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -364,3 +364,37 @@ class TestCreateService(BaseApplicationTest):
     def test_post_create_service_without_lot_selected_fails(self, request):
         request.form.get.return_value = None
         self._test_post_create_service(if_error_expected=True)
+
+
+@mock.patch('app.main.views.services.data_api_client')
+class TestCopyDraft(BaseApplicationTest):
+
+    def setup(self):
+        super(TestCopyDraft, self).setup()
+
+        with self.app.test_client():
+            self.login()
+
+        self.draft = {
+            'id': 1,
+            'supplierId': 1234,
+            'supplierName': "supplierName",
+            'lot': "SCS",
+            'status': "not-submitted",
+            'frameworkName': "frameworkName",
+            'links': {},
+            'updatedAt': "2015-06-29T15:26:07.650368Z"
+        }
+
+    def test_copy_draft(self, api_client):
+        api_client.get_draft_service.return_value = {'services': self.draft}
+
+        res = self.client.post('/suppliers/submission/services/1/copy')
+        assert_equal(res.status_code, 302)
+
+    def test_copy_draft_checks_supplier_id(self, api_client):
+        self.draft['supplierId'] = 2
+        api_client.get_draft_service.return_value = {'services': self.draft}
+
+        res = self.client.post('/suppliers/submission/services/1/copy')
+        assert_equal(res.status_code, 404)


### PR DESCRIPTION
Requires https://github.com/alphagov/digitalmarketplace-supplier-frontend/pull/114

[#97536644](https://www.pivotaltracker.com/story/show/97536644)

"Make a copy" copies a draft using the API copy endpoint.
Draft is requested first to check that the draft supplier matches
the currently logged in user.