### PR TITLE
[#101414610] Add more audit logging

### DIFF
--- a/app/main/helpers/frameworks.py
+++ b/app/main/helpers/frameworks.py
@@ -19,12 +19,13 @@ def has_registered_interest_in_framework(client, framework_slug):
 
 
 def register_interest_in_framework(client, framework_slug):
-    client.create_audit_event(
-        audit_type=AuditTypes.register_framework_interest.value,
-        user=current_user.email_address,
-        object_type='suppliers',
-        object_id=current_user.supplier_id,
-        data={'frameworkSlug': framework_slug})
+    if not has_registered_interest_in_framework(client, framework_slug):
+        client.create_audit_event(
+            audit_type=AuditTypes.register_framework_interest.value,
+            user=current_user.email_address,
+            object_type='suppliers',
+            object_id=current_user.supplier_id,
+            data={'frameworkSlug': framework_slug})
 
 
 def get_required_fields(all_fields, answers):

--- a/app/main/helpers/frameworks.py
+++ b/app/main/helpers/frameworks.py
@@ -9,7 +9,7 @@ from werkzeug.datastructures import ImmutableOrderedMultiDict
 
 def has_registered_interest_in_framework(client, framework_slug):
     audits = client.find_audit_events(
-        audit_type=AuditTypes.register_framework_interest.value,
+        audit_type=AuditTypes.register_framework_interest,
         object_type='suppliers',
         object_id=current_user.supplier_id)
     for audit in audits['auditEvents']:
@@ -21,7 +21,7 @@ def has_registered_interest_in_framework(client, framework_slug):
 def register_interest_in_framework(client, framework_slug):
     if not has_registered_interest_in_framework(client, framework_slug):
         client.create_audit_event(
-            audit_type=AuditTypes.register_framework_interest.value,
+            audit_type=AuditTypes.register_framework_interest,
             user=current_user.email_address,
             object_type='suppliers',
             object_id=current_user.supplier_id,

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -4,6 +4,7 @@ from flask import render_template, request, abort, flash, redirect, url_for, esc
 from flask_login import login_required, current_user
 
 from dmutils.apiclient import APIError
+from dmutils.audit import AuditTypes
 from dmutils import flask_featureflags
 from dmutils.email import send_email, MandrillException
 from dmutils.formats import format_service_price
@@ -181,6 +182,13 @@ def framework_updates_email_clarification_question():
             "Clarification question email failed to send error {} supplier_id {} user_email_address {}".format(
                 e, current_user.supplier_id, current_user.email_address))
         abort(503, "Clarification question email failed to send")
+
+    data_api_client.create_audit_event(
+        audit_type=AuditTypes.send_clarification_question,
+        user=current_user.email_address,
+        object_type="suppliers",
+        object_id=current_user.supplier_id,
+        data={"question": clarification_question})
 
     flash('message_sent', 'success')
     return _framework_updates_page()

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -144,6 +144,8 @@ def download_supplier_pack():
 @login_required
 @flask_featureflags.is_active_feature('GCLOUD7_OPEN')
 def framework_updates():
+    current_app.logger.info("g7updates.viewed: user_id:%s supplier_id:%s",
+                            current_user.email_address, current_user.supplier_id)
     return _framework_updates_page()
 
 

--- a/app/main/views/login.py
+++ b/app/main/views/login.py
@@ -190,6 +190,7 @@ def create_user(encoded_token):
 
     if token is None:
         flash('token_invalid', 'error')
+        current_app.logger.warning("createuser.token_invalid: %s", encoded_token)
         return render_template(
             "auth/create-user.html",
             form=form,
@@ -230,6 +231,7 @@ def submit_update_user(encoded_token):
     token = decode_invitation_token(encoded_token)
     if token is None:
         flash('token_invalid', 'error')
+        current_app.logger.warning("createuser.token_invalid: %s", encoded_token)
         return render_template(
             "auth/update-user.html",
             token=None,
@@ -241,7 +243,11 @@ def submit_update_user(encoded_token):
 
         user = User.from_json(user_json)
         if user.is_locked() or not user.is_active() or not user_has_role(user_json, 'buyer'):
-            abort("should not update an existing supplier"),  400
+            current_app.logger.warning(
+                "createuser.user_invalid: user_id:%s supplier_id:%s user_locked:%s user_active:%s user_role:%s",
+                user.id, token.get("supplier_id"), user.is_locked(), user.is_active(), user_json['users']['role']
+            )
+            abort(400, "should not update an existing supplier")
 
         data_api_client.update_user(
             user_id=user.id,
@@ -260,6 +266,7 @@ def submit_create_user(encoded_token):
     token = decode_invitation_token(encoded_token)
     if token is None:
         flash('token_invalid', 'error')
+        current_app.logger.warning("createuser.token_invalid: %s", encoded_token)
         return render_template(
             "auth/create-user.html",
             form=form,
@@ -282,6 +289,7 @@ def submit_create_user(encoded_token):
 
             return redirect(url_for('.dashboard'))
         else:
+            current_app.logger.warning("createuser.invalid: %s", ", ".join(form.errors))
             return render_template(
                 "auth/create-user.html",
                 valid_token=False,

--- a/app/main/views/login.py
+++ b/app/main/views/login.py
@@ -356,7 +356,7 @@ def send_invite_user():
             abort(503, "Failed to send user invite reset")
 
         data_api_client.create_audit_event(
-            audit_type=AuditTypes.invite_user.value,
+            audit_type=AuditTypes.invite_user,
             user=current_user.email_address,
             object_type='suppliers',
             object_id=current_user.supplier_id,

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ Flask-Login==0.2.11
 Flask-Script==2.0.5
 Flask-WTF==0.11
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@6.0.0#egg=digitalmarketplace-utils==6.0.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@6.1.0#egg=digitalmarketplace-utils==6.1.0
 markdown==2.6.2
 
 requests==2.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ Flask-Login==0.2.11
 Flask-Script==2.0.5
 Flask-WTF==0.11
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@5.4.0#egg=digitalmarketplace-utils==5.4.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@6.0.0#egg=digitalmarketplace-utils==6.0.0
 markdown==2.6.2
 
 requests==2.5.1

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -32,7 +32,7 @@ class TestFrameworksDashboard(BaseApplicationTest):
 
             assert_equal(res.status_code, 200)
             data_api_client.create_audit_event.assert_called_once_with(
-                audit_type="register_framework_interest",
+                audit_type=AuditTypes.register_framework_interest,
                 user="email@email.com",
                 object_type="suppliers",
                 object_id=1234,
@@ -298,8 +298,9 @@ class TestSendClarificationQuestionEmail(BaseApplicationTest):
                 in self.strip_all_whitespace(response.get_data(as_text=True))
             )
 
+    @mock.patch('app.main.views.frameworks.data_api_client')
     @mock.patch('app.main.views.frameworks.send_email')
-    def test_should_call_send_email_with_correct_params(self, send_email):
+    def test_should_call_send_email_with_correct_params(self, send_email, data_api_client):
 
         clarification_question = 'This is a clarification question.'
         response = self._send_email(clarification_question)

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -23,6 +23,9 @@ class TestFrameworksDashboard(BaseApplicationTest):
     def test_interest_registered_in_framework(self, data_api_client):
         with self.app.test_client():
             self.login()
+            data_api_client.find_audit_events.return_value = {
+                "auditEvents": []
+            }
 
             res = self.client.get("/suppliers/frameworks/g-cloud-7")
 
@@ -33,6 +36,18 @@ class TestFrameworksDashboard(BaseApplicationTest):
                 object_type="suppliers",
                 object_id=1234,
                 data={"frameworkSlug": "g-cloud-7"})
+
+    def test_interest_in_framework_only_registered_once(self, data_api_client):
+        with self.app.test_client():
+            self.login()
+            data_api_client.find_audit_events.return_value = {
+                "auditEvents": [{"data": {"frameworkSlug": "g-cloud-7"}}]
+            }
+
+            res = self.client.get("/suppliers/frameworks/g-cloud-7")
+
+            assert_equal(res.status_code, 200)
+            assert not data_api_client.create_audit_event.called
 
     def test_declaration_status_when_complete(self, data_api_client):
         with self.app.test_client():

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -4,6 +4,7 @@ import mock
 from mock import Mock
 from lxml import html
 from dmutils.apiclient import APIError
+from dmutils.audit import AuditTypes
 from dmutils.email import MandrillException
 from flask import render_template
 
@@ -310,6 +311,22 @@ class TestSendClarificationQuestionEmail(BaseApplicationTest):
             self.strip_all_whitespace('<p class="banner-message">Your clarification message has been sent.</p>')
             in self.strip_all_whitespace(response.get_data(as_text=True))
         )
+
+    @mock.patch('app.main.views.frameworks.data_api_client')
+    @mock.patch('app.main.views.frameworks.send_email')
+    def test_should_create_audit_event(self, send_email, data_api_client):
+        clarification_question = 'This is a clarification question'
+        response = self._send_email(clarification_question)
+
+        self._assert_email(send_email)
+
+        assert_equal(response.status_code, 200)
+        data_api_client.create_audit_event.assert_called_with(
+            audit_type=AuditTypes.send_clarification_question,
+            user="email@email.com",
+            object_type="suppliers",
+            object_id=1234,
+            data={"question": clarification_question})
 
     @mock.patch('app.main.views.frameworks.send_email')
     def test_should_be_a_503_if_email_fails(self, send_email):

--- a/tests/app/main/test_login.py
+++ b/tests/app/main/test_login.py
@@ -1044,9 +1044,11 @@ class TestInviteUser(BaseApplicationTest):
             )
 
             res = self.client.post(
-                '/suppliers/create-user/{}'.format(token)
+                '/suppliers/update-user/{}'.format(token),
+                data={"password": "password1234", "name": "Joe Bloggs"}
             )
 
+            assert data_api_client.get_user.called
             assert_equal(res.status_code, 400)
 
     @mock.patch('app.main.views.login.data_api_client')
@@ -1074,9 +1076,11 @@ class TestInviteUser(BaseApplicationTest):
             )
 
             res = self.client.post(
-                '/suppliers/create-user/{}'.format(token)
+                '/suppliers/update-user/{}'.format(token),
+                data={"password": "password1234", "name": "Joe Bloggs"}
             )
 
+            assert data_api_client.get_user.called
             assert_equal(res.status_code, 400)
 
     @mock.patch('app.main.views.login.data_api_client')
@@ -1104,9 +1108,11 @@ class TestInviteUser(BaseApplicationTest):
             )
 
             res = self.client.post(
-                '/suppliers/create-user/{}'.format(token)
+                '/suppliers/update-user/{}'.format(token),
+                data={"password": "password1234", "name": "Joe Bloggs"}
             )
 
+            assert data_api_client.get_user.called
             assert_equal(res.status_code, 400)
 
     @mock.patch('app.main.views.login.data_api_client')
@@ -1134,9 +1140,11 @@ class TestInviteUser(BaseApplicationTest):
             )
 
             res = self.client.post(
-                '/suppliers/create-user/{}'.format(token)
+                '/suppliers/update-user/{}'.format(token),
+                data={"password": "password1234", "name": "Joe Bloggs"}
             )
 
+            assert data_api_client.get_user.called
             assert_equal(res.status_code, 400)
 
     @mock.patch('app.main.views.login.data_api_client')

--- a/tests/app/main/test_login.py
+++ b/tests/app/main/test_login.py
@@ -580,7 +580,7 @@ class TestInviteUser(BaseApplicationTest):
             assert_equal(res.status_code, 302)
 
             data_api_client.create_audit_event.assert_called_once_with(
-                audit_type=AuditTypes.invite_user.value,
+                audit_type=AuditTypes.invite_user,
                 user='email@email.com',
                 object_type='suppliers',
                 object_id=1234,


### PR DESCRIPTION
## Fix some tests on update-user

They were pointing at create-user and were not giving any data so the failure was actually coming from the form validation. I couldn't find anything useful to test in the response to distinguish them so I've added an assertion on get_user being called which will at least confirm that the right view is being requested.

## Only register interest in a framework once

See: https://www.pivotaltracker.com/story/show/101415342

## Add various application and audit logs

See: https://www.pivotaltracker.com/story/show/101414610

## Depends on
- [x] https://github.com/alphagov/digitalmarketplace-utils/pull/140