### PR TITLE
Fix margin-top on the "Move to complete" button

### DIFF
--- a/app/assets/scss/_service_submission.scss
+++ b/app/assets/scss/_service_submission.scss
@@ -2,6 +2,10 @@
     margin-top: 45px;
 }
 
+.align-with-heading .button-save {
+    margin-top: 0px;
+}
+
 .last-edited {
     margin: 10px 0 15px 0;
 }

--- a/app/templates/services/service_submission.html
+++ b/app/templates/services/service_submission.html
@@ -27,7 +27,7 @@
 
 {% block before_sections %}
 <div class="column-one-third align-with-heading">
-  <p class="normal-paragraph">
+  <p>
     <strong>Last edited</strong>
   </p>
   <p class="last-edited">


### PR DESCRIPTION
Overwrite the new .button-save "margin-top: 45px" for the "Move to
complete" button on the service submission page.

![screen shot 2015-08-14 at 12 21 33](https://cloud.githubusercontent.com/assets/246664/9272924/0a0ea2f6-427f-11e5-8b67-88bb1754cc14.png)