### PR TITLE
Go to services page after 'delete' and 'copy'

### DIFF
--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -276,7 +276,7 @@ def copy_draft_service(service_id):
 
     flash({'service_name': draft.get('serviceName')}, 'service_copied')
 
-    return redirect(url_for(".framework_dashboard"))
+    return redirect(url_for(".framework_services"))
 
 
 @main.route('/submission/services/<string:service_id>/delete', methods=['POST'])
@@ -298,7 +298,7 @@ def delete_draft_service(service_id):
             abort(e.status_code)
 
         flash({'service_name': draft.get('serviceName')}, 'service_deleted')
-        return redirect(url_for(".framework_dashboard"))
+        return redirect(url_for(".framework_services"))
     else:
         return redirect(url_for(".view_service_submission",
                                 service_id=service_id,

--- a/app/templates/frameworks/dashboard.html
+++ b/app/templates/frameworks/dashboard.html
@@ -21,25 +21,6 @@
 
 {% block main_content %}
 
-  {% with messages = get_flashed_messages(with_categories=True, category_filter=['service_deleted']) %}
-  {% for category, message in messages %}
-  <div class="banner-success-without-action">
-    <p class="banner-message">
-      &ldquo;{{message.service_name}}&rdquo; was deleted.
-    </p>
-  </div>
-  {% endfor %}
-  {% endwith %}
-  {% with messages = get_flashed_messages(with_categories=True, category_filter=['service_copied']) %}
-    {% for category, message in messages %}
-      <div class="banner-success-without-action">
-        <p class="banner-message">
-          <strong>{{message.service_name}}</strong> was copied.
-        </p>
-      </div>
-    {% endfor %}
-  {% endwith %}
-
   <div class="grid-row">
     <div class="column-two-thirds">
       {% with

--- a/app/templates/frameworks/services.html
+++ b/app/templates/frameworks/services.html
@@ -27,19 +27,19 @@
 {% block main_content %}
 
   {% with messages = get_flashed_messages(with_categories=True, category_filter=['service_deleted']) %}
-  {% for category, message in messages %}
-  <div class="banner-success-without-action">
-    <p class="banner-message">
-      &ldquo;{{message.service_name}}&rdquo; was deleted.
-    </p>
-  </div>
-  {% endfor %}
+    {% for category, message in messages %}
+      <div class="banner-success-without-action">
+        <p class="banner-message">
+          <strong>{{message.service_name}}</strong> was deleted
+        </p>
+      </div>
+    {% endfor %}
   {% endwith %}
   {% with messages = get_flashed_messages(with_categories=True, category_filter=['service_copied']) %}
     {% for category, message in messages %}
       <div class="banner-success-without-action">
         <p class="banner-message">
-          <strong>{{message.service_name}}</strong> was copied.
+          <strong>{{message.service_name}}</strong> was copied
         </p>
       </div>
     {% endfor %}

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -861,7 +861,7 @@ class TestDeleteDraftService(BaseApplicationTest):
         assert_equal(res.status_code, 302)
         assert_equal(
             res.location,
-            'http://localhost/suppliers/frameworks/g-cloud-7'
+            'http://localhost/suppliers/frameworks/g-cloud-7/services'
         )
 
     def test_cannot_delete_other_suppliers_draft(self, data_api_client):


### PR DESCRIPTION
Previously all services were on the dashboard.

Now that they are on a separate page it makes sense for said page to be where the user sees the messages for 'deleted' and 'copied'.

It also feels like the next thing they do after deleting or copying a service would be accessible from the services page.

![image](https://cloud.githubusercontent.com/assets/355079/9136732/daa00794-3d10-11e5-95da-da81526075d4.png)
