### PR TITLE
Add ITT supplier pack link endpoint

### DIFF
--- a/app/main/helpers/services.py
+++ b/app/main/helpers/services.py
@@ -9,6 +9,11 @@ from dmutils.content_loader import PRICE_FIELDS
 
 from ...main import new_service_content
 
+try:
+    import urlparse
+except ImportError:
+    import urllib.parse as urlparse
+
 
 def get_service_attributes(service_data, service_questions):
     return map(
@@ -58,7 +63,11 @@ def unformat_section_data(section_data):
 def get_draft_document_url(document_path):
     uploader = s3.S3(current_app.config['DM_G7_DRAFT_DOCUMENTS_BUCKET'])
 
-    return uploader.get_signed_url(document_path)
+    url = uploader.get_signed_url(document_path)
+    if url is not None:
+        url = urlparse.urlparse(url)
+        base_url = urlparse.urlparse(current_app.config['DM_G7_DRAFT_DOCUMENTS_URL'])
+        return url._replace(netloc=base_url.netloc, scheme=base_url.scheme).geturl()
 
 
 def upload_draft_documents(service, request_files, section):

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -3,10 +3,10 @@ from flask_login import login_required, current_user
 
 from dmutils.apiclient import APIError
 from dmutils import flask_featureflags
-from dmutils.content_loader import ContentBuilder
 
 from ...main import main, declaration_content
 from ... import data_api_client
+from ..helpers.services import get_draft_document_url
 
 
 @main.route('/frameworks/g-cloud-7', methods=['GET'])
@@ -92,6 +92,17 @@ def framework_supplier_declaration():
         service_data=answers,
         **template_data
     ), 200
+
+
+@main.route('/frameworks/g-cloud-7/download-supplier-pack', methods=['GET', 'POST'])
+@login_required
+@flask_featureflags.is_active_feature('GCLOUD7_OPEN')
+def download_supplier_pack():
+    url = get_draft_document_url('g-cloud-7-supplier-pack.zip')
+    if not url:
+        abort(404)
+
+    return redirect(url)
 
 
 @main.route('/frameworks/g-cloud-7/ask-a-question', methods=['GET', 'POST'])

--- a/app/templates/frameworks/dashboard.html
+++ b/app/templates/frameworks/dashboard.html
@@ -140,7 +140,7 @@
 
       <div class="column-one-whole">
         <li class="browse-list-item framework-application-section">
-          <a class="browse-list-item-link" href="#"><span>Download supplier pack (.zip)</span></a>
+          <a class="browse-list-item-link" href="{{ url_for('.download_supplier_pack') }}"><span>Download supplier pack (.zip)</span></a>
           <p class="browse-list-item-body">
             Read guidance and legal documentation.
           </p>

--- a/config.py
+++ b/config.py
@@ -17,7 +17,10 @@ class Config(object):
     DM_DATA_API_URL = None
     DM_DATA_API_AUTH_TOKEN = None
     DM_MANDRILL_API_KEY = None
+
     DM_G7_DRAFT_DOCUMENTS_BUCKET = None
+    DM_G7_DRAFT_DOCUMENTS_URL = None
+
     DEBUG = False
 
     RESET_PASSWORD_EMAIL_NAME = 'Digital Marketplace Admin'

--- a/scripts/run_app.sh
+++ b/scripts/run_app.sh
@@ -12,6 +12,7 @@ export DM_DATA_API_AUTH_TOKEN=${DM_DATA_API_AUTH_TOKEN:=myToken}
 export DM_API_AUTH_TOKEN=${DM_API_AUTH_TOKEN:=myToken}
 
 export DM_G7_DRAFT_DOCUMENTS_BUCKET=${DM_S3_DOCUMENTS_BUCKET:=digitalmarketplace-dev-documents}
+export DM_G7_DRAFT_DOCUMENTS_URL=${DM_S3_DOCUMENTS_URL:=https://${DM_S3_DOCUMENTS_BUCKET}.s3-eu-west-1.amazonaws.com}
 
 export DM_MANDRILL_API_KEY=${DM_MANDRILL_API_KEY:=not_a_real_key}
 export DM_PASSWORD_SECRET_KEY=${DM_PASSWORD_SECRET_KEY:=verySecretKey}

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -9,6 +9,8 @@
 export DM_DATA_API_AUTH_TOKEN=${DM_DATA_API_AUTH_TOKEN:=myToken}
 export DM_PASSWORD_SECRET_KEY=${DM_PASSWORD_SECRET_KEY:=not_very_secret}
 
+export DM_G7_DRAFT_DOCUMENTS_URL=${DM_S3_DOCUMENTS_URL:=http://localhost}
+
 echo "Environment variables in use:"
 env | grep DM_
 

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -891,7 +891,7 @@ class TestSubmissionDocuments(BaseApplicationTest):
         )
 
         assert_equal(res.status_code, 302)
-        assert_equal(res.headers['Location'], 'http://example.com/document.pdf')
+        assert_equal(res.headers['Location'], 'http://localhost/document.pdf')
 
     def test_missing_document_url(self, s3):
         s3.return_value = mock.Mock()


### PR DESCRIPTION
[#100213582](https://www.pivotaltracker.com/story/show/100213582)

Similar to submission service documents, /download-supplier-pack
generates a temporary signed S3 link for the supplier pack.

Supplier pack S3 path is always set to `g-cloud-7-supplier-pack.zip`.
`g-cloud-7` prefix allows to use a single location prefix in assets
nginx to redirect all relevant G7 URLs to the draft bucket.

Versioning is not implemented, but could achieved by relying on
`dmutils.s3.S3.move_existing` during service pack uploads, although
copied file name should use suffix instead of prefix to keep the
`g-cloud-7-...` name/location pattern if old versions need to be
accessible through the assets domain.

Supplier pack "last updated" date is static, but could be wired to
the S3 object "last modified" timestamp in the future.

Requires:
* [ ] https://github.com/alphagov/digitalmarketplace-aws/pull/129