### PR TITLE
Include fix for bug with toolkit summary tables

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "jquery": "1.11.2",
     "hogan": "3.0.2",
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
-    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v8.2.1",
+    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v8.2.2",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.14.1/jinja_govuk_template-0.14.1.tgz",
     "digital-marketplace-ssp-content": "git://github.com/alphagov/digitalmarketplace-ssp-content#c1150946db3f145a686d491eb216d4a7e55dd321"
   }


### PR DESCRIPTION
Dashboard was throwing a 500 for suppliers with clients.

This was because of a mis-named variable in one of the toolkit templates, fixed in:
https://github.com/alphagov/digitalmarketplace-frontend-toolkit/pull/127/files

This commit updates the toolkit version to include the fix.