### PR TITLE
Fix empty drafts list layout bug

### DIFF
--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -70,8 +70,8 @@ def framework_services():
 
     return render_template(
         "frameworks/services.html",
-        complete_drafts=reversed(complete_drafts),
-        drafts=reversed(drafts),
+        complete_drafts=list(reversed(complete_drafts)),
+        drafts=list(reversed(drafts)),
         **template_data
     ), 200
 


### PR DESCRIPTION
Using an empty iterator in the summary-table renders an empty table
instead of empty message text since `{% if items %}` returns True
even for empty iterators.