### PR TITLE
Align current service editing with SSP

### DIFF
--- a/app/assets/scss/_service-status.scss
+++ b/app/assets/scss/_service-status.scss
@@ -6,7 +6,7 @@
 .service-status-removed,
 .service-status-disabled {
   @extend %service-status;
-  color: $red;
+  color: $mellow-red;
 }
 
 .service-status-published,
@@ -19,5 +19,5 @@
 .service-status-enabled,
 .service-status-private {
   @extend %service-status;
-  color: $grey-2;
+  color: $secondary-text-colour;
 }

--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -32,6 +32,7 @@ $path: "/suppliers/static/images/";
 @import "toolkit/_service-id.scss";
 @import "toolkit/document";
 @import "toolkit/contact-details";
+@import "toolkit/link-button";
 @import "toolkit/forms/_questions.scss";
 @import "toolkit/forms/_summary.scss";
 @import "toolkit/forms/_hint.scss";

--- a/app/templates/services/list_services.html
+++ b/app/templates/services/list_services.html
@@ -50,7 +50,6 @@
       'Name',
       'Framework',
       'Lot',
-      'Status',
       summary.hidden_field_heading("Action")
     ],
     field_headings_visible=True,
@@ -60,33 +59,43 @@
 
       {{ summary.service_link(
           item.serviceName,
-          '/g-cloud/services/' + item.id
+          url_for('.edit_service', service_id=item.id)
       ) }}
 
       {{ summary.text(item.frameworkName) }}
 
       {{ summary.text(item.lot) }}
 
-      {% call summary.field() %}
-        <span class="service-status-{{ item.status }}">
-          {% if item.status == "published" %}
-            Public
-          {% elif item.status == "enabled" %}
-            Private
-          {% elif item.status == "disabled" %}
-            Removed
-          {% else %}
-            {{ item.status|title }}
-          {% endif %}
-        </span>
-      {% endcall %}
-
       {% if 'EDIT_SERVICE_PAGE' is active_feature %}
-        {% if item.status == "disabled" %}
-          {{ summary.edit_link("Details", url_for('.edit_service', service_id=item.id)) }}
-        {% else %}
-          {{ summary.edit_link("Edit", url_for('.edit_service', service_id=item.id)) }}
+        {% if item.status == "published" %}
+          {{ summary.edit_link("View service", '/g-cloud/services/' + item.id) }}
+        {% elif item.status == "disabled" %}
+          {% call summary.field(action=True) %}
+            <span class="service-status-{{ item.status }}">
+              Removed
+            </span>
+          {% endcall %}
+        {% elif item.status == "enabled" %}
+          {% call summary.field(action=True) %}
+            <span class="service-status-{{ item.status }}">
+              Private
+            </span>
+          {% endcall %}
         {% endif %}
+      {% else %}
+        {% call summary.field(action=True) %}
+          <span class="service-status-{{ item.status }}">
+            {% if item.status == "published" %}
+              Public
+            {% elif item.status == "enabled" %}
+              Private
+            {% elif item.status == "disabled" %}
+              Removed
+            {% else %}
+              {{ item.status|title }}
+            {% endif %}
+          </span>
+        {% endcall %}
       {% endif %}
 
     {% endcall %}

--- a/app/templates/services/service.html
+++ b/app/templates/services/service.html
@@ -22,6 +22,13 @@
 {% endblock %}
 
 {% block before_sections %}
+  {% if service_data.status == "published" %}
+    <div class="column-one-third">
+      {% with label="View service", url="/g-cloud/services/" + service_id %}
+        {% include "toolkit/link-button.html" %}
+      {% endwith %}
+    </div>
+  {% endif %}
   {% if error %}
     <div class="column-one-whole">
       {% with
@@ -32,7 +39,7 @@
       {% endwith %}
     </div>
   {% endif %}
-    <div class="column-two-thirds">
+    <div class="column-one-whole">
       {% include "services/_edit-status.html" %}
     </div>
 {% endblock %}

--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "jquery": "1.11.2",
     "hogan": "3.0.2",
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
-    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v8.2.7",
+    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v8.3.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.14.1/jinja_govuk_template-0.14.1.tgz",
     "digital-marketplace-ssp-content": "git://github.com/alphagov/digitalmarketplace-ssp-content#ff5438d5bbb0ad993001539ee92a7292dd35b937"
   }


### PR DESCRIPTION
Add a 'view service' button from the admin app to the page for editing a current service

![image](https://cloud.githubusercontent.com/assets/355079/9174978/1cf9521e-3f7b-11e5-8f04-74e95a0f4082.png)

--

Add a 'view service' link to the table of current services and changes the name-of-service link to point to the edit page and simplifies the table of current services to show either the 'bad' status (private/removed) _or_ the link to view the service

![image](https://cloud.githubusercontent.com/assets/355079/9175001/3d824c3e-3f7b-11e5-83ab-469f1d82a304.png)
