### PR TITLE
Fix bug when assurance question is not answered

### DIFF
--- a/app/main/helpers/services.py
+++ b/app/main/helpers/services.py
@@ -78,7 +78,7 @@ def get_formatted_section_data(section):
         if _has_assurance(key):
             section_data[key] = {
                 "value": section_data[key],
-                "assurance": request.form.get(key + '--assurance')
+                "assurance": request.form.get(key + '--assurance', '')
             }
 
     return section_data


### PR DESCRIPTION
If a user tries to save a page but doesn't answer all the assurance questions the following error occurs:

```
argument of type 'NoneType' is not iterable
```

This commit makes sure that assurance is never set to `None`, so that the template always has a value (albeit an empty one) to look `in` [here](https://github.com/alphagov/digitalmarketplace-frontend-toolkit/blob/master/toolkit/templates/forms/selection-buttons.html#L33).