### PR TITLE
Change design of "Apply to G-Cloud" page

### DIFF
--- a/app/assets/scss/_framework-application.scss
+++ b/app/assets/scss/_framework-application.scss
@@ -1,17 +1,90 @@
-.framework-deadline {
-  padding-left: $gutter-half;
-  border-left: solid 5px $error-colour;
-  margin-bottom: $gutter;
+@import "conditionals";
+@import "shims";
 
-  .framework-notification {
-    color: $error-colour;
-  }
-}
+.framework-application-status {
 
-.framework-declaration {
-  margin-bottom: $gutter;
+  padding-bottom: $gutter * 2/3;
+  padding-top: $gutter/2;
 
   @include media(tablet) {
-    margin-bottom: 0;
+    padding-top: 50px;
   }
+
+  h2 {
+    @include bold-19;
+    margin-bottom: 10px;
+  }
+
+}
+
+.big-number {
+  @include bold-48;
+}
+
+.big-number-hint {
+  @include copy-16;
+  color: $secondary-text-colour;
+}
+
+.framework-application-section {
+  border-top: 1px solid $grey-2;
+  padding-top: $gutter * 2/3;
+}
+
+%framework-section-status,
+.framework-section-status {
+
+  @include bold-19;
+  margin-top: $gutter / 3;
+
+  @include media(tablet) {
+    margin-top: 0;
+  }
+
+}
+
+.framework-section-status-neutral {
+  @extend %framework-section-status;
+  color: $secondary-text-colour;
+  font-weight: normal;
+}
+
+.framework-section-status-bad {
+  @extend %framework-section-status;
+  color: $mellow-red;
+}
+
+.framework-section-status-good {
+  @extend %framework-section-status;
+  color: $grass-green;
+}
+
+.submission-status-bad {
+
+  @extend %submission-status;
+  color: $mellow-red;
+
+  @include bold-16;
+
+  @include media(desktop) {
+    @include bold-19;
+  }
+
+}
+
+.submission-service-counts-column {
+
+  float: left;
+  box-sizing: border-box;
+  margin-top: 10px;
+  width: 49%;
+  padding-right: 10px;
+  vertical-align: top;
+  @include core-16;
+
+  @include media(desktop) {
+    margin-top: 0;
+    @include core-19;
+  }
+
 }

--- a/app/assets/scss/_grids.scss
+++ b/app/assets/scss/_grids.scss
@@ -8,6 +8,10 @@
   @include grid-column( 1 );
 }
 
+.column-one-half {
+  @include grid-column( 1/2 );
+}
+
 .column-one-third {
   @include grid-column( 1/3 );
 }

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -20,12 +20,37 @@ def framework_dashboard():
             current_user.supplier_id,
             framework='g-cloud-7'
         )['services']
-
     except APIError as e:
         abort(e.status_code)
 
     return render_template(
         "frameworks/dashboard.html",
+        counts={
+            "draft": len(drafts),
+            "complete": 1,
+        },
+        declaration_made=False,
+        **template_data
+    ), 200
+
+
+@main.route('/frameworks/g-cloud-7/services', methods=['GET'])
+@login_required
+@flask_featureflags.is_active_feature('GCLOUD7_OPEN')
+def framework_services():
+    template_data = main.config['BASE_TEMPLATE_DATA']
+
+    try:
+        drafts = data_api_client.find_draft_services(
+            current_user.supplier_id,
+            framework='g-cloud-7'
+        )['services']
+
+    except APIError as e:
+        abort(e.status_code)
+
+    return render_template(
+        "frameworks/services.html",
         drafts=drafts,
         **template_data
     ), 200

--- a/app/templates/frameworks/dashboard.html
+++ b/app/templates/frameworks/dashboard.html
@@ -40,81 +40,148 @@
     {% endfor %}
   {% endwith %}
 
-  {% with
-     heading = "Apply to G-Cloud 7",
-     smaller = True,
-     with_breadcrumb = True
-  %}
-    {% include "toolkit/page-heading.html" %}
-  {% endwith %}
-
   <div class="grid-row">
-    <div class="column-two-thirds ">
-      <div class="framework-deadline">
-        <h2 id="framework-deadline">
-          Deadline 2 October 2015
-        </h2>
-        <p>
-          0 services will be submitted
-        </p>
-        <p class="framework-notification">
-          <strong>No services will be submitted if supplier declaration is incomplete</strong>
-        </p>
-      </div>
-      <div class="framework-declaration">
-        {%
-          with items = [
-            {
-                "title": "Make supplier declaration",
-                "body": "Legal declaration required to supply G-Cloud 7 services",
-                "link": url_for('.framework_supplier_declaration')
-            }
-          ]
-        %}
-          {% include "toolkit/browse-list.html" %}
-        {% endwith %}
-      </div>
-    </div>
-    <aside role="complementary" class="column-one-third framework-help">
-      <p>
-        <a href="#" class="clarification-link">Read updates or ask clarification questions</a>
-      </p>
-      {%
-        with
-        items = [
-          {
-            "file_type": "ZIP",
-            "link": "#",
-            "title": "Download supplier pack"
-          }
-        ]
+    <div class="column-two-thirds">
+      {% with
+         heading = "Apply to G-Cloud 7",
+         smaller = True,
+         with_breadcrumb = True
       %}
-        {% include "toolkit/documents.html" %}
+        {% include "toolkit/page-heading.html" %}
       {% endwith %}
+    </div>
+    <aside role="complementary" class="column-one-third framework-application-status">
+      <h2>
+        Deadline 11am, 20 October 2015
+      </h2>
+      {% if not declaration_made and counts.complete %}
+        <div class="submission-status-bad">
+          <p class="big-number">
+            0
+          </p>
+          <p>
+            Eligible services
+          </p>
+        </div>
+      {% else %}
+        <p class="big-number">
+          {{ counts.complete }}
+        </p>
+        <p>
+          Eligible {{ 'service' if counts.complete == 1 else 'services' }}
+        </p>
+      {% endif %}
     </aside>
   </div>
 
-  <div class="grid-row">
-    <div class="column-one-whole">
-      {% import "toolkit/summary-table.html" as summary %}
-      {{ summary.heading("Draft services") }}
-      {{ summary.top_link("Add a service", url_for(".start_new_draft_service")) }}
-      {% call(draft) summary.list_table(
-        drafts,
-        caption="Draft services",
-        empty_message="You haven't added any services yet.",
-        field_headings=["Service name", "Lot", summary.hidden_field_heading("Make a copy")],
-        field_headings_visible=False
-      ) %}
-        {% call summary.row() %}
-          {{ summary.service_link(draft.serviceName,
-                                  url_for(".view_service_submission", service_id=draft.id)) }}
-          {{ summary.text(draft.lot) }}
-          {{ summary.button(text="Make a copy",
-                             action=url_for('.copy_draft_service', service_id=draft.id)) }}
-        {% endcall %}
-      {% endcall %}
-    </div>
-  </div>
+  <nav role="navigation" class="grid-row">
+    <ul class="browse-list">
+      <div class="column-one-whole">
+        <li class="browse-list-item framework-application-section">
+          <div class="grid-row">
+            <div class="column-two-thirds">
+              <a class="browse-list-item-link" href="{{ url_for('.framework_supplier_declaration') }}">
+                {% if declaration_made %}
+                  <span>Edit supplier declaration</span>
+                {% else %}
+                  <span>Make supplier declaration</span>
+                {% endif %}
+              </a>
+              <p class="browse-list-item-body">
+                Agree to the terms of participation, provide company information and confirm eligibility.
+              </p>
+            </div>
+            <div class="column-one-third">
+              {% if not declaration_made and not counts.complete %}
+                <div class="framework-section-status-neutral">
+                  <p>
+                    You haven't made the supplier declaration
+                  </p>
+                </div>
+              {% elif not declaration_made and counts.complete %}
+                <div class="framework-section-status-bad">
+                  <p>
+                    You must make the supplier declaration before any services are eligible for submission
+                  </p>
+                </div>
+              {% elif declaration_made %}
+                <div class="framework-section-status-good">
+                  <p>
+                    You have made the declaration
+                  </p>
+                </div>
+              {% endif %}
+            </div>
+          </div>
+        </li>
+      </div>
+
+      <div class="column-one-whole">
+        <li class="browse-list-item framework-application-section">
+          <div class="grid-row">
+            <div class="column-two-thirds">
+              <a class="browse-list-item-link" href="{{ url_for('.framework_services') }}"><span>Add services</span></a>
+              <p class="browse-list-item-body">
+                Add, edit and delete your services.
+              </p>
+            </div>
+            <div class="column-one-third">
+              {% if counts.draft or counts.complete %}
+                <div class="submission-service-counts-column">
+                  <div class="big-number">
+                    {{ counts.complete }}
+                  </div>
+                  Complete {{ 'service' if counts.complete == 1 else 'services' }}
+                </div>
+                <div class="submission-service-counts-column">
+                  <div class="big-number">
+                    {{ counts.draft }}
+                  </div>
+                  Draft<br>{{ 'service' if counts.draft == 1 else 'services' }}
+                  {% if counts.draft and declaration_made %}
+                    <p class="big-number-hint">
+                      {{ 'This' if counts.draft == 1 else 'These' }}
+                      will not be submitted
+                    </p>
+                  {% endif %}
+                </div>
+              {% else %}
+                <div class="framework-section-status-neutral">
+                  <p>
+                    You haven't added any services
+                  </p>
+                </div>
+              {% endif %}
+            </div>
+          </div>
+        </li>
+      </div>
+
+      <div class="column-one-whole">
+        <li class="browse-list-item framework-application-section">
+          <a class="browse-list-item-link" href="#"><span>Download supplier pack (.zip)</span></a>
+          <p class="browse-list-item-body">
+            Read guidance and legal documentation.
+          </p>
+          <p class="browse-list-item-subtext">
+            Last updated 28 August
+          </p>
+        </li>
+      </div>
+
+      <div class="column-one-whole">
+        <li class="browse-list-item framework-application-section">
+          <a class="browse-list-item-link" href="#"><span>Read framework updates</span></a>
+          <p class="browse-list-item-body">
+            Read updates and ask clarification questions.
+          </p>
+          <p class="browse-list-item-subtext">
+            Last updated 28 August
+          </p>
+        </li>
+      </div>
+
+    </ul>
+  </nav>
 
 {% endblock %}

--- a/app/templates/frameworks/services.html
+++ b/app/templates/frameworks/services.html
@@ -1,0 +1,74 @@
+{% extends "_base_page.html" %}
+{% import "toolkit/summary-table.html" as summary %}
+
+{% block page_title %}Apply to G-Cloud 7 – Digital Marketplace{% endblock %}
+
+{% block breadcrumb %}
+  {%
+    with items = [
+      {
+        "link": "/",
+        "label": "Digital Marketplace",
+      },
+      {
+        "link": url_for(".dashboard"),
+        "label": "Your account",
+      },
+      {
+        "link": url_for(".framework_dashboard"),
+        "label": "Apply to G-Cloud 7",
+      }
+    ]
+  %}
+    {% include "toolkit/breadcrumb.html" %}
+  {% endwith %}
+{% endblock %}
+
+{% block main_content %}
+
+  {% with messages = get_flashed_messages(with_categories=True, category_filter=['service_deleted']) %}
+  {% for category, message in messages %}
+  <div class="banner-success-without-action">
+    <p class="banner-message">
+      &ldquo;{{message.service_name}}&rdquo; was deleted.
+    </p>
+  </div>
+  {% endfor %}
+  {% endwith %}
+  {% with messages = get_flashed_messages(with_categories=True, category_filter=['service_copied']) %}
+    {% for category, message in messages %}
+      <div class="banner-success-without-action">
+        <p class="banner-message">
+          <strong>{{message.service_name}}</strong> was copied.
+        </p>
+      </div>
+    {% endfor %}
+  {% endwith %}
+
+  {% with
+     heading = "G-Cloud 7 services",
+     smaller = True,
+     with_breadcrumb = True
+  %}
+    {% include "toolkit/page-heading.html" %}
+  {% endwith %}
+
+  {{ summary.heading("Draft services") }}
+  {{ summary.top_link("Add a service", url_for(".start_new_draft_service")) }}
+  {% call(draft) summary.list_table(
+    drafts,
+    caption="Draft services",
+    empty_message="You haven't added any services yet.",
+    field_headings=["Service name", "Lot", summary.hidden_field_heading("Make a copy")],
+    field_headings_visible=False
+  ) %}
+    {% call summary.row() %}
+      {{ summary.service_link(draft.serviceName,
+                              url_for(".view_service_submission", service_id=draft.id)) }}
+      {{ summary.text(draft.lot) }}
+      {{ summary.button(text="Make a copy",
+                         action=url_for('.copy_draft_service', service_id=draft.id)) }}
+    {% endcall %}
+  {% endcall %}
+
+{% endblock %}

--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "jquery": "1.11.2",
     "hogan": "3.0.2",
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
-    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v8.2.6",
+    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v8.2.7",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.14.1/jinja_govuk_template-0.14.1.tgz",
     "digital-marketplace-ssp-content": "git://github.com/alphagov/digitalmarketplace-ssp-content#e8c900ffafe5d724f939780ae3b2c219b1a2af79"
   }


### PR DESCRIPTION
The changes in this pull request mostly follow [Ralph's prototype](http://dm-prototype.herokuapp.com/new-framework-service-complete).

It passes some extra information to the templates, for trying out the different combinations.

They are:
- whether the declaration has been made <sub>mocked</sub>
- count of complete services <sub>mocked</sub>
- count of draft services <sub>real</sub>

--

![image](https://cloud.githubusercontent.com/assets/355079/9114847/ded2ed3a-3c53-11e5-8dc5-2cca087d2eca.png)

--

![image](https://cloud.githubusercontent.com/assets/355079/9114832/d0b3e1e6-3c53-11e5-89ab-79ee32ea59ab.png)

--

![image](https://cloud.githubusercontent.com/assets/355079/9114748/55408d3e-3c53-11e5-84ce-a2f52701a230.png)

--

![image](https://cloud.githubusercontent.com/assets/355079/9114757/66f6a5cc-3c53-11e5-82cd-3edbf04b74c5.png)

--

:phone: | :phone: |
--- | ---
![image](https://cloud.githubusercontent.com/assets/355079/9114871/ffd0b08a-3c53-11e5-8018-a95136a225e1.png) | ![image](https://cloud.githubusercontent.com/assets/355079/9114893/1baaddda-3c54-11e5-9fd9-da64baf50be1.png)

--

[#100515606](https://www.pivotaltracker.com/story/show/100515606)