### PR TITLE
Fix caption on supplier dashboard

### DIFF
--- a/app/templates/suppliers/dashboard.html
+++ b/app/templates/suppliers/dashboard.html
@@ -47,7 +47,7 @@
   {% endif %}
   {% call(item) summary.list_table(
     supplier.service_counts|dictsort,
-    caption='Supplier information',
+    caption='Current services',
     field_headings=[
       'Label',
       'Value'


### PR DESCRIPTION
One of the tables had the wrong caption.
Probably the first time CPDD has proved to be problematic.