### PR TITLE
Updated 503 tests

### DIFF
--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -1,7 +1,7 @@
 from flask import render_template, request, redirect, url_for, abort
 from flask_login import login_required, current_user
 
-from dmutils.apiclient import HTTPError
+from dmutils.apiclient import APIError
 from dmutils import flask_featureflags
 
 from ...main import main
@@ -21,7 +21,7 @@ def dashboard():
             current_user.supplier_id
         )['suppliers']
         supplier['contact'] = supplier['contactInformation'][0]
-    except HTTPError as e:
+    except APIError as e:
         abort(e.status_code)
 
     return render_template(

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -1,7 +1,7 @@
 from flask import render_template, request, redirect, url_for, abort
 from flask_login import login_required, current_user
 
-from dmutils.apiclient import APIError
+from dmutils.apiclient import HTTPError
 from dmutils import flask_featureflags
 
 from ...main import main
@@ -21,7 +21,7 @@ def dashboard():
             current_user.supplier_id
         )['suppliers']
         supplier['contact'] = supplier['contactInformation'][0]
-    except APIError as e:
+    except HTTPError as e:
         abort(e.status_code)
 
     return render_template(

--- a/tests/app/test_application.py
+++ b/tests/app/test_application.py
@@ -6,6 +6,7 @@ from nose.tools import assert_equal, assert_true
 from app import data_api_client
 from requests import ConnectionError
 from .helpers import BaseApplicationTest
+from dmutils.apiclient.errors import HTTPError
 
 
 class TestApplication(BaseApplicationTest):
@@ -45,8 +46,8 @@ class TestApplication(BaseApplicationTest):
         with self.app.test_client():
             self.login()
 
-            data_api_client.find_services = Mock(
-                side_effect=ConnectionError('API is down')
+            data_api_client.get_supplier = Mock(
+                side_effect=HTTPError('API is down')
             )
             self.app.config['DEBUG'] = False
 


### PR DESCRIPTION
The 503 test needed to stub out the `get_supplier` method because it is the only method of the API client the view code for the base ('/') suppliers route calls.

In addition to that, failed requests handled by the API Client return instances of the `HTTPError` class, not its derived class, `APIError` so the existing code behaved unpredictably.