### PR TITLE
Do not connect S3 if no files are being uploaded

### DIFF
--- a/app/main/helpers/services.py
+++ b/app/main/helpers/services.py
@@ -110,6 +110,9 @@ def upload_draft_documents(service, request_files, section):
     if errors:
         return None, errors
 
+    if len(files) == 0:
+        return {}, {}
+
     uploader = s3.S3(current_app.config['DM_G7_DRAFT_DOCUMENTS_BUCKET'])
 
     for field, contents in files.items():

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -578,6 +578,17 @@ class TestEditDraftService(BaseApplicationTest):
             page_questions=['serviceSummary']
         )
 
+    def test_S3_should_not_be_instantiated_if_there_are_no_files(self, data_api_client, s3):
+        data_api_client.get_draft_service.return_value = self.empty_draft
+        res = self.client.post(
+            '/suppliers/submission/services/1/edit/service_description',
+            data={
+                'serviceSummary': 'This is the service',
+            })
+
+        assert_equal(res.status_code, 302)
+        assert not s3.called
+
     def test_editing_readonly_section_is_not_allowed(self, data_api_client, s3):
         data_api_client.get_draft_service.return_value = self.empty_draft
 


### PR DESCRIPTION
I only noticed this because I was trying to manually test the supplier app when not connected to the internet. Instantiating `S3` talks to S3, this isn't necessary if we're not uploading files.