### PR TITLE
Allow editing of assurance questions

### DIFF
--- a/app/assets/scss/_assurance-question.scss
+++ b/app/assets/scss/_assurance-question.scss
@@ -1,0 +1,12 @@
+.assurance-question {
+
+  .question {
+    margin: $gutter / -2 0 $gutter * 1.5 0;
+  }
+
+  .question-heading {
+    @include core-19;
+    margin-top: -10px;
+  }
+
+}

--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -47,6 +47,7 @@ $path: "/suppliers/static/images/";
 @import "_service-status.scss";
 @import "_return-link.scss";
 @import "_framework-application.scss";
+@import "_assurance-question.scss";
 
 .filter-field-text {
   @include core-16;

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -10,6 +10,7 @@ from ..helpers.services import (
 from ... import data_api_client, flask_featureflags
 from dmutils.apiclient import APIError, HTTPError
 from dmutils.presenters import Presenters
+from dmutils.service_attribute import Attribute
 
 presenters = Presenters()
 
@@ -303,8 +304,8 @@ def view_service_submission(service_id):
     return render_template(
         "services/service_submission.html",
         service_id=service_id,
-        service_data=presenters.present_all(draft, new_service_content),
-        sections=content,
+        sections=_get_service_attributes(draft, content),
+        service_data=draft,
         **main.config['BASE_TEMPLATE_DATA']), 200
 
 
@@ -320,15 +321,19 @@ def edit_service_submission(service_id, section_id):
     if not is_service_associated_with_supplier(draft):
         abort(404)
 
+    serviceName = draft.get('serviceName', '')
     content = new_service_content.get_builder().filter(draft)
     section = content.get_section(section_id)
     if section is None:
         abort(404)
 
+    formatted_service_data = _section_data_formatted_for_page(section, draft)
+    formatted_service_data['serviceName'] = serviceName
+
     return render_template(
         "services/edit_submission_section.html",
         section=section,
-        service_data=draft,
+        service_data=formatted_service_data,
         service_id=service_id,
         **main.config['BASE_TEMPLATE_DATA']
     )
@@ -379,10 +384,13 @@ def update_section_submission(service_id, section_id):
         errors_map = get_section_error_messages(e.message, draft['lot'])
         if not posted_data.get('serviceName', None):
             posted_data['serviceName'] = draft.get('serviceName', '')
+        displayed_data = _section_data_formatted_for_page(section, updated_data)
+        errors_map = _get_section_error_messages(e, draft['lot'])
+        displayed_data['serviceName'] = serviceName
         return render_template(
             "services/edit_submission_section.html",
             section=section,
-            service_data=posted_data,
+            service_data=displayed_data,
             service_id=service_id,
             errors=errors_map,
             **main.config['BASE_TEMPLATE_DATA']
@@ -395,6 +403,72 @@ def update_section_submission(service_id, section_id):
         return redirect(url_for(".edit_service_submission", service_id=service_id, section_id=next_section))
     else:
         return redirect(url_for(".view_service_submission", service_id=service_id))
+
+
+def _is_service_associated_with_supplier(service):
+    return service.get('supplierId') == current_user.supplier_id
+
+
+def _is_service_modifiable(service):
+    return service.get('status') != 'disabled'
+
+
+def _get_error_message(error, message_key, content):
+    validations = [
+        validation for validation in content.get_question(error)['validations']
+        if validation['name'] == message_key]
+
+    if len(validations):
+        return validations[0]['message']
+    else:
+        return 'There was a problem with the answer to this question'
+
+
+def _is_list_type(key):
+    """Return True if a given key is a list type"""
+    print(new_service_content.get_question(key)['type'])
+    if key == 'serviceTypes':
+        return True
+    return new_service_content.get_question(key)['type'] in [
+        'list', 'checkbox', 'checkboxes', 'pricing'
+    ]
+
+
+def _is_boolean_type(key):
+    """Return True if a given key is a boolean type"""
+    return new_service_content.get_question(key)['type'] == 'boolean'
+
+
+def _question_has_assurance(key):
+    """Return True if a question has an assurance component"""
+    question = new_service_content.get_question(key)
+    return (
+        'assuranceApproach' in question and
+        question['assuranceApproach']
+    )
+
+
+def _section_data_formatted(section, section_data):
+    filtered_section_data = _filter_keys(section_data, get_section_questions(section))
+    additional_section_data = {}
+    for key in filtered_section_data:
+        # Turn responses which have multiple parts into lists
+        if _is_list_type(key):
+            filtered_section_data[key] = request.form.getlist(key)
+        # Turn booleans into booleans
+        elif _is_boolean_type(key):
+            filtered_section_data[key] = convert_to_boolean(filtered_section_data[key])
+        # Format assurance how the API expects it
+        if _question_has_assurance(key):
+            assurance = ''
+            key_with_assurance = key + '--assurance'
+            if key_with_assurance in section_data:
+                assurance = section_data[key_with_assurance]
+            filtered_section_data[key] = {
+                'value': filtered_section_data[key],
+                'assurance': assurance
+            }
+    return filtered_section_data
 
 
 def _update_service_status(service, error_message=None):

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -5,12 +5,11 @@ from ...main import main, existing_service_content, new_service_content
 from ..helpers.services import (
     get_formatted_section_data, get_section_questions, get_section_error_messages,
     is_service_modifiable, is_service_associated_with_supplier,
-    upload_draft_documents
+    upload_draft_documents, get_service_attributes
 )
 from ... import data_api_client, flask_featureflags
 from dmutils.apiclient import APIError, HTTPError
 from dmutils.presenters import Presenters
-from dmutils.service_attribute import Attribute
 
 presenters = Presenters()
 
@@ -304,7 +303,7 @@ def view_service_submission(service_id):
     return render_template(
         "services/service_submission.html",
         service_id=service_id,
-        sections=_get_service_attributes(draft, content),
+        sections=get_service_attributes(draft, content),
         service_data=draft,
         **main.config['BASE_TEMPLATE_DATA']), 200
 
@@ -321,22 +320,15 @@ def edit_service_submission(service_id, section_id):
     if not is_service_associated_with_supplier(draft):
         abort(404)
 
-    serviceName = draft.get('serviceName', '')
     content = new_service_content.get_builder().filter(draft)
     section = content.get_section(section_id)
     if section is None:
         abort(404)
 
-    formatted_service_data = dict(
-        draft,
-        **_section_data_formatted_for_page(section, draft)
-    )
-    formatted_service_data['serviceName'] = serviceName
-
     return render_template(
         "services/edit_submission_section.html",
         section=section,
-        service_data=formatted_service_data,
+        service_data=draft,
         service_id=service_id,
         **main.config['BASE_TEMPLATE_DATA']
     )

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -3,7 +3,8 @@ from flask import render_template, request, redirect, url_for, abort, flash
 
 from ...main import main, existing_service_content, new_service_content
 from ..helpers.services import (
-    get_formatted_section_data, get_section_questions, get_section_error_messages,
+    get_formatted_section_data, unformat_section_data,
+    get_section_questions, get_section_error_messages,
     is_service_modifiable, is_service_associated_with_supplier,
     upload_draft_documents, get_service_attributes
 )
@@ -325,6 +326,8 @@ def edit_service_submission(service_id, section_id):
     if section is None:
         abort(404)
 
+    unformat_section_data(draft)
+
     return render_template(
         "services/edit_submission_section.html",
         section=section,
@@ -376,6 +379,7 @@ def update_section_submission(service_id, section_id):
             page_questions=get_section_questions(section)
         )
     except HTTPError as e:
+        unformat_section_data(update_data)
         errors_map = get_section_error_messages(e.message, draft['lot'])
         if not posted_data.get('serviceName', None):
             posted_data['serviceName'] = draft.get('serviceName', '')

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -426,7 +426,6 @@ def _get_error_message(error, message_key, content):
 
 def _is_list_type(key):
     """Return True if a given key is a list type"""
-    print(new_service_content.get_question(key)['type'])
     if key == 'serviceTypes':
         return True
     return new_service_content.get_question(key)['type'] in [
@@ -437,6 +436,11 @@ def _is_list_type(key):
 def _is_boolean_type(key):
     """Return True if a given key is a boolean type"""
     return new_service_content.get_question(key)['type'] == 'boolean'
+
+
+def _is_numeric_type(key):
+    """Return True if a given key is a boolean type"""
+    return new_service_content.get_question(key)['type'] == 'percentage'
 
 
 def _question_has_assurance(key):
@@ -458,6 +462,8 @@ def _section_data_formatted(section, section_data):
         # Turn booleans into booleans
         elif _is_boolean_type(key):
             filtered_section_data[key] = convert_to_boolean(filtered_section_data[key])
+        elif _is_numeric_type(key):
+            filtered_section_data[key] = convert_to_number(filtered_section_data[key])
         # Format assurance how the API expects it
         if _question_has_assurance(key):
             assurance = ''

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -327,7 +327,10 @@ def edit_service_submission(service_id, section_id):
     if section is None:
         abort(404)
 
-    formatted_service_data = _section_data_formatted_for_page(section, draft)
+    formatted_service_data = dict(
+        draft,
+        **_section_data_formatted_for_page(section, draft)
+    )
     formatted_service_data['serviceName'] = serviceName
 
     return render_template(
@@ -384,13 +387,11 @@ def update_section_submission(service_id, section_id):
         errors_map = get_section_error_messages(e.message, draft['lot'])
         if not posted_data.get('serviceName', None):
             posted_data['serviceName'] = draft.get('serviceName', '')
-        displayed_data = _section_data_formatted_for_page(section, updated_data)
-        errors_map = _get_section_error_messages(e, draft['lot'])
-        displayed_data['serviceName'] = serviceName
+        errors_map = get_section_error_messages(e.message, draft['lot'])
         return render_template(
             "services/edit_submission_section.html",
             section=section,
-            service_data=displayed_data,
+            service_data=update_data,
             service_id=service_id,
             errors=errors_map,
             **main.config['BASE_TEMPLATE_DATA']

--- a/app/templates/macros/assurance.html
+++ b/app/templates/macros/assurance.html
@@ -67,7 +67,7 @@
   {{
     radios(
       question_content = {
-        'question': 'Assurance approach',
+        'question': 'Assured by',
         'id': name + '--assurance',
         'hint': '',
         'options': assurance_options[type],

--- a/app/templates/macros/assurance.html
+++ b/app/templates/macros/assurance.html
@@ -1,0 +1,80 @@
+{% from "macros/toolkit_forms.html" import radios %}
+
+{% macro assurance_question(
+  name,
+  value='',
+  type,
+  errors
+) %}
+
+  {% set assurance_options = {
+    '2answers-type1': [
+      {'label': 'Service provider assertion'},
+      {'label': 'Independent validation of assertion'}
+    ],
+    '3answers-type1': [
+      {'label': 'Service provider assertion'},
+      {'label': 'Contractual commitment'},
+      {'label': 'Independent validation of assertion'}
+    ],
+    '3answers-type2': [
+      {'label': 'Service provider assertion'},
+      {'label': 'Independent validation of assertion'},
+      {'label': 'Independent testing of implementation'}
+    ],
+    '2answers-type2': [
+      {'label': 'Service provider assertion'},
+      {'label': 'Independent validation of assertion'},
+      {'label': 'Independent testing of implementation'}
+    ],
+    '3answers-type3': [
+      {'label': 'Service provider assertion'},
+      {'label': 'Independent testing of implementation'},
+      {'label': 'CESG-assured components'}
+    ],
+    '3answers-type4': [
+      {'label': 'Service provider assertion'},
+      {'label': 'Independent validation of assertion'},
+      {'label': 'Independent testing of implementation'}
+    ],
+    '4answers-type1': [
+      {'label': 'Service provider assertion'},
+      {'label': 'Independent validation of assertion'},
+      {'label': 'Independent testing of implementation'},
+      {'label': 'CESG-assured components'}
+    ],
+    '4answers-type2': [
+      {'label': 'Service provider assertion'},
+      {'label': 'Contractual commitment'},
+      {'label': 'Independent validation of assertion'},
+      {'label': 'CESG-assured components'}
+    ],
+    '4answers-type3': [
+      {'label': 'Service provider assertion'},
+      {'label': 'Independent testing of implementation'},
+      {'label': 'Assurance of service design'},
+      {'label': 'CESG-assured components'}
+    ],
+    '5answers-type1': [
+      {'label': 'Service provider assertion'},
+      {'label': 'Contractual commitment'},
+      {'label': 'Independent validation of assertion'},
+      {'label': 'Independent testing of implementation'},
+      {'label': 'CESG-assured components'}
+    ]
+  } %}
+
+  {{
+    radios(
+      question_content = {
+        'question': 'Assurance approach',
+        'id': name + '--assurance',
+        'hint': '',
+        'options': assurance_options[type],
+      },
+      service_data={},
+      errors = errors
+    )
+  }}
+
+{% endmacro %}

--- a/app/templates/macros/assurance.html
+++ b/app/templates/macros/assurance.html
@@ -2,7 +2,7 @@
 
 {% macro assurance_question(
   name,
-  value='',
+  service_data,
   type,
   errors
 ) %}
@@ -72,7 +72,7 @@
         'hint': '',
         'options': assurance_options[type],
       },
-      service_data={},
+      service_data=service_data,
       errors = errors
     )
   }}

--- a/app/templates/services/_base_edit_section_page.html
+++ b/app/templates/services/_base_edit_section_page.html
@@ -1,5 +1,6 @@
 {% extends "_base_page.html" %}
 {% import "macros/toolkit_forms.html" as forms %}
+{% from "macros/assurance.html" import assurance_question %}
 
 {% block page_title %}{{ section.name }} – Digital Marketplace{% endblock %}
 
@@ -31,11 +32,19 @@
       {% else %}
         {{ forms[question.type](question, service_data, {}) }}
       {% endif %}
+      {% if question.assuranceApproach %}
+        {{ assurance_question(
+          name=question.id,
+          value='',
+          type=question.assuranceApproach,
+          errors={}
+        ) }}
+      {% endif %}
     {% endfor %}
 
     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
     {% block save_button %}{% endblock %}
-    
+
     <a href="{% block return_to_service %}{% endblock %}">Return to service</a>
 
   </form>

--- a/app/templates/services/_base_edit_section_page.html
+++ b/app/templates/services/_base_edit_section_page.html
@@ -35,7 +35,7 @@
       {% if question.assuranceApproach %}
         {{ assurance_question(
           name=question.id,
-          value='',
+          service_data=service_data,
           type=question.assuranceApproach,
           errors={}
         ) }}

--- a/app/templates/services/_base_edit_section_page.html
+++ b/app/templates/services/_base_edit_section_page.html
@@ -33,12 +33,14 @@
         {{ forms[question.type](question, service_data, {}) }}
       {% endif %}
       {% if question.assuranceApproach %}
-        {{ assurance_question(
-          name=question.id,
-          service_data=service_data,
-          type=question.assuranceApproach,
-          errors={}
-        ) }}
+        <div class='assurance-question'>
+          {{ assurance_question(
+            name=question.id,
+            service_data=service_data,
+            type=question.assuranceApproach,
+            errors={}
+          ) }}
+        </div>
       {% endif %}
     {% endfor %}
 

--- a/app/templates/services/_base_service_page.html
+++ b/app/templates/services/_base_service_page.html
@@ -23,7 +23,7 @@
           {% block edit_link scoped %}{% endblock %}
         {% endif %}
         {% call(question) summary.list_table(
-          section.questions,
+          section.rows,
           caption=section.name,
           field_headings=[
             "Service attribute name",
@@ -31,12 +31,19 @@
           ],
           field_headings_visible=False
         ) %}
-          {% call summary.row() %}
-            {{ summary.field_name(question.question) }}
-            {% call summary.field() %}
-              {{ answers[question.type](service_data[question.id]) }}
+          {% if question.answer_required %}
+            {% call summary.row(complete=False) %}
+              {{ summary.field_name(question.label) }}
+              {% call summary.field() %}
+                <a href="{{ url_for(".edit_service_submission", service_id=service_id, section_id=section.id) }}">Answer required</a>
+              {% endcall %}
             {% endcall %}
-          {% endcall %}
+          {% else %}
+            {% call summary.row() %}
+              {{ summary.field_name(question.label) }}
+              {{ summary[question.type](question.value, question.assurance) }}
+            {% endcall %}
+          {% endif %}
         {% endcall %}
       {% endfor %}
     </div>

--- a/app/templates/services/edit_submission_section.html
+++ b/app/templates/services/edit_submission_section.html
@@ -17,7 +17,7 @@
       },
       {
         "link": url_for(".view_service_submission", service_id=service_id),
-        "label": service_data["serviceName"] or 'New service'
+        "label": service_data['serviceName'] or 'New service'
       }
     ]
   %}

--- a/bower.json
+++ b/bower.json
@@ -5,8 +5,8 @@
     "jquery": "1.11.2",
     "hogan": "3.0.2",
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
-    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v8.2.2",
+    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v8.2.3",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.14.1/jinja_govuk_template-0.14.1.tgz",
-    "digital-marketplace-ssp-content": "git://github.com/alphagov/digitalmarketplace-ssp-content#c1150946db3f145a686d491eb216d4a7e55dd321"
+    "digital-marketplace-ssp-content": "git://github.com/alphagov/digitalmarketplace-ssp-content#03439549e8357a4d79f37c41a21918a619f9413"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -7,6 +7,6 @@
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
     "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v8.2.3",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.14.1/jinja_govuk_template-0.14.1.tgz",
-    "digital-marketplace-ssp-content": "git://github.com/alphagov/digitalmarketplace-ssp-content#03439549e8357a4d79f37c41a21918a619f9413"
+    "digital-marketplace-ssp-content": "git://github.com/alphagov/digitalmarketplace-ssp-content#e8c900ffafe5d724f939780ae3b2c219b1a2af79"
   }
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ Flask==0.10.1
 Flask-Login==0.2.11
 Flask-Script==2.0.5
 Flask-WTF==0.11
-git+https://github.com/alphagov/digitalmarketplace-utils.git@4.0.0#egg=digitalmarketplace-utils==4.0.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@4.1.0#egg=digitalmarketplace-utils==4.1.0
 
 mandrill==1.0.57
 


### PR DESCRIPTION
_Depends on https://github.com/alphagov/digitalmarketplace-utils/pull/121_

--

![image](https://cloud.githubusercontent.com/assets/355079/9067144/aa99851e-3ad3-11e5-982d-4296bbc6950e.png)

For each applicable SSP question this pull request:
- displays the correct set of radio buttons for the user to choose their assurance approach
- `POST`s the users selected assurance approach back to the API

_The UI and markup aren't ideal at the moment, especially because the red validation border isn't scoped properly. But it's at least something we could put in front of users tomorrow._

It also fixes a problem where 'Service availability' couldn't be saved because it wasn't getting coerced to a number before being posted to the API.

## Bonus feature

This pull request also implements the 'Answer required' message for a draft service:
![image](https://cloud.githubusercontent.com/assets/355079/9059549/ecee1492-3aa2-11e5-9b29-95d261433d03.png)
