### PR TITLE
Remove service name links to edit page if editing services flag is False

### DIFF
--- a/app/templates/services/list_services.html
+++ b/app/templates/services/list_services.html
@@ -57,43 +57,31 @@
   ) %}
     {% call summary.row() %}
 
-      {{ summary.service_link(
-          item.serviceName,
-          url_for('.edit_service', service_id=item.id)
-      ) }}
+      {% if 'EDIT_SERVICE_PAGE' is active_feature %}
+        {{ summary.service_link(
+            item.serviceName,
+            url_for('.edit_service', service_id=item.id)
+        ) }}
+      {% else %}
+        {{ summary.field_name(item.serviceName, wide=True) }}
+      {% endif %}
 
       {{ summary.text(item.frameworkName) }}
 
       {{ summary.text(item.lot) }}
 
-      {% if 'EDIT_SERVICE_PAGE' is active_feature %}
-        {% if item.status == "published" %}
-          {{ summary.edit_link("View service", '/g-cloud/services/' + item.id) }}
-        {% elif item.status == "disabled" %}
-          {% call summary.field(action=True) %}
-            <span class="service-status-{{ item.status }}">
-              Removed
-            </span>
-          {% endcall %}
-        {% elif item.status == "enabled" %}
-          {% call summary.field(action=True) %}
-            <span class="service-status-{{ item.status }}">
-              Private
-            </span>
-          {% endcall %}
-        {% endif %}
-      {% else %}
+      {% if item.status == "published" %}
+        {{ summary.edit_link("View service", '/g-cloud/services/' + item.id) }}
+      {% elif item.status == "disabled" %}
         {% call summary.field(action=True) %}
           <span class="service-status-{{ item.status }}">
-            {% if item.status == "published" %}
-              Public
-            {% elif item.status == "enabled" %}
-              Private
-            {% elif item.status == "disabled" %}
-              Removed
-            {% else %}
-              {{ item.status|title }}
-            {% endif %}
+            Removed
+          </span>
+        {% endcall %}
+      {% elif item.status == "enabled" %}
+        {% call summary.field(action=True) %}
+          <span class="service-status-{{ item.status }}">
+            Private
           </span>
         {% endcall %}
       {% endif %}


### PR DESCRIPTION
Previous feature flag check removed the "View service" link if the
service editing was turned off, but there's still a service name link
to the "edit" page.

Instead, we keep the "View service" links and remove the service name
link if the editing is disabled.