### PR TITLE
[#100214390] Email Clarification Questions from "updates" page

### DIFF
--- a/app/assets/scss/_updates.scss
+++ b/app/assets/scss/_updates.scss
@@ -1,0 +1,3 @@
+#clarification_question {
+  height: 20.5em;
+}

--- a/app/assets/scss/_updates.scss
+++ b/app/assets/scss/_updates.scss
@@ -1,3 +1,18 @@
 #clarification_question {
-  height: 20.5em;
+  height: 20.75em;
+}
+
+.updates-document-tables {
+
+  table.summary-item-body tbody td {
+    vertical-align: middle;
+  }
+
+  .document-link-with-icon {
+    width: auto;
+    @include core-16;
+    padding-top: 0;
+    padding-bottom: 0;
+  }
+
 }

--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -50,6 +50,7 @@ $path: "/suppliers/static/images/";
 @import "_framework-application.scss";
 @import "_assurance-question.scss";
 @import "_supplier-declaration.scss";
+@import "_updates.scss";
 
 .filter-field-text {
   @include core-16;

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -1,12 +1,16 @@
-from flask import render_template, request, abort, flash, redirect, url_for
+from flask import render_template, request, abort, flash, redirect, url_for, escape, current_app
 from flask_login import login_required, current_user
 
 from dmutils.apiclient import APIError
 from dmutils import flask_featureflags
+from dmutils.email import send_email, MandrillException
 
 from ...main import main, declaration_content
 from ... import data_api_client
 from ..helpers.services import get_draft_document_url
+
+
+CLARIFICATION_QUESTION_NAME = 'clarification_question'
 
 
 @main.route('/frameworks/g-cloud-7', methods=['GET'])
@@ -105,25 +109,61 @@ def download_supplier_pack():
     return redirect(url)
 
 
-@main.route('/frameworks/g-cloud-7/ask-a-question', methods=['GET', 'POST'])
+@main.route('/frameworks/g-cloud-7/updates', methods=['GET'])
 @login_required
 @flask_featureflags.is_active_feature('GCLOUD7_OPEN')
-def framework_ask_a_question():
-    template_data = main.config['BASE_TEMPLATE_DATA']
-
-    return render_template(
-        "frameworks/ask-a-question.html",
-        **template_data
-    ), 200
+def framework_updates():
+    return _framework_updates_page()
 
 
-@main.route('/frameworks/g-cloud-7/communications', methods=['GET'])
+@main.route('/frameworks/g-cloud-7/updates', methods=['POST'])
 @login_required
 @flask_featureflags.is_active_feature('GCLOUD7_OPEN')
-def framework_communications():
+def framework_updates_email_clarification_question():
+
+    # Stripped input should not empty
+    clarification_question = escape(request.form.get(CLARIFICATION_QUESTION_NAME, '')).strip()
+
+    if not clarification_question:
+        return _framework_updates_page("Question cannot be empty")
+    elif len(clarification_question.split()) > 500 or len(clarification_question) > 5000:
+        return _framework_updates_page("Question cannot be more than 500 words or 5000 characters")
+
+    email_body = render_template(
+        "emails/clarification_question.html",
+        supplier_name=current_user.supplier_name,
+        user_name=current_user.name,
+        message=clarification_question
+    )
+
+    try:
+        send_email(
+            current_app.config['DM_CLARIFICATION_QUESTION_EMAIL'],
+            email_body,
+            current_app.config['DM_MANDRILL_API_KEY'],
+            "Clarification question",
+            "suppliers@digitalmarketplace.service.gov.uk",
+            "G-Cloud 7 Supplier",
+            ["clarification-question"]
+        )
+    except MandrillException as e:
+        current_app.logger.error(
+            "Clarification question email failed to send error {} supplier_id {} user_email_address {}".format(
+                e, current_user.supplier_id, current_user.email_address))
+        abort(503, "Clarification question email failed to send")
+
+    flash('message_sent', 'success')
+    return _framework_updates_page()
+
+
+def _framework_updates_page(error_message=None):
+
     template_data = main.config['BASE_TEMPLATE_DATA']
+    status_code = 200 if not error_message else 400
 
     return render_template(
-        "frameworks/communications.html",
+        "frameworks/updates.html",
+        clarification_question_name=CLARIFICATION_QUESTION_NAME,
+        error_message=error_message,
         **template_data
-    ), 200
+    ), status_code

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -126,8 +126,8 @@ def framework_updates_email_clarification_question():
 
     if not clarification_question:
         return _framework_updates_page("Question cannot be empty")
-    elif len(clarification_question.split()) > 500 or len(clarification_question) > 5000:
-        return _framework_updates_page("Question cannot be more than 500 words or 5000 characters")
+    elif len(clarification_question) > 5000:
+        return _framework_updates_page("Question cannot be longer than 5000 characters")
 
     email_body = render_template(
         "emails/clarification_question.html",

--- a/app/templates/emails/clarification_question.html
+++ b/app/templates/emails/clarification_question.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head lang="en">
+    <meta charset="UTF-8">
+</head>
+<body>
+Supplier name: {{ supplier_name }}
+<br />
+User name: {{ user_name }}
+<br /><br />
+Clarification question asked:
+<br />
+{{ message }}
+</body>
+</html>

--- a/app/templates/frameworks/dashboard.html
+++ b/app/templates/frameworks/dashboard.html
@@ -152,7 +152,7 @@
 
       <div class="column-one-whole">
         <li class="browse-list-item framework-application-section">
-          <a class="browse-list-item-link" href="#"><span>Read framework updates</span></a>
+          <a class="browse-list-item-link" href="{{ url_for('.framework_updates') }}"><span>Read framework updates</span></a>
           <p class="browse-list-item-body">
             Read updates and ask clarification questions.
           </p>

--- a/app/templates/frameworks/updates.html
+++ b/app/templates/frameworks/updates.html
@@ -66,14 +66,14 @@
   </div>
 
   <div class="grid-row">
-    <div class="column-two-thirds">
+    <div class="column-one-whole updates-document-tables">
       {{ summary.heading("Framework application information") }}
       {% call(item) summary.list_table(
         [
-          {"date_uploaded": "Monday 1 November 2015", "document": "example.pdf"},
-          {"date_uploaded": "Friday 20 October 2015", "document": "example.pdf"},
-          {"date_uploaded": "Wednesday 17 November 2015", "document": "example.pdf"},
-          {"date_uploaded": "Monday 15 November 2015", "document": "example.pdf"},
+          {"date_uploaded": "Monday 1 November 2015", "document": "Example"},
+          {"date_uploaded": "Friday 20 October 2015", "document": "Example"},
+          {"date_uploaded": "Wednesday 17 November 2015", "document": "Example"},
+          {"date_uploaded": "Monday 15 November 2015", "document": "Example"},
         ],
         caption="Framework application information",
         empty_message="No application information exists",
@@ -84,7 +84,7 @@
         field_headings_visible=False
       ) %}
         {% call summary.row() %}
-          {{ summary.field_name(item.date_uploaded, wide=True) }}
+          {{ summary.field_name(item.date_uploaded) }}
           {% call summary.field() %}
              <a href="#" class="document-link-with-icon">
               <span class='document-icon'>pdf<span> document:</span></span>
@@ -93,17 +93,13 @@
           {% endcall %}
         {% endcall %}
       {% endcall %}
-    </div>
-  </div>
 
-  <div class="grid-row">
-    <div class="column-two-thirds">
       {{ summary.heading("Clarification questions") }}
       {% call(item) summary.list_table(
         [
-          {"date_uploaded": "Tuesday 20 September 2015", "document": "Clarification questions and answers.odf"},
-          {"date_uploaded": "Tuesday 13 September 2015", "document": "Clarification questions and answers.odf"},
-          {"date_uploaded": "Tuesday 6 September 2015", "document": "Clarification questions and answers.odf"},
+          {"date_uploaded": "Tuesday 20 September 2015", "document": "Clarification questions and answers"},
+          {"date_uploaded": "Tuesday 13 September 2015", "document": "Clarification questions and answers"},
+          {"date_uploaded": "Tuesday 6 September 2015", "document": "Clarification questions and answers"},
         ],
         caption="Clarification questions",
         empty_message="No clarification questions exist",
@@ -114,7 +110,7 @@
         field_headings_visible=False
       ) %}
         {% call summary.row() %}
-          {{ summary.field_name(item.date_uploaded, wide=True) }}
+          {{ summary.field_name(item.date_uploaded) }}
           {% call summary.field() %}
              <a href="#" class="document-link-with-icon">
               <span class='document-icon'>odf<span> document:</span></span>

--- a/app/templates/frameworks/updates.html
+++ b/app/templates/frameworks/updates.html
@@ -29,7 +29,7 @@
   {% with messages = get_flashed_messages(with_categories=true) %}
     {% for category, message in messages %}
       {% if message == 'message_sent' %}
-        {% set message = "Message sent. Cheers." %}
+        {% set message = "Your clarification message has been sent." %}
       {% endif %}
       {%
         with

--- a/app/templates/frameworks/updates.html
+++ b/app/templates/frameworks/updates.html
@@ -1,6 +1,8 @@
 {% extends "_base_page.html" %}
 {% import "toolkit/summary-table.html" as summary %}
 
+{% block page_title %}G-Cloud 7 updates – Digital Marketplace{% endblock %}
+
 {% block breadcrumb %}
   {%
     with items = [

--- a/app/templates/frameworks/updates.html
+++ b/app/templates/frameworks/updates.html
@@ -130,7 +130,6 @@
         question = "Ask a G-Cloud 7 clarification question",
         name = clarification_question_name,
         hint = "Questions will be collated and answered weekly",
-        max_length_in_words = 500,
         error = error_message
       %}
         {% include "toolkit/forms/textbox.html" %}

--- a/app/templates/frameworks/updates.html
+++ b/app/templates/frameworks/updates.html
@@ -1,0 +1,151 @@
+{% extends "_base_page.html" %}
+{% import "toolkit/summary-table.html" as summary %}
+
+{% block breadcrumb %}
+  {%
+    with items = [
+      {
+        "link": "/",
+        "label": "Digital Marketplace",
+      },
+      {
+        "link": url_for(".dashboard"),
+        "label": "Your account",
+      },
+      {
+        "link": url_for(".framework_dashboard"),
+        "label": "Apply to G-Cloud 7",
+      }
+    ]
+  %}
+    {% include "toolkit/breadcrumb.html" %}
+  {% endwith %}
+{% endblock %}
+
+{% block main_content %}
+
+  {% with messages = get_flashed_messages(with_categories=true) %}
+    {% for category, message in messages %}
+      {% if message == 'message_sent' %}
+        {% set message = "Message sent. Cheers." %}
+      {% endif %}
+      {%
+        with
+        message = message,
+        type = "destructive" if category == 'error' else "success"
+      %}
+        {% include "toolkit/notification-banner.html" %}
+      {% endwith %}
+    {% endfor %}
+  {% endwith %}
+
+  {% if error_message %}
+    {%
+      with
+      errors = [
+        {
+            "input_name": clarification_question_name,
+            "question": "Ask a G-Cloud 7 clarification question"
+        }
+    ],
+      lede = "There was a problem with your submitted question"
+    %}
+      {% include "toolkit/forms/validation.html" %}
+    {% endwith %}
+  {% endif %}
+
+  <div class="grid-row">
+    <div class="column-two-thirds">
+      {% with
+         smaller = true,
+         heading = "G-Cloud 7 updates"
+      %}
+        {% include "toolkit/page-heading.html" %}
+      {% endwith %}
+    </div>
+  </div>
+
+  <div class="grid-row">
+    <div class="column-two-thirds">
+      {{ summary.heading("Framework application information") }}
+      {% call(item) summary.list_table(
+        [
+          {"date_uploaded": "Monday 1 November 2015", "document": "example.pdf"},
+          {"date_uploaded": "Friday 20 October 2015", "document": "example.pdf"},
+          {"date_uploaded": "Wednesday 17 November 2015", "document": "example.pdf"},
+          {"date_uploaded": "Monday 15 November 2015", "document": "example.pdf"},
+        ],
+        caption="Framework application information",
+        empty_message="No application information exists",
+        field_headings=[
+          "Date uploaded",
+          "Document"
+        ],
+        field_headings_visible=False
+      ) %}
+        {% call summary.row() %}
+          {{ summary.field_name(item.date_uploaded, wide=True) }}
+          {% call summary.field() %}
+             <a href="#" class="document-link-with-icon">
+              <span class='document-icon'>pdf<span> document:</span></span>
+              {{ item.document }}
+            </a>
+          {% endcall %}
+        {% endcall %}
+      {% endcall %}
+    </div>
+  </div>
+
+  <div class="grid-row">
+    <div class="column-two-thirds">
+      {{ summary.heading("Clarification questions") }}
+      {% call(item) summary.list_table(
+        [
+          {"date_uploaded": "Tuesday 20 September 2015", "document": "Clarification questions and answers.odf"},
+          {"date_uploaded": "Tuesday 13 September 2015", "document": "Clarification questions and answers.odf"},
+          {"date_uploaded": "Tuesday 6 September 2015", "document": "Clarification questions and answers.odf"},
+        ],
+        caption="Clarification questions",
+        empty_message="No clarification questions exist",
+        field_headings=[
+          "Date uploaded",
+          "Document"
+        ],
+        field_headings_visible=False
+      ) %}
+        {% call summary.row() %}
+          {{ summary.field_name(item.date_uploaded, wide=True) }}
+          {% call summary.field() %}
+             <a href="#" class="document-link-with-icon">
+              <span class='document-icon'>odf<span> document:</span></span>
+              {{ item.document }}
+            </a>
+          {% endcall %}
+        {% endcall %}
+      {% endcall %}
+    </div>
+  </div>
+
+  <form method="post">
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+      {%
+        with
+        large=true,
+        question = "Ask a G-Cloud 7 clarification question",
+        name = clarification_question_name,
+        hint = "Questions will be collated and answered weekly",
+        max_length_in_words = 500,
+        error = error_message
+      %}
+        {% include "toolkit/forms/textbox.html" %}
+      {% endwith %}
+      {%
+        with
+        label="Submit question",
+        type="save"
+      %}
+        {% include "toolkit/button.html" %}
+      {% endwith %}
+  </form>
+
+{% endblock %}

--- a/config.py
+++ b/config.py
@@ -17,6 +17,7 @@ class Config(object):
     DM_DATA_API_URL = None
     DM_DATA_API_AUTH_TOKEN = None
     DM_MANDRILL_API_KEY = None
+    DM_CLARIFICATION_QUESTION_EMAIL = 'digitalmarketplace@mailinator.com'
 
     DM_G7_DRAFT_DOCUMENTS_BUCKET = None
     DM_G7_DRAFT_DOCUMENTS_URL = None
@@ -69,6 +70,7 @@ class Test(Config):
     DM_API_URL = 'http://localhost'
     WTF_CSRF_ENABLED = False
     SERVER_NAME = 'localhost'
+    DM_MANDRILL_API_KEY = 'MANDRILL'
 
     FEATURE_FLAGS_EDIT_SERVICE_PAGE = enabled_since('2015-06-03')
     FEATURE_FLAGS_SUPPLIER_DASHBOARD = enabled_since('2015-06-10')

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -137,12 +137,10 @@ class TestSendClarificationQuestionEmail(BaseApplicationTest):
             }, {
                 'question': '\t   \n\n\n',  # whitespace-only question
                 'error_message': 'Question cannot be empty'
-            }, {
-                'question': 'word ' * 501,  # 500+ word question
-                'error_message': 'Question cannot be more than 500 words or 5000 characters'
-            }, {
+            },
+            {
                 'question': ('ten__chars' * 500) + '1',  # 5000+ char question
-                'error_message': 'Question cannot be more than 500 words or 5000 characters'
+                'error_message': 'Question cannot be longer than 5000 characters'
             }
         ]:
 

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -1,8 +1,10 @@
-from nose.tools import assert_equal
+from nose.tools import assert_equal, assert_true
 import mock
 from mock import Mock
 from lxml import html
 from dmutils.apiclient import APIError
+from dmutils.email import MandrillException
+from flask import render_template
 
 from ..helpers import BaseApplicationTest
 
@@ -93,3 +95,90 @@ class TestSupplierDeclaration(BaseApplicationTest):
                 })
 
             assert_equal(res.status_code, 400)
+
+
+class TestSendClarificationQuestionEmail(BaseApplicationTest):
+
+    def _send_email(self, clarification_question):
+        with self.app.test_client():
+            self.login()
+
+            return self.client.post(
+                "/suppliers/frameworks/g-cloud-7/updates",
+                data={
+                    'clarification_question': clarification_question,
+                }
+            )
+
+    def _assert_email(self, send_email, is_called=True):
+
+        if is_called:
+            assert_equal(1, send_email.call_count)
+            send_email.assert_called_once_with(
+                "digitalmarketplace@mailinator.com",
+                mock.ANY,
+                "MANDRILL",
+                "Clarification question",
+                "suppliers@digitalmarketplace.service.gov.uk",
+                "G-Cloud 7 Supplier",
+                ["clarification-question"]
+            )
+
+        else:
+            assert_equal(0, send_email.call_count)
+
+    @mock.patch('app.main.views.frameworks.send_email')
+    def test_should_not_send_email_if_invalid_clarification_question(self, send_email):
+
+        for invalid_clarification_question in [
+            {
+                'question': '',  # empty question
+                'error_message': 'Question cannot be empty'
+            }, {
+                'question': '\t   \n\n\n',  # whitespace-only question
+                'error_message': 'Question cannot be empty'
+            }, {
+                'question': 'word ' * 501,  # 500+ word question
+                'error_message': 'Question cannot be more than 500 words or 5000 characters'
+            }, {
+                'question': ('ten__chars' * 500) + '1',  # 5000+ char question
+                'error_message': 'Question cannot be more than 500 words or 5000 characters'
+            }
+        ]:
+
+            response = self._send_email(invalid_clarification_question['question'])
+            self._assert_email(send_email, is_called=False)
+
+            assert_equal(response.status_code, 400)
+            assert_true(
+                self.strip_all_whitespace('There was a problem with your submitted question')
+                in self.strip_all_whitespace(response.get_data(as_text=True))
+            )
+            assert_true(
+                self.strip_all_whitespace(invalid_clarification_question['error_message'])
+                in self.strip_all_whitespace(response.get_data(as_text=True))
+            )
+
+    @mock.patch('app.main.views.frameworks.send_email')
+    def test_should_call_send_email_with_correct_params(self, send_email):
+
+        clarification_question = 'This is a clarification question.'
+        response = self._send_email(clarification_question)
+
+        self._assert_email(send_email)
+
+        assert_equal(response.status_code, 200)
+        assert_true(
+            self.strip_all_whitespace('<p class="banner-message">Message sent. Cheers.</p>')
+            in self.strip_all_whitespace(response.get_data(as_text=True))
+        )
+
+    @mock.patch('app.main.views.frameworks.send_email')
+    def test_should_be_a_503_if_email_fails(self, send_email):
+        send_email.side_effect = MandrillException("Arrrgh")
+
+        clarification_question = 'This is a clarification question.'
+        response = self._send_email(clarification_question)
+        self._assert_email(send_email)
+
+        assert_equal(response.status_code, 503)

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -167,7 +167,7 @@ class TestSendClarificationQuestionEmail(BaseApplicationTest):
 
         assert_equal(response.status_code, 200)
         assert_true(
-            self.strip_all_whitespace('<p class="banner-message">Message sent. Cheers.</p>')
+            self.strip_all_whitespace('<p class="banner-message">Your clarification message has been sent.</p>')
             in self.strip_all_whitespace(response.get_data(as_text=True))
         )
 


### PR DESCRIPTION
**Still waiting on Roz's copy edits, but feel free to code review in the meanwhile.**

This pull request adds in an 'G-Cloud 7 updates' page from which a logged-in supplier can ask a tender question.
Empty questions are prohibited, as are questions that are too long (500+ words or 5000+ characters), but anything else is allowed.
The actual email address we're sending to is stored behind a new `DM_CLARIFICATION_QUESTION_EMAIL` config variable so that we don't have any meddlesome troublemakers asking lots of questions illicitly.
Needs the Mailchimp API key before it properly sends emails.

Lists of documents (based on [Ralph's prototype](http://dm-prototype.herokuapp.com/updates)) are quite rough still, but the skeleton is more or less in place.
<sup>Anyway, @quis said he'd look at it.</sup>
 
[>> Story on Pivotal](https://www.pivotaltracker.com/story/show/100214390)

***

#### G-Cloud 7 updates page

![screen shot 2015-08-10 at 15 04 44](https://cloud.githubusercontent.com/assets/2454380/9173420/ed8dc7f2-3f71-11e5-9843-9609881124a2.png)

_More screenshots once on-screen messages are approved_