### PR TITLE
[#100210316] Add audit logging for invite-user

### DIFF
--- a/app/main/views/login.py
+++ b/app/main/views/login.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from flask import current_app, flash, redirect, render_template, url_for, \
     request, abort
 from flask_login import logout_user, login_user
+from dmutils.audit import AuditTypes
 from dmutils.user import user_has_role, User
 from dmutils.formats import DATETIME_FORMAT
 from dmutils.email import send_email, \
@@ -345,6 +346,14 @@ def send_invite_user():
                     current_user.supplier_id)
             )
             abort(503, "Failed to send user invite reset")
+
+        data_api_client.create_audit_event(
+            audit_type=AuditTypes.invite_user,
+            user=current_user.email_address,
+            object_type='suppliers',
+            object_id=current_user.supplier_id,
+            data={'invitedEmail': form.email_address.data},
+        )
 
         flash('user_invited', 'success')
         return redirect(url_for('.list_users'))

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ Flask-Login==0.2.11
 Flask-Script==2.0.5
 Flask-WTF==0.11
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@5.3.1#egg=digitalmarketplace-utils==5.3.1
+git+https://github.com/alphagov/digitalmarketplace-utils.git@5.4.0#egg=digitalmarketplace-utils==5.4.0
 markdown==2.6.2
 
 requests==2.5.1


### PR DESCRIPTION
See: https://www.pivotaltracker.com/story/show/100210316

This covers invitations sent from the supplier frontend.

## Depends on

- [x] https://github.com/alphagov/digitalmarketplace-supplier-frontend/pull/183