### PR TITLE
Change messages, add warnings

### DIFF
--- a/app/assets/scss/_framework-application.scss
+++ b/app/assets/scss/_framework-application.scss
@@ -18,7 +18,10 @@
 }
 
 .big-number {
-  @include bold-48;
+  @include bold-27;
+  @include inline-block;
+  padding-right: 1px;
+  padding-bottom: 10px;
 }
 
 .big-number-hint {
@@ -91,4 +94,9 @@
     @include core-19;
   }
 
+}
+
+.draft-service-count {
+  margin-top: $gutter/3;
+  color: $secondary-text-colour;
 }

--- a/app/assets/scss/_framework-application.scss
+++ b/app/assets/scss/_framework-application.scss
@@ -34,7 +34,6 @@
 %framework-section-status,
 .framework-section-status {
 
-  @include bold-19;
   margin-top: $gutter / 3;
 
   @include media(tablet) {
@@ -57,6 +56,11 @@
 .framework-section-status-good {
   @extend %framework-section-status;
   color: $grass-green;
+}
+
+.framework-section-validation-bar {
+  border-left: 7px solid $mellow-red;
+  padding-left: 15px;
 }
 
 .submission-status-bad {

--- a/app/assets/scss/_framework-application.scss
+++ b/app/assets/scss/_framework-application.scss
@@ -3,68 +3,79 @@
 
 .framework-application-status {
 
+  @include core-19;
+  font-weight: bold;
   padding-bottom: $gutter * 2/3;
-  padding-top: $gutter/2;
+  padding-top: $gutter * 1/2;
 
   @include media(tablet) {
-    padding-top: 50px;
-  }
-
-  h2 {
-    @include bold-19;
-    margin-bottom: 10px;
+    padding-top: 0;
   }
 
 }
 
 .big-number {
-  @include bold-27;
+  //@include bold-27;
   @include inline-block;
-  padding-right: 1px;
-  padding-bottom: 10px;
+  padding-top: 5px;
+  //padding-right: 1px;
 }
 
-.big-number-hint {
-  @include copy-16;
-  color: $secondary-text-colour;
-}
-
+%framework-application-section,
 .framework-application-section {
+
   border-top: 1px solid $grey-2;
   padding-top: $gutter * 2/3;
-}
+  margin-bottom: $gutter * 2/3;
 
-%framework-section-status,
-.framework-section-status {
-
-  margin-top: $gutter / 3;
-
-  @include media(tablet) {
-    margin-top: 0;
+  p {
+    margin-bottom: 5px;
   }
 
+  h2 {
+    @include bold-24;
+  }
+
+  li {
+    margin-top: 5px;
+  }
+
+}
+
+.framework-application-section-last {
+  @extend %framework-application-section;
+  border-bottom: 1px solid $grey-2;
+  padding-bottom: $gutter * 2/3;
 }
 
 .framework-section-status-neutral {
   @extend %framework-section-status;
   color: $secondary-text-colour;
   font-weight: normal;
+  margin-top: 5px;
 }
 
 .framework-section-status-bad {
+
   @extend %framework-section-status;
   color: $mellow-red;
+
+  p {
+    margin-bottom: -5px;
+  }
+
 }
 
 .framework-section-status-good {
   @extend %framework-section-status;
-  color: $grass-green;
 }
 
 .framework-section-validation-bar {
-  border-left: 7px solid $mellow-red;
+  border-left: 5px solid $mellow-red;
   padding-left: 15px;
+  margin-bottom: 25px;
 }
+
 
 .submission-status-bad {
 

--- a/app/assets/scss/_service_submission.scss
+++ b/app/assets/scss/_service_submission.scss
@@ -6,6 +6,10 @@
     margin-top: 0px;
 }
 
+.space-underneath {
+  margin-bottom: $gutter * 1.5;
+}
+
 .last-edited {
     margin: 10px 0 15px 0;
 }

--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -87,7 +87,7 @@ $path: "/suppliers/static/images/";
 
 .delete-draft-button {
 
-  padding: 0 0 $gutter * 2 0;
+  padding: $gutter 0 $gutter * 2 0;
 
   button {
     width: 100%;

--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -87,7 +87,7 @@ $path: "/suppliers/static/images/";
 
 .delete-draft-button {
 
-  padding: $gutter * 2 0;
+  padding: 0 0 $gutter * 2 0;
 
   button {
     width: 100%;

--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -12,7 +12,7 @@ $path: "/suppliers/static/images/";
 
 @import "_reset.scss";
 
-#wrapper {
+#wrapper, .wrapper {
   @extend %site-width-container;
 }
 

--- a/app/main/helpers/frameworks.py
+++ b/app/main/helpers/frameworks.py
@@ -2,6 +2,8 @@ from dmutils.apiclient import APIError
 from flask import abort
 from flask_login import current_user
 from dmutils.audit import AuditTypes
+from ... import data_api_client
+from dmutils.apiclient import APIError
 import re
 from operator import add
 from functools import reduce

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -69,10 +69,20 @@ def framework_services():
             'unanswered_optional': unanswered_optional,
         })
 
+    try:
+        declaration_made = bool(data_api_client.get_selection_answers(
+            current_user.supplier_id, 'g-cloud-7'))
+    except APIError as e:
+        if e.status_code == 404:
+            declaration_made = False
+        else:
+            abort(e.status_code)
+
     return render_template(
         "frameworks/services.html",
         complete_drafts=list(reversed(complete_drafts)),
         drafts=list(reversed(drafts)),
+        declaration_made=declaration_made,
         **template_data
     ), 200
 

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -42,18 +42,6 @@ def framework_dashboard():
     return render_template(
         "frameworks/dashboard.html",
         counts={
-            "draft": 0,
-            "complete": 13,
-        },
-        declaration_status='complete',
-        **template_data
-    ), 200
-
-    #/#
-
-    return render_template(
-        "frameworks/dashboard.html",
-        counts={
             "draft": len(drafts),
             "complete": len(complete_drafts),
         },
@@ -85,7 +73,7 @@ def framework_services():
         "frameworks/services.html",
         complete_drafts=list(reversed(complete_drafts)),
         drafts=list(reversed(drafts)),
-        declaration_status=get_declaration_status(),
+        declaration_status=get_declaration_status(data_api_client),
         **template_data
     ), 200
 

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -42,6 +42,18 @@ def framework_dashboard():
     return render_template(
         "frameworks/dashboard.html",
         counts={
+            "draft": 0,
+            "complete": 13,
+        },
+        declaration_status='complete',
+        **template_data
+    ), 200
+
+    #/#
+
+    return render_template(
+        "frameworks/dashboard.html",
+        counts={
             "draft": len(drafts),
             "complete": len(complete_drafts),
         },
@@ -69,20 +81,11 @@ def framework_services():
             'unanswered_optional': unanswered_optional,
         })
 
-    try:
-        declaration_made = bool(data_api_client.get_selection_answers(
-            current_user.supplier_id, 'g-cloud-7'))
-    except APIError as e:
-        if e.status_code == 404:
-            declaration_made = False
-        else:
-            abort(e.status_code)
-
     return render_template(
         "frameworks/services.html",
         complete_drafts=list(reversed(complete_drafts)),
         drafts=list(reversed(drafts)),
-        declaration_made=declaration_made,
+        declaration_status=get_declaration_status(),
         **template_data
     ), 200
 

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -8,6 +8,7 @@ from ..helpers.services import (
     upload_draft_documents, get_service_attributes,
     get_draft_document_url, count_unanswered_questions
 )
+from ..helpers.frameworks import get_declaration_status
 from ... import data_api_client, flask_featureflags
 from dmutils.apiclient import APIError, HTTPError
 from dmutils.presenters import Presenters
@@ -356,15 +357,6 @@ def view_service_submission(service_id):
     if not is_service_associated_with_supplier(draft):
         abort(404)
 
-    try:
-        declaration_made = bool(data_api_client.get_selection_answers(
-            current_user.supplier_id, 'g-cloud-7'))
-    except APIError as e:
-        if e.status_code == 404:
-            declaration_made = False
-        else:
-            abort(e.status_code)
-
     draft['priceString'] = format_service_price(draft)
     content = new_service_content.get_builder().filter(draft)
 
@@ -382,7 +374,7 @@ def view_service_submission(service_id):
         unanswered_required=unanswered_required,
         unanswered_optional=unanswered_optional,
         delete_requested=delete_requested,
-        declaration_made=declaration_made,
+        declaration_status=get_declaration_status(),
         **main.config['BASE_TEMPLATE_DATA']), 200
 
 

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -356,6 +356,15 @@ def view_service_submission(service_id):
     if not is_service_associated_with_supplier(draft):
         abort(404)
 
+    try:
+        declaration_made = bool(data_api_client.get_selection_answers(
+            current_user.supplier_id, 'g-cloud-7'))
+    except APIError as e:
+        if e.status_code == 404:
+            declaration_made = False
+        else:
+            abort(e.status_code)
+
     draft['priceString'] = format_service_price(draft)
     content = new_service_content.get_builder().filter(draft)
 
@@ -373,6 +382,7 @@ def view_service_submission(service_id):
         unanswered_required=unanswered_required,
         unanswered_optional=unanswered_optional,
         delete_requested=delete_requested,
+        declaration_made=declaration_made,
         **main.config['BASE_TEMPLATE_DATA']), 200
 
 

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -374,7 +374,7 @@ def view_service_submission(service_id):
         unanswered_required=unanswered_required,
         unanswered_optional=unanswered_optional,
         delete_requested=delete_requested,
-        declaration_status=get_declaration_status(),
+        declaration_status=get_declaration_status(data_api_client),
         **main.config['BASE_TEMPLATE_DATA']), 200
 
 

--- a/app/templates/frameworks/dashboard.html
+++ b/app/templates/frameworks/dashboard.html
@@ -118,7 +118,7 @@
             {% elif declaration_status == 'started' and not counts.complete %}
               <div class="framework-section-status-neutral">
                 <p>
-                  You need to complete the supplier declaration
+                  You need to finish making the supplier declaration
                 </p>
               </div>
             {% elif declaration_status == 'unstarted' and counts.complete %}

--- a/app/templates/frameworks/dashboard.html
+++ b/app/templates/frameworks/dashboard.html
@@ -20,151 +20,150 @@
 {% endblock %}
 
 {% block main_content %}
-  
-  <div class="grid-row">
-    <div class="column-two-thirds">
-      {% with
-         heading = "Apply to G-Cloud 7",
-         smaller = True,
-         with_breadcrumb = True
-      %}
-        {% include "toolkit/page-heading.html" %}
-      {% endwith %}
-    </div>
-    <aside role="complementary" class="column-one-third framework-application-status">
-      <h2>
-        Deadline <strong>3pm <abbr title="British Standard Time">BST</abbr>, 6 October 2015</strong>
-      </h2>
-    </aside>
-  </div>
 
-  <nav role="navigation" class="grid-row">
+  {% with
+     heading = "Apply to G-Cloud 7",
+     smaller = True,
+     with_breadcrumb = True
+  %}
+    {% include "toolkit/page-heading.html" %}
+  {% endwith %}
+
+  <aside role="complementary" class="framework-application-status">
+    Deadline <strong>3pm <abbr title="British Standard Time">BST</abbr>, 6 October 2015</strong>
+  </aside>
+
+  <nav role="navigation">
     <ul class="browse-list">
-      <div class="column-one-whole">
-        <li class="browse-list-item framework-application-section">
-          <div class="grid-row">
-            <div class="column-two-thirds">
-              {% if not declaration_made and counts.complete %}
-                <div class="framework-section-validation-bar">
-              {% endif %}
-              <a class="browse-list-item-link" href="{{ url_for('.framework_supplier_declaration', section_id='g_cloud_7_essentials') }}">
-                {% if declaration_status == 'unstarted' %}
-                  <span>Make supplier declaration</span>
-                {% else %}
-                  <span>Edit supplier declaration</span>
-                {% endif %}
-              </a>
-              <p class="browse-list-item-body">
-                Agree to the terms of the bid, provide supplier information and
-                confirm eligibility.
-              </p>
-              {% if not declaration_made and counts.complete %}
-                </div>
-              {% endif %}
-            </div>
-            <div class="column-one-third">
-              {% if declaration_status == 'unstarted' and not counts.complete %}
-                <div class="framework-section-status-neutral">
-                  <p>
-                    You haven't made the supplier declaration
-                  </p>
-                </div>
-              {% elif declaration_status == 'started' and not counts.complete %}
-                <div class="framework-section-status-neutral">
-                  <p>
-                    You have started making the supplier declaration, but it is not yet finished
-                  </p>
-                </div>
-              {% elif declaration_status == 'unstarted' and counts.complete %}
-                <div class="framework-section-status-bad">
-                  <p>
-                    <strong>No services will be submitted because you haven’t made the
-                    supplier declaration</strong>
-                  </p>
-                </div>
-              {% elif declaration_status == 'started' and counts.complete %}
-                <div class="framework-section-status-bad">
-                  <p>
-                    <strong>No services will be submitted because you haven’t finished making the
-                    supplier declaration</strong>
-                  </p>
-                </div>
-              {% elif declaration_status == 'complete' %}
-                <div class="framework-section-status-neutral">
-                  <p>
-                    You have made the declaration
-                  </p>
-                </div>
-              {% endif %}
-            </div>
-          </div>
-        </li>
-      </div>
-
-      <div class="column-one-whole">
-        <li class="browse-list-item framework-application-section">
-          <div class="grid-row">
-            <div class="column-two-thirds">
+      <li class="browse-list-item framework-application-section">
+        <div class="grid-row">
+          <div class="column-two-thirds">
+            {% if not counts.draft %}
+              <div class="framework-section-validation-bar-good">
+            {% endif %}
               <a class="browse-list-item-link" href="{{ url_for('.framework_services') }}"><span>Add, edit and delete services</span></a>
-            </div>
-            <div class="column-one-third">
-
-              {% if not counts.complete and not counts.draft %}
-                <div class="framework-section-status-neutral">
-                  <p>
-                    You haven’t added any services
-                  </p>
-                </div>
-              {% endif %}
-
-              {% if counts.draft and not counts.complete %}
-                <div class="framework-section-status-neutral">
-                  You have
-                  {{ counts.draft }} draft
-                  {{ 'service' if counts.draft == 1 else 'services' }}
-                  that won’t be submitted
-                </div>
-              {% endif %}
-
-              {% if counts.complete and not declaration_made %}
-                <div class="framework-section-status-neutral">
-                  You have added {{ counts.complete + counts.draft }} {{ 'service' if (counts.draft + counts.complete) == 1 else 'services' }}
-                </div>
-              {% endif %}
-
-              {% if counts.complete and declaration_made %}
-                <p>
-                  <strong><span class="big-number">{{ counts.complete }}</span> {{ 'service' if counts.complete == 1 else 'services' }} will be submitted</strong>
-                </p>
-                {% if counts.draft %}
-                  <p class="framework-section-status-neutral">
-                    {{ counts.draft }} draft {{ 'service' if counts.draft == 1 else 'services' }} won’t be submitted
-                  </p>
-                {% endif %}
-              {% endif %}
-            </div>
+            {% if not counts.draft %}
+              </div>
+            {% endif %}
           </div>
-        </li>
-      </div>
+          <div class="column-two-thirds">
 
-      <div class="column-one-whole">
-        <li class="browse-list-item framework-application-section">
-          <a class="browse-list-item-link" href="{{ url_for('.download_supplier_file', filepath='g-cloud-7-supplier-pack.zip') }}"><span>Download supplier pack (.zip)</span></a>
-          <p class="browse-list-item-body">
-            Read guidance and legal documentation.
-          </p>
-        </li>
-      </div>
+            {% if not counts.complete and not counts.draft %}
+              <div class="framework-section-status-neutral">
+                <p>
+                  You need to add and complete services
+                </p>
+              </div>
+            {% endif %}
 
-      <div class="column-one-whole">
-        <li class="browse-list-item framework-application-section">
-          <a class="browse-list-item-link" href="{{ url_for('.framework_updates') }}"><span>Read G-Cloud 7 updates and ask clarification questions</span></a>
-          <p class="browse-list-item-body">
-            View all published G-Cloud 7 communications.
-          </p>
-        </li>
-      </div>
+            {% if counts.draft and not counts.complete %}
+              <div class="framework-section-status-neutral">
+                You have
+                {{ counts.draft }} draft
+                {{ 'service' if counts.draft == 1 else 'services' }}
+                that won’t be submitted
+              </div>
+            {% endif %}
 
+            {% if counts.complete and declaration_status != 'complete' %}
+              <div class="framework-section-status-neutral">
+                You have {{ counts.complete }} complete and {{ counts.draft }} draft services
+              </div>
+            {% endif %}
+
+            {% if counts.complete and declaration_status == 'complete' %}
+              {% if not counts.draft %}
+                <div class="framework-section-status-good">
+              {% endif %}
+              <p>
+                <strong><span class="big-number">{{ counts.complete }}</span> complete
+                 {{ 'service' if counts.complete == 1 else 'services' }} will be submitted at the deadline</strong>
+              </p>
+              {% if not counts.draft %}
+                </div>
+              {% endif %}
+              {% if counts.draft %}
+                <p class="framework-section-status-neutral">
+                  {{ counts.draft }} draft {{ 'service' if counts.draft == 1 else 'services' }} won’t be submitted
+                </p>
+              {% endif %}
+            {% endif %}
+          </div>
+        </div>
+      </li>
+
+      <li class="browse-list-item framework-application-section">
+        {% if declaration_status != 'complete' and counts.complete %}
+          <div class="framework-section-validation-bar">
+        {% endif %}
+        <div class="grid-row">
+          <div class="column-two-thirds">
+            <a class="browse-list-item-link" href="{{ url_for('.framework_supplier_declaration', section_id='g_cloud_7_essentials') }}">
+              {% if declaration_status == 'unstarted' %}
+                <span>Make supplier declaration</span>
+              {% else %}
+                <span>Edit supplier declaration</span>
+              {% endif %}
+            </a>
+            <p class="browse-list-item-body">
+              Agree to the terms of the bid, provide supplier information and
+              confirm&nbsp;eligibility.
+            </p>
+            {% if declaration_status == 'unstarted' and not counts.complete %}
+              <div class="framework-section-status-neutral">
+                <p>
+                  You need to make the supplier declaration
+                </p>
+              </div>
+            {% elif declaration_status == 'started' and not counts.complete %}
+              <div class="framework-section-status-neutral">
+                <p>
+                  You need to complete the supplier declaration
+                </p>
+              </div>
+            {% elif declaration_status == 'unstarted' and counts.complete %}
+              <div class="framework-section-status-bad">
+                <p>
+                  <strong>No services will be submitted because you haven’t made the
+                  supplier declaration</strong>
+                </p>
+              </div>
+            {% elif declaration_status == 'started' and counts.complete %}
+              <div class="framework-section-status-bad">
+                <p>
+                  <strong>No services will be submitted because you haven’t finished making the
+                  supplier declaration</strong>
+                </p>
+              </div>
+            {% elif declaration_status == 'complete' %}
+              <div class="framework-section-status-good">
+                <p>
+                  <strong>You’ve made the declaration</strong>
+                </p>
+              </div>
+            {% endif %}
+          </div>
+        </div>
+        {% if declaration_status != 'complete' and counts.complete %}
+          </div>
+        {% endif %}
+      </li>
+
+      <li class="browse-list-item framework-application-section-last">
+        <div class="grid-row">
+          <div class="column-two-thirds">
+            <h2>About G-Cloud 7</h2>
+            <ul>
+              <li>
+                <a href="{{ url_for('.download_supplier_file', filepath='g-cloud-7-supplier-pack.zip') }}"><span>Download guidance and legal documentation (.zip)</span></a>
+              </li>
+              <li>
+                <a href="{{ url_for('.framework_updates') }}"><span>Read updates and ask clarification questions</span></a>
+              </li>
+            </ul>
+          </div>
+        </div>
+      </li>
     </ul>
   </nav>
 

--- a/app/templates/frameworks/dashboard.html
+++ b/app/templates/frameworks/dashboard.html
@@ -33,24 +33,16 @@
     </div>
     <aside role="complementary" class="column-one-third framework-application-status">
       <h2>
-        Deadline for submissions<br />
-        3pm <abbr title="British Standard Time">BST</abbr>, 6 October 2015
+        Deadline <strong>3pm <abbr title="British Standard Time">BST</abbr>, 6 October 2015</strong>
       </h2>
       {% if not declaration_status == 'complete' and counts.complete %}
-        <div class="submission-status-bad">
-          <p class="big-number">
-            0
-          </p>
-          <p>
-            Eligible services
-          </p>
-        </div>
+
       {% else %}
         <p class="big-number">
           {{ counts.complete }}
         </p>
         <p>
-          Eligible {{ 'service' if counts.complete == 1 else 'services' }}
+          {{ 'service' if counts.complete == 1 else 'services' }} will be submitted
         </p>
       {% endif %}
     </aside>
@@ -62,6 +54,9 @@
         <li class="browse-list-item framework-application-section">
           <div class="grid-row">
             <div class="column-two-thirds">
+              {% if not declaration_made and counts.complete %}
+                <div class="framework-section-validation-bar">
+              {% endif %}
               <a class="browse-list-item-link" href="{{ url_for('.framework_supplier_declaration', section_id='g_cloud_7_essentials') }}">
                 {% if declaration_status == 'unstarted' %}
                   <span>Make supplier declaration</span>
@@ -73,6 +68,9 @@
                 Agree to the terms of the bid, provide supplier information and
                 confirm eligibility.
               </p>
+              {% if not declaration_made and counts.complete %}
+                </div>
+              {% endif %}
             </div>
             <div class="column-one-third">
               {% if declaration_status == 'unstarted' and not counts.complete %}
@@ -90,7 +88,8 @@
               {% elif declaration_status == 'unstarted' and counts.complete %}
                 <div class="framework-section-status-bad">
                   <p>
-                    You must make the supplier declaration before any services are eligible for submission
+                    <strong>No services will be submitted because you haven’t made the
+                    supplier declaration</strong>
                   </p>
                 </div>
               {% elif declaration_status == 'started' and counts.complete %}
@@ -102,7 +101,7 @@
               {% elif declaration_status == 'complete' %}
                 <div class="framework-section-status-good">
                   <p>
-                    All services marked as complete will be automatically submitted at 3pm BST, 6 October
+                    <strong>You have made the declaration</strong>
                   </p>
                 </div>
               {% endif %}
@@ -115,10 +114,7 @@
         <li class="browse-list-item framework-application-section">
           <div class="grid-row">
             <div class="column-two-thirds">
-              <a class="browse-list-item-link" href="{{ url_for('.framework_services') }}"><span>Add services</span></a>
-              <p class="browse-list-item-body">
-                Add, edit and delete your services.
-              </p>
+              <a class="browse-list-item-link" href="{{ url_for('.framework_services') }}"><span>Add, edit and delete services</span></a>
             </div>
             <div class="column-one-third">
               {% if counts.draft or counts.complete %}
@@ -126,14 +122,14 @@
                   <div class="big-number">
                     {{ counts.complete }}
                   </div>
-                  Complete {{ 'service' if counts.complete == 1 else 'services' }}
+                  complete {{ 'service' if counts.complete == 1 else 'services' }}
                 </div>
                 <div class="submission-service-counts-column">
                   <div class="big-number">
                     {{ counts.draft }}
                   </div>
-                  Draft<br>{{ 'service' if counts.draft == 1 else 'services' }}
-                  {% if counts.draft and declaration_status == 'complete' %}
+                  draft<br>{{ 'service' if counts.draft == 1 else 'services' }}
+                  {% if counts.draft and declaration_made %}
                     <p class="big-number-hint">
                       {{ 'This' if counts.draft == 1 else 'These' }}
                       will not be submitted

--- a/app/templates/frameworks/dashboard.html
+++ b/app/templates/frameworks/dashboard.html
@@ -35,16 +35,6 @@
       <h2>
         Deadline <strong>3pm <abbr title="British Standard Time">BST</abbr>, 6 October 2015</strong>
       </h2>
-      {% if not declaration_status == 'complete' and counts.complete %}
-
-      {% else %}
-        <p class="big-number">
-          {{ counts.complete }}
-        </p>
-        <p>
-          {{ 'service' if counts.complete == 1 else 'services' }} will be submitted
-        </p>
-      {% endif %}
     </aside>
   </div>
 
@@ -95,13 +85,14 @@
               {% elif declaration_status == 'started' and counts.complete %}
                 <div class="framework-section-status-bad">
                   <p>
-                    You must finish making the supplier declaration before any services are eligible for submission
+                    <strong>No services will be submitted because you haven’t finished making the
+                    supplier declaration</strong>
                   </p>
                 </div>
               {% elif declaration_status == 'complete' %}
-                <div class="framework-section-status-good">
+                <div class="framework-section-status-neutral">
                   <p>
-                    <strong>You have made the declaration</strong>
+                    You have made the declaration
                   </p>
                 </div>
               {% endif %}
@@ -117,31 +108,39 @@
               <a class="browse-list-item-link" href="{{ url_for('.framework_services') }}"><span>Add, edit and delete services</span></a>
             </div>
             <div class="column-one-third">
-              {% if counts.draft or counts.complete %}
-                <div class="submission-service-counts-column">
-                  <div class="big-number">
-                    {{ counts.complete }}
-                  </div>
-                  complete {{ 'service' if counts.complete == 1 else 'services' }}
-                </div>
-                <div class="submission-service-counts-column">
-                  <div class="big-number">
-                    {{ counts.draft }}
-                  </div>
-                  draft<br>{{ 'service' if counts.draft == 1 else 'services' }}
-                  {% if counts.draft and declaration_made %}
-                    <p class="big-number-hint">
-                      {{ 'This' if counts.draft == 1 else 'These' }}
-                      will not be submitted
-                    </p>
-                  {% endif %}
-                </div>
-              {% else %}
+
+              {% if not counts.complete and not counts.draft %}
                 <div class="framework-section-status-neutral">
                   <p>
-                    You haven't added any services
+                    You haven’t added any services
                   </p>
                 </div>
+              {% endif %}
+
+              {% if counts.draft and not counts.complete %}
+                <div class="framework-section-status-neutral">
+                  You have
+                  {{ counts.draft }} draft
+                  {{ 'service' if counts.draft == 1 else 'services' }}
+                  that won’t be submitted
+                </div>
+              {% endif %}
+
+              {% if counts.complete and not declaration_made %}
+                <div class="framework-section-status-neutral">
+                  You have added {{ counts.complete + counts.draft }} {{ 'service' if (counts.draft + counts.complete) == 1 else 'services' }}
+                </div>
+              {% endif %}
+
+              {% if counts.complete and declaration_made %}
+                <p>
+                  <strong><span class="big-number">{{ counts.complete }}</span> {{ 'service' if counts.complete == 1 else 'services' }} will be submitted</strong>
+                </p>
+                {% if counts.draft %}
+                  <p class="framework-section-status-neutral">
+                    {{ counts.draft }} draft {{ 'service' if counts.draft == 1 else 'services' }} won’t be submitted
+                  </p>
+                {% endif %}
               {% endif %}
             </div>
           </div>

--- a/app/templates/frameworks/dashboard.html
+++ b/app/templates/frameworks/dashboard.html
@@ -67,7 +67,10 @@
 
             {% if counts.complete and declaration_status != 'complete' %}
               <div class="framework-section-status-neutral">
-                You have {{ counts.complete }} complete and {{ counts.draft }} draft services
+                You have {{ counts.complete }} complete
+                {{ 'service' if counts.complete == 1 else 'services' }}
+                and {{ counts.draft }} draft
+                {{ 'service' if counts.draft == 1 else 'services' }}
               </div>
             {% endif %}
 
@@ -138,7 +141,7 @@
             {% elif declaration_status == 'complete' %}
               <div class="framework-section-status-good">
                 <p>
-                  <strong>You’ve made the declaration</strong>
+                  <strong>You’ve made the supplier declaration</strong>
                 </p>
               </div>
             {% endif %}

--- a/app/templates/frameworks/edit_declaration_section.html
+++ b/app/templates/frameworks/edit_declaration_section.html
@@ -38,7 +38,7 @@
     {% include 'toolkit/page-heading.html' %}
   {% endwith %}
   <p>
-    You must complete this declaration for your services to be eligible for G-Cloud 7 submission.
+    You must make this declaration before your services can be submitted.
   </p>
   <form method="post" class="supplier-declaration">
 
@@ -70,7 +70,7 @@
       <p class="last-edited move-to-complete-hint">
         You can edit the declaration until the application deadline.
       </p>
-    
+
     {% else %}
       {%
         with

--- a/app/templates/frameworks/services.html
+++ b/app/templates/frameworks/services.html
@@ -49,6 +49,16 @@
     {% include "toolkit/page-heading.html" %}
   {% endwith %}
 
+  {% if not declaration_made and complete_drafts %}
+    {%
+      with
+      message = "No services will be submitted at the deadline because the <a href=\"" + url_for('.framework_supplier_declaration') + "\">supplier&nbsp;declaration</a> hasn’t been made.",
+      type = "warning"
+    %}
+      {% include "toolkit/notification-banner.html" %}
+    {% endwith %}
+  {% endif %}
+
   {{ summary.heading("Draft services") }}
   {{ summary.top_link("Add a service", url_for(".start_new_draft_service")) }}
   {% call(draft) summary.list_table(

--- a/app/templates/frameworks/services.html
+++ b/app/templates/frameworks/services.html
@@ -36,12 +36,22 @@
           {% elif category == 'service_copied' %}
             <strong>{{message.service_name}}</strong> was copied
           {% elif category == 'service_completed' %}
-            <strong>{{message.service_name}}</strong> was completed
+            <strong>{{message.service_name}}</strong> was marked as complete
           {% endif %}
         </p>
       </div>
     {% endfor %}
   {% endwith %}
+
+  {% if complete_drafts and declaration_status != 'complete' %}
+    {%
+      with
+      message = 'You need to <a href="' + url_for('.framework_supplier_declaration', section_id='g_cloud_7_essentials') + '">make the supplier&nbsp;declaration</a> before any services can be submitted',
+      type = 'warning'
+    %}
+      {% include 'toolkit/notification-banner.html' %}
+    {% endwith %}
+  {% endif %}
 
   {% with
      heading = "G-Cloud 7 services",
@@ -50,16 +60,6 @@
   %}
     {% include "toolkit/page-heading.html" %}
   {% endwith %}
-
-  {% if not declaration_made and complete_drafts %}
-    {%
-      with
-      message = "No services will be submitted at the deadline because the <a href=\"" + url_for('.framework_supplier_declaration') + "\">supplier&nbsp;declaration</a> hasn’t been made.",
-      type = "warning"
-    %}
-      {% include "toolkit/notification-banner.html" %}
-    {% endwith %}
-  {% endif %}
 
   {{ summary.heading("Draft services") }}
   {{ summary.top_link("Add a service", url_for(".start_new_draft_service")) }}

--- a/app/templates/frameworks/services.html
+++ b/app/templates/frameworks/services.html
@@ -33,6 +33,8 @@
         <p class="banner-message">
           {% if category == 'service_deleted' %}
             <strong>{{message.service_name}}</strong> was deleted
+          {% elif category == 'service_copied' %}
+            <strong>{{message.service_name}}</strong> was copied
           {% elif category == 'service_completed' %}
             <strong>{{message.service_name}}</strong> was completed
           {% endif %}
@@ -69,7 +71,7 @@
         "Service name",
         "Lot",
         summary.hidden_field_heading("Progress"),
-        summary.hidden_field_heading("Make a copy")
+        summary.hidden_field_heading("Clone service")
     ],
     field_headings_visible=True
   ) %}
@@ -82,7 +84,7 @@
         submission.unanswered_required_text(draft.unanswered_required, draft.unanswered_optional),
         submission.unanswered_optional_text(draft.unanswered_required, draft.unanswered_optional)
       )) }}
-      {{ summary.button(text="Make a copy",
+      {{ summary.button(text="Clone service",
                          action=url_for('.copy_draft_service', service_id=draft.id)) }}
     {% endcall %}
   {% endcall %}
@@ -96,7 +98,7 @@
         "Service name",
         "Lot",
         summary.hidden_field_heading("Progress"),
-        summary.hidden_field_heading("Make a copy")
+        summary.hidden_field_heading("Clone service")
     ],
     field_headings_visible=True
   ) %}
@@ -107,7 +109,7 @@
       {{ summary.text(
         submission.unanswered_optional_text(draft.unanswered_required, draft.unanswered_optional)
       ) }}
-      {{ summary.button(text="Make a copy",
+      {{ summary.button(text="Clone service",
                          action=url_for('.copy_draft_service', service_id=draft.id)) }}
     {% endcall %}
   {% endcall %}

--- a/app/templates/frameworks/services.html
+++ b/app/templates/frameworks/services.html
@@ -71,7 +71,7 @@
         "Service name",
         "Lot",
         summary.hidden_field_heading("Progress"),
-        summary.hidden_field_heading("Clone service")
+        summary.hidden_field_heading("Make a copy")
     ],
     field_headings_visible=True
   ) %}
@@ -84,7 +84,7 @@
         submission.unanswered_required_text(draft.unanswered_required, draft.unanswered_optional),
         submission.unanswered_optional_text(draft.unanswered_required, draft.unanswered_optional)
       )) }}
-      {{ summary.button(text="Clone service",
+      {{ summary.button(text="Make a copy",
                          action=url_for('.copy_draft_service', service_id=draft.id)) }}
     {% endcall %}
   {% endcall %}
@@ -93,12 +93,12 @@
   {% call(draft) summary.list_table(
     complete_drafts,
     caption="Complete services",
-    empty_message="You haven't completed any services yet.",
+    empty_message="You haven’t completed any services yet.",
     field_headings=[
         "Service name",
         "Lot",
         summary.hidden_field_heading("Progress"),
-        summary.hidden_field_heading("Clone service")
+        summary.hidden_field_heading("Make a copy")
     ],
     field_headings_visible=True
   ) %}
@@ -109,7 +109,7 @@
       {{ summary.text(
         submission.unanswered_optional_text(draft.unanswered_required, draft.unanswered_optional)
       ) }}
-      {{ summary.button(text="Clone service",
+      {{ summary.button(text="Make a copy",
                          action=url_for('.copy_draft_service', service_id=draft.id)) }}
     {% endcall %}
   {% endcall %}

--- a/app/templates/frameworks/services.html
+++ b/app/templates/frameworks/services.html
@@ -71,7 +71,7 @@
         "Service name",
         "Lot",
         summary.hidden_field_heading("Progress"),
-        summary.hidden_field_heading("Make a copy")
+        summary.hidden_field_heading("Clone service")
     ],
     field_headings_visible=True
   ) %}

--- a/app/templates/frameworks/services.html
+++ b/app/templates/frameworks/services.html
@@ -93,7 +93,7 @@
   {% call(draft) summary.list_table(
     complete_drafts,
     caption="Complete services",
-    empty_message="You haven’t completed any services yet.",
+    empty_message="You haven’t marked any services as complete yet.",
     field_headings=[
         "Service name",
         "Lot",
@@ -113,5 +113,7 @@
                          action=url_for('.copy_draft_service', service_id=draft.id)) }}
     {% endcall %}
   {% endcall %}
+
+  <a href="{{ url_for('.framework_dashboard') }}">Return to G-Cloud 7 application</a>
 
 {% endblock %}

--- a/app/templates/frameworks/updates.html
+++ b/app/templates/frameworks/updates.html
@@ -29,7 +29,7 @@
   {% with messages = get_flashed_messages(with_categories=true) %}
     {% for category, message in messages %}
       {% if message == 'message_sent' %}
-        {% set message = "Your clarification message has been sent." %}
+        {% set message = "Your clarification question has been sent. Answers to all clarification questions will be published on this page." %}
       {% endif %}
       {%
         with
@@ -87,11 +87,13 @@
                <a href="{{ url_for('.download_supplier_file', filepath=item.path) }}" class="document-link-with-icon">
                 <span class='document-icon'>{{ item.ext }}<span> document:</span></span>
                 {{ item.filename }}
-              </a>
             {% endcall %}
           {% endcall %}
         {% endcall %}
       {% endfor %}
+      <p class="hint">
+        All clarification questions and answers will be published here regularly. You will receive an email when new answers are posted.
+      </p>
     </div>
   </div>
 
@@ -108,9 +110,12 @@
       %}
         {% include "toolkit/forms/textbox.html" %}
       {% endwith %}
+      <p>
+        The deadline for clarification questions is x
+      </p>
       {%
         with
-        label="Submit question",
+        label="Ask question",
         type="save"
       %}
         {% include "toolkit/button.html" %}

--- a/app/templates/macros/submission.html
+++ b/app/templates/macros/submission.html
@@ -24,7 +24,7 @@
 
 {% macro can_be_completed_text(unanswered_required) %}
   {% if unanswered_required == 0%}
-    Service can be moved to complete
+    Service can be marked as complete
   {% endif %}
 {% endmacro %}
 
@@ -40,4 +40,3 @@
     </span>
   {% endif %}
 {% endmacro %}
-

--- a/app/templates/macros/submission.html
+++ b/app/templates/macros/submission.html
@@ -12,9 +12,9 @@
     <span class="move-to-complete-hint">
     {% with unanswered_total = unanswered_required + unanswered_optional %}
       {% if unanswered_total == 1 %}
-      {{ unanswered_total }} question unanswered
+      {{ unanswered_total }} unanswered question
       {% else %}
-        {{ unanswered_total }} questions unanswered
+        {{ unanswered_total }} unanswered questions
       {% endif %}
     {% endwith %}
     </span>

--- a/app/templates/partials/complete_service.html
+++ b/app/templates/partials/complete_service.html
@@ -1,0 +1,9 @@
+<form action="{{ url_for('.complete_draft_service', service_id=service_id) }}" method="POST">
+  <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+  {% with type = "save", label = "Mark as complete" %}
+    {% include "toolkit/button.html" %}
+  {% endwith %}
+</form>
+<p class="last-edited move-to-complete-hint">
+  You can still edit services once they're complete.
+</p>

--- a/app/templates/partials/service_warning.html
+++ b/app/templates/partials/service_warning.html
@@ -1,0 +1,9 @@
+{% if true %}
+  {%
+    with
+    message = 'This service will not be submitted at the deadline because the <a href="' + url_for('.framework_supplier_declaration', section_id='g_cloud_7_essentials') + '">supplier&nbsp;declaration</a> hasn’t been made.',
+    type = 'warning'
+  %}
+    {% include 'toolkit/notification-banner.html' %}
+  {% endwith %}
+{% endif %}

--- a/app/templates/services/_base_service_page.html
+++ b/app/templates/services/_base_service_page.html
@@ -7,7 +7,6 @@
     {% block before_heading %}{% endblock %}
     <div class="column-two-thirds">
       {% with
-        context = "Edit",
         heading = service_data['serviceName'] or 'New service',
         smaller = true
       %}

--- a/app/templates/services/service_submission.html
+++ b/app/templates/services/service_submission.html
@@ -44,20 +44,24 @@
       ) }}
     </p>
   {% endif %}
-  {% if service_data.status == 'submitted' %}
+  {% if service_data.status == 'submitted' and declaration_made %}
     <span class="service-status-published">This service is complete and will be automatically submitted at 3pm&nbsp;BST, 6 October</span>
-  {% elif unanswered_required == 0 %}
-    <form action="{{ url_for('.complete_draft_service', service_id=service_id) }}" method="POST">
-      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
-      {% with type = "save", label = "Move to complete" %}
-        {% include "toolkit/button.html" %}
-      {% endwith %}
-    </form>
-    <p class="last-edited move-to-complete-hint">
-      You can still edit services once they're complete.
-    </p>
-  {% else %}
-    <p class="move-to-complete-hint">When you have added all the required information, you can move the service to complete.</p>
+  {% endif %}
+  {% if service_data.status == 'not-submitted' and unanswered_required == 0 %}
+    {% include "partials/complete_service.html" %}
+  {% elif unanswered_required > 0 %}
+    <p class="move-to-complete-hint">When you have added all the required information, you can mark the service as complete.</p>
+  {% endif %}
+</div>
+<div class="column-one-whole">
+  {% if service_data.status == 'submitted' and not declaration_made %}
+    {%
+      with
+      message = "This service will not be submitted at the deadline because the <a href=\"" + url_for('.framework_supplier_declaration') + "\">supplier&nbsp;declaration</a> hasn’t been made.",
+      type = "warning"
+    %}
+      {% include "toolkit/notification-banner.html" %}
+    {% endwith %}
   {% endif %}
 </div>
 {% endblock %}
@@ -90,6 +94,11 @@
         &nbsp;
       </div>
       <div class="column-one-third delete-draft-button">
+        {% if service_data.status == 'not-submitted' and unanswered_required == 0 %}
+          <div class="space-underneath">
+            {% include "partials/complete_service.html" %}
+          </div>
+        {% endif %}
         <form action="{{ url_for('.delete_draft_service', service_id=service_id ) }}" method="POST">
           <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
           {% with type = "destructive", label = "Delete this service" %}

--- a/app/templates/services/service_submission.html
+++ b/app/templates/services/service_submission.html
@@ -25,15 +25,27 @@
   %}
     {% include "toolkit/breadcrumb.html" %}
   {% endwith %}
+  {% if service_data.status == 'submitted' and declaration_status != 'complete' %}
+    <div class="wrapper">
+      {%
+        with
+        message = 'You need to <a href="' + url_for('.framework_supplier_declaration', section_id='g_cloud_7_essentials') + '">make the supplier&nbsp;declaration</a> before this service can be submitted',
+        type = 'warning'
+      %}
+        {% include 'toolkit/notification-banner.html' %}
+      {% endwith %}
+    </div>
+  {% endif %}
 {% endblock %}
 
 {% block before_sections %}
+
 <div class="column-one-third align-with-heading">
   <p>
     <strong>Last edited</strong>
   </p>
   <p class="last-edited">
-    {{ last_edit.createdAt|datetimeformat }}<br />
+    {{ last_edit.createdAt|datetimeformat }}
     by {{ last_edit.userName }}
   </p>
   {% if unanswered_required or unanswered_optional %}
@@ -51,17 +63,6 @@
     {% include "partials/complete_service.html" %}
   {% elif unanswered_required > 0 %}
     <p class="move-to-complete-hint">When you have added all the required information, you can mark the service as complete.</p>
-  {% endif %}
-</div>
-<div class="column-one-whole">
-  {% if service_data.status == 'submitted' and not declaration_made %}
-    {%
-      with
-      message = "This service will not be submitted at the deadline because the <a href=\"" + url_for('.framework_supplier_declaration') + "\">supplier&nbsp;declaration</a> hasn’t been made.",
-      type = "warning"
-    %}
-      {% include "toolkit/notification-banner.html" %}
-    {% endwith %}
   {% endif %}
 </div>
 {% endblock %}

--- a/app/templates/services/service_submission.html
+++ b/app/templates/services/service_submission.html
@@ -56,8 +56,8 @@
       ) }}
     </p>
   {% endif %}
-  {% if service_data.status == 'submitted' and declaration_made %}
-    <span class="service-status-published">This service is complete and will be automatically submitted at 3pm&nbsp;BST, 6 October</span>
+  {% if service_data.status == 'submitted' and declaration_status == 'complete' %}
+    <span class="service-status-published">This service is marked as complete and will be submitted at 3pm&nbsp;BST, 6 October</span>
   {% endif %}
   {% if service_data.status == 'not-submitted' and unanswered_required == 0 %}
     {% include "partials/complete_service.html" %}

--- a/app/templates/suppliers/dashboard.html
+++ b/app/templates/suppliers/dashboard.html
@@ -133,7 +133,7 @@
 
   {{ summary.heading("Contributors") }}
   {% if 'USER_DASHBOARD' is active_feature %}
-    {{ summary.top_link("Add or remove", '/suppliers/users') }}
+    {{ summary.top_link("Invite or remove", '/suppliers/users') }}
   {% endif %}
   {% call(item) summary.table(
     users,

--- a/app/templates/users/list_users.html
+++ b/app/templates/users/list_users.html
@@ -42,7 +42,7 @@
     {% endwith %}
     {% with
       context = current_user.email_address,
-      heading = "Add or remove contributors",
+      heading = "Invite or remove contributors",
       smaller = true
     %}
       {% include 'toolkit/page-heading.html' %}
@@ -70,5 +70,3 @@
     {% endcall %}
   </div>
 {% endblock %}
-
-

--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "jquery": "1.11.2",
     "hogan": "3.0.2",
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
-    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v8.4.1",
+    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v8.5.1",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.14.1/jinja_govuk_template-0.14.1.tgz",
     "digital-marketplace-ssp-content": "git://github.com/alphagov/digitalmarketplace-ssp-content#cf7bb6f370560fa5a69f81d3a5d06e45b4922c02"
   }

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -63,7 +63,7 @@ class TestFrameworksDashboard(BaseApplicationTest):
 
             doc = html.fromstring(res.get_data(as_text=True))
             assert_equal(
-                len(doc.xpath('//p/strong[contains(text(), "You have made the declaration")]')),  # noqa
+                len(doc.xpath('//p[contains(text(), "You have made the declaration")]')),  # noqa
                 1)
 
     def test_declaration_status_when_started(self, data_api_client):
@@ -563,7 +563,7 @@ class TestG7ServicesList(BaseApplicationTest):
         res = self.client.get('/suppliers/frameworks/g-cloud-7/services')
 
         assert_true(u'Service can be moved to complete' not in res.get_data(as_text=True))
-        assert_in(u'4 questions unanswered', res.get_data(as_text=True))
+        assert_in(u'4 unanswered questions', res.get_data(as_text=True))
 
     def test_drafts_list_can_be_completed(self, count_unanswered, apiclient):
         with self.app.test_client():

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -87,7 +87,7 @@ class TestFrameworksDashboard(BaseApplicationTest):
 
             doc = html.fromstring(res.get_data(as_text=True))
             assert_equal(
-                len(doc.xpath('//p[contains(text(), "You have started making the supplier declaration, but it is not yet finished")]')),  # noqa
+                len(doc.xpath('//p[contains(text(), "You haven’t finished making the supplier declaration")]')),  # noqa
                 1)
 
     def test_declaration_status_when_not_complete(self, data_api_client):
@@ -100,7 +100,7 @@ class TestFrameworksDashboard(BaseApplicationTest):
 
             doc = html.fromstring(res.get_data(as_text=True))
             assert_equal(
-                len(doc.xpath('//p[contains(text(), "You haven\'t made the supplier declaration")]')),
+                len(doc.xpath('//p[contains(text(), "You haven’t made the supplier declaration")]')),
                 1)
 
 

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -63,7 +63,7 @@ class TestFrameworksDashboard(BaseApplicationTest):
 
             doc = html.fromstring(res.get_data(as_text=True))
             assert_equal(
-                len(doc.xpath('//p/strong[contains(text(), "You’ve made the declaration")]')),
+                len(doc.xpath('//p/strong[contains(text(), "You’ve made the supplier declaration")]')),
                 1)
 
     def test_declaration_status_when_started(self, data_api_client):

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -63,7 +63,7 @@ class TestFrameworksDashboard(BaseApplicationTest):
 
             doc = html.fromstring(res.get_data(as_text=True))
             assert_equal(
-                len(doc.xpath('//p/strong[contains(text(), "You’ve made the supplier declaration")]')),
+                len(doc.xpath(u'//p/strong[contains(text(), "You’ve made the supplier declaration")]')),
                 1)
 
     def test_declaration_status_when_started(self, data_api_client):

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -63,7 +63,7 @@ class TestFrameworksDashboard(BaseApplicationTest):
 
             doc = html.fromstring(res.get_data(as_text=True))
             assert_equal(
-                len(doc.xpath('//p[contains(text(), "All services marked as complete will be automatically submitted at 3pm BST, 6 October")]')),  # noqa
+                len(doc.xpath('//p/strong[contains(text(), "You have made the declaration")]')),  # noqa
                 1)
 
     def test_declaration_status_when_started(self, data_api_client):
@@ -512,7 +512,7 @@ class TestSendClarificationQuestionEmail(BaseApplicationTest):
 
         assert_equal(response.status_code, 200)
         assert_true(
-            self.strip_all_whitespace('<p class="banner-message">Your clarification message has been sent.</p>')
+            self.strip_all_whitespace('<p class="banner-message">Your clarification question has been sent. Answers to all clarification questions will be published on this page.</p>')  # noqa
             in self.strip_all_whitespace(response.get_data(as_text=True))
         )
 
@@ -579,7 +579,7 @@ class TestG7ServicesList(BaseApplicationTest):
 
         res = self.client.get('/suppliers/frameworks/g-cloud-7/services')
 
-        assert_in(u'Service can be moved to complete', res.get_data(as_text=True))
+        assert_in(u'Service can be marked as complete', res.get_data(as_text=True))
         assert_in(u'1 optional question unanswered', res.get_data(as_text=True))
 
     def test_drafts_list_completed(self, count_unanswered, apiclient):

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -63,7 +63,7 @@ class TestFrameworksDashboard(BaseApplicationTest):
 
             doc = html.fromstring(res.get_data(as_text=True))
             assert_equal(
-                len(doc.xpath('//p[contains(text(), "You have made the declaration")]')),  # noqa
+                len(doc.xpath('//p/strong[contains(text(), "You’ve made the declaration")]')),
                 1)
 
     def test_declaration_status_when_started(self, data_api_client):
@@ -87,7 +87,7 @@ class TestFrameworksDashboard(BaseApplicationTest):
 
             doc = html.fromstring(res.get_data(as_text=True))
             assert_equal(
-                len(doc.xpath('//p[contains(text(), "You haven’t finished making the supplier declaration")]')),  # noqa
+                len(doc.xpath('//p[contains(text(), "You need to finish making the supplier declaration")]')),  # noqa
                 1)
 
     def test_declaration_status_when_not_complete(self, data_api_client):
@@ -100,7 +100,7 @@ class TestFrameworksDashboard(BaseApplicationTest):
 
             doc = html.fromstring(res.get_data(as_text=True))
             assert_equal(
-                len(doc.xpath('//p[contains(text(), "You haven’t made the supplier declaration")]')),
+                len(doc.xpath('//p[contains(text(), "You need to make the supplier declaration")]')),
                 1)
 
 

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -877,7 +877,7 @@ class TestShowDraftService(BaseApplicationTest):
         count_unanswered.return_value = 1, 2
         res = self.client.get('/suppliers/submission/services/1')
 
-        assert_in(u'3 questions unanswered', res.get_data(as_text=True))
+        assert_in(u'3 unanswered questions', res.get_data(as_text=True))
 
     @mock.patch('app.main.views.services.count_unanswered_questions')
     def test_move_to_complete_button(self, count_unanswered, data_api_client):

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -886,7 +886,7 @@ class TestShowDraftService(BaseApplicationTest):
         res = self.client.get('/suppliers/submission/services/1')
 
         assert_in(u'1 optional question unanswered', res.get_data(as_text=True))
-        assert_in(u'<button class="button-save">Move to complete</button>',
+        assert_in(u'<button class="button-save">Mark as complete</button>',
                   res.get_data(as_text=True))
 
 


### PR DESCRIPTION
This pull request encompases a bunch of changes:
- from @superroz and @cathrooney's Google Doc
- from when @ralph-hawkins, @katieminatie and I took some creative license yesterday and researched the dashboard page
- from when @ralph-hawkins and I did some guerilla research at the DS£MED

It mostly involves:
- wording of how things are labelled
- more, contextual warning messages if your application to G-Cloud 7 wont  succeed
- ~~the renaming of 'copy' to 'clone'~~
- duplicating the 'mark complete' button at the bottom of the page (because you'll probably click it after reviewing the whole service)

Stepping through a submission:
--
<img width="1017" alt="screen shot 2015-08-21 at 07 45 17" src="https://cloud.githubusercontent.com/assets/355079/9402980/985d9d22-47da-11e5-90a9-60f7e0f66f02.png">

<img width="1034" alt="screen shot 2015-08-21 at 07 45 34" src="https://cloud.githubusercontent.com/assets/355079/9402981/985f67c4-47da-11e5-820c-c51ce9825fd5.png">

<img width="1068" alt="screen shot 2015-08-21 at 07 45 55" src="https://cloud.githubusercontent.com/assets/355079/9402982/986ecdd6-47da-11e5-86a0-7f90a15c47e9.png">

<img width="1055" alt="screen shot 2015-08-21 at 07 47 56" src="https://cloud.githubusercontent.com/assets/355079/9402985/98790eb8-47da-11e5-8493-8fb4ec0f91e7.png">

<img width="1054" alt="screen shot 2015-08-21 at 07 52 29" src="https://cloud.githubusercontent.com/assets/355079/9402986/987caa32-47da-11e5-81df-3ff05f317b2f.png">

<img width="1031" alt="screen shot 2015-08-21 at 07 46 14" src="https://cloud.githubusercontent.com/assets/355079/9402983/9872d6e2-47da-11e5-8d97-137442018168.png">

<img width="1043" alt="screen shot 2015-08-21 at 07 46 34" src="https://cloud.githubusercontent.com/assets/355079/9402984/9876e034-47da-11e5-954b-b09b2a6bcf0b.png">