### PR TITLE
Register interest in framework

### DIFF
--- a/app/main/helpers/frameworks.py
+++ b/app/main/helpers/frameworks.py
@@ -1,8 +1,30 @@
+from flask_login import current_user
+from dmutils.audit import AuditTypes
 import re
 from operator import add
 from functools import reduce
 import six
 from werkzeug.datastructures import ImmutableOrderedMultiDict
+
+
+def has_registered_interest_in_framework(client, framework_slug):
+    audits = client.find_audit_events(
+        audit_type=AuditTypes.register_framework_interest.value,
+        object_type='suppliers',
+        object_id=current_user.supplier_id)
+    for audit in audits['auditEvents']:
+        if audit['data'].get('frameworkSlug') == framework_slug:
+            return True
+    return False
+
+
+def register_interest_in_framework(client, framework_slug):
+    client.create_audit_event(
+        audit_type=AuditTypes.register_framework_interest.value,
+        user=current_user.email_address,
+        object_type='suppliers',
+        object_id=current_user.supplier_id,
+        data={'frameworkSlug': framework_slug})
 
 
 def get_required_fields(all_fields, answers):

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -9,6 +9,7 @@ from ...main import main, declaration_content
 from ..helpers.frameworks import get_error_messages
 from ... import data_api_client
 from ..helpers.services import get_draft_document_url
+from ..helpers.frameworks import register_interest_in_framework
 
 
 CLARIFICATION_QUESTION_NAME = 'clarification_question'
@@ -21,6 +22,7 @@ def framework_dashboard():
     template_data = main.config['BASE_TEMPLATE_DATA']
 
     try:
+        register_interest_in_framework(data_api_client, 'g-cloud-7')
         drafts = data_api_client.find_draft_services(
             current_user.supplier_id,
             framework='g-cloud-7'

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -7,6 +7,7 @@ from dmutils import flask_featureflags
 from ...main import main
 from ... import data_api_client
 from ..forms.suppliers import EditSupplierForm, EditContactInformationForm
+from ..helpers.frameworks import has_registered_interest_in_framework
 from .users import get_current_suppliers_users
 
 
@@ -29,6 +30,7 @@ def dashboard():
         "suppliers/dashboard.html",
         supplier=supplier,
         users=get_current_suppliers_users(),
+        g7_interested=has_registered_interest_in_framework(data_api_client, 'g-cloud-7'),
         **template_data
     ), 200
 

--- a/app/templates/suppliers/dashboard.html
+++ b/app/templates/suppliers/dashboard.html
@@ -29,16 +29,31 @@
   </div>
 
   {% if 'GCLOUD7_OPEN' is active_feature %}
-    {%
-      with
-      items = [{
-        "title": "Apply to become a G-Cloud 7 supplier and add services",
-        "link": url_for(".framework_dashboard"),
-        "body": "G-Cloud 7 is open for applications until 1 October 2015"
-      }]
-    %}
-      {% include "toolkit/browse-list.html" %}
-    {% endwith %}
+    {% if g7_interested %}
+      {%
+        with
+        items = [{
+          "title": "Continue your G-Cloud 7 application",
+          "link": url_for(".framework_dashboard"),
+          "body": "Make your supplier declaration, add services and view G-Cloud 7 updates and clarification questions.",
+          "subtext": "Deadline for submissions: 3pm BST, 6 October 2015"
+        }]
+      %}
+        {% include "toolkit/browse-list.html" %}
+      {% endwith %}
+    {% else %}
+      {%
+        with
+        items = [{
+          "title": "Register your interest in becoming a G-Cloud 7 supplier",
+          "link": url_for(".framework_dashboard"),
+          "body": "Get G-Cloud 7 update emails and learn about applying to G-Cloud 7",
+          "subtext": "Deadline for submissions: 3pm BST, 6 October 2015"
+        }]
+      %}
+        {% include "toolkit/browse-list.html" %}
+      {% endwith %}
+    {% endif %}
   {% endif %}
 
   {{ summary.heading("Current services") }}

--- a/app/templates/suppliers/dashboard.html
+++ b/app/templates/suppliers/dashboard.html
@@ -47,7 +47,7 @@
         items = [{
           "title": "Register your interest in becoming a G-Cloud 7 supplier",
           "link": url_for(".framework_dashboard"),
-          "body": "Get G-Cloud 7 update emails and learn about applying to G-Cloud 7",
+          "body": "Read about G-Cloud 7, receive email updates and start the application process.",
           "subtext": "Deadline for submissions: 3pm BST, 6 October 2015"
         }]
       %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ Flask-Login==0.2.11
 Flask-Script==2.0.5
 Flask-WTF==0.11
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@5.0.0#egg=digitalmarketplace-utils==5.0.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@5.3.1#egg=digitalmarketplace-utils==5.3.1
 markdown==2.6.2
 
 requests==2.5.1

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -20,6 +20,20 @@ class TestFrameworksDashboard(BaseApplicationTest):
 
             assert_equal(res.status_code, 200)
 
+    def test_interest_registered_in_framework(self, data_api_client):
+        with self.app.test_client():
+            self.login()
+
+            res = self.client.get("/suppliers/frameworks/g-cloud-7")
+
+            assert_equal(res.status_code, 200)
+            data_api_client.create_audit_event.assert_called_once_with(
+                audit_type="register_framework_interest",
+                user="email@email.com",
+                object_type="suppliers",
+                object_id=1234,
+                data={"frameworkSlug": "g-cloud-7"})
+
     def test_declaration_status_when_complete(self, data_api_client):
         with self.app.test_client():
             self.login()

--- a/tests/app/main/test_suppliers.py
+++ b/tests/app/main/test_suppliers.py
@@ -2,6 +2,7 @@ import mock
 from mock import Mock
 from nose.tools import assert_equal, assert_true, assert_in, assert_false
 from tests.app.helpers import BaseApplicationTest
+from lxml import html
 
 
 def get_supplier(*args, **kwargs):
@@ -49,6 +50,9 @@ class TestSuppliersDashboard(BaseApplicationTest):
     @mock.patch("app.main.views.suppliers.get_current_suppliers_users")
     def test_shows_supplier_info(self, get_current_suppliers_users, data_api_client):
         data_api_client.get_supplier.side_effect = get_supplier
+        data_api_client.find_audit_events.return_value = {
+            "auditEvents": []
+        }
         get_current_suppliers_users.side_effect = get_user
         with self.app.test_client():
             self.login()
@@ -92,6 +96,9 @@ class TestSuppliersDashboard(BaseApplicationTest):
     @mock.patch("app.main.views.suppliers.get_current_suppliers_users")
     def test_shows_edit_buttons(self, get_current_suppliers_users, data_api_client):
         data_api_client.get_supplier.side_effect = get_supplier
+        data_api_client.find_audit_events.return_value = {
+            "auditEvents": []
+        }
         get_current_suppliers_users.side_effect = get_user
         with self.app.test_client():
             self.login()
@@ -101,6 +108,47 @@ class TestSuppliersDashboard(BaseApplicationTest):
 
             assert_true("/suppliers/edit" in res.get_data(as_text=True))
             assert_true("/suppliers/services" in res.get_data(as_text=True))
+
+    @mock.patch("app.main.views.suppliers.data_api_client")
+    @mock.patch("app.main.views.suppliers.get_current_suppliers_users")
+    def test_shows_gcloud_7_application_link(self, get_current_suppliers_users, data_api_client):
+        data_api_client.get_supplier.side_effect = get_supplier
+        data_api_client.find_audit_events.return_value = {
+            "auditEvents": []
+        }
+        get_current_suppliers_users.side_effect = get_user
+        with self.app.test_client():
+            self.login()
+
+            res = self.client.get("/suppliers")
+            doc = html.fromstring(res.get_data(as_text=True))
+
+            assert_equal(res.status_code, 200)
+
+            assert_equal(doc.xpath('//a[@href="/suppliers/frameworks/g-cloud-7"]/span/text()')[0],
+                         "Register your interest in becoming a G-Cloud 7 supplier")
+
+    @mock.patch("app.main.views.suppliers.data_api_client")
+    @mock.patch("app.main.views.suppliers.get_current_suppliers_users")
+    def test_shows_gcloud_7_continue_link(self, get_current_suppliers_users, data_api_client):
+        data_api_client.get_supplier.side_effect = get_supplier
+        data_api_client.find_audit_events.return_value = {
+            "auditEvents": [{
+                "data": {
+                    "frameworkSlug": "g-cloud-7"
+                }
+            }]
+        }
+        get_current_suppliers_users.side_effect = get_user
+        with self.app.test_client():
+            self.login()
+
+            res = self.client.get("/suppliers")
+            doc = html.fromstring(res.get_data(as_text=True))
+
+            assert_equal(res.status_code, 200)
+            assert_equal(doc.xpath('//a[@href="/suppliers/frameworks/g-cloud-7"]/span/text()')[0],
+                         "Continue your G-Cloud 7 application")
 
 
 class TestSupplierDashboardLogin(BaseApplicationTest):


### PR DESCRIPTION
When a user clicks the 'Apply to become a G-Cloud 7 supplier' link on the supplier dashboard this registers their interest in the framework. This in turn will result in them going on an email list for framework information and changes the dashboard link.