### PR TITLE
Fix bug with features, benefits, client list

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "jquery": "1.11.2",
     "hogan": "3.0.2",
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
-    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v8.4.0",
+    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v8.4.1",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.14.1/jinja_govuk_template-0.14.1.tgz",
     "digital-marketplace-ssp-content": "git://github.com/alphagov/digitalmarketplace-ssp-content#2a09fdc7650b5f68fac0a08c9ef66e7c4337dd11"
   }


### PR DESCRIPTION
Implements: https://github.com/alphagov/digitalmarketplace-frontend-toolkit/pull/142

--

Ensure list entries keep their 'name' attribute

Any changes made to features and/or benefits are not being persisted on a save.

Replication:
- Navigate to the edit features and benefits page of a service.
- Edit features and/or benefits and click "Save and return to service"

Actual:
- Changes made are not persisted

Expected:
- Changes to either features and/or benefits should be persisted.

Reason:
- `name` parameter of each feature is getting changed by the JS from
`serviceFeatures` to `input-serviceFeatures`