### PR TITLE
[#101485630] Fix bug in invite audit events

### DIFF
--- a/app/main/views/login.py
+++ b/app/main/views/login.py
@@ -348,7 +348,7 @@ def send_invite_user():
             abort(503, "Failed to send user invite reset")
 
         data_api_client.create_audit_event(
-            audit_type=AuditTypes.invite_user,
+            audit_type=AuditTypes.invite_user.value,
             user=current_user.email_address,
             object_type='suppliers',
             object_id=current_user.supplier_id,

--- a/tests/app/main/test_login.py
+++ b/tests/app/main/test_login.py
@@ -580,7 +580,7 @@ class TestInviteUser(BaseApplicationTest):
             assert_equal(res.status_code, 302)
 
             data_api_client.create_audit_event.assert_called_once_with(
-                audit_type=AuditTypes.invite_user,
+                audit_type=AuditTypes.invite_user.value,
                 user='email@email.com',
                 object_type='suppliers',
                 object_id=1234,


### PR DESCRIPTION
See: https://www.pivotaltracker.com/story/show/101485630

The API client expects a string rather than an Enum object.