### PR TITLE
Make Heroku-friendly

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,0 +1,2 @@
+https://github.com/heroku/heroku-buildpack-nodejs.git
+https://github.com/heroku/heroku-buildpack-python.git

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: python application.py runserver

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: python application.py runserver
+web: python application.py runserver -p $PORT -h 0.0.0.0

--- a/README.md
+++ b/README.md
@@ -111,3 +111,11 @@ The supplier frontend runs on port 5003. Use the app at [http://127.0.0.1:5003/]
 
 To use feature flags, check out the documentation in (the README of)
 [digitalmarketplace-utils](https://github.com/alphagov/digitalmarketplace-utils#using-featureflags).
+
+### Running on Heroku
+
+- Setup the heroku command https://devcenter.heroku.com/articles/getting-started-with-python#set-up
+- Create the app with `heroku create`
+- Set the app to have a multi-buildpack with `heroku buildpacks:set https://github.com/ddollar/heroku-buildpack-multi.git`
+- Set environment variables with `heroku config:set`
+- Deploy the app with `git push heroku <your-branch>:master`

--- a/application.py
+++ b/application.py
@@ -4,6 +4,8 @@ import os
 from app import create_app
 from flask.ext.script import Manager, Server
 
+port = int(os.getenv('PORT', 5003))
+
 application = create_app(
     os.getenv('DM_ENVIRONMENT') or 'development'
 )
@@ -14,7 +16,7 @@ application.jinja_options = {
 }
 
 manager = Manager(application)
-manager.add_command("runserver", Server(port=5003))
+manager.add_command("runserver", Server(host='0.0.0.0', port=port))
 
 if __name__ == '__main__':
     manager.run()

--- a/application.py
+++ b/application.py
@@ -4,8 +4,6 @@ import os
 from app import create_app
 from flask.ext.script import Manager, Server
 
-port = int(os.getenv('PORT', 5003))
-
 application = create_app(
     os.getenv('DM_ENVIRONMENT') or 'development'
 )
@@ -16,7 +14,7 @@ application.jinja_options = {
 }
 
 manager = Manager(application)
-manager.add_command("runserver", Server(host='0.0.0.0', port=port))
+manager.add_command("runserver", Server(port=5003))
 
 if __name__ == '__main__':
     manager.run()

--- a/package.json
+++ b/package.json
@@ -20,6 +20,6 @@
     "frontend-build:development": "./node_modules/gulp/bin/gulp.js build:development",
     "frontend-build:production": "./node_modules/gulp/bin/gulp.js build:production",
     "frontend-build:watch": "./node_modules/gulp/bin/gulp.js watch",
-    "postinstall": "./node_modules/bower/bin/bower install"
+    "postinstall": "npm run frontend-install && npm run frontend-build:production"
   }
 }


### PR DESCRIPTION
This adds the changes @minglis put together for running frontend apps in heroku. The intention is to separate it out from the pull request on supplier declarations.

Other than adding heroku specific things like buildpacks, Procfile and README changes this also includes;
- Allow the port the app runs on to be controlled by an environment
  variable
- Bind to 0.0.0.0 rather than the default 127.0.0.1
- Change how the npm post install is called