### PR TITLE
Add updates for SSP content & validation for declaration

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,6 +7,6 @@
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
     "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v8.4.1",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.14.1/jinja_govuk_template-0.14.1.tgz",
-    "digital-marketplace-ssp-content": "git://github.com/alphagov/digitalmarketplace-ssp-content#7436353bffde126e93d7a0aacfbb6ce108d97299"
+    "digital-marketplace-ssp-content": "git://github.com/alphagov/digitalmarketplace-ssp-content#ef0b3c8d396f31d36dfdd01c970619d0972f727b"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -7,6 +7,6 @@
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
     "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v8.4.1",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.14.1/jinja_govuk_template-0.14.1.tgz",
-    "digital-marketplace-ssp-content": "git://github.com/alphagov/digitalmarketplace-ssp-content#81479e20475ce607946c3710b154ce94106971a6"
+    "digital-marketplace-ssp-content": "git://github.com/alphagov/digitalmarketplace-ssp-content#7436353bffde126e93d7a0aacfbb6ce108d97299"
   }
 }


### PR DESCRIPTION
Brings in the following changes to the SSP:

1. copy changes to the hint text for the 'add a new service' journey:

https://github.com/alphagov/digitalmarketplace-ssp-content/pull/63

2. validation messages for the supplier declaration:

https://github.com/alphagov/digitalmarketplace-ssp-content/pull/53