### PR TITLE
Complete draft

### DIFF
--- a/app/assets/scss/_service_submission.scss
+++ b/app/assets/scss/_service_submission.scss
@@ -1,0 +1,11 @@
+.align-with-heading {
+    margin-top: 45px;
+}
+
+.last-edited {
+    margin: 10px 0 15px 0;
+}
+
+.move-to-complete-hint {
+    color: $secondary-text-colour;
+}

--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -54,6 +54,7 @@ $path: "/suppliers/static/images/";
 @import "_assurance-question.scss";
 @import "_supplier-declaration.scss";
 @import "_updates.scss";
+@import "_service_submission.scss";
 
 .filter-field-text {
   @include core-16;

--- a/app/main/helpers/services.py
+++ b/app/main/helpers/services.py
@@ -34,6 +34,15 @@ def get_drafts(apiclient, supplier_id, framework_slug):
     return drafts, complete_drafts
 
 
+def count_unanswered_questions(service_attributes):
+    return len([
+        q.label
+        for s in service_attributes
+        for q in s['rows']
+        if q.answer_required
+    ])
+
+
 def get_service_attributes(service_data, service_questions):
     return list(map(
         lambda section: {

--- a/app/main/helpers/services.py
+++ b/app/main/helpers/services.py
@@ -2,6 +2,7 @@ from flask import abort, current_app, url_for
 from flask_login import current_user
 
 from dmutils import s3
+from dmutils.apiclient import APIError
 from dmutils.documents import filter_empty_files, validate_documents, upload_document
 from dmutils.service_attribute import Attribute
 from dmutils.content_loader import PRICE_FIELDS
@@ -12,6 +13,22 @@ try:
     import urlparse
 except ImportError:
     import urllib.parse as urlparse
+
+
+def get_drafts(apiclient, supplier_id, framework_slug):
+    try:
+        drafts = apiclient.find_draft_services(
+            current_user.supplier_id,
+            framework='g-cloud-7'
+        )['services']
+
+    except APIError as e:
+        abort(e.status_code)
+
+    complete_drafts = [draft for draft in drafts if draft['status'] == 'submitted']
+    drafts = [draft for draft in drafts if draft['status'] == 'not-submitted']
+
+    return drafts, complete_drafts
 
 
 def get_service_attributes(service_data, service_questions):

--- a/app/main/helpers/services.py
+++ b/app/main/helpers/services.py
@@ -25,6 +25,9 @@ def get_drafts(apiclient, supplier_id, framework_slug):
     except APIError as e:
         abort(e.status_code)
 
+    # Hide drafts without service name
+    drafts = [draft for draft in drafts if draft.get('serviceName')]
+
     complete_drafts = [draft for draft in drafts if draft['status'] == 'submitted']
     drafts = [draft for draft in drafts if draft['status'] == 'not-submitted']
 

--- a/app/main/helpers/services.py
+++ b/app/main/helpers/services.py
@@ -35,7 +35,7 @@ def get_drafts(apiclient, supplier_id, framework_slug):
 
 
 def get_service_attributes(service_data, service_questions):
-    return map(
+    return list(map(
         lambda section: {
             'name': section['name'],
             'rows': _get_rows(section, service_data),
@@ -43,7 +43,7 @@ def get_service_attributes(service_data, service_questions):
             'id': section['id']
         },
         service_questions
-    )
+    ))
 
 
 def _get_rows(section, service_data):

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -8,7 +8,7 @@ from dmutils.email import send_email, MandrillException
 from ...main import main, declaration_content
 from ..helpers.frameworks import get_error_messages
 from ... import data_api_client
-from ..helpers.services import get_draft_document_url
+from ..helpers.services import get_draft_document_url, get_drafts
 from ..helpers.frameworks import register_interest_in_framework
 
 
@@ -23,12 +23,10 @@ def framework_dashboard():
 
     try:
         register_interest_in_framework(data_api_client, 'g-cloud-7')
-        drafts = data_api_client.find_draft_services(
-            current_user.supplier_id,
-            framework='g-cloud-7'
-        )['services']
     except APIError as e:
         abort(e.status_code)
+
+    drafts, complete_drafts = get_drafts(data_api_client, current_user.supplier_id, 'g-cloud-7')
 
     try:
         declaration_made = bool(data_api_client.get_selection_answers(
@@ -43,7 +41,7 @@ def framework_dashboard():
         "frameworks/dashboard.html",
         counts={
             "draft": len(drafts),
-            "complete": 1,
+            "complete": len(complete_drafts),
         },
         declaration_made=declaration_made,
         **template_data
@@ -56,17 +54,11 @@ def framework_dashboard():
 def framework_services():
     template_data = main.config['BASE_TEMPLATE_DATA']
 
-    try:
-        drafts = data_api_client.find_draft_services(
-            current_user.supplier_id,
-            framework='g-cloud-7'
-        )['services']
-
-    except APIError as e:
-        abort(e.status_code)
+    drafts, complete_drafts = get_drafts(data_api_client, current_user.supplier_id, 'g-cloud-7')
 
     return render_template(
         "frameworks/services.html",
+        complete_drafts=complete_drafts,
         drafts=drafts,
         **template_data
     ), 200

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -10,7 +10,10 @@ from ...main import main, declaration_content, new_service_content
 from ..helpers.frameworks import get_error_messages
 
 from ... import data_api_client
-from ..helpers.services import get_draft_document_url, get_service_attributes, get_drafts
+from ..helpers.services import (
+    get_draft_document_url, get_service_attributes, get_drafts,
+    count_unanswered_questions
+)
 from ..helpers.frameworks import register_interest_in_framework
 
 
@@ -63,12 +66,7 @@ def framework_services():
         content = new_service_content.get_builder().filter(draft)
         sections = get_service_attributes(draft, content)
 
-        draft['unanswered_questions'] = len([
-            q.label
-            for s in sections
-            for q in s['rows']
-            if q.answer_required
-        ])
+        draft['unanswered_questions'] = count_unanswered_questions(sections)
 
     return render_template(
         "frameworks/services.html",

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -58,8 +58,8 @@ def framework_services():
 
     return render_template(
         "frameworks/services.html",
-        complete_drafts=complete_drafts,
-        drafts=drafts,
+        complete_drafts=reversed(complete_drafts),
+        drafts=reversed(drafts),
         **template_data
     ), 200
 

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -116,7 +116,7 @@ def edit_section(service_id, section_id):
 
     content = existing_service_content.get_builder().filter(service)
     section = content.get_section(section_id)
-    if section is None:
+    if section is None or not section.editable:
         abort(404)
 
     return render_template(
@@ -142,7 +142,7 @@ def update_section(service_id, section_id):
 
     content = existing_service_content.get_builder().filter(service)
     section = content.get_section(section_id)
-    if section is None:
+    if section is None or not section.editable:
         abort(404)
 
     posted_data = section.get_data(request.form)
@@ -360,7 +360,7 @@ def edit_service_submission(service_id, section_id):
 
     content = new_service_content.get_builder().filter(draft)
     section = content.get_section(section_id)
-    if section is None:
+    if section is None or not section.editable:
         abort(404)
 
     unformat_section_data(draft)
@@ -388,7 +388,7 @@ def update_section_submission(service_id, section_id):
 
     content = new_service_content.get_builder().filter(draft)
     section = content.get_section(section_id)
-    if section is None:
+    if section is None or not section.editable:
         abort(404)
 
     posted_data = section.get_data(request.form)

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -348,7 +348,8 @@ def service_submission_document(framework_slug, supplier_id, document_name):
 @flask_featureflags.is_active_feature('GCLOUD7_OPEN')
 def view_service_submission(service_id):
     try:
-        draft = data_api_client.get_draft_service(service_id)['services']
+        data = data_api_client.get_draft_service(service_id)
+        draft, last_edit = data['services'], data['auditEvents']
     except HTTPError as e:
         abort(e.status_code)
 
@@ -373,6 +374,7 @@ def view_service_submission(service_id):
         "services/service_submission.html",
         service_id=service_id,
         service_data=draft,
+        last_edit=last_edit,
         sections=sections,
         unanswered_questions=unanswered_questions,
         delete_requested=delete_requested,

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -358,13 +358,23 @@ def view_service_submission(service_id):
     draft['priceString'] = format_service_price(draft)
     content = new_service_content.get_builder().filter(draft)
 
+    sections = get_service_attributes(draft, content)
+
+    unanswered_questions = len([
+        q.label
+        for s in sections
+        for q in s['rows']
+        if q.answer_required
+    ])
+
     delete_requested = True if request.args.get('delete_requested') else False
 
     return render_template(
         "services/service_submission.html",
         service_id=service_id,
-        sections=get_service_attributes(draft, content),
         service_data=draft,
+        sections=sections,
+        unanswered_questions=unanswered_questions,
         delete_requested=delete_requested,
         **main.config['BASE_TEMPLATE_DATA']), 200
 

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -279,6 +279,29 @@ def copy_draft_service(service_id):
     return redirect(url_for(".framework_services"))
 
 
+@main.route('/submission/services/<string:service_id>/complete', methods=['POST'])
+@login_required
+@flask_featureflags.is_active_feature('GCLOUD7_OPEN')
+def complete_draft_service(service_id):
+    draft = data_api_client.get_draft_service(service_id).get('services')
+
+    if not is_service_associated_with_supplier(draft):
+        abort(404)
+
+    try:
+        data_api_client.complete_draft_service(
+            service_id,
+            current_user.email_address
+        )
+
+    except APIError as e:
+        abort(e.status_code)
+
+    flash({'service_name': draft.get('serviceName')}, 'service_completed')
+
+    return redirect(url_for(".framework_services"))
+
+
 @main.route('/submission/services/<string:service_id>/delete', methods=['POST'])
 @login_required
 @flask_featureflags.is_active_feature('GCLOUD7_OPEN')

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -7,7 +7,7 @@ from ..helpers.services import (
     get_section_error_messages,
     is_service_modifiable, is_service_associated_with_supplier,
     upload_draft_documents, get_service_attributes,
-    get_draft_document_url
+    get_draft_document_url, count_unanswered_questions
 )
 from ... import data_api_client, flask_featureflags
 from dmutils.apiclient import APIError, HTTPError
@@ -361,13 +361,7 @@ def view_service_submission(service_id):
 
     sections = get_service_attributes(draft, content)
 
-    unanswered_questions = len([
-        q.label
-        for s in sections
-        for q in s['rows']
-        if q.answer_required
-    ])
-
+    unanswered_questions = count_unanswered_questions(sections)
     delete_requested = True if request.args.get('delete_requested') else False
 
     return render_template(

--- a/app/new_service_manifest.yml
+++ b/app/new_service_manifest.yml
@@ -4,10 +4,14 @@
   questions:
     - lot
 -
-  name: Service description
+  name: Service name
   editable: true
   questions:
     - serviceName
+-
+  name: Service description
+  editable: true
+  questions:
     - serviceSummary
 -
   name: Service type

--- a/app/templates/frameworks/services.html
+++ b/app/templates/frameworks/services.html
@@ -64,7 +64,7 @@
     field_headings_visible=True
   ) %}
     {% call summary.row() %}
-      {{ summary.service_link(draft.serviceName or 'New service',
+      {{ summary.service_link(draft.serviceName,
                               url_for(".view_service_submission", service_id=draft.id)) }}
       {{ summary.text(draft.lot) }}
       {{ summary.button(text="Make a copy",
@@ -81,7 +81,7 @@
     field_headings_visible=True
   ) %}
     {% call summary.row() %}
-      {{ summary.service_link(draft.serviceName or 'New service',
+      {{ summary.service_link(draft.serviceName,
                               url_for(".view_service_submission", service_id=draft.id)) }}
       {{ summary.text(draft.lot) }}
       {{ summary.button(text="Make a copy",

--- a/app/templates/frameworks/services.html
+++ b/app/templates/frameworks/services.html
@@ -56,8 +56,29 @@
     drafts,
     caption="Draft services",
     empty_message="You haven't added any services yet.",
+    field_headings=[
+        "Service name",
+        "Lot",
+        summary.hidden_field_heading("Make a copy")
+    ],
+    field_headings_visible=True
+  ) %}
+    {% call summary.row() %}
+      {{ summary.service_link(draft.serviceName or 'New service',
+                              url_for(".view_service_submission", service_id=draft.id)) }}
+      {{ summary.text(draft.lot) }}
+      {{ summary.button(text="Make a copy",
+                         action=url_for('.copy_draft_service', service_id=draft.id)) }}
+    {% endcall %}
+  {% endcall %}
+
+  {{ summary.heading("Complete services") }}
+  {% call(draft) summary.list_table(
+    complete_drafts,
+    caption="Complete services",
+    empty_message="You haven't completed any services yet.",
     field_headings=["Service name", "Lot", summary.hidden_field_heading("Make a copy")],
-    field_headings_visible=False
+    field_headings_visible=True
   ) %}
     {% call summary.row() %}
       {{ summary.service_link(draft.serviceName or 'New service',

--- a/app/templates/frameworks/services.html
+++ b/app/templates/frameworks/services.html
@@ -59,6 +59,7 @@
     field_headings=[
         "Service name",
         "Lot",
+        summary.hidden_field_heading("Progress"),
         summary.hidden_field_heading("Make a copy")
     ],
     field_headings_visible=True
@@ -67,6 +68,13 @@
       {{ summary.service_link(draft.serviceName,
                               url_for(".view_service_submission", service_id=draft.id)) }}
       {{ summary.text(draft.lot) }}
+      {% if draft.unanswered_questions == 0 %}
+        {{ summary.text("") }}
+      {% elif draft.unanswered_questions == 1 %}
+        {{ summary.text("%s answer required" % draft.unanswered_questions) }}
+      {% else %}
+        {{ summary.text("%s answers required" % draft.unanswered_questions) }}
+      {% endif %}
       {{ summary.button(text="Make a copy",
                          action=url_for('.copy_draft_service', service_id=draft.id)) }}
     {% endcall %}

--- a/app/templates/frameworks/services.html
+++ b/app/templates/frameworks/services.html
@@ -26,20 +26,17 @@
 
 {% block main_content %}
 
-  {% with messages = get_flashed_messages(with_categories=True, category_filter=['service_deleted']) %}
+  {% with messages = get_flashed_messages(with_categories=True) %}
     {% for category, message in messages %}
       <div class="banner-success-without-action">
         <p class="banner-message">
-          <strong>{{message.service_name}}</strong> was deleted
-        </p>
-      </div>
-    {% endfor %}
-  {% endwith %}
-  {% with messages = get_flashed_messages(with_categories=True, category_filter=['service_copied']) %}
-    {% for category, message in messages %}
-      <div class="banner-success-without-action">
-        <p class="banner-message">
-          <strong>{{message.service_name}}</strong> was copied
+          {% if category == 'service_deleted' %}
+            <strong>{{message.service_name}}</strong> was deleted
+          {% elif category == 'service_copied' %}
+            <strong>{{message.service_name}}</strong> was copied
+          {% elif category == 'service_completed' %}
+            <strong>{{message.service_name}}</strong> was completed
+          {% endif %}
         </p>
       </div>
     {% endfor %}

--- a/app/templates/frameworks/services.html
+++ b/app/templates/frameworks/services.html
@@ -69,11 +69,11 @@
                               url_for(".view_service_submission", service_id=draft.id)) }}
       {{ summary.text(draft.lot) }}
       {% if draft.unanswered_questions == 0 %}
-        {{ summary.text("") }}
+        {{ summary.text("Service can be moved to complete") }}
       {% elif draft.unanswered_questions == 1 %}
-        {{ summary.text("%s answer required" % draft.unanswered_questions) }}
+        {{ summary.text("%s question unanswered" % draft.unanswered_questions) }}
       {% else %}
-        {{ summary.text("%s answers required" % draft.unanswered_questions) }}
+        {{ summary.text("%s questions unanswered" % draft.unanswered_questions) }}
       {% endif %}
       {{ summary.button(text="Make a copy",
                          action=url_for('.copy_draft_service', service_id=draft.id)) }}

--- a/app/templates/services/_base_edit_section_page.html
+++ b/app/templates/services/_base_edit_section_page.html
@@ -47,7 +47,9 @@
     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
     {% block save_button %}{% endblock %}
 
+    {% block return_to_service_link %}
     <a href="{% block return_to_service %}{% endblock %}">Return to service summary</a>
+    {% endblock %}
 
   </form>
 {% endblock %}

--- a/app/templates/services/edit_submission_section.html
+++ b/app/templates/services/edit_submission_section.html
@@ -21,7 +21,7 @@
       },
       {
         "link": url_for(".view_service_submission", service_id=service_id),
-        "label": service_data['serviceName'] or 'New service'
+        "label": service_data['serviceName']
       }
     ]
   %}
@@ -49,4 +49,8 @@
   {% endif %}
 {% endblock %}
 
-{% block return_to_service %}{{ url_for(".view_service_submission", service_id=service_id) }}{% endblock %}
+{% block return_to_service_link %}
+  {% if service_data['serviceName'] %}
+  <a href="{{ url_for(".view_service_submission", service_id=service_id) }}">Return to service summary</a>
+  {% endif %}
+{% endblock %}

--- a/app/templates/services/service_submission.html
+++ b/app/templates/services/service_submission.html
@@ -47,7 +47,7 @@
     <p class="last-edited">
       {{ unanswered_questions }} answer{% if unanswered_questions > 1 %}s{% endif %} required
     </p>
-    <p class="move-to-complete-hint">When you have added all the required information, you can mark the service as complete.</p>
+    <p class="move-to-complete-hint">When you have added all the required information, you can move the service to complete.</p>
   {% endif %}
 </div>
 {% endblock %}

--- a/app/templates/services/service_submission.html
+++ b/app/templates/services/service_submission.html
@@ -45,7 +45,7 @@
     <span class="service-status-published">Service is complete</span>
   {% else %}
     <p class="last-edited">
-      {{ unanswered_questions }} answer{% if unanswered_questions > 1 %}s{% endif %} required
+      {{ unanswered_questions }} question{% if unanswered_questions > 1 %}s{% endif %} unanswered
     </p>
     <p class="move-to-complete-hint">When you have added all the required information, you can move the service to complete.</p>
   {% endif %}

--- a/app/templates/services/service_submission.html
+++ b/app/templates/services/service_submission.html
@@ -25,6 +25,26 @@
   {% endwith %}
 {% endblock %}
 
+{% block before_sections %}
+<div class="column-one-third align-with-heading">
+  {% if service_data.status == 'not-submitted' and unanswered_questions == 0 %}
+    <form action="{{ url_for('.complete_draft_service', service_id=service_id) }}" method="POST">
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+      {% with type = "save", label = "Move to complete" %}
+        {% include "toolkit/button.html" %}
+      {% endwith %}
+    </form>
+  {% elif service_data.status == 'submitted' %}
+    <span class="service-status-published">Service is complete</span>
+  {% else %}
+    <p class="last-edited">
+      {{ unanswered_questions }} answer{% if unanswered_questions > 1 %}s{% endif %} required
+    </p>
+    <p class="move-to-complete-hint">When you have added all the required information, you can mark the service as complete.</p>
+  {% endif %}
+</div>
+{% endblock %}
+
 {% block before_heading %}
   {% if delete_requested %}
     <div class="column-one-whole">

--- a/app/templates/services/service_submission.html
+++ b/app/templates/services/service_submission.html
@@ -27,6 +27,13 @@
 
 {% block before_sections %}
 <div class="column-one-third align-with-heading">
+  <p class="normal-paragraph">
+    <strong>Last edited</strong>
+  </p>
+  <p class="last-edited">
+    {{ last_edit.createdAt|datetimeformat }}<br />
+    by {{ last_edit.userName }}
+  </p>
   {% if service_data.status == 'not-submitted' and unanswered_questions == 0 %}
     <form action="{{ url_for('.complete_draft_service', service_id=service_id) }}" method="POST">
       <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />

--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "jquery": "1.11.2",
     "hogan": "3.0.2",
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
-    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v8.3.0",
+    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v8.3.1",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.14.1/jinja_govuk_template-0.14.1.tgz",
     "digital-marketplace-ssp-content": "git://github.com/alphagov/digitalmarketplace-ssp-content#a5ef5f4149bd0296f3f6a0aaf019fe063995cff9"
   }

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -853,6 +853,11 @@ class TestShowDraftService(BaseApplicationTest):
             'priceInterval': 'Second',
             'links': {},
             'updatedAt': "2015-06-29T15:26:07.650368Z"
+        },
+        'auditEvents': {
+            'createdAt': "2015-06-29T15:26:07.650368Z",
+            'userName': "Supplier User",
+
         }
     }
 
@@ -890,6 +895,10 @@ class TestDeleteDraftService(BaseApplicationTest):
             'serviceName': 'My rubbish draft',
             'serviceSummary': 'This is the worst service ever',
             'updatedAt': "2015-06-29T15:26:07.650368Z"
+        },
+        'auditEvents': {
+            'createdAt': "2015-06-29T15:26:07.650368Z",
+            'userName': "Supplier User",
         }
     }
 

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -543,6 +543,40 @@ class TestCopyDraft(BaseApplicationTest):
         assert_equal(res.status_code, 404)
 
 
+@mock.patch('app.main.views.services.data_api_client')
+class TestCompleteDraft(BaseApplicationTest):
+
+    def setup(self):
+        super(TestCompleteDraft, self).setup()
+
+        with self.app.test_client():
+            self.login()
+
+        self.draft = {
+            'id': 1,
+            'supplierId': 1234,
+            'supplierName': "supplierName",
+            'lot': "SCS",
+            'status': "not-submitted",
+            'frameworkName': "frameworkName",
+            'links': {},
+            'updatedAt': "2015-06-29T15:26:07.650368Z"
+        }
+
+    def test_complete_draft(self, api_client):
+        api_client.get_draft_service.return_value = {'services': self.draft}
+
+        res = self.client.post('/suppliers/submission/services/1/complete')
+        assert_equal(res.status_code, 302)
+
+    def test_complete_draft_checks_supplier_id(self, api_client):
+        self.draft['supplierId'] = 2
+        api_client.get_draft_service.return_value = {'services': self.draft}
+
+        res = self.client.post('/suppliers/submission/services/1/complete')
+        assert_equal(res.status_code, 404)
+
+
 @mock.patch('dmutils.s3.S3')
 @mock.patch('app.main.views.services.data_api_client')
 class TestEditDraftService(BaseApplicationTest):

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -557,16 +557,15 @@ class TestEditDraftService(BaseApplicationTest):
         res = self.client.post(
             '/suppliers/submission/services/1/edit/service_description',
             data={
-                'serviceName': 'The service',
                 'serviceSummary': 'This is the service',
             })
 
         assert_equal(res.status_code, 302)
         data_api_client.update_draft_service.assert_called_once_with(
             '1',
-            {'serviceName': 'The service', 'serviceSummary': 'This is the service'},
+            {'serviceSummary': 'This is the service'},
             'email@email.com',
-            page_questions=['serviceName', 'serviceSummary']
+            page_questions=['serviceSummary']
         )
 
     def test_only_questions_for_this_section_can_be_changed(self, data_api_client, s3):
@@ -580,7 +579,7 @@ class TestEditDraftService(BaseApplicationTest):
         assert_equal(res.status_code, 302)
         data_api_client.update_draft_service.assert_called_once_with(
             '1', {}, 'email@email.com',
-            page_questions=['serviceName', 'serviceSummary']
+            page_questions=['serviceSummary']
         )
 
     def test_file_upload(self, data_api_client, s3):

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -343,6 +343,20 @@ class TestEditService(BaseApplicationTest):
             '1', {'serviceName': 'The service', 'serviceSummary': 'This is the service'},
             'email@email.com', 'supplier app')
 
+    def test_editing_readonly_section_is_not_allowed(self, data_api_client):
+        data_api_client.get_service.return_value = self.empty_service
+
+        res = self.client.get('/suppliers/services/1/edit/service_attributes')
+        assert_equal(res.status_code, 404)
+
+        data_api_client.get_draft_service.return_value = self.empty_service
+        res = self.client.post(
+            '/suppliers/services/1/edit/service_attributes',
+            data={
+                'lot': 'SCS',
+            })
+        assert_equal(res.status_code, 404)
+
     def test_only_questions_for_this_section_can_be_changed(self, data_api_client):
         data_api_client.get_service.return_value = self.empty_service
         res = self.client.post(
@@ -567,6 +581,20 @@ class TestEditDraftService(BaseApplicationTest):
             'email@email.com',
             page_questions=['serviceSummary']
         )
+
+    def test_editing_readonly_section_is_not_allowed(self, data_api_client, s3):
+        data_api_client.get_draft_service.return_value = self.empty_draft
+
+        res = self.client.get('/suppliers/submission/services/1/edit/service_attributes')
+        assert_equal(res.status_code, 404)
+
+        data_api_client.get_draft_service.return_value = self.empty_draft
+        res = self.client.post(
+            '/suppliers/submission/services/1/edit/service_attributes',
+            data={
+                'lot': 'SCS',
+            })
+        assert_equal(res.status_code, 404)
 
     def test_only_questions_for_this_section_can_be_changed(self, data_api_client, s3):
         data_api_client.get_draft_service.return_value = self.empty_draft


### PR DESCRIPTION
### Add /complete draft endpoint
Sends the service id to the API to mark the service as "completed"
and redirects to the draft services page.

Shows "service was completed" message on the services page.

### Split service name and description into separate sections
Since services without names are not shown in the service list
saving the service name should be as simple as possible and
shouldn't require a value for the service summary.

### Hide "return to service" links for drafts without a name
![screen shot 2015-08-12 at 17 06 05](https://cloud.githubusercontent.com/assets/246664/9229322/7a364ca8-4114-11e5-94fb-857744f751be.png)

Drafts without a name won't appear in the drafts list, so it shouldn't
be possible to input any other data until the draft name is set.

Hiding the links for unnamed drafts means there's no way to get to
the draft sections page before entering the service name.

### Don't allow updates to non-editable sections
Section editable flag affects whether section "Edit" link is visible.
But it was still possible to open the section edit page for non-editable
sections and the changed data was validated and saved as service update.

This aborts any edit attempts to readonly sections with a 404.

### Show complete and draft submission lists and counts
Splits draft services based on status into complete and incomplete
drafts.

### Hide unnamed services from the draft services list
The need for non-stored "New service" name for unnamed services
pops up in different contexts (message notifications, button labels,
copied service names etc.), so in order to avoid these edge cases
we've decided to pretend that unnamed services weren't saved in the
first place.

Service name is the section right after service lot, so we've removed
any links to the draft overview page for unnamed services and split
the description into a separate section to make this step easier.

This way if the user decides not to enter a service name the service
is never displayed in the drafts list and there's no way to get to
any other edit page to enter other service data (apart from manually
entering the URL).

Unnamed drafts can be cleaned up when the framework goes live.

### Reverse draft lists so that newer drafts are always first
Since API returns drafts order by asc(id), reversing the list shows
newly created or copied drafts at the top of the list.

### Add "Move to complete" button and questions count to the draft page
Uses content questions data to count required questions that don't
have a value (this matches the check for "Answer required" in the
section fields).

If all required questions are answered a "Move to complete" button
is displayed.

### Add last edit information to the draft service page …
Shows time and user name of the last update using the auditEvents
data sent by the API endpoint.

![screen shot 2015-08-12 at 17 02 47](https://cloud.githubusercontent.com/assets/246664/9229383/c8fe10be-4114-11e5-920d-baa4b619d7d3.png)
![screen shot 2015-08-12 at 17 03 11](https://cloud.githubusercontent.com/assets/246664/9229387/ccf9a822-4114-11e5-8cce-c26644edb34f.png)
![screen shot 2015-08-12 at 17 03 25](https://cloud.githubusercontent.com/assets/246664/9229388/d101d340-4114-11e5-92c4-0c572a1071a3.png)

### Show unanswered question counts on the drafts list page
![screen shot 2015-08-12 at 17 01 17](https://cloud.githubusercontent.com/assets/246664/9229804/d69b315a-4116-11e5-8b50-5b582ddad2a9.png)
