### PR TITLE
Add links to declaration questions

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,6 +7,6 @@
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
     "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v8.4.1",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.14.1/jinja_govuk_template-0.14.1.tgz",
-    "digital-marketplace-ssp-content": "git://github.com/alphagov/digitalmarketplace-ssp-content#ef0b3c8d396f31d36dfdd01c970619d0972f727b"
+    "digital-marketplace-ssp-content": "git://github.com/alphagov/digitalmarketplace-ssp-content#cf7bb6f370560fa5a69f81d3a5d06e45b4922c02"
   }
 }


### PR DESCRIPTION
Also includes the addition of a link and some changes to the service submission questions.

Includes these pull requests:

https://github.com/alphagov/digitalmarketplace-ssp-content/pull/67
https://github.com/alphagov/digitalmarketplace-ssp-content/pull/66
https://github.com/alphagov/digitalmarketplace-ssp-content/pull/68
https://github.com/alphagov/digitalmarketplace-ssp-content/pull/69

...which is all of these changes:

https://github.com/alphagov/digitalmarketplace-ssp-content/compare/367594a11c8c1364dd09086c6b265c35dcf8f658...cf7bb6f370560fa5a69f81d3a5d06e45b4922c02