### PR TITLE
Tidy breadcrumbs and nameless services

### DIFF
--- a/app/templates/frameworks/services.html
+++ b/app/templates/frameworks/services.html
@@ -63,7 +63,7 @@
     field_headings_visible=False
   ) %}
     {% call summary.row() %}
-      {{ summary.service_link(draft.serviceName,
+      {{ summary.service_link(draft.serviceName or 'New service',
                               url_for(".view_service_submission", service_id=draft.id)) }}
       {{ summary.text(draft.lot) }}
       {{ summary.button(text="Make a copy",

--- a/app/templates/services/_base_service_page.html
+++ b/app/templates/services/_base_service_page.html
@@ -1,6 +1,6 @@
 {% extends "_base_page.html" %}
 
-{% block page_title %}{{service_data['serviceName']}} – Digital Marketplace{% endblock %}
+{% block page_title %}{{service_data['serviceName'] or 'New service'}} – Digital Marketplace{% endblock %}
 
 {% block main_content %}
   <div class="grid-row">
@@ -8,7 +8,7 @@
     <div class="column-two-thirds">
       {% with
         context = "Edit",
-        heading = service_data['serviceName'],
+        heading = service_data['serviceName'] or 'New service',
         smaller = true
       %}
         {% include "toolkit/page-heading.html" %}

--- a/app/templates/services/edit_section.html
+++ b/app/templates/services/edit_section.html
@@ -9,11 +9,11 @@
       },
       {
         "link": url_for(".dashboard"),
-        "label": current_user.supplier_name
+        "label": "Your account"
       },
       {
         "link": url_for(".list_services"),
-        "label": "Services"
+        "label": "Current services"
       },
       {
         "link": url_for(".edit_service", service_id=service_id),

--- a/app/templates/services/edit_submission_section.html
+++ b/app/templates/services/edit_submission_section.html
@@ -9,11 +9,15 @@
       },
       {
         "link": url_for(".dashboard"),
-        "label": current_user.supplier_name
+        "label": "Your account"
       },
       {
         "link": url_for(".framework_dashboard"),
         "label": "Apply to G-Cloud 7"
+      },
+      {
+        "link": url_for(".framework_services"),
+        "label": "Services"
       },
       {
         "link": url_for(".view_service_submission", service_id=service_id),

--- a/app/templates/services/service.html
+++ b/app/templates/services/service.html
@@ -9,11 +9,11 @@
       },
       {
         "link": url_for(".dashboard"),
-        "label": current_user.supplier_name
+        "label": "Your account"
       },
       {
         "link": url_for(".list_services"),
-        "label": "Services"
+        "label": "Current services"
       }
     ]
   %}

--- a/app/templates/services/service_submission.html
+++ b/app/templates/services/service_submission.html
@@ -9,11 +9,15 @@
       },
       {
         "link": url_for(".dashboard"),
-        "label": current_user.supplier_name
+        "label": "Your account"
       },
       {
         "link": url_for(".framework_dashboard"),
         "label": "Apply to G-Cloud 7"
+      },
+      {
+        "link": url_for(".framework_services"),
+        "label": "Services"
       }
     ]
   %}


### PR DESCRIPTION
## Display 'new service' for services with no name

![image](https://cloud.githubusercontent.com/assets/355079/9136431/76698298-3d0e-11e5-83ca-bde98522e8a3.png)

![image](https://cloud.githubusercontent.com/assets/355079/9136502/f8f161f4-3d0e-11e5-907f-566647253675.png)


## Tidy up breadcrumbs

- Finish removal of supplier name in favour of "Your account"
- Show hierarchy of where you are in the G-Cloud 7 application process

![image](https://cloud.githubusercontent.com/assets/355079/9136413/5dc41f78-3d0e-11e5-8175-e8cb829b0727.png)