### PR TITLE
Extract script to set test environment

### DIFF
--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -6,11 +6,7 @@
 # ./scripts/run_tests.sh
 
 # Use default environment vars for localhost if not already set
-export DM_DATA_API_AUTH_TOKEN=${DM_DATA_API_AUTH_TOKEN:=myToken}
-export DM_PASSWORD_SECRET_KEY=${DM_PASSWORD_SECRET_KEY:=not_very_secret}
-export DM_SHARED_EMAIL_KEY=${DM_SHARED_EMAIL_KEY:=not_very_secret}
-
-export DM_G7_DRAFT_DOCUMENTS_URL=${DM_S3_DOCUMENTS_URL:=http://localhost}
+. ./scripts/test_env.sh
 
 echo "Environment variables in use:"
 env | grep DM_

--- a/scripts/test_env.sh
+++ b/scripts/test_env.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+export DM_DATA_API_AUTH_TOKEN=${DM_DATA_API_AUTH_TOKEN:=myToken}
+export DM_PASSWORD_SECRET_KEY=${DM_PASSWORD_SECRET_KEY:=not_very_secret}
+export DM_SHARED_EMAIL_KEY=${DM_SHARED_EMAIL_KEY:=not_very_secret}
+export DM_G7_DRAFT_DOCUMENTS_URL=${DM_S3_DOCUMENTS_URL:=http://localhost}
+


### PR DESCRIPTION
This makes it easier to set the environment into your current shell for running specific tests.