### PR TITLE
[#101511456] Should not send a "create account" email if an account already exists

### DIFF
--- a/app/templates/auth/update-user.html
+++ b/app/templates/auth/update-user.html
@@ -11,16 +11,17 @@
 </header>
 <p>
     Check you’ve entered the correct link or ask the person who invited you to send a new invitation.
-    If you still can’t create a contributor account, email <a href="mailto:enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.service.gov.uk</a>
+    If you still can’t create a contributor account, email <a href="mailto:enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.service.gov.uk</a>.
 </p>
 
 {% elif invalid_user %}
 
 <header class="page-heading-smaller">
-  <h1>This account may be inactive or locked</h1>
+  <h1>The account associated with this email address is inactive, locked, or already registered with a different supplier.</h1>
 </header>
 <p>
-    Email <a href="mailto:enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.service.gov.uk</a> if you need help.</p>
+    Please email <a href="mailto:enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.service.gov.uk</a> for help with setting up a new contributor account.
+</p>
 
 {% else %}
 

--- a/tests/app/main/test_login.py
+++ b/tests/app/main/test_login.py
@@ -936,13 +936,15 @@ class TestInviteUser(BaseApplicationTest):
             )
 
             assert_equal(res.status_code, 200)
-            assert_true(
-                "This account may be inactive or locked"
-                in res.get_data(as_text=True)
+            assert_in(
+                "The account associated with this email address is inactive, "
+                "locked, or already registered with a different supplier",
+                res.get_data(as_text=True)
             )
-            assert_true(
-                'Email <a href="mailto:enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.service.gov.uk</a> if you need help.</p>'  # noqa
-                in res.get_data(as_text=True)
+            assert_in(
+                'Please email <a href="mailto:enquiries@digitalmarketplace.service.gov.uk">'
+                'enquiries@digitalmarketplace.service.gov.uk</a> for help with setting up a new contributor account.',
+                res.get_data(as_text=True)
             )
 
     @mock.patch('app.main.views.login.data_api_client')
@@ -973,13 +975,15 @@ class TestInviteUser(BaseApplicationTest):
             )
 
             assert_equal(res.status_code, 200)
-            assert_true(
-                "This account may be inactive or locked"
-                in res.get_data(as_text=True)
+            assert_in(
+                "The account associated with this email address is inactive, "
+                "locked, or already registered with a different supplier",
+                res.get_data(as_text=True)
             )
-            assert_true(
-                'Email <a href="mailto:enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.service.gov.uk</a> if you need help.</p>'  # noqa
-                in res.get_data(as_text=True)
+            assert_in(
+                'Please email <a href="mailto:enquiries@digitalmarketplace.service.gov.uk">'
+                'enquiries@digitalmarketplace.service.gov.uk</a> for help with setting up a new contributor account.',
+                res.get_data(as_text=True)
             )
 
     @mock.patch('app.main.views.login.data_api_client')
@@ -1009,15 +1013,16 @@ class TestInviteUser(BaseApplicationTest):
             res = self.client.get(
                 '/suppliers/create-user/{}'.format(token)
             )
-
             assert_equal(res.status_code, 200)
-            assert_true(
-                "This account may be inactive or locked"
-                in res.get_data(as_text=True)
+            assert_in(
+                "The account associated with this email address is inactive, "
+                "locked, or already registered with a different supplier",
+                res.get_data(as_text=True)
             )
-            assert_true(
-                'Email <a href="mailto:enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.service.gov.uk</a> if you need help.</p>'  # noqa
-                in res.get_data(as_text=True)
+            assert_in(
+                'Please email <a href="mailto:enquiries@digitalmarketplace.service.gov.uk">'
+                'enquiries@digitalmarketplace.service.gov.uk</a> for help with setting up a new contributor account.',
+                res.get_data(as_text=True)
             )
 
     @mock.patch('app.main.views.login.data_api_client')


### PR DESCRIPTION
Fixes this bug: https://www.pivotaltracker.com/story/show/101511456

"Create your account" shouldn't send an email if an account already exists for the email address supplied.  This adds a check that a user account with the supplied email doesn't already exist.

I also learned a lot about how mocks need to be ordered to make the tests pass OK... ouch.