### PR TITLE
Fix URL parameter name in link generation

### DIFF
--- a/app/templates/services/service.html
+++ b/app/templates/services/service.html
@@ -53,7 +53,7 @@
       {% for section in sections %}
         {{ summary.heading(section.name) }}
         {% if section.editable %}
-          {{ summary.top_link("Edit", url_for(".edit_section", service_id=service_id, section=section.id)) }}
+          {{ summary.top_link("Edit", url_for(".edit_section", service_id=service_id, section_id=section.id)) }}
         {% endif %}
         {% call(question) summary.list_table(
           section.questions,


### PR DESCRIPTION
The URL parameter was changed from section to section_id.