### PR TITLE
Fix variable name in template

### DIFF
--- a/app/templates/users/list_users.html
+++ b/app/templates/users/list_users.html
@@ -24,7 +24,7 @@
   {% with messages = get_flashed_messages(with_categories=true) %}
     {% if messages %}
       {% for category, message in messages %}
-        {% if message['deactivate_user_email_address'] and ['deactivate_user_name'] %}
+        {% if message['deactivate_user_name'] and message['deactivate_user_email_address'] %}
           {% set message = "{} ({}) has been removed as a contributor. They can be invited again at any time.".format(message['deactivate_user_name'], message['deactivate_user_email_address']) %}
         {% endif %}
         {%


### PR DESCRIPTION
Accidentally a word in the `list_users` template.

It doesn't cause any practical problems at the moment, but it could eventually.