### PR TITLE
[#98558456] Add pricing fields to draft service editing

### DIFF
--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -39,6 +39,7 @@ $path: "/suppliers/static/images/";
 @import "toolkit/forms/_textboxes.scss";
 @import "toolkit/forms/_validation.scss";
 @import "toolkit/forms/_upload.scss";
+@import "toolkit/forms/_pricing.scss";
 
 @import "_text.scss";
 @import "_grids.scss";

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -5,6 +5,7 @@ from ...main import main, existing_service_content, new_service_content
 from ... import data_api_client, flask_featureflags, convert_to_boolean
 from dmutils.apiclient import APIError, HTTPError
 from dmutils.presenters import Presenters
+from dmutils.formats import format_service_price
 
 presenters = Presenters()
 
@@ -286,11 +287,13 @@ def view_service_submission(service_id):
         abort(404)
 
     content = new_service_content.get_builder().filter(draft)
+    service_data = presenters.present_all(draft, new_service_content)
+    service_data['priceString'] = format_service_price(service_data)
 
     return render_template(
         "services/service_submission.html",
         service_id=service_id,
-        service_data=presenters.present_all(draft, new_service_content),
+        service_data=service_data,
         sections=content,
         **main.config['BASE_TEMPLATE_DATA']), 200
 

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -412,25 +412,17 @@ def _get_formatted_section_data(section, with_page_questions=False):
         elif _is_boolean_type(key):
             section_data[key] = convert_to_boolean(section_data[key])
         elif _is_type(key, ['pricing']):
-            pricing = request.form.getlist(key)
-            if len(pricing[0]) > 0:
-                try:
-                    section_data['priceMin'] = float(pricing[0])
-                except ValueError:
-                    section_data['priceMin'] = pricing[0]
-            section_questions.append('priceMin')
-            if len(pricing[1]) > 0:
-                try:
-                    section_data['priceMax'] = float(pricing[1])
-                except ValueError:
-                    section_data['priceMax'] = pricing[1]
-            section_questions.append('priceMax')
-            if len(pricing[2]) > 0:
-                section_data['priceUnit'] = pricing[2]
-            section_questions.append('priceUnit')
-            section_data['priceInterval'] = pricing[3]
-            section_questions.append('priceInterval')
-            del section_data[key]
+            pricing_field = request.form.getlist(key)
+            field_names = ['priceMin', 'priceMax', 'priceUnit', 'priceInterval']
+
+            pricing_data = {
+                field_name: pricing_field[i] for i, field_name in enumerate(field_names)
+                if len(pricing_field[i]) > 0
+            }
+            section_data.update(pricing_data)
+            section_questions += field_names
+
+            del section_data['priceString']
             section_questions.remove('priceString')
     if with_page_questions:
         section_data['page_questions'] = section_questions

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -503,7 +503,7 @@ def _rewrite_pricing_message_key(error, message_key):
             return 'no_min_price_specified'
         elif error == 'priceUnit':
             return 'no_unit_specified'
-    elif message_key == 'not_a_number':
+    elif message_key == 'not_money_format':
         if error == 'priceMin':
             return 'min_price_not_a_number'
         elif error == 'priceMax':

--- a/app/templates/macros/toolkit_forms.html
+++ b/app/templates/macros/toolkit_forms.html
@@ -107,13 +107,16 @@
   {%
     with
     name=question_content.id,
-    value=service_data[question_content.id],
+    priceMin=service_data.priceMin,
+    priceMax=service_data.priceMax,
+    priceUnit=service_data.priceUnit,
+    priceInterval=service_data.priceInterval,
     question=question_content.question,
     hint=question_content.hint,
     id=question_content.id,
     error=errors.get(question_content.id)['message']
   %}
-    {% include "toolkit/forms/textbox.html" %}
+    {% include "toolkit/forms/pricing.html" %}
   {% endwith %}
 {%- endmacro %}
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ Flask==0.10.1
 Flask-Login==0.2.11
 Flask-Script==2.0.5
 Flask-WTF==0.11
-git+https://github.com/alphagov/digitalmarketplace-utils.git@3.6.0#egg=digitalmarketplace-utils==3.6.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@3.9.0#egg=digitalmarketplace-utils==3.9.0
 
 mandrill==1.0.57
 

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -554,6 +554,26 @@ class TestEditDraftService(BaseApplicationTest):
         data_api_client.update_draft_service.assert_called_once_with(
             '1', {'page_questions': ['serviceName', 'serviceSummary']}, 'email@email.com')
 
+    def test_pricing_fields_are_added_correctly(self, data_api_client):
+        data_api_client.get_draft_service.return_value = self.empty_draft
+        res = self.client.post(
+            '/suppliers/submission/services/1/edit/pricing',
+            data={
+                'priceString': ["10.10", "11.10", "Person", "Second"],
+            })
+
+        assert_equal(res.status_code, 302)
+        data_api_client.update_draft_service.assert_called_once_with(
+            '1',
+            {
+                'priceMin': "10.10", 'priceMax': "11.10", "priceUnit": "Person", 'priceInterval': 'Second',
+                'page_questions': [
+                    'vatIncluded', 'educationPricing', 'pricingDocumentURL', 'sfiaRateDocumentURL',
+                    'priceMin', 'priceMax', 'priceUnit', 'priceInterval'
+                ]
+            },
+            'email@email.com')
+
     def test_edit_non_existent_draft_service_returns_404(self, data_api_client):
         data_api_client.get_draft_service.side_effect = HTTPError(mock.Mock(status_code=404))
         res = self.client.get('/suppliers/submission/services/1/edit/service_description')

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from dmutils.apiclient import HTTPError
 import mock
 from lxml import html
@@ -725,4 +726,4 @@ class TestShowDraftService(BaseApplicationTest):
         service_price_xpath = service_price_row_xpath + '/td[@class="summary-item-field"]/span/text()'
         assert_equal(
             document.xpath(service_price_xpath)[0].strip(),
-            "£12.50 to £15 per Person per Second")
+            u"£12.50 to £15 per person per second")


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/98558456

- Use the pricing form template from the frontend toolkit to render the pricing fields.
- Parse the pricing fields into the correct fields for the data API
- Render pricing specific error messages
- Render a human readable price string on the service edit page

![screen shot 2015-08-03 at 17 29 07](https://cloud.githubusercontent.com/assets/14287/9042235/408185b0-3a05-11e5-94b3-f8d492b62f4b.png)

![screen shot 2015-08-03 at 17 29 19](https://cloud.githubusercontent.com/assets/14287/9042242/4bad6bd4-3a05-11e5-8a15-38ddd00e6cb9.png)

## Depends on
- [x] https://github.com/alphagov/digitalmarketplace-utils/pull/114
- [ ] https://github.com/alphagov/digitalmarketplace-api/pull/195