### PR TITLE
Fix summary table caption on supplier dashboard

### DIFF
--- a/app/templates/suppliers/dashboard.html
+++ b/app/templates/suppliers/dashboard.html
@@ -122,7 +122,7 @@
   {% endif %}
   {% call(item) summary.table(
     users,
-    caption="Users for " + current_user.supplier_name,
+    caption="Contributors",
     field_headings=[
       "Name",
       "Email address"


### PR DESCRIPTION
All of our other summary tables have the table header as the caption.
The "Contributors" table should too.

##### Note
This change affects the [functional tests](https://github.com/alphagov/digitalmarketplace-functional-tests/pull/53) I've written, so I've labeled that PR as `[WIP]` until this goes through.