### PR TITLE
Optional questions count on service submission

### DIFF
--- a/app/main/helpers/services.py
+++ b/app/main/helpers/services.py
@@ -35,12 +35,15 @@ def get_drafts(apiclient, supplier_id, framework_slug):
 
 
 def count_unanswered_questions(service_attributes):
-    return len([
-        q.label
-        for s in service_attributes
-        for q in s['rows']
-        if q.answer_required
-    ])
+    unanswered_required, unanswered_optional = (0, 0)
+    for section in service_attributes:
+        for question in section['rows']:
+            if question.answer_required:
+                unanswered_required += 1
+            elif question.value in ['', [], None]:
+                unanswered_optional += 1
+
+    return unanswered_required, unanswered_optional
 
 
 def get_service_attributes(service_data, service_questions):

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -1,3 +1,5 @@
+import itertools
+
 from flask import render_template, request, abort, flash, redirect, url_for, escape, current_app
 from flask_login import login_required, current_user
 
@@ -61,12 +63,16 @@ def framework_services():
 
     drafts, complete_drafts = get_drafts(data_api_client, current_user.supplier_id, 'g-cloud-7')
 
-    for draft in drafts:
+    for draft in itertools.chain(drafts, complete_drafts):
         draft['priceString'] = format_service_price(draft)
         content = new_service_content.get_builder().filter(draft)
         sections = get_service_attributes(draft, content)
 
-        draft['unanswered_questions'] = count_unanswered_questions(sections)
+        unanswered_required, unanswered_optional = count_unanswered_questions(sections)
+        draft.update({
+            'unanswered_required': unanswered_required,
+            'unanswered_optional': unanswered_optional,
+        })
 
     return render_template(
         "frameworks/services.html",

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -361,7 +361,7 @@ def view_service_submission(service_id):
 
     sections = get_service_attributes(draft, content)
 
-    unanswered_questions = count_unanswered_questions(sections)
+    unanswered_required, unanswered_optional = count_unanswered_questions(sections)
     delete_requested = True if request.args.get('delete_requested') else False
 
     return render_template(
@@ -370,7 +370,8 @@ def view_service_submission(service_id):
         service_data=draft,
         last_edit=last_edit,
         sections=sections,
-        unanswered_questions=unanswered_questions,
+        unanswered_required=unanswered_required,
+        unanswered_optional=unanswered_optional,
         delete_requested=delete_requested,
         **main.config['BASE_TEMPLATE_DATA']), 200
 

--- a/app/templates/frameworks/services.html
+++ b/app/templates/frameworks/services.html
@@ -1,5 +1,6 @@
 {% extends "_base_page.html" %}
 {% import "toolkit/summary-table.html" as summary %}
+{% import "macros/submission.html" as submission %}
 
 {% block page_title %}Apply to G-Cloud 7 – Digital Marketplace{% endblock %}
 
@@ -68,13 +69,11 @@
       {{ summary.service_link(draft.serviceName,
                               url_for(".view_service_submission", service_id=draft.id)) }}
       {{ summary.text(draft.lot) }}
-      {% if draft.unanswered_questions == 0 %}
-        {{ summary.text("Service can be moved to complete") }}
-      {% elif draft.unanswered_questions == 1 %}
-        {{ summary.text("%s question unanswered" % draft.unanswered_questions) }}
-      {% else %}
-        {{ summary.text("%s questions unanswered" % draft.unanswered_questions) }}
-      {% endif %}
+      {{ summary.text(submission.multiline_string(
+        submission.can_be_completed_text(draft.unanswered_required),
+        submission.unanswered_required_text(draft.unanswered_required, draft.unanswered_optional),
+        submission.unanswered_optional_text(draft.unanswered_required, draft.unanswered_optional)
+      )) }}
       {{ summary.button(text="Make a copy",
                          action=url_for('.copy_draft_service', service_id=draft.id)) }}
     {% endcall %}
@@ -85,13 +84,21 @@
     complete_drafts,
     caption="Complete services",
     empty_message="You haven't completed any services yet.",
-    field_headings=["Service name", "Lot", summary.hidden_field_heading("Make a copy")],
+    field_headings=[
+        "Service name",
+        "Lot",
+        summary.hidden_field_heading("Progress"),
+        summary.hidden_field_heading("Make a copy")
+    ],
     field_headings_visible=True
   ) %}
     {% call summary.row() %}
       {{ summary.service_link(draft.serviceName,
                               url_for(".view_service_submission", service_id=draft.id)) }}
       {{ summary.text(draft.lot) }}
+      {{ summary.text(
+        submission.unanswered_optional_text(draft.unanswered_required, draft.unanswered_optional)
+      ) }}
       {{ summary.button(text="Make a copy",
                          action=url_for('.copy_draft_service', service_id=draft.id)) }}
     {% endcall %}

--- a/app/templates/macros/submission.html
+++ b/app/templates/macros/submission.html
@@ -1,0 +1,43 @@
+{% macro multiline_string() %}
+  {% for arg in varargs %}
+    {% if arg|trim %}
+      {{ arg }}{% if not loop.last %}<br />{% endif %}
+    {% endif %}
+  {% endfor %}
+{% endmacro %}
+
+
+{% macro unanswered_required_text(unanswered_required, unanswered_optional) %}
+  {% if unanswered_required %}
+    <span class="move-to-complete-hint">
+    {% with unanswered_total = unanswered_required + unanswered_optional %}
+      {% if unanswered_total == 1 %}
+      {{ unanswered_total }} question unanswered
+      {% else %}
+        {{ unanswered_total }} questions unanswered
+      {% endif %}
+    {% endwith %}
+    </span>
+  {% endif %}
+{% endmacro %}
+
+
+{% macro can_be_completed_text(unanswered_required) %}
+  {% if unanswered_required == 0%}
+    Service can be moved to complete
+  {% endif %}
+{% endmacro %}
+
+
+{% macro unanswered_optional_text(unanswered_required, unanswered_optional) %}
+  {% if not unanswered_required and unanswered_optional %}
+    <span class="move-to-complete-hint">
+      {% if unanswered_optional == 1 %}
+        {{ unanswered_optional }} optional question unanswered
+      {% else %}
+        {{ unanswered_optional }} optional questions unanswered
+      {% endif %}
+    </span>
+  {% endif %}
+{% endmacro %}
+

--- a/app/templates/services/service_submission.html
+++ b/app/templates/services/service_submission.html
@@ -1,5 +1,7 @@
 {% extends "services/_base_service_page.html" %}
 
+{% import "macros/submission.html" as submission %}
+
 {% block breadcrumb %}
   {%
     with items = [
@@ -34,7 +36,17 @@
     {{ last_edit.createdAt|datetimeformat }}<br />
     by {{ last_edit.userName }}
   </p>
-  {% if service_data.status == 'not-submitted' and unanswered_questions == 0 %}
+  {% if unanswered_required or unanswered_optional %}
+    <p class="last-edited">
+      {{ submission.multiline_string(
+        submission.unanswered_required_text(unanswered_required, unanswered_optional),
+        submission.unanswered_optional_text(unanswered_required, unanswered_optional)
+      ) }}
+    </p>
+  {% endif %}
+  {% if service_data.status == 'submitted' %}
+    <span class="service-status-published">This service is complete and will be automatically submitted at 3pm&nbsp;BST, 6 October</span>
+  {% elif unanswered_required == 0 %}
     <form action="{{ url_for('.complete_draft_service', service_id=service_id) }}" method="POST">
       <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
       {% with type = "save", label = "Move to complete" %}
@@ -44,12 +56,7 @@
     <p class="last-edited move-to-complete-hint">
       You can still edit services once they're complete.
     </p>
-  {% elif service_data.status == 'submitted' %}
-    <span class="service-status-published">Service is complete</span>
   {% else %}
-    <p class="last-edited">
-      {{ unanswered_questions }} question{% if unanswered_questions > 1 %}s{% endif %} unanswered
-    </p>
     <p class="move-to-complete-hint">When you have added all the required information, you can move the service to complete.</p>
   {% endif %}
 </div>

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -878,6 +878,24 @@ class TestShowDraftService(BaseApplicationTest):
             document.xpath(service_price_xpath)[0].strip(),
             u"£12.50 to £15 per person per second")
 
+    @mock.patch('app.main.views.services.count_unanswered_questions')
+    def test_unanswered_questions_count(self, count_unanswered, data_api_client):
+        data_api_client.get_draft_service.return_value = self.draft_service
+        count_unanswered.return_value = 1, 2
+        res = self.client.get('/suppliers/submission/services/1')
+
+        assert_in(u'3 questions unanswered', res.get_data(as_text=True))
+
+    @mock.patch('app.main.views.services.count_unanswered_questions')
+    def test_move_to_complete_button(self, count_unanswered, data_api_client):
+        data_api_client.get_draft_service.return_value = self.draft_service
+        count_unanswered.return_value = 0, 1
+        res = self.client.get('/suppliers/submission/services/1')
+
+        assert_in(u'1 optional question unanswered', res.get_data(as_text=True))
+        assert_in(u'<button class="button-save">Move to complete</button>',
+                  res.get_data(as_text=True))
+
 
 @mock.patch('app.main.views.services.data_api_client')
 class TestDeleteDraftService(BaseApplicationTest):


### PR DESCRIPTION
Adds optional questions to the progress counters.

![screen shot 2015-08-17 at 12 34 09](https://cloud.githubusercontent.com/assets/246664/9304126/c6875446-44dc-11e5-9404-28c5fc1ff123.png)

Possible progress messages:

* Services with missing answers for required questions show
  total unanswered questions count: `x questions unanswered`
![screen shot 2015-08-17 at 12 33 37](https://cloud.githubusercontent.com/assets/246664/9304132/dea3846e-44dc-11e5-9ed9-b227efd2b925.png)

* Services with all required questions answered show:

        Service  can be moved to complete  
        x optional questions unanswered
![screen shot 2015-08-17 at 12 33 45](https://cloud.githubusercontent.com/assets/246664/9304139/eab036d0-44dc-11e5-993e-37a8001b2b65.png)

* Services with all questions answered show
  `Service can be moved to complete`

* Complete services show either `x optional questions unanswered`
  or an empty field if all optional questions are answered.
  ![screen shot 2015-08-17 at 12 33 52](https://cloud.githubusercontent.com/assets/246664/9304143/f44ed250-44dc-11e5-8dbc-65b512c9999f.png)
