### PR TITLE
[#100214054] Add Communications and Clarifications files to updates page.

### DIFF
--- a/app/assets/scss/_updates.scss
+++ b/app/assets/scss/_updates.scss
@@ -1,4 +1,4 @@
-#clarification_question {
+#input-clarification_question {
   height: 20.75em;
 }
 

--- a/app/main/errors.py
+++ b/app/main/errors.py
@@ -1,11 +1,17 @@
 from flask import render_template
 from app.main import main
 from dmutils.apiclient import APIError
+from dmutils.s3 import S3ResponseError
 
 
 @main.app_errorhandler(APIError)
 def api_error_handler(e):
     return _render_error_page(e.status_code)
+
+
+@main.app_errorhandler(S3ResponseError)
+def s3_response_error_handler(e):
+    return _render_error_page(503)
 
 
 @main.app_errorhandler(404)

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -142,11 +142,11 @@ def framework_supplier_declaration(section_id):
     ), status_code
 
 
-@main.route('/frameworks/g-cloud-7/download-supplier-pack', methods=['GET', 'POST'])
+@main.route('/frameworks/g-cloud-7/<path:filepath>', methods=['GET'])
 @login_required
 @flask_featureflags.is_active_feature('GCLOUD7_OPEN')
-def download_supplier_pack():
-    url = get_draft_document_url('g-cloud-7-supplier-pack.zip')
+def download_supplier_file(filepath):
+    url = get_draft_document_url(filepath)
     if not url:
         abort(404)
 
@@ -196,7 +196,7 @@ def framework_updates(error_message=None):
 def framework_updates_email_clarification_question():
 
     # Stripped input should not empty
-    clarification_question = escape(request.form.get(CLARIFICATION_QUESTION_NAME, '')).strip()
+    clarification_question = request.form.get(CLARIFICATION_QUESTION_NAME, '').strip()
 
     if not clarification_question:
         return framework_updates("Question cannot be empty")

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -165,21 +165,23 @@ def framework_updates(error_message=None):
     uploader = s3.S3(current_app.config['DM_G7_DRAFT_DOCUMENTS_BUCKET'])
     file_list = uploader.list('g-cloud-7-updates/')
 
-    sections = {
-        'clarifications': {
+    sections = [
+        {
+            'section': 'communications',
             'heading': "G-Cloud 7 communications",
             'empty_message': "No communications have been sent out",
             'files': []
         },
-        'communications': {
+        {
+            'section': 'clarifications',
             'heading': "G-Cloud 7 clarification questions and answers",
             'empty_message': "No clarification questions exist",
             'files': []
         }
-    }
+    ]
 
-    for key in sections:
-        sections[key]['files'] = [file for file in file_list if key == file['path'].split('/')[1]]
+    for section in sections:
+        section['files'] = [file for file in file_list if section['section'] == file['path'].split('/')[1]]
 
     return render_template(
         "frameworks/updates.html",

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -1,6 +1,6 @@
 import itertools
 
-from flask import render_template, request, abort, flash, redirect, url_for, escape, current_app
+from flask import render_template, request, abort, flash, redirect, url_for, current_app
 from flask_login import login_required, current_user
 
 from dmutils.apiclient import APIError
@@ -156,7 +156,8 @@ def download_supplier_file(filepath):
 @main.route('/frameworks/g-cloud-7/updates', methods=['GET'])
 @login_required
 @flask_featureflags.is_active_feature('GCLOUD7_OPEN')
-def framework_updates(error_message=None):
+def framework_updates(error_message=None, default_textbox_value=None):
+
     current_app.logger.info("g7updates.viewed: user_id:%s supplier_id:%s",
                             current_user.email_address, current_user.supplier_id)
 
@@ -175,7 +176,7 @@ def framework_updates(error_message=None):
         {
             'section': 'clarifications',
             'heading': "G-Cloud 7 clarification questions and answers",
-            'empty_message': "No clarification questions exist",
+            'empty_message': "No clarification answers exist",
             'files': []
         }
     ]
@@ -186,6 +187,7 @@ def framework_updates(error_message=None):
     return render_template(
         "frameworks/updates.html",
         clarification_question_name=CLARIFICATION_QUESTION_NAME,
+        clarification_question_value=default_textbox_value,
         error_message=error_message,
         sections=sections,
         **template_data
@@ -203,7 +205,10 @@ def framework_updates_email_clarification_question():
     if not clarification_question:
         return framework_updates("Question cannot be empty")
     elif len(clarification_question) > 5000:
-        return framework_updates("Question cannot be longer than 5000 characters")
+        return framework_updates(
+            error_message="Question cannot be longer than 5000 characters",
+            default_textbox_value=clarification_question
+        )
 
     email_body = render_template(
         "emails/clarification_question.html",

--- a/app/templates/frameworks/dashboard.html
+++ b/app/templates/frameworks/dashboard.html
@@ -154,7 +154,7 @@
 
       <div class="column-one-whole">
         <li class="browse-list-item framework-application-section">
-          <a class="browse-list-item-link" href="{{ url_for('.download_supplier_pack') }}"><span>Download supplier pack (.zip)</span></a>
+          <a class="browse-list-item-link" href="{{ url_for('.download_supplier_file', filepath='g-cloud-7-supplier-pack.zip') }}"><span>Download supplier pack (.zip)</span></a>
           <p class="browse-list-item-body">
             Read guidance and legal documentation.
           </p>

--- a/app/templates/frameworks/updates.html
+++ b/app/templates/frameworks/updates.html
@@ -82,7 +82,7 @@
           field_headings_visible=False
         ) %}
           {% call summary.row() %}
-            {{ summary.field_name(item.last_modified|datetimeformat) }}
+            {{ summary.field_name(item.last_modified|dateformat) }}
             {% call summary.field() %}
                <a href="{{ url_for('.download_supplier_file', filepath=item.path) }}" class="document-link-with-icon">
                 <span class='document-icon'>{{ item.ext }}<span> document:</span></span>

--- a/app/templates/frameworks/updates.html
+++ b/app/templates/frameworks/updates.html
@@ -114,6 +114,9 @@
       %}
         {% include "toolkit/button.html" %}
       {% endwith %}
+
+      <a href="{{ url_for('.framework_dashboard') }}">Return to G-Cloud 7 application</a>
+
   </form>
 
 {% endblock %}

--- a/app/templates/frameworks/updates.html
+++ b/app/templates/frameworks/updates.html
@@ -103,7 +103,8 @@
         question = "Ask a G-Cloud 7 clarification question",
         name = clarification_question_name,
         hint = "You should ask any questions you have about G-Cloud 7 here. The Crown Commercial Service will not respond to you individually. All answers to clarification questions will be published here regularly. (Maximum 5000 characters per question.)",
-        error = error_message
+        error = error_message,
+        value = clarification_question_value
       %}
         {% include "toolkit/forms/textbox.html" %}
       {% endwith %}

--- a/app/templates/frameworks/updates.html
+++ b/app/templates/frameworks/updates.html
@@ -69,49 +69,29 @@
 
   <div class="grid-row">
     <div class="column-one-whole updates-document-tables">
-      {{ summary.heading("G-Cloud 7 communications") }}
-      {% call(item) summary.list_table(
-        files.communications,
-        caption="G-Cloud 7 communications",
-        empty_message="No application information exists",
-        field_headings=[
-          "Last modified",
-          "File"
-        ],
-        field_headings_visible=False
-      ) %}
-        {% call summary.row() %}
-          {{ summary.field_name(item.last_modified|datetimeformat) }}
-          {% call summary.field() %}
-             <a href="#" class="document-link-with-icon">
-              <span class='document-icon'>{{ item.ext }}<span> document:</span></span>
-              {{ item.filename }}
-            </a>
+      {% for section in sections.values() %}
+        {{ summary.heading(section.heading) }}
+        {% call(item) summary.list_table(
+          section.files,
+          caption=section.heading,
+          empty_message=section.empty_message,
+          field_headings=[
+            "Last modified",
+            "File"
+          ],
+          field_headings_visible=False
+        ) %}
+          {% call summary.row() %}
+            {{ summary.field_name(item.last_modified|datetimeformat) }}
+            {% call summary.field() %}
+               <a href="{{ url_for('.download_supplier_file', filepath=item.path) }}" class="document-link-with-icon">
+                <span class='document-icon'>{{ item.ext }}<span> document:</span></span>
+                {{ item.filename }}
+              </a>
+            {% endcall %}
           {% endcall %}
         {% endcall %}
-      {% endcall %}
-
-      {{ summary.heading("G-Cloud 7 clarification questions and answers") }}
-      {% call(item) summary.list_table(
-        files.clarifications,
-        caption="G-Cloud 7 clarification questions and answers",
-        empty_message="No clarification questions exist",
-        field_headings=[
-          "Last modified",
-          "File"
-        ],
-        field_headings_visible=False
-      ) %}
-        {% call summary.row() %}
-          {{ summary.field_name(item.last_modified|datetimeformat) }}
-          {% call summary.field() %}
-             <a href="#" class="document-link-with-icon">
-              <span class='document-icon'>{{ item.ext }}<span> document:</span></span>
-              {{ item.filename }}
-            </a>
-          {% endcall %}
-        {% endcall %}
-      {% endcall %}
+      {% endfor %}
     </div>
   </div>
 

--- a/app/templates/frameworks/updates.html
+++ b/app/templates/frameworks/updates.html
@@ -69,7 +69,7 @@
 
   <div class="grid-row">
     <div class="column-one-whole updates-document-tables">
-      {% for section in sections.values() %}
+      {% for section in sections %}
         {{ summary.heading(section.heading) }}
         {% call(item) summary.list_table(
           section.files,

--- a/app/templates/frameworks/updates.html
+++ b/app/templates/frameworks/updates.html
@@ -71,26 +71,21 @@
     <div class="column-one-whole updates-document-tables">
       {{ summary.heading("G-Cloud 7 communications") }}
       {% call(item) summary.list_table(
-        [
-          {"date_uploaded": "Monday 1 November 2015", "document": "Example"},
-          {"date_uploaded": "Friday 20 October 2015", "document": "Example"},
-          {"date_uploaded": "Wednesday 17 November 2015", "document": "Example"},
-          {"date_uploaded": "Monday 15 November 2015", "document": "Example"},
-        ],
+        files.communications,
         caption="G-Cloud 7 communications",
         empty_message="No application information exists",
         field_headings=[
-          "Date uploaded",
-          "Document"
+          "Last modified",
+          "File"
         ],
         field_headings_visible=False
       ) %}
         {% call summary.row() %}
-          {{ summary.field_name(item.date_uploaded) }}
+          {{ summary.field_name(item.last_modified|datetimeformat) }}
           {% call summary.field() %}
              <a href="#" class="document-link-with-icon">
-              <span class='document-icon'>pdf<span> document:</span></span>
-              {{ item.document }}
+              <span class='document-icon'>{{ item.ext }}<span> document:</span></span>
+              {{ item.filename }}
             </a>
           {% endcall %}
         {% endcall %}
@@ -98,25 +93,21 @@
 
       {{ summary.heading("G-Cloud 7 clarification questions and answers") }}
       {% call(item) summary.list_table(
-        [
-          {"date_uploaded": "Tuesday 20 September 2015", "document": "Clarification questions and answers"},
-          {"date_uploaded": "Tuesday 13 September 2015", "document": "Clarification questions and answers"},
-          {"date_uploaded": "Tuesday 6 September 2015", "document": "Clarification questions and answers"},
-        ],
+        files.clarifications,
         caption="G-Cloud 7 clarification questions and answers",
         empty_message="No clarification questions exist",
         field_headings=[
-          "Date uploaded",
-          "Document"
+          "Last modified",
+          "File"
         ],
         field_headings_visible=False
       ) %}
         {% call summary.row() %}
-          {{ summary.field_name(item.date_uploaded) }}
+          {{ summary.field_name(item.last_modified|datetimeformat) }}
           {% call summary.field() %}
              <a href="#" class="document-link-with-icon">
-              <span class='document-icon'>odf<span> document:</span></span>
-              {{ item.document }}
+              <span class='document-icon'>{{ item.ext }}<span> document:</span></span>
+              {{ item.filename }}
             </a>
           {% endcall %}
         {% endcall %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ Flask-Login==0.2.11
 Flask-Script==2.0.5
 Flask-WTF==0.11
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@6.1.1#egg=digitalmarketplace-utils==6.1.1
+git+https://github.com/alphagov/digitalmarketplace-utils.git@6.2.2#egg=digitalmarketplace-utils==6.2.2
 markdown==2.6.2
 
 requests==2.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ Flask-Login==0.2.11
 Flask-Script==2.0.5
 Flask-WTF==0.11
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@6.1.0#egg=digitalmarketplace-utils==6.1.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@6.1.1#egg=digitalmarketplace-utils==6.1.1
 markdown==2.6.2
 
 requests==2.5.1

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -354,7 +354,7 @@ class TestFrameworkUpdatesPage(BaseApplicationTest):
 
             for empty_message in [
                 '<p class="summary-item-no-content">No communications have been sent out</p>',
-                '<p class="summary-item-no-content">No clarification questions exist</p>',
+                '<p class="summary-item-no-content">No clarification answers exist</p>',
             ]:
                 assert_true(
                     self.strip_all_whitespace(empty_message)

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -1,11 +1,13 @@
 # -*- coding: utf-8 -*-
 from nose.tools import assert_equal, assert_true, assert_in
+import os
 import mock
 from mock import Mock
 from lxml import html
 from dmutils.apiclient import APIError
 from dmutils.audit import AuditTypes
 from dmutils.email import MandrillException
+from dmutils.s3 import S3ResponseError
 
 from ..helpers import BaseApplicationTest
 
@@ -275,6 +277,177 @@ class TestSupplierDeclaration(BaseApplicationTest):
             assert not data_api_client.answer_selection_questions.called
 
 
+@mock.patch('dmutils.s3.S3')
+class TestFrameworkUpdatesPage(BaseApplicationTest):
+
+    def _assert_page_title_and_table_headings(self, doc, tables_exist=True):
+
+        assert_true(
+            self.strip_all_whitespace('G-Cloud 7 updates')
+            in self.strip_all_whitespace(doc.xpath('//h1')[0].text)
+        )
+
+        section_names = [
+            'G-Cloud 7 communications',
+            'G-Cloud 7 clarification questions and answers',
+        ]
+
+        headers = doc.xpath('//div[contains(@class, "updates-document-tables")]/h2[@class="summary-item-heading"]')
+        assert_equal(len(headers), 2)
+        for index, section_name in enumerate(section_names):
+            assert_true(
+                self.strip_all_whitespace(section_name)
+                in self.strip_all_whitespace(headers[index].text)
+            )
+
+        if tables_exist:
+            table_captions = doc.xpath('//div[contains(@class, "updates-document-tables")]/table/caption')
+            assert_equal(len(table_captions), 2)
+            for index, section_name in enumerate(section_names):
+                assert_true(
+                    self.strip_all_whitespace(section_name)
+                    in self.strip_all_whitespace(table_captions[index].text)
+                )
+
+    @staticmethod
+    def _return_fake_s3_file_dict(directory, file, last_modified=None, size=None):
+
+        filename, ext = os.path.splitext(file)
+
+        return {
+            'path': 'g-cloud-7-updates/{}/{}'.format(directory, file),
+            'filename': filename,
+            'ext': ext[:1],
+            'last_modified': last_modified or '2015-08-17T14:00:00.000Z',
+            'size': size if size is not None else 1
+        }
+
+    def test_should_be_a_503_if_connecting_to_amazon_fails(self, s3):
+        # if s3 throws a 500-level error
+        s3.side_effect = S3ResponseError(500, 'Amazon has collapsed. The internet is over.')
+
+        with self.app.test_client():
+            self.login()
+
+            response = self.client.get(
+                '/suppliers/frameworks/g-cloud-7/updates'
+            )
+
+            assert_equal(response.status_code, 503)
+            assert_true(
+                self.strip_all_whitespace("<h1>Sorry, we're experiencing technical difficulties</h1>")
+                in self.strip_all_whitespace(response.get_data(as_text=True))
+            )
+
+    def test_empty_messages_exist_if_no_files_returned(self, s3):
+
+        with self.app.test_client():
+            self.login()
+
+            response = self.client.get(
+                '/suppliers/frameworks/g-cloud-7/updates'
+            )
+
+            assert_equal(response.status_code, 200)
+            doc = html.fromstring(response.get_data(as_text=True))
+            self._assert_page_title_and_table_headings(doc, tables_exist=False)
+
+            for empty_message in [
+                '<p class="summary-item-no-content">No communications have been sent out</p>',
+                '<p class="summary-item-no-content">No clarification questions exist</p>',
+            ]:
+                assert_true(
+                    self.strip_all_whitespace(empty_message)
+                    in self.strip_all_whitespace(response.get_data(as_text=True))
+                )
+
+    def test_the_tables_should_be_displayed_correctly(self, s3):
+
+        filenames = [
+            ('communications', 'file 1', 'odt'),
+            ('communications', 'file 2', 'odt'),
+            ('clarifications', 'file 3', 'odt'),
+            ('clarifications', 'file 4', 'odt'),
+        ]
+
+        # the communications table is always before the clarifications table
+        s3.return_value.list.return_value = [
+            self._return_fake_s3_file_dict(section, "{}.{}".format(filename, ext))
+            for section, filename, ext in filenames
+        ]
+
+        with self.app.test_client():
+            self.login()
+
+            response = self.client.get(
+                '/suppliers/frameworks/g-cloud-7/updates'
+            )
+            doc = html.fromstring(response.get_data(as_text=True))
+            self._assert_page_title_and_table_headings(doc)
+
+            tables = doc.xpath('//div[contains(@class, "updates-document-tables")]/table')
+
+            # test that for each table, we have the right number of rows
+            for table in tables:
+                item_rows = table.findall('.//tr[@class="summary-item-row"]')
+                assert_equal(len(item_rows), 2)
+
+                # test that the file names and urls are right
+                for row in item_rows:
+                    section, filename, ext = filenames.pop(0)
+                    filename_link = row.find('.//a[@class="document-link-with-icon"]')
+
+                    assert_true(filename in filename_link.text_content())
+                    assert_equal(
+                        filename_link.get('href'),
+                        '/suppliers/frameworks/g-cloud-7/g-cloud-7-updates/{}/{}.{}'.format(
+                            section, filename.replace(' ', '%20'), ext
+                        )
+                    )
+
+    def test_names_with_the_section_name_in_them_will_display_correctly(self, s3):
+
+        # for example: 'g-cloud-7-updates/clarifications/communications.odf'
+        filenames = [
+            ('communications', 'clarifications file', 'odt'),
+            ('clarifications', 'communications file', 'odt')
+        ]
+
+        s3.return_value.list.return_value = [
+            self._return_fake_s3_file_dict(section, "{}.{}".format(filename, ext))
+            for section, filename, ext in filenames
+        ]
+
+        with self.app.test_client():
+            self.login()
+
+            response = self.client.get(
+                '/suppliers/frameworks/g-cloud-7/updates'
+            )
+            doc = html.fromstring(response.get_data(as_text=True))
+            self._assert_page_title_and_table_headings(doc)
+
+            tables = doc.xpath('//div[contains(@class, "updates-document-tables")]/table')
+
+            # test that for each table, we have the right number of rows
+            for table in tables:
+                item_rows = table.findall('.//tr[@class="summary-item-row"]')
+                assert_equal(len(item_rows), 1)
+
+                # test that the file names and urls are right
+                for row in item_rows:
+                    section, filename, ext = filenames.pop(0)
+                    filename_link = row.find('.//a[@class="document-link-with-icon"]')
+
+                    assert_true(filename in filename_link.text_content())
+                    assert_equal(
+                        filename_link.get('href'),
+                        '/suppliers/frameworks/g-cloud-7/g-cloud-7-updates/{}/{}.{}'.format(
+                            section, filename.replace(' ', '%20'), ext
+                        )
+                    )
+
+
 class TestSendClarificationQuestionEmail(BaseApplicationTest):
 
     def _send_email(self, clarification_question):
@@ -305,8 +478,9 @@ class TestSendClarificationQuestionEmail(BaseApplicationTest):
         else:
             assert_equal(0, send_email.call_count)
 
+    @mock.patch('dmutils.s3.S3')
     @mock.patch('app.main.views.frameworks.send_email')
-    def test_should_not_send_email_if_invalid_clarification_question(self, send_email):
+    def test_should_not_send_email_if_invalid_clarification_question(self, send_email, s3):
 
         for invalid_clarification_question in [
             {
@@ -335,9 +509,10 @@ class TestSendClarificationQuestionEmail(BaseApplicationTest):
                 in self.strip_all_whitespace(response.get_data(as_text=True))
             )
 
+    @mock.patch('dmutils.s3.S3')
     @mock.patch('app.main.views.frameworks.data_api_client')
     @mock.patch('app.main.views.frameworks.send_email')
-    def test_should_call_send_email_with_correct_params(self, send_email, data_api_client):
+    def test_should_call_send_email_with_correct_params(self, send_email, data_api_client, s3):
 
         clarification_question = 'This is a clarification question.'
         response = self._send_email(clarification_question)

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -525,9 +525,10 @@ class TestSendClarificationQuestionEmail(BaseApplicationTest):
             in self.strip_all_whitespace(response.get_data(as_text=True))
         )
 
+    @mock.patch('dmutils.s3.S3')
     @mock.patch('app.main.views.frameworks.data_api_client')
     @mock.patch('app.main.views.frameworks.send_email')
-    def test_should_create_audit_event(self, send_email, data_api_client):
+    def test_should_create_audit_event(self, send_email, data_api_client, s3):
         clarification_question = 'This is a clarification question'
         response = self._send_email(clarification_question)
 


### PR DESCRIPTION
### Still left to do

- [x] Merge [utils PR 137](https://github.com/alphagov/digitalmarketplace-utils/pull/137) and update `requirements.txt` accordingly.
- [x] Depends on https://github.com/alphagov/digitalmarketplace-utils/pull/141
- [x] @tombye had some opinions about the date formats

***

[>> Story on Pivotal](https://www.pivotaltracker.com/story/show/100214054)

This update displays (on the framework updates page) a listing of files in an s3 bucket based on an assumed directory structure.  Links for each file are signed URLs which are valid for 30 seconds -- exactly like the ITT .zip file.

Taking [Ralph's prototype](http://dm-prototype.herokuapp.com/updates) as a basis, I created a root-level directory with two subdirectories: one for communications (emails) and one for clarification questions.

```
# Adding an email file 
g-cloud-7-updates/communications/Title of Email.odt

# Adding a clarifications questions file
g-cloud-7-updates/communications/Clarification questions and answers.odt
```
If the directory structure doesn't exist, then both tables display their empty messages.


##### Things to know about files 

- Listing the [Keys](http://boto.readthedocs.org/en/latest/ref/s3.html#module-boto.s3.key) in an S3 bucket gives us each one's `name` (path), `size`, and `last_modified` timestamp, which we process in utils before returning to the app.
- There's a problem [getting back metadata](https://github.com/boto/boto/issues/570) when listing files, so we're not setting/getting any.  
 - It looks like [we can use spaces](https://github.com/boto/boto/issues/570) in filenames without any problems, so it didn't seem like a concern.
- Uploading a file with the same name as an existing file overwrites the existing file.
- Slashes (`/`) in filenames will be converted to colons (`:`) during the upload.

***

### Screenshot

![g7-updates](https://cloud.githubusercontent.com/assets/14287/9442570/71cdd1e4-4a74-11e5-8d7b-75ebde927615.png)
