### PR TITLE
Edit copy service name

### DIFF
--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -274,7 +274,10 @@ def copy_draft_service(service_id):
     except APIError as e:
         abort(e.status_code)
 
-    return redirect(url_for(".edit_service_submission", service_id=draft_copy['id'], section_id='service_name'))
+    return redirect(url_for(".edit_service_submission",
+                            service_id=draft_copy['id'],
+                            section_id='service_name',
+                            return_to_summary=1))
 
 
 @main.route('/submission/services/<string:service_id>/complete', methods=['POST'])

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -266,17 +266,15 @@ def copy_draft_service(service_id):
         abort(404)
 
     try:
-        data_api_client.copy_draft_service(
+        draft_copy = data_api_client.copy_draft_service(
             service_id,
             current_user.email_address
-        )
+        )['services']
 
     except APIError as e:
         abort(e.status_code)
 
-    flash({'service_name': draft.get('serviceName')}, 'service_copied')
-
-    return redirect(url_for(".framework_services"))
+    return redirect(url_for(".edit_service_submission", service_id=draft_copy['id'], section_id='service_name'))
 
 
 @main.route('/submission/services/<string:service_id>/complete', methods=['POST'])

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -419,42 +419,35 @@ def update_section_submission(service_id, section_id):
     if section is None or not section.editable:
         abort(404)
 
-    posted_data = section.get_data(request.form)
-
+    errors = None
+    update_data = section.get_data(request.form)
     uploaded_documents, document_errors = upload_draft_documents(draft, request.files, section)
 
     if document_errors:
-        return render_template(
-            "services/edit_submission_section.html",
-            section=section,
-            service_data=posted_data,
-            service_id=service_id,
-            errors=get_section_error_messages(document_errors, draft['lot']),
-            **main.config['BASE_TEMPLATE_DATA']
-        )
+        errors = get_section_error_messages(document_errors, draft['lot'])
+    else:
+        update_data.update(uploaded_documents)
 
-    update_data = posted_data.copy()
-    update_data.update(uploaded_documents)
+        try:
+            data_api_client.update_draft_service(
+                service_id,
+                update_data,
+                current_user.email_address,
+                page_questions=section.get_field_names()
+            )
+        except HTTPError as e:
+            unformat_section_data(update_data)
+            errors = get_section_error_messages(e.message, draft['lot'])
 
-    try:
-        data_api_client.update_draft_service(
-            service_id,
-            update_data,
-            current_user.email_address,
-            page_questions=section.get_field_names()
-        )
-    except HTTPError as e:
-        unformat_section_data(update_data)
-        errors_map = get_section_error_messages(e.message, draft['lot'])
-        if not posted_data.get('serviceName', None):
-            posted_data['serviceName'] = draft.get('serviceName', '')
-        errors_map = get_section_error_messages(e.message, draft['lot'])
+    if errors:
+        if not update_data.get('serviceName', None):
+            update_data['serviceName'] = draft.get('serviceName', '')
         return render_template(
             "services/edit_submission_section.html",
             section=section,
             service_data=update_data,
             service_id=service_id,
-            errors=errors_map,
+            errors=errors,
             **main.config['BASE_TEMPLATE_DATA']
             )
 

--- a/app/templates/frameworks/services.html
+++ b/app/templates/frameworks/services.html
@@ -33,8 +33,6 @@
         <p class="banner-message">
           {% if category == 'service_deleted' %}
             <strong>{{message.service_name}}</strong> was deleted
-          {% elif category == 'service_copied' %}
-            <strong>{{message.service_name}}</strong> was copied
           {% elif category == 'service_completed' %}
             <strong>{{message.service_name}}</strong> was completed
           {% endif %}

--- a/app/templates/services/service_submission.html
+++ b/app/templates/services/service_submission.html
@@ -80,7 +80,7 @@
 {% endblock %}
 
 {% block edit_link %}
-  {{ summary.top_link("Edit", url_for(".edit_service_submission", service_id=service_id, section_id=section.id)) }}
+  {{ summary.top_link("Edit", url_for(".edit_service_submission", service_id=service_id, section_id=section.id, return_to_summary=1)) }}
 {% endblock %}
 
 {% block after_sections %}


### PR DESCRIPTION
#### Redirect to service name edit page after making a copy
After discussing this a bit, we've decided to change the way "Make
a copy" works. It still creates a new draft as before, but instead
of returning to the services dashboard it will redirect to the
editing of service name section of the newly created draft.

The assumption is that this will encourage suppliers to give
unique and meaningful names to the copied drafts so that we
don't end up with multiple copies of the same service with the
same name.

#### Fix "Return to summary" link disappearing after validation errors
[#101571000](https://www.pivotaltracker.com/story/show/101571000)

"Return to summary" was hidden for services without a service name
in 09acc4f. The page rendered after validation only uses the update
data, not the full draft service data, so serviceName should be
explicitly added to the context. This was achieved by adding
serviceName to the `posted_data`, but `posted_data` is no longer
passed to the template as it was replaced by `update_data`.

This adds `serviceName` to update_data for both API and document
validation failures.

#### Redirect to summary after editing single section/make a copy
After submitting a section update instead of redirecting to the
next section the user is returned to the summary page if:

* Section edit was started by clicking the "Edit" link on the
  service summary page
* Section edit was started after clicking the "Make a copy" button.
  After editing the service name the user is returned to the new
  service summary page