### PR TITLE
Hide submission document urls

### DIFF
--- a/app/templates/frameworks/dashboard.html
+++ b/app/templates/frameworks/dashboard.html
@@ -25,7 +25,7 @@
     {% for category, message in messages %}
       <div class="banner-success-without-action">
         <p class="banner-message">
-          "{{message.service_name}}" was copied.
+          <strong>{{message.service_name}}</strong> was copied.
         </p>
       </div>
     {% endfor %}

--- a/app/templates/macros/answers.html
+++ b/app/templates/macros/answers.html
@@ -10,7 +10,11 @@
 
 {% macro upload(value) -%}
   {% if 'url' in value and 'filename' in value %}
-    <a href="{{ value.url }}">{{ value.filename }}</a>
+    {% if value.url.startswith(url_for(".service_submission_document", document='', _external=True)) %}
+      A document was uploaded
+    {% else %}
+      <a href="{{ value.url }}">{{ value.filename }}</a>
+    {% endif %}
   {% endif %}
 {%- endmacro %}
 

--- a/app/templates/macros/toolkit_forms.html
+++ b/app/templates/macros/toolkit_forms.html
@@ -96,7 +96,7 @@
     question=question_content.question,
     hint=question_content.hint,
     name=question_content.id,
-    value=service_data[question_content.id],
+    value="A document was uploaded" if service_data[question_content.id].startswith(url_for(".service_submission_document", document='', _external=True)) else service_data[question_content.id],
     error=errors.get(question_content.id)['message']
   %}
     {% include "toolkit/forms/upload.html" %}


### PR DESCRIPTION
### Hide the document URL for uploaded G7 submission documents
Ralph suggested that document upload and draft section view pages
should show "A document was uploaded" instead of the info URL for
uploaded G7 documents.

Since we use the same macros and toolkit templates for both live
and submission services (and there's no easy way to split them
that I can think of) this adds an additional check to the `upload`
macros that checks if the document is attached to a submission
draft (by checking that the URL starts with an "info" URL prefix).

Also removes quotes from the "service copied" message
