### PR TITLE
Don't lowercase service IDs

### DIFF
--- a/app/templates/services/list_services.html
+++ b/app/templates/services/list_services.html
@@ -60,7 +60,7 @@
 
       {{ summary.service_link(
           item.serviceName,
-          '/g-cloud/services/' + item.id.lower()
+          '/g-cloud/services/' + item.id
       ) }}
 
       {{ summary.text(item.frameworkName) }}


### PR DESCRIPTION
- Service IDs are stored as uppercase
- Old URLs may be in lower case but they are in the `/services/x-xxx-xxx` format,
  and the redirect uppercases them to `/g-cloud/services/X-XXX-XXXX`