### PR TITLE
Service use template inheritance

### DIFF
--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -116,9 +116,6 @@ def edit_section(service_id, section_id):
         section=section,
         service_data=service,
         service_id=service_id,
-        return_to=".edit_service",
-        dashboard=".list_services",
-        dash_label="Services",
         **main.config['BASE_TEMPLATE_DATA']
     )
 
@@ -161,9 +158,6 @@ def update_section(service_id, section_id):
             section=section,
             service_data=posted_data,
             service_id=service_id,
-            return_to=".edit_service",
-            dashboard=".list_services",
-            dash_label="Services",
             errors=errors_map,
             **main.config['BASE_TEMPLATE_DATA']
         )
@@ -319,13 +313,10 @@ def edit_service_submission(service_id, section_id):
         abort(404)
 
     return render_template(
-        "services/edit_section.html",
+        "services/edit_submission_section.html",
         section=section,
         service_data=draft,
         service_id=service_id,
-        dashboard=".framework_dashboard",
-        dash_label="Apply to G-Cloud 7",
-        return_to=".view_service_submission",
         **main.config['BASE_TEMPLATE_DATA']
     )
 
@@ -360,13 +351,10 @@ def update_section_submission(service_id, section_id):
         if not posted_data.get('serviceName', None):
             posted_data['serviceName'] = draft.get('serviceName', '')
         return render_template(
-            "services/edit_section.html",
+            "services/edit_submission_section.html",
             section=section,
             service_data=posted_data,
             service_id=service_id,
-            return_to=".view_service_submission",
-            dashboard=".framework_dashboard",
-            dash_label="Apply to G-Cloud 7",
             errors=errors_map,
             **main.config['BASE_TEMPLATE_DATA']
             )

--- a/app/templates/services/_base_edit_section_page.html
+++ b/app/templates/services/_base_edit_section_page.html
@@ -1,0 +1,42 @@
+{% extends "_base_page.html" %}
+{% import "macros/toolkit_forms.html" as forms %}
+
+{% block page_title %}{{ section.name }} – Digital Marketplace{% endblock %}
+
+{% block main_content %}
+
+  {% if errors %}
+    {% with errors = errors.values() %}
+      {% include 'toolkit/forms/validation.html' %}
+    {% endwith %}
+  {% endif %}
+
+  <div class="grid-row">
+    <div class="column-two-thirds">
+
+      {% with
+        heading = section.name,
+        smaller = true
+      %}
+        {% include 'toolkit/page-heading.html' %}
+      {% endwith %}
+
+    </div>
+  </div>
+  <form method="post">
+
+    {% for question in section.questions %}
+      {% if errors and errors[question.id] %}
+        {{ forms[question.type](question, service_data, errors) }}
+      {% else %}
+        {{ forms[question.type](question, service_data, {}) }}
+      {% endif %}
+    {% endfor %}
+
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+    {% block save_button %}{% endblock %}
+    
+    <a href="{% block return_to_service %}{% endblock %}">Return to service</a>
+
+  </form>
+{% endblock %}

--- a/app/templates/services/_base_service_page.html
+++ b/app/templates/services/_base_service_page.html
@@ -1,0 +1,44 @@
+{% extends "_base_page.html" %}
+{% import 'macros/answers.html' as answers %}
+
+{% block page_title %}{{service_data['serviceName']}} – Digital Marketplace{% endblock %}
+
+{% block main_content %}
+  <div class="grid-row">
+    <div class="column-two-thirds">
+      {% with
+        context = "Edit",
+        heading = service_data['serviceName'],
+        smaller = true
+      %}
+        {% include "toolkit/page-heading.html" %}
+      {% endwith %}
+    </div>
+    {% block before_sections %}{% endblock %}
+    <div class="column-one-whole">
+      {% import "toolkit/summary-table.html" as summary %}
+      {% for section in sections %}
+        {{ summary.heading(section.name) }}
+        {% if section.editable %}
+          {% block edit_link scoped %}{% endblock %}
+        {% endif %}
+        {% call(question) summary.list_table(
+          section.questions,
+          caption=section.name,
+          field_headings=[
+            "Service attribute name",
+            "Service attribute"
+          ],
+          field_headings_visible=False
+        ) %}
+          {% call summary.row() %}
+            {{ summary.field_name(question.question) }}
+            {% call summary.field() %}
+              {{ answers[question.type](service_data[question.id]) }}
+            {% endcall %}
+          {% endcall %}
+        {% endcall %}
+      {% endfor %}
+    </div>
+  </div>
+{% endblock %}

--- a/app/templates/services/edit_section.html
+++ b/app/templates/services/edit_section.html
@@ -1,7 +1,4 @@
-{% extends "_base_page.html" %}
-{% import "macros/toolkit_forms.html" as forms %}
-
-{% block page_title %}{{ section.name }} – Digital Marketplace{% endblock %}
+{% extends "services/_base_edit_section_page.html" %}
 
 {% block breadcrumb %}
   {%
@@ -15,12 +12,12 @@
         "label": current_user.supplier_name
       },
       {
-        "link": url_for(dashboard),
-        "label": dash_label
+        "link": url_for(".list_services"),
+        "label": "Services"
       },
       {
-        "link": url_for(return_to, service_id=service_id),
-        "label": service_data["serviceName"] or 'New service'
+        "link": url_for(".edit_service", service_id=service_id),
+        "label": service_data["serviceName"]
       }
     ]
   %}
@@ -28,56 +25,14 @@
   {% endwith %}
 {% endblock %}
 
-{% block main_content %}
-
-  {% if errors %}
-    {% with errors = errors.values() %}
-      {% include 'toolkit/forms/validation.html' %}
-    {% endwith %}
-  {% endif %}
-
-  <div class="grid-row">
-    <div class="column-two-thirds">
-
-      {% with
-        heading = section.name,
-        smaller = true
-      %}
-        {% include 'toolkit/page-heading.html' %}
-      {% endwith %}
-
-    </div>
-  </div>
-  <form method="post" action="">
-
-    {% for question in section.questions %}
-      {% if errors and errors[question.id] %}
-        {{ forms[question.type](question, service_data, errors) }}
-      {% else %}
-        {{ forms[question.type](question, service_data, {}) }}
-      {% endif %}
-    {% endfor %}
-
-    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
-    {% if request.args.get('return_to_summary') or "suppliers/submission/" not in request.url %}
-      {%
-        with
-        label="Save and return to service",
-        type="save"
-      %}
-      {% include "toolkit/button.html" %}
-      {% endwith %}
-    {% else %}
-      {%
-        with
-        label="Save and continue",
-        type="save"
-      %}
-      {% include "toolkit/button.html" %}
-      {% endwith %}
-    {% endif %}
-    
-    <a href="{{ url_for(return_to, service_id=service_id) }}">Return to service</a>
-
-  </form>
+{% block save_button %}
+  {%
+    with
+    label="Save and return to service",
+    type="save"
+  %}
+  {% include "toolkit/button.html" %}
+  {% endwith %}
 {% endblock %}
+
+{% block return_to_service %}{{ url_for(".edit_service", service_id=service_id) }}{% endblock %}

--- a/app/templates/services/edit_submission_section.html
+++ b/app/templates/services/edit_submission_section.html
@@ -1,0 +1,48 @@
+{% extends "services/_base_edit_section_page.html" %}
+
+{% block breadcrumb %}
+  {%
+    with items = [
+      {
+        "link": "/",
+        "label": "Digital Marketplace"
+      },
+      {
+        "link": url_for(".dashboard"),
+        "label": current_user.supplier_name
+      },
+      {
+        "link": url_for(".framework_dashboard"),
+        "label": "Apply to G-Cloud 7"
+      },
+      {
+        "link": url_for(".view_service_submission", service_id=service_id),
+        "label": service_data["serviceName"] or 'New service'
+      }
+    ]
+  %}
+    {% include "toolkit/breadcrumb.html" %}
+  {% endwith %}
+{% endblock %}
+
+{% block save_button %}
+  {% if request.args.get('return_to_summary') %}
+    {%
+      with
+      label="Save and return to service",
+      type="save"
+    %}
+    {% include "toolkit/button.html" %}
+    {% endwith %}
+  {% else %}
+    {%
+      with
+      label="Save and continue",
+      type="save"
+    %}
+    {% include "toolkit/button.html" %}
+    {% endwith %}
+  {% endif %}
+{% endblock %}
+
+{% block return_to_service %}{{ url_for(".view_service_submission", service_id=service_id) }}{% endblock %}

--- a/app/templates/services/service.html
+++ b/app/templates/services/service.html
@@ -1,7 +1,5 @@
-{% extends "_base_page.html" %}
+{% extends "services/_base_service_page.html" %}
 {% import 'macros/answers.html' as answers %}
-
-{% block page_title %}{{service_data['serviceName']}} – Digital Marketplace{% endblock %}
 
 {% block breadcrumb %}
   {%
@@ -24,17 +22,7 @@
   {% endwith %}
 {% endblock %}
 
-{% block main_content %}
-  <div class="grid-row">
-    <div class="column-two-thirds">
-      {% with
-        context = "Edit" if service_data.status != 'disabled',
-        heading = service_data['serviceName'],
-        smaller = true
-      %}
-        {% include "toolkit/page-heading.html" %}
-      {% endwith %}
-    </div>
+{% block before_sections %}
   {% if error %}
     <div class="column-one-whole">
       {% with
@@ -48,30 +36,8 @@
     <div class="column-two-thirds">
       {% include "services/_edit-status.html" %}
     </div>
-    <div class="column-one-whole">
-      {% import "toolkit/summary-table.html" as summary %}
-      {% for section in sections %}
-        {{ summary.heading(section.name) }}
-        {% if section.editable %}
-          {{ summary.top_link("Edit", url_for(".edit_section", service_id=service_id, section_id=section.id)) }}
-        {% endif %}
-        {% call(question) summary.list_table(
-          section.questions,
-          caption=section.name,
-          field_headings=[
-            "Service attribute name",
-            "Service attribute"
-          ],
-          field_headings_visible=True
-        ) %}
-          {% call summary.row() %}
-            {{ summary.field_name(question.question) }}
-            {% call summary.field() %}
-              {{ answers[question.type](service_data[question.id]) }}
-            {% endcall %}
-          {% endcall %}
-        {% endcall %}
-      {% endfor %}
-    </div>
-  </div>
+{% endblock %}
+
+{% block edit_link %}
+  {{ summary.top_link("Edit", url_for(".edit_section", service_id=service_id, section_id=section.id)) }}
 {% endblock %}

--- a/app/templates/services/service_submission.html
+++ b/app/templates/services/service_submission.html
@@ -1,7 +1,5 @@
-{% extends "_base_page.html" %}
+{% extends "services/_base_service_page.html" %}
 {% import 'macros/answers.html' as answers %}
-
-{% block page_title %}{{service_data['serviceName']}} – Digital Marketplace{% endblock %}
 
 {% block breadcrumb %}
   {%
@@ -24,41 +22,6 @@
   {% endwith %}
 {% endblock %}
 
-{% block main_content %}
-  <div class="grid-row">
-    <div class="column-two-thirds">
-      {% with
-        context = "Edit",
-        heading = service_data['serviceName'],
-        smaller = true
-      %}
-        {% include "toolkit/page-heading.html" %}
-      {% endwith %}
-    </div>
-    <div class="column-one-whole">
-      {% import "toolkit/summary-table.html" as summary %}
-      {% for section in sections %}
-        {{ summary.heading(section.name) }}
-        {% if section.editable %}
-          {{ summary.top_link("Edit", url_for(".edit_service_submission", service_id=service_id, section_id=section.id)) }}
-        {% endif %}
-        {% call(question) summary.list_table(
-          section.questions,
-          caption=section.name,
-          field_headings=[
-            "Service attribute name",
-            "Service attribute"
-          ],
-          field_headings_visible=True
-        ) %}
-          {% call summary.row() %}
-            {{ summary.field_name(question.question) }}
-            {% call summary.field() %}
-              {{ answers[question.type](service_data[question.id]) }}
-            {% endcall %}
-          {% endcall %}
-        {% endcall %}
-      {% endfor %}
-    </div>
-  </div>
+{% block edit_link %}
+  {{ summary.top_link("Edit", url_for(".edit_service_submission", service_id=service_id, section_id=section.id)) }}
 {% endblock %}


### PR DESCRIPTION
Refactor the service overview and edit section templates for services and service submissions so that they inherit from common base templates. This means that we have less duplication and can avoid passing configuration variables into the templates. It does add a bit of indirection that may make the templates less obvious.