### PR TITLE
[##100216314] Delete draft service button

### DIFF
--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -61,3 +61,13 @@ $path: "/suppliers/static/images/";
   @include core-19;
   margin: (1.5 * $gutter) 0 (2 * $gutter);
 }
+
+.delete-draft-button {
+
+  padding: $gutter * 2 0;
+
+  button {
+    width: 100%;
+  }
+
+}

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -276,6 +276,27 @@ def copy_draft_service(service_id):
 
     return redirect(url_for(".framework_dashboard"))
 
+@main.route('/submission/services/<string:service_id>/delete', methods=['POST'])
+@login_required
+@flask_featureflags.is_active_feature('GCLOUD7_OPEN')
+def delete_draft_service(service_id):
+    draft = data_api_client.get_draft_service(service_id).get('services')
+
+    if not is_service_associated_with_supplier(draft):
+        abort(404)
+
+    try:
+        data_api_client.delete_draft_service(
+            service_id,
+            current_user.email_address
+        )
+
+    except APIError as e:
+        abort(e.status_code)
+
+    flash({'service_name': draft.get('serviceName')}, 'service_deleted')
+
+    return redirect(url_for(".framework_dashboard"))
 
 @main.route('/submission/documents/<path:document>', methods=['GET'])
 @login_required

--- a/app/templates/frameworks/dashboard.html
+++ b/app/templates/frameworks/dashboard.html
@@ -25,7 +25,7 @@
   {% for category, message in messages %}
   <div class="banner-success-without-action">
     <p class="banner-message">
-      "{{message.service_name}}" was deleted.
+      &ldquo;{{message.service_name}}&rdquo; was deleted.
     </p>
   </div>
   {% endfor %}

--- a/app/templates/frameworks/dashboard.html
+++ b/app/templates/frameworks/dashboard.html
@@ -21,6 +21,15 @@
 
 {% block main_content %}
 
+  {% with messages = get_flashed_messages(with_categories=True, category_filter=['service_deleted']) %}
+  {% for category, message in messages %}
+  <div class="banner-success-without-action">
+    <p class="banner-message">
+      "{{message.service_name}}" was deleted.
+    </p>
+  </div>
+  {% endfor %}
+  {% endwith %}
   {% with messages = get_flashed_messages(with_categories=True, category_filter=['service_copied']) %}
     {% for category, message in messages %}
       <div class="banner-success-without-action">

--- a/app/templates/services/_base_service_page.html
+++ b/app/templates/services/_base_service_page.html
@@ -46,6 +46,7 @@
           {% endif %}
         {% endcall %}
       {% endfor %}
+      {% block after_sections %}{% endblock %}
     </div>
   </div>
 {% endblock %}

--- a/app/templates/services/_base_service_page.html
+++ b/app/templates/services/_base_service_page.html
@@ -5,6 +5,7 @@
 
 {% block main_content %}
   <div class="grid-row">
+    {% block before_heading %}{% endblock %}
     <div class="column-two-thirds">
       {% with
         context = "Edit",

--- a/app/templates/services/service_submission.html
+++ b/app/templates/services/service_submission.html
@@ -22,19 +22,32 @@
   {% endwith %}
 {% endblock %}
 
+{% block before_heading %}
+  {% if delete_requested %}
+    <form action="{{ url_for('.delete_draft_service', service_id=service_id ) }}" method="POST">
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+      <input type="hidden" name="delete_confirmed" value="true" />
+      <div class="banner-destructive-with-action">
+        <p class="banner-message">
+          Are you sure you want to delete this service?
+        </p>
+        <button class="button-destructive banner-action">Yes, delete {{ service_data['serviceName'] }}</button>
+      </div>
+    </form>
+  {% endif %}
+{% endblock %}
+
 {% block edit_link %}
   {{ summary.top_link("Edit", url_for(".edit_service_submission", service_id=service_id, section_id=section.id)) }}
 {% endblock %}
 
 {% block after_sections %}
+{% if not delete_requested %}
 <form action="{{ url_for('.delete_draft_service', service_id=service_id ) }}" method="POST">
   <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
-  {%
-  with
-  type = "destructive",
-  label = "Delete this service"
-  %}
-  {% include "toolkit/button.html" %}
+  {% with type = "destructive", label = "Delete this service" %}
+    {% include "toolkit/button.html" %}
   {% endwith %}
 </form>
+{% endif %}
 {% endblock %}

--- a/app/templates/services/service_submission.html
+++ b/app/templates/services/service_submission.html
@@ -25,3 +25,16 @@
 {% block edit_link %}
   {{ summary.top_link("Edit", url_for(".edit_service_submission", service_id=service_id, section_id=section.id)) }}
 {% endblock %}
+
+{% block after_sections %}
+<form action="{{ url_for('.delete_draft_service', service_id=service_id ) }}" method="POST">
+  <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+  {%
+  with
+  type = "destructive",
+  label = "Delete this service"
+  %}
+  {% include "toolkit/button.html" %}
+  {% endwith %}
+</form>
+{% endblock %}

--- a/app/templates/services/service_submission.html
+++ b/app/templates/services/service_submission.html
@@ -32,7 +32,7 @@
           <p class="banner-message">
             Are you sure you want to delete this service?
           </p>
-          <button class="button-destructive banner-action">Yes, delete {{ service_data['serviceName'] }}</button>
+          <button class="button-destructive banner-action">Yes, delete &ldquo;{{ service_data['serviceName'] }}&rdquo;</button>
         </div>
       </form>
     </div>

--- a/app/templates/services/service_submission.html
+++ b/app/templates/services/service_submission.html
@@ -42,12 +42,19 @@
 {% endblock %}
 
 {% block after_sections %}
-{% if not delete_requested %}
-<form action="{{ url_for('.delete_draft_service', service_id=service_id ) }}" method="POST">
-  <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
-  {% with type = "destructive", label = "Delete this service" %}
-    {% include "toolkit/button.html" %}
-  {% endwith %}
-</form>
-{% endif %}
+  {% if not delete_requested %}
+    <div class="grid-row">
+      <div class="column-two-thirds">
+        &nbsp;
+      </div>
+      <div class="column-one-third delete-draft-button">
+        <form action="{{ url_for('.delete_draft_service', service_id=service_id ) }}" method="POST">
+          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+          {% with type = "destructive", label = "Delete this service" %}
+            {% include "toolkit/button.html" %}
+          {% endwith %}
+        </form>
+      </div>
+    </div>
+  {% endif %}
 {% endblock %}

--- a/app/templates/services/service_submission.html
+++ b/app/templates/services/service_submission.html
@@ -24,16 +24,18 @@
 
 {% block before_heading %}
   {% if delete_requested %}
-    <form action="{{ url_for('.delete_draft_service', service_id=service_id ) }}" method="POST">
-      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
-      <input type="hidden" name="delete_confirmed" value="true" />
-      <div class="banner-destructive-with-action">
-        <p class="banner-message">
-          Are you sure you want to delete this service?
-        </p>
-        <button class="button-destructive banner-action">Yes, delete {{ service_data['serviceName'] }}</button>
-      </div>
-    </form>
+    <div class="column-one-whole">
+      <form action="{{ url_for('.delete_draft_service', service_id=service_id ) }}" method="POST">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+        <input type="hidden" name="delete_confirmed" value="true" />
+        <div class="banner-destructive-with-action">
+          <p class="banner-message">
+            Are you sure you want to delete this service?
+          </p>
+          <button class="button-destructive banner-action">Yes, delete {{ service_data['serviceName'] }}</button>
+        </div>
+      </form>
+    </div>
   {% endif %}
 {% endblock %}
 

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -767,7 +767,7 @@ class TestDeleteDraftService(BaseApplicationTest):
         )
         res2 = self.client.get('/suppliers/submission/services/1?delete_requested=True')
         assert_in(
-            "Are you sure you want to delete this service?", res2.get_data()
+            b"Are you sure you want to delete this service?", res2.get_data()
         )
 
     def test_confirm_delete_button_deletes_and_redirects_to_dashboard(self, data_api_client):

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -1,3 +1,5 @@
+import copy
+
 try:
     from StringIO import StringIO
 except ImportError:
@@ -727,3 +729,66 @@ class TestEditDraftService(BaseApplicationTest):
             '/suppliers/submission/services/1/edit/invalid_section'
         )
         assert_equal(404, res.status_code)
+
+
+@mock.patch('app.main.views.services.data_api_client')
+class TestDeleteDraftService(BaseApplicationTest):
+
+    draft_to_delete = {
+        'services': {
+            'id': 1,
+            'supplierId': 1234,
+            'supplierName': "supplierName",
+            'lot': "SCS",
+            'status': "not-submitted",
+            'frameworkSlug': 'g-slug',
+            'frameworkName': "frameworkName",
+            'links': {},
+            'serviceName': 'My rubbish draft',
+            'serviceSummary': 'This is the worst service ever',
+            'updatedAt': "2015-06-29T15:26:07.650368Z"
+        }
+    }
+
+    def setup(self):
+        super(TestDeleteDraftService, self).setup()
+        with self.app.test_client():
+            self.login()
+
+    def test_delete_button_redirects_with_are_you_sure(self, data_api_client):
+        data_api_client.get_draft_service.return_value = self.draft_to_delete
+        res = self.client.post(
+            '/suppliers/submission/services/1/delete',
+            data={})
+        assert_equal(res.status_code, 302)
+        assert_equal(
+            res.location,
+            'http://localhost/suppliers/submission/services/1?delete_requested=True'
+        )
+        res2 = self.client.get('/suppliers/submission/services/1?delete_requested=True')
+        assert_in(
+            "Are you sure you want to delete this service?", res2.get_data()
+        )
+
+    def test_confirm_delete_button_deletes_and_redirects_to_dashboard(self, data_api_client):
+        data_api_client.get_draft_service.return_value = self.draft_to_delete
+        res = self.client.post(
+            '/suppliers/submission/services/1/delete',
+            data={'delete_confirmed': 'true'})
+
+        data_api_client.delete_draft_service.assert_called_with('1', 'email@email.com')
+        assert_equal(res.status_code, 302)
+        assert_equal(
+            res.location,
+            'http://localhost/suppliers/frameworks/g-cloud-7'
+        )
+
+    def test_cannot_delete_other_suppliers_draft(self, data_api_client):
+        other_draft = copy.deepcopy(self.draft_to_delete)
+        other_draft['services']['supplierId'] = 12345
+        data_api_client.get_draft_service.return_value = other_draft
+        res = self.client.post(
+            '/suppliers/submission/services/1/delete',
+            data={'delete_confirmed': 'true'})
+
+        assert_equal(res.status_code, 404)


### PR DESCRIPTION
See: https://www.pivotaltracker.com/story/show/100216314

This adds a "Delete this service" button at the bottom of draft service pages.
When clicked the page is reloaded with an "Are you sure?" button at the top of the page.
When this second button is clicked the draft is deleted and the user redirected to the G-7 dashboard.

The story specifies that deleting drafts should be audited - this is already taken care of in the API endpoint so no further work needs to be done on that - see screenshot for example audit events:
![screen shot 2015-08-05 at 15 19 47](https://cloud.githubusercontent.com/assets/6525554/9087955/973708ae-3b85-11e5-99cb-b502c7c77865.png)
