### PR TITLE
Move file uploads to the end of the question sequence

### DIFF
--- a/app/new_service_manifest.yml
+++ b/app/new_service_manifest.yml
@@ -10,11 +10,6 @@
     - serviceName
     - serviceSummary
 -
-  name: Service definition
-  editable: true
-  questions:
-    - serviceDefinitionDocumentURL
--
   name: Service type
   editable: true
   questions:
@@ -37,26 +32,11 @@
     - trialOption
     - freeOption
 -
-  name: Pricing document
-  editable: true
-  questions:
-    - pricingDocumentURL
--
-  name: SFIA rate card
-  editable: true
-  questions:
-    - sfiaRateDocumentURL
--
   name: Terms and conditions
   editable: true
   questions:
     - terminationCost
     - minimumContractPeriod
--
-  name: Terms and conditions document
-  editable: true
-  questions:
-    - termsAndConditionsDocumentURL
 -
   name: Support
   editable: True
@@ -266,3 +246,23 @@
     - deviceAccessMethod
     - serviceConfigurationGuidance
     - trainingProvided
+-
+  name: Service definition
+  editable: true
+  questions:
+    - serviceDefinitionDocumentURL
+-
+  name: Terms and conditions document
+  editable: true
+  questions:
+    - termsAndConditionsDocumentURL
+-
+  name: Pricing document
+  editable: true
+  questions:
+    - pricingDocumentURL
+-
+  name: SFIA rate card
+  editable: true
+  questions:
+    - sfiaRateDocumentURL

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -644,7 +644,7 @@ class TestEditDraftService(BaseApplicationTest):
             data={})
 
         assert_equal(302, res.status_code)
-        assert_equal('http://localhost/suppliers/submission/services/1/edit/service_definition',
+        assert_equal('http://localhost/suppliers/submission/services/1/edit/service_type',
                      res.headers['Location'])
 
     def test_update_redirects_to_edit_submission_if_no_next_editable_section(self, data_api_client, s3):
@@ -652,7 +652,7 @@ class TestEditDraftService(BaseApplicationTest):
         data_api_client.update_draft_service.return_value = None
 
         res = self.client.post(
-            '/suppliers/submission/services/1/edit/certifications',
+            '/suppliers/submission/services/1/edit/sfia_rate_card',
             data={})
 
         assert_equal(302, res.status_code)


### PR DESCRIPTION
We don't want users to be blocked part-way through completing details of a service because they don't have the right document to hand.  By putting documents at the end of the question flow they can answer all questions without having the documents to upload.