### PR TITLE
BUGFIX: serviceTypes isn't a real question

### DIFF
--- a/app/main/helpers/services.py
+++ b/app/main/helpers/services.py
@@ -241,7 +241,7 @@ def _is_pricing_type(key):
 
 def _is_type(key, *types):
     """Return True if a given key is one of the provided types"""
-    return new_service_content.get_question(key)['type'] in types
+    return new_service_content.get_question(key).get('type') in types
 
 
 def _has_assurance(key):


### PR DESCRIPTION
This was causing a KeyError on the Service type page because the field name `serviceTypes` isn't really a question. There are specific question types for each of the different lots.