### PR TITLE
Changes to declaration from John Willams

### DIFF
--- a/app/declaration_manifest.yml
+++ b/app/declaration_manifest.yml
@@ -1,15 +1,15 @@
 -
-  name: Terms of participation
+  name: G-Cloud 7 essentials
   questions:
     - PR1
     - PR2
+    - PR5
     - PR3
     - PR4
-    - PR5
     - SQ1-3
     - SQ5-1a
 -
-  name: Company information
+  name: About you
   questions:
     - SQ1-2a
     - SQ1-2b
@@ -17,6 +17,7 @@
     - SQ1-1b
     - SQ1-1ci
     - SQ1-1cii
+    - SQ1-1k
     - SQ1-1d
     - SQ1-1e
     - SQ1-1f
@@ -27,7 +28,6 @@
     - SQ1-1i-ii
     - SQ1-1j-i
     - SQ1-1j-ii
-    - SQ1-1k
     - SQ1-1l
     - SQ1-1m
     - SQ1-1n
@@ -63,6 +63,7 @@
     - SQ3-1i-i
     - SQ3-1i-ii
     - SQ3-1j
+    - SQ3-1k
     - SQ4-1a
     - SQ4-1b
     - SQ4-1c

--- a/app/templates/frameworks/dashboard.html
+++ b/app/templates/frameworks/dashboard.html
@@ -69,7 +69,8 @@
                 {% endif %}
               </a>
               <p class="browse-list-item-body">
-                Agree to the terms of participation, provide company information and confirm eligibility.
+                Agree to the terms of the bid, provide supplier information and
+                confirm eligibility.
               </p>
             </div>
             <div class="column-one-third">

--- a/app/templates/frameworks/edit_declaration_section.html
+++ b/app/templates/frameworks/edit_declaration_section.html
@@ -37,6 +37,9 @@
   %}
     {% include 'toolkit/page-heading.html' %}
   {% endwith %}
+  <p>
+    You must complete this declaration for your services to be eligible for G-Cloud 7 submission.
+  </p>
   <form method="post" class="supplier-declaration">
 
     {% set question_index = [0] %}
@@ -67,7 +70,7 @@
       {% include "toolkit/button.html" %}
     {% endwith %}
 
-    <a href="/suppliers">Return to application</a>
+    <a href="/suppliers">Return to G-Cloud 7 application</a>
 
   </form>
 {% endblock %}

--- a/bower.json
+++ b/bower.json
@@ -7,6 +7,6 @@
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
     "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v8.2.7",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.14.1/jinja_govuk_template-0.14.1.tgz",
-    "digital-marketplace-ssp-content": "git://github.com/alphagov/digitalmarketplace-ssp-content#3610985639135e821cb664a70a8e556c11cd813e"
+    "digital-marketplace-ssp-content": "git://github.com/alphagov/digitalmarketplace-ssp-content#11cb090b425df8e3befbf67288a3b4fbdd285ee7"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -7,6 +7,6 @@
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
     "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v8.2.7",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.14.1/jinja_govuk_template-0.14.1.tgz",
-    "digital-marketplace-ssp-content": "git://github.com/alphagov/digitalmarketplace-ssp-content#ff5438d5bbb0ad993001539ee92a7292dd35b937"
+    "digital-marketplace-ssp-content": "git://github.com/alphagov/digitalmarketplace-ssp-content#3610985639135e821cb664a70a8e556c11cd813e"
   }
 }


### PR DESCRIPTION
> 1. Could we add in some (slightly edited) introductory copy at the top of the supplier declaration page that says:
>
> You must complete this declaration for your services to be eligible for G-Cloud 7 submission.
>
> ~~2. The links aren't working in the hint text. If we can't fix, let me know and I'll change the format in the hints.~~
>
> 3. Can we change the link at the bottom to say 'Return to G-Cloud 7 application'?
>
> 4. ‘Terms of participation’ header => G-Cloud 7 essentials
>
> 5. Exactly the same as current q56, we need to add a why box for questions 41-53
> If you responded yes to any of questions 41-53, please provide details of any mitigating factors that you think should be taken into consideration.
>
> 6. Change order of questions 3-5
> 5 => 3
> 3 => 4
> 4 => 5
>
> 7. Move question 24 (trading name SQ1-1k) up to below SQ1.1cii
> It becomes question 14
>
> 8. Page header change
> Company information => About you
>
> 9. On the following page:
> https://preview.development.digitalmarketplace.service.gov.uk/suppliers/frameworks/g-cloud-7
>
> Make supplier declaration
> Agree to the terms of the bid, provide supplier information and confirm eligibility.