### PR TITLE
Ensure edit page can handle the reduced data from create supplier

### DIFF
--- a/app/main/forms/suppliers.py
+++ b/app/main/forms/suppliers.py
@@ -34,9 +34,7 @@ class EditContactInformationForm(Form):
     address2 = StringField('Business address')
     city = StringField('Town or city')
     country = StringField()
-    postcode = StringField(validators=[
-        DataRequired(message="Postcode can not be empty"),
-    ])
+    postcode = StringField()
     website = StringField()
     phoneNumber = StringField('Phone number')
     email = StringField('Email address', validators=[

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -52,8 +52,8 @@ def edit_supplier(supplier_form=None, contact_form=None, error=None):
 
     if supplier_form is None:
         supplier_form = EditSupplierForm(
-            description=supplier['description'],
-            clients=supplier['clients']
+            description=supplier.get('description', None),
+            clients=supplier.get('clients', None)
         )
         contact_form = EditContactInformationForm(
             prefix='contact_',

--- a/tests/app/main/test_suppliers.py
+++ b/tests/app/main/test_suppliers.py
@@ -236,6 +236,31 @@ class TestSupplierUpdate(BaseApplicationTest):
         res = self.client.post("/suppliers/edit", data=data)
         return res.status_code, res.get_data(as_text=True)
 
+    def test_should_render_edit_page_with_minimum_data(self, data_api_client):
+        self._login(data_api_client)
+
+        def limited_supplier(self):
+            return {
+                'suppliers': {
+                    'contactInformation': [
+                        {
+                            'phoneNumber': '099887',
+                            'id': 1234,
+                            'contactName': 'contact name',
+                            'email': 'email@email.com'
+                        }
+                    ],
+                    'dunsNumber': '999999999',
+                    'id': 12345,
+                    'name': 'Supplier Name'
+                }
+            }
+
+        data_api_client.get_supplier.side_effect = limited_supplier
+
+        response = self.client.get("/suppliers/edit")
+        assert_equal(response.status_code, 200)
+
     def test_update_all_supplier_fields(self, data_api_client):
         self._login(data_api_client)
 


### PR DESCRIPTION


- Supplier creation only provides name, duns, email and phone.
- Current edit page expects a description
- Also expects postcode to be present

This removes those requirements.