### PR TITLE
Rewrite supplier edit forms with toolkit form patterns

### DIFF
--- a/app/templates/macros/forms.html
+++ b/app/templates/macros/forms.html
@@ -1,54 +1,36 @@
-{% macro question_input(name, label, value='', hint='', errors=None) -%}
-  {{ _question_header(name, label, hint, errors) }}
-    <input type="text" class="text-box" name="{{ name }}" id="{{ name }}-input" value="{{ value }}" />
-  {{ _question_footer(name, label, hint, errors) }}
+{% macro question_input(name, question, value='', hint='', errors=None) -%}
+  {% with
+    value=value or '',
+    error=errors[0]
+  %}
+    {% include "toolkit/forms/textbox.html" %}
+  {% endwith %}
 {%- endmacro %}
 
 
 {% macro input(name, value='', errors=None, type='text') -%}
   {{ field_errors(name, errors) }}
-  <input type="{{ type }}" class="text-box" name="{{ name }}" id="{{ name }}-input" value="{{ value }}" />
+  <input type="{{ type }}" class="text-box" name="{{ name }}" id="{{ name }}-input" value="{{ value or '' }}" />
 {%- endmacro %}
 
 
-{% macro question_textarea(name, label, value='', hint='', errors=None, words=None) -%}
-  {{ _question_header(name, label, hint, errors) }}
-    {% if words %}
-    <div class="word-count">
-      <textarea class="text-box text-box-large" name="{{ name }}" id="{{ name }}-input" data-max-length-in-words="{{ words }}">{{ value }}</textarea>
-    </div>
-    {% else %}
-    <textarea class="text-box text-box-large" name="{{ name }}" id="{{ name }}-input">{{ value }}</textarea>
-    {% endif %}
-  {{ _question_footer(name, label, hint, errors) }}
+{% macro question_textarea(name, question, value='', hint='', errors=None, max_length_in_words=None) -%}
+  {% with
+    large=True,
+    error=errors[0]
+  %}
+    {% include "toolkit/forms/textbox.html" %}
+  {% endwith %}
 {%- endmacro %}
 
 
-{% macro question_list_entry(name, label, value='', hint='', errors=None, item_name='', count=10) -%}
-  {{ _question_header(name, label, hint, errors) }}
-    <div class="input-list" id="{{ name }}" data-list-item-name="{{ item_name }}">
-    {% for index in range(count) %}
-      <div class="list-entry">
-        <label for="{{ name }}-input-{{ index }}" class="text-box-number-label">
-          <span class="visuallyhidden">{{ item_name }} number </span>{{ index + 1 }}.
-        </label>
-        <input type="text" name="{{ name }}-{{ index }}" id="{{ name }}-input-{{ index }}" class="text-box" value="{{ value[index] }}" />
-      </div>
-    {% endfor %}
-    </div>
-  {{ _question_footer(name, label, hint, errors) }}
-{%- endmacro %}
-
-
-{% macro field_label(name, label, hint='') -%}
-  <label id="{{ name }}-label" for="{{ name }}-input" class="question-heading{% if hint %}-with-hint{% endif %}">
-    {{ label }}
-  </label>
-  {% if hint %}
-    <p class="hint box-label">
-      {{ hint }}
-    </p>
-  {% endif %}
+{% macro question_list_entry(id, question, value='', hint='', errors=None, item_name='', number_of_items=10) -%}
+  {% with
+    values=value,
+    error=errors[0]
+  %}
+    {% include "toolkit/forms/list-entry.html" %}
+  {% endwith %}
 {%- endmacro %}
 
 
@@ -57,23 +39,5 @@
   <p class="validation-message" id="{{ name }}-errors">
       {% for error in errors %}{{ error }}{% endfor %}
   </p>
-  {% endif %}
-{%- endmacro %}
-
-
-{% macro _question_header(name, label, hint='', errors=None) -%}
-  {% if errors %}
-  <div class="validation-wrapper">
-  {% endif %}
-  <div class="question">
-    {{ field_label(name, label, hint) }}
-    {{ field_errors(name, errors) }}
-{%- endmacro %}
-
-
-{% macro _question_footer(name, label, hint='', errors=None) -%}
-  </div>
-  {% if errors %}
-  </div>
   {% endif %}
 {%- endmacro %}

--- a/app/templates/suppliers/edit_supplier.html
+++ b/app/templates/suppliers/edit_supplier.html
@@ -64,9 +64,9 @@
 
   <div class="grid-row">
     <div class="column-one-whole">
-      {{ forms.question_textarea('description', 'Supplier summary', supplier_form.description.data, '50 words max', errors=supplier_form.description.errors, words=50) }}
+      {{ forms.question_textarea('description', 'Supplier summary', supplier_form.description.data, '50 words max', errors=supplier_form.description.errors, max_length_in_words=50) }}
 
-      {{ forms.question_list_entry('clients', 'Clients', supplier_form.clients.data, '1 client per box, max 10 clients', errors=supplier_form.clients.errors, item_name='client', count=10) }}
+      {{ forms.question_list_entry('clients', 'Clients', supplier_form.clients.data, '1 client per box, max 10 clients', errors=supplier_form.clients.errors, item_name='client', number_of_items=10) }}
 
       {{ forms.question_input('contact_contactName', 'Contact name', contact_form.contactName.data, 'Primary contact', errors=contact_form.contactName.errors) }}
       {{ forms.question_input('contact_website', 'Website', contact_form.website.data, errors=contact_form.website.errors) }}


### PR DESCRIPTION
Fixes `"None"` strings in address/contact input fields by setting
`value=value or ''`. Jinja renders missing variables as empty
strings, but "None" gets converted to string. We've only seen this
happen with contact details since other fields shouldn't have `None`
values.

There's an interesting interaction between macros and the context of
variable-based pattern templates: macro arguments are visible to the
included template as normal variables, so as long as macro argument
name matches the variable name used by the pattern template there's
no need to set it using `{% with name=name %}`.