### PR TITLE
Add a "you can still edit" hint after "Move to complete" button

### DIFF
--- a/app/templates/services/service_submission.html
+++ b/app/templates/services/service_submission.html
@@ -41,6 +41,9 @@
         {% include "toolkit/button.html" %}
       {% endwith %}
     </form>
+    <p class="last-edited move-to-complete-hint">
+      You can still edit services once they're complete.
+    </p>
   {% elif service_data.status == 'submitted' %}
     <span class="service-status-published">Service is complete</span>
   {% else %}


### PR DESCRIPTION
@quis:

    Need to speak to @ralph-hawkins about this, but I think we need a line under the complete button
    that says something like "You can still edit services once they're complete".

    Otherwise we'll probably have a situation where everyone waits until the last minute to complete
    their services, just in case they want to make changes.

![screen shot 2015-08-13 at 14 49 24](https://cloud.githubusercontent.com/assets/246664/9251323/85e0b4ec-41ca-11e5-9396-d65df03b0ffe.png)
