### PR TITLE
Remove extra template variable

### DIFF
--- a/app/templates/macros/toolkit_forms.html
+++ b/app/templates/macros/toolkit_forms.html
@@ -35,7 +35,6 @@
     hint=(question_content.hint or '')|markdown,
     values=service_data[question_content.id],
     id=question_content.id,
-    hint=question_content.hint,
     error=errors.get(question_content.id)['message']
   %}
     {% include "toolkit/forms/list-entry.html" %}


### PR DESCRIPTION
The list macro had two 'hint' variables declared
so was using the second, which wasn't being
filtered for markdown.