### PR TITLE
Documents upload

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -3,7 +3,6 @@ import re
 from datetime import timedelta
 from flask import Flask, request, redirect, session
 from flask_login import LoginManager
-from flask._compat import string_types
 from flask_wtf.csrf import CsrfProtect
 
 from dmutils import apiclient, init_app, flask_featureflags
@@ -68,27 +67,3 @@ def config_attrs(config):
     """Returns config attributes from a Config object"""
     p = re.compile('^[A-Z_]+$')
     return filter(lambda attr: bool(p.match(attr)), dir(config))
-
-
-def convert_to_boolean(value):
-    """Turn strings to bools if they look like them
-
-    Truthy things should be True
-    >>> for truthy in ['true', 'on', 'yes', '1']:
-    ...   assert convert_to_boolean(truthy) == True
-
-    Falsey things should be False
-    >>> for falsey in ['false', 'off', 'no', '0']:
-    ...   assert convert_to_boolean(falsey) == False
-
-    Other things should be unchanged
-    >>> for value in ['falsey', 'other', True, 0]:
-    ...   assert convert_to_boolean(value) == value
-    """
-    if isinstance(value, string_types):
-        if value.lower() in ['t', 'true', 'on', 'yes', '1']:
-            return True
-        elif value.lower() in ['f', 'false', 'off', 'no', '0']:
-            return False
-
-    return value

--- a/app/main/helpers/services.py
+++ b/app/main/helpers/services.py
@@ -1,4 +1,4 @@
-from flask import request, abort, current_app
+from flask import request, abort, current_app, url_for
 from flask_login import current_user
 
 from dmutils.config import convert_to_boolean
@@ -59,7 +59,7 @@ def upload_draft_documents(service, request_files, section):
 
     for field, contents in files.items():
         url = upload_document(
-            uploader, current_app.config['DOCUMENTS_URL'],
+            uploader, url_for('.service_submission_document', document='', _external=True),
             service, field, contents,
             public=False
         )

--- a/app/main/helpers/services.py
+++ b/app/main/helpers/services.py
@@ -2,7 +2,7 @@ from flask import request, abort, current_app
 from flask_login import current_user
 
 from dmutils.config import convert_to_boolean
-from dmutils.s3 import S3
+from dmutils import s3
 from dmutils.documents import filter_empty_files, validate_documents, upload_document
 
 from ...main import new_service_content
@@ -46,7 +46,7 @@ def get_formatted_section_data(section):
     return section_data
 
 
-def upload_documents(service, request_files, section):
+def upload_draft_documents(service, request_files, section):
     request_files = request_files.to_dict(flat=True)
     files = _filter_keys(request_files, get_section_questions(section))
     files = filter_empty_files(files)
@@ -55,7 +55,7 @@ def upload_documents(service, request_files, section):
     if errors:
         return None, errors
 
-    uploader = S3(current_app.config['S3_DOCUMENTS_BUCKET'])
+    uploader = s3.S3(current_app.config['DM_G7_DRAFT_DOCUMENTS_BUCKET'])
 
     for field, contents in files.items():
         url = upload_document(

--- a/app/main/helpers/services.py
+++ b/app/main/helpers/services.py
@@ -1,0 +1,82 @@
+from flask import request, abort
+from flask_login import current_user
+
+from dmutils.config import convert_to_boolean
+
+from ...main import new_service_content
+
+
+def get_section_questions(section):
+    return [question['id'] for question in section['questions']]
+
+
+def is_service_associated_with_supplier(service):
+    return service.get('supplierId') == current_user.supplier_id
+
+
+def is_service_modifiable(service):
+    return service.get('status') != 'disabled'
+
+
+def get_formatted_section_data(section):
+    section_data = dict(list(request.form.items()))
+    section_data = _filter_keys(section_data, get_section_questions(section))
+    # Turn responses which have multiple parts into lists and booleans into booleans
+    for key in section_data:
+        if _is_list_type(key):
+            section_data[key] = request.form.getlist(key)
+        elif _is_boolean_type(key):
+            section_data[key] = convert_to_boolean(section_data[key])
+    return section_data
+
+
+def get_section_error_messages(e, lot):
+    errors_map = {}
+    for error in e.message.keys():
+        if error == '_form':
+            abort(400, "Submitted data was not in a valid format")
+        else:
+            message_key = e.message[error]
+            if error == 'serviceTypes':
+                error = 'serviceTypes{}'.format(lot)
+            validation_message = get_error_message(error, message_key, new_service_content)
+            question_id = new_service_content.get_question(error)['id']
+            errors_map[question_id] = {
+                'input_name': error,
+                'question': new_service_content.get_question(error)['question'],
+                'message': validation_message
+            }
+    return errors_map
+
+
+def get_error_message(error, message_key, content):
+    validations = [
+        validation for validation in content.get_question(error)['validations']
+        if validation['name'] == message_key]
+
+    if len(validations):
+        return validations[0]['message']
+    else:
+        return 'There was a problem with the answer to this question'
+
+
+def _filter_keys(data, keys):
+    """Return a dictionary filtered by a list of keys
+
+    >>> _filter_keys({'a': 1, 'b': 2}, ['a'])
+    {'a': 1}
+    """
+    key_set = set(keys) & set(data.keys())
+    return {key: data[key] for key in key_set}
+
+
+def _is_list_type(key):
+    """Return True if a given key is a list type"""
+    if key == 'serviceTypes':
+        return True
+    return new_service_content.get_question(key)['type'] in ['list', 'checkbox', 'pricing']
+
+
+def _is_boolean_type(key):
+    """Return True if a given key is a boolean type"""
+    return new_service_content.get_question(key)['type'] == 'boolean'

--- a/app/main/helpers/services.py
+++ b/app/main/helpers/services.py
@@ -60,7 +60,8 @@ def upload_draft_documents(service, request_files, section):
     for field, contents in files.items():
         url = upload_document(
             uploader, current_app.config['DOCUMENTS_URL'],
-            service, field, contents
+            service, field, contents,
+            public=False
         )
 
         if not url:

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -365,13 +365,14 @@ def update_section_submission(service_id, section_id):
 
     update_data = posted_data.copy()
     update_data.update(uploaded_documents)
-    update_data['page_questions'] = get_section_questions(section)
 
     try:
         data_api_client.update_draft_service(
             service_id,
             update_data,
-            current_user.email_address)
+            current_user.email_address,
+            page_questions=get_section_questions(section)
+        )
     except HTTPError as e:
         errors_map = get_section_error_messages(e.message, draft['lot'])
         if not posted_data.get('serviceName', None):

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -274,6 +274,16 @@ def copy_draft_service(service_id):
     return redirect(url_for(".framework_dashboard"))
 
 
+@main.route('/submission/documents/<path:document>', methods=['GET'])
+@login_required
+@flask_featureflags.is_active_feature('GCLOUD7_OPEN')
+def service_submission_document(document):
+    return render_template(
+        "services/submission_document.html",
+        document=document,
+        **main.config['BASE_TEMPLATE_DATA']), 200
+
+
 @main.route('/submission/services/<string:service_id>', methods=['GET'])
 @login_required
 @flask_featureflags.is_active_feature('GCLOUD7_OPEN')

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -1,5 +1,5 @@
 from flask_login import login_required, current_user
-from flask import render_template, request, redirect, url_for, abort
+from flask import render_template, request, redirect, url_for, abort, flash
 
 from ...main import main, existing_service_content, new_service_content
 from ..helpers.services import (
@@ -270,6 +270,8 @@ def copy_draft_service(service_id):
 
     except APIError as e:
         abort(e.status_code)
+
+    flash({'service_name': draft.get('serviceName')}, 'service_copied')
 
     return redirect(url_for(".framework_dashboard"))
 

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -5,7 +5,7 @@ from ...main import main, existing_service_content, new_service_content
 from ..helpers.services import (
     get_formatted_section_data, get_section_questions, get_section_error_messages,
     is_service_modifiable, is_service_associated_with_supplier,
-    upload_documents
+    upload_draft_documents
 )
 from ... import data_api_client, flask_featureflags
 from dmutils.apiclient import APIError, HTTPError
@@ -341,7 +341,7 @@ def update_section_submission(service_id, section_id):
 
     posted_data = get_formatted_section_data(section)
 
-    uploaded_documents, document_errors = upload_documents(draft, request.files, section)
+    uploaded_documents, document_errors = upload_draft_documents(draft, request.files, section)
 
     if document_errors:
         return render_template(

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -353,13 +353,14 @@ def update_section_submission(service_id, section_id):
             **main.config['BASE_TEMPLATE_DATA']
         )
 
-    posted_data.update(uploaded_documents)
-    posted_data['page_questions'] = get_section_questions(section)
+    update_data = posted_data.copy()
+    update_data.update(uploaded_documents)
+    update_data['page_questions'] = get_section_questions(section)
 
     try:
         data_api_client.update_draft_service(
             service_id,
-            posted_data,
+            update_data,
             current_user.email_address)
     except HTTPError as e:
         errors_map = get_section_error_messages(e.message, draft['lot'])

--- a/app/new_service_manifest.yml
+++ b/app/new_service_manifest.yml
@@ -36,7 +36,15 @@
     - educationPricing
     - trialOption
     - freeOption
+-
+  name: Pricing document
+  editable: true
+  questions:
     - pricingDocumentURL
+-
+  name: SFIA rate card
+  editable: true
+  questions:
     - sfiaRateDocumentURL
 -
   name: Terms and conditions
@@ -44,6 +52,10 @@
   questions:
     - terminationCost
     - minimumContractPeriod
+-
+  name: Terms and conditions document
+  editable: true
+  questions:
     - termsAndConditionsDocumentURL
 -
   name: Support

--- a/app/templates/frameworks/dashboard.html
+++ b/app/templates/frameworks/dashboard.html
@@ -20,6 +20,17 @@
 {% endblock %}
 
 {% block main_content %}
+
+  {% with messages = get_flashed_messages(with_categories=True, category_filter=['service_copied']) %}
+    {% for category, message in messages %}
+      <div class="banner-success-without-action">
+        <p class="banner-message">
+          "{{message.service_name}}" was copied.
+        </p>
+      </div>
+    {% endfor %}
+  {% endwith %}
+
   {% with
      heading = "Apply to G-Cloud 7",
      smaller = True,

--- a/app/templates/services/_base_edit_section_page.html
+++ b/app/templates/services/_base_edit_section_page.html
@@ -23,7 +23,7 @@
 
     </div>
   </div>
-  <form method="post">
+  <form method="post" enctype="multipart/form-data">
 
     {% for question in section.questions %}
       {% if errors and errors[question.id] %}

--- a/app/templates/services/submission_document.html
+++ b/app/templates/services/submission_document.html
@@ -1,0 +1,17 @@
+{% extends "_base_page.html" %}
+
+{% block page_title %}Uploaded Document - Digital Marketplace{% endblock %}
+
+{% block main_content %}
+
+<div class="error-page">
+  <header class="page-heading-smaller">
+    <h1>Your document has been uploaded</h1>
+  </header>
+
+  <p>
+    Document name: {{ document }}
+  </p>
+</div>
+
+{% endblock %}

--- a/config.py
+++ b/config.py
@@ -86,7 +86,13 @@ class Development(Config):
     FEATURE_FLAGS_USER_DASHBOARD = enabled_since('2015-07-09')
 
 
-class Preview(Config):
+class Live(Config):
+    """Base config for deployed environments"""
+    DEBUG = False
+    DM_HTTP_PROTO = 'https'
+
+
+class Preview(Live):
     FEATURE_FLAGS_EDIT_SERVICE_PAGE = enabled_since('2015-06-03')
     FEATURE_FLAGS_SUPPLIER_DASHBOARD = enabled_since('2015-06-10')
     FEATURE_FLAGS_EDIT_SUPPLIER_PAGE = enabled_since('2015-06-18')
@@ -94,14 +100,12 @@ class Preview(Config):
     FEATURE_FLAGS_USER_DASHBOARD = enabled_since('2015-07-09')
 
 
-class Live(Config):
-    DEBUG = False
-
+class Production(Live):
     FEATURE_FLAGS_SUPPLIER_DASHBOARD = enabled_since('2015-06-10')
     FEATURE_FLAGS_EDIT_SUPPLIER_PAGE = enabled_since('2015-06-18')
 
 
-class Staging(Live):
+class Staging(Production):
     pass
 
 
@@ -109,6 +113,6 @@ configs = {
     'development': Development,
     'preview': Preview,
     'staging': Staging,
-    'production': Live,
+    'production': Production,
     'test': Test,
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ Flask==0.10.1
 Flask-Login==0.2.11
 Flask-Script==2.0.5
 Flask-WTF==0.11
-git+https://github.com/alphagov/digitalmarketplace-utils.git@3.6.0#egg=digitalmarketplace-utils==3.6.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@4.0.0#egg=digitalmarketplace-utils==4.0.0
 
 mandrill==1.0.57
 

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -4,3 +4,4 @@ pep8==1.5.7
 requests-mock==0.6.0
 mock==1.0.1
 lxml==3.4.4
+freezegun==0.3.4

--- a/scripts/run_app.sh
+++ b/scripts/run_app.sh
@@ -10,6 +10,9 @@ fi
 export DM_DATA_API_URL=${DM_DATA_API_URL:=http://localhost:5000}
 export DM_DATA_API_AUTH_TOKEN=${DM_DATA_API_AUTH_TOKEN:=myToken}
 export DM_API_AUTH_TOKEN=${DM_API_AUTH_TOKEN:=myToken}
+
+export DM_G7_DRAFT_DOCUMENTS_BUCKET=${DM_S3_DOCUMENTS_BUCKET:=digitalmarketplace-dev-documents}
+
 export DM_MANDRILL_API_KEY=${DM_MANDRILL_API_KEY:=not_a_real_key}
 export DM_PASSWORD_SECRET_KEY=${DM_PASSWORD_SECRET_KEY:=verySecretKey}
 

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -554,6 +554,20 @@ class TestEditDraftService(BaseApplicationTest):
         data_api_client.update_draft_service.assert_called_once_with(
             '1', {'page_questions': ['serviceName', 'serviceSummary']}, 'email@email.com')
 
+    def test_upload_question_not_accepted_as_form_data(self, data_api_client):
+        data_api_client.get_draft_service.return_value = self.empty_draft
+        res = self.client.post(
+            '/suppliers/submission/services/1/edit/service_definition',
+            data={
+                'serviceDefinitionDocumentURL': 'http://example.com/document.pdf',
+            })
+
+        assert_equal(res.status_code, 302)
+        data_api_client.update_draft_service.assert_called_once_with(
+            '1', {}, 'email@email.com',
+            page_questions=['serviceDefinitionDocumentURL']
+        )
+
     def test_edit_non_existent_draft_service_returns_404(self, data_api_client):
         data_api_client.get_draft_service.side_effect = HTTPError(mock.Mock(status_code=404))
         res = self.client.get('/suppliers/submission/services/1/edit/service_description')

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -547,9 +547,10 @@ class TestEditDraftService(BaseApplicationTest):
         assert_equal(res.status_code, 302)
         data_api_client.update_draft_service.assert_called_once_with(
             '1',
-            {'serviceName': 'The service', 'serviceSummary': 'This is the service',
-             'page_questions': ['serviceName', 'serviceSummary']},
-            'email@email.com')
+            {'serviceName': 'The service', 'serviceSummary': 'This is the service'},
+            'email@email.com',
+            page_questions=['serviceName', 'serviceSummary']
+        )
 
     def test_only_questions_for_this_section_can_be_changed(self, data_api_client, s3):
         data_api_client.get_draft_service.return_value = self.empty_draft
@@ -561,7 +562,9 @@ class TestEditDraftService(BaseApplicationTest):
 
         assert_equal(res.status_code, 302)
         data_api_client.update_draft_service.assert_called_once_with(
-            '1', {'page_questions': ['serviceName', 'serviceSummary']}, 'email@email.com')
+            '1', {}, 'email@email.com',
+            page_questions=['serviceName', 'serviceSummary']
+        )
 
     def test_file_upload(self, data_api_client, s3):
         s3.return_value = mock.Mock()


### PR DESCRIPTION
## Enable document upload from edit draft section page
Validates files using dmutils to check file size and document type
and uploads to S3 if there were no errors.

Uploaded file URLs are sent to the API with the rest of form data
for validation.

If other fields fail validation the form is displayed again with
errors.

### Don't display uploaded file URL if form failed validation
If other form fields on the same page fail validation the file
has to be attached again, so file URLs shouldn't be added to the
form data.

### Filter file uploads from request data
File URLs shouldn't be submitted directly since there's no validation
that the URL matches the file uploaded to S3.

### Save submission documents to S3_DRAFT_DOCUMENTS_BUCKET
Draft bucket is intended for drafts that don't yet have a service ID.

Since the documents will have to be copied when the draft gets a
service ID storing them separately makes it easier to clean up
unused files after the framework goes live and makes sure the files
are not accessible through the assets domain.

### Upload draft documents as private
Documents should not be publicly visible before the framework goes
live.

### Save info page as the uploaded draft document URL
Uses a buyer frontend page as a base URL for the document uploads
during the service submission. The URL links to an info page that
displays some text about the state of the document and the reason
it can't be displayed before the framework goes live.

Since the documents will have to be moved once the draft gets a
service ID the URLs will change anyway and temporary base URL
doesn't matter.

## Move document questions to separate sections
After looking at different ways to do data + files validation
flow it looks like moving each document upload to a separate
page is the most reasonable option right now.

Mixing documents with other fields on a single form behaves
differently from a simple form:
* If the file is uploaded first but sent to the API together
  with the form fields then, errors in other fields fail the
  form and the file URL is not saved
* If the uploaded file URL is saved to form data and sent
  back after the user resubmits the form then the URL needs
  to be validated (which we don't need to do otherwise).
  If the user closes the page without submitting the form the
  file URL is not saved to the API (which is consistent with
  how other forms behave, but might be different from what
  you'd expect from a file upload field)
* If the file is uploaded and the URL is saved to the API before
  other form fields are sent to the API then the form behaves
  differently from other sections (field value is saved even
  though the form submission showed errors)

The main downside to current approach is that some documents are
optional (SFIA rate card), which means that the whole section can
be skipped, but there's no indication of that on the page.

## Restore DM_HTTP_PROTO config variable
Fixes an issue with password reset links starting with 'http://'.
Adds common base config for live environments.

### Add a flash message when creating a draft copy