### PR TITLE
Refactor tests login method

### DIFF
--- a/tests/app/helpers.py
+++ b/tests/app/helpers.py
@@ -1,5 +1,5 @@
 import re
-from mock import Mock
+from mock import patch, Mock
 from app import create_app
 from werkzeug.http import parse_cookie
 from app import data_api_client
@@ -11,6 +11,9 @@ class BaseApplicationTest(object):
     def setup(self):
         self.app = create_app('test')
         self.client = self.app.test_client()
+
+    def teardown(self):
+        self.teardown_login()
 
     @staticmethod
     def get_cookie_by_name(response, name):
@@ -89,19 +92,24 @@ class BaseApplicationTest(object):
             ]
         }
 
+    def teardown_login(self):
+        if getattr(self, 'original_get_user', None) is not None:
+            data_api_client.get_user = self.original_get_user
+            self.original_get_user = None
+
     def login(self):
-        data_api_client.authenticate_user = Mock(
-            return_value=(self.user(
-                123, "email@email.com", 1234, 'Supplier Name', 'Name')))
+        with patch('app.main.views.login.data_api_client') as login_api_client:
+            login_api_client.authenticate_user.return_value = self.user(
+                123, "email@email.com", 1234, 'Supplier Name', 'Name')
 
-        data_api_client.get_user = Mock(
-            return_value=(self.user(
-                123, "email@email.com", 1234, 'Supplier Name', 'Name')))
+            self.original_get_user = data_api_client.get_user
+            data_api_client.get_user = Mock(return_value=self.user(
+                123, "email@email.com", 1234, 'Supplier Name', 'Name'))
 
-        self.client.post("/suppliers/login", data={
-            'email_address': 'valid@email.com',
-            'password': '1234567890'
-        })
+            self.client.post("/suppliers/login", data={
+                'email_address': 'valid@email.com',
+                'password': '1234567890'
+            })
 
-        data_api_client.authenticate_user.assert_called_once_with(
-            "valid@email.com", "1234567890")
+            login_api_client.authenticate_user.assert_called_once_with(
+                "valid@email.com", "1234567890")

--- a/tests/app/main/test_login.py
+++ b/tests/app/main/test_login.py
@@ -2,7 +2,6 @@
 
 from dmutils.apiclient import HTTPError
 from dmutils.email import generate_token, MandrillException
-from itsdangerous import BadTimeSignature
 from nose.tools import assert_equal, assert_true, assert_is_not_none, assert_in, assert_false
 from ..helpers import BaseApplicationTest
 from lxml import html

--- a/tests/app/main/test_suppliers.py
+++ b/tests/app/main/test_suppliers.py
@@ -162,6 +162,7 @@ class TestSupplierDashboardLogin(BaseApplicationTest):
     ):
         get_current_suppliers_users.side_effect = get_user
         with self.app.test_client():
+            self.login()
             data_api_client.authenticate_user = Mock(
                 return_value=(self.user(
                     123, "email@email.com", 1234, "Supplier Name", "Name")))
@@ -200,22 +201,6 @@ class TestSupplierDashboardLogin(BaseApplicationTest):
 
 @mock.patch("app.main.views.suppliers.data_api_client")
 class TestSupplierUpdate(BaseApplicationTest):
-    def _login(self, data_api_client):
-        data_api_client.authenticate_user.return_value = self.user(
-            123, "email@email.com", 1234, "name", "Name"
-        )
-
-        data_api_client.get_user.return_value = self.user(
-            123, "email@email.com", 1234, "name", "Name"
-        )
-
-        data_api_client.get_supplier.side_effect = get_supplier
-
-        self.client.post("/suppliers/login", data={
-            "email_address": "email@email.com",
-            "password": "1234567890"
-        })
-
     def post_supplier_edit(self, data=None, **kwargs):
         if data is None:
             data = {
@@ -237,7 +222,7 @@ class TestSupplierUpdate(BaseApplicationTest):
         return res.status_code, res.get_data(as_text=True)
 
     def test_should_render_edit_page_with_minimum_data(self, data_api_client):
-        self._login(data_api_client)
+        self.login()
 
         def limited_supplier(self):
             return {
@@ -262,9 +247,9 @@ class TestSupplierUpdate(BaseApplicationTest):
         assert_equal(response.status_code, 200)
 
     def test_update_all_supplier_fields(self, data_api_client):
-        self._login(data_api_client)
+        self.login()
 
-        status, resp = self.post_supplier_edit()
+        status, _ = self.post_supplier_edit()
 
         assert_equal(status, 302)
 
@@ -294,7 +279,7 @@ class TestSupplierUpdate(BaseApplicationTest):
         )
 
     def test_missing_required_supplier_fields(self, data_api_client):
-        self._login(data_api_client)
+        self.login()
 
         status, resp = self.post_supplier_edit({
             "description": "New Description",
@@ -332,7 +317,7 @@ class TestSupplierUpdate(BaseApplicationTest):
         assert_in('value="11 AB"', resp)
 
     def test_description_below_word_length(self, data_api_client):
-        self._login(data_api_client)
+        self.login()
 
         status, resp = self.post_supplier_edit(
             description="DESCR " * 49
@@ -344,7 +329,7 @@ class TestSupplierUpdate(BaseApplicationTest):
         assert_true(data_api_client.update_contact_information.called)
 
     def test_description_above_word_length(self, data_api_client):
-        self._login(data_api_client)
+        self.login()
 
         status, resp = self.post_supplier_edit(
             description="DESCR " * 51
@@ -357,7 +342,7 @@ class TestSupplierUpdate(BaseApplicationTest):
         assert_false(data_api_client.update_contact_information.called)
 
     def test_clients_above_limit(self, data_api_client):
-        self._login(data_api_client)
+        self.login()
 
         status, resp = self.post_supplier_edit(
             clients=["", "A Client"] * 11


### PR DESCRIPTION
Refactor the login method method that it only mocks the login `data_api_client` for the duration of the login so that other tests on the same views module are not affected. The mocking of get_user method in a more aggressive way stays the same because it is needed for subsequent
requests. However, it is now cleaned up in the teardown.

This change also updates all the tests to use the same login method. Some tests had replaced the core one in an attempt to allow testing of the things it was mocking. This should no longer be necessary.