### PR TITLE
Patch data_api_client more better

### DIFF
--- a/tests/app/helpers.py
+++ b/tests/app/helpers.py
@@ -1,5 +1,5 @@
 import re
-from mock import patch, Mock
+from mock import patch
 from app import create_app
 from werkzeug.http import parse_cookie
 from app import data_api_client

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -2,7 +2,6 @@
 from nose.tools import assert_equal, assert_true, assert_in
 import os
 import mock
-from mock import Mock
 from lxml import html
 from dmutils.apiclient import APIError
 from dmutils.audit import AuditTypes
@@ -95,9 +94,7 @@ class TestFrameworksDashboard(BaseApplicationTest):
         with self.app.test_client():
             self.login()
 
-            response = Mock()
-            response.status_code = 404
-            data_api_client.get_selection_answers.side_effect = APIError(response)
+            data_api_client.get_selection_answers.side_effect = APIError(mock.Mock(status_code=404))
 
             res = self.client.get("/suppliers/frameworks/g-cloud-7")
 
@@ -188,10 +185,7 @@ class TestSupplierDeclaration(BaseApplicationTest):
         with self.app.test_client():
             self.login()
 
-            response = Mock()
-            response.status_code = 404
-            data_api_client.get_selection_answers.side_effect = \
-                APIError(response)
+            data_api_client.get_selection_answers.side_effect = APIError(mock.Mock(status_code=404))
 
             res = self.client.get(
                 '/suppliers/frameworks/g-cloud-7/declaration/g_cloud_7_essentials')
@@ -242,15 +236,12 @@ class TestSupplierDeclaration(BaseApplicationTest):
     def test_post_valid_data_with_api_failure(self, data_api_client):
         with self.app.test_client():
             self.login()
-            response = Mock()
-            response.status_code = 400
             data_api_client.get_selection_answers.return_value = {
                 "selectionAnswers": {
                     "questionAnswers": {"status": "started"}
                 }
             }
-            data_api_client.answer_selection_questions.side_effect = \
-                APIError(response)
+            data_api_client.answer_selection_questions.side_effect = APIError(mock.Mock(status_code=400))
 
             res = self.client.post(
                 '/suppliers/frameworks/g-cloud-7/declaration/g_cloud_7_essentials',

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -8,7 +8,6 @@ from dmutils.apiclient import HTTPError
 import copy
 import mock
 from lxml import html
-from mock import Mock
 from freezegun import freeze_time
 
 from nose.tools import assert_equal, assert_true, assert_false, \
@@ -23,10 +22,9 @@ class TestListServices(BaseApplicationTest):
         with self.app.test_client():
             self.login()
 
-            data_api_client.find_services = Mock(
-                return_value={
-                    "services": []
-                })
+            data_api_client.find_services.return_value = {
+                "services": []
+                }
 
             res = self.client.get('/suppliers/services')
             assert_equal(res.status_code, 200)
@@ -42,15 +40,15 @@ class TestListServices(BaseApplicationTest):
         with self.app.test_client():
             self.login()
 
-            data_api_client.find_services = Mock(
-                return_value={'services': [{
+            data_api_client.find_services.return_value = {
+                'services': [{
                     'serviceName': 'Service name 123',
                     'status': 'published',
                     'id': '123',
                     'lot': 'SaaS',
                     'frameworkName': 'G-Cloud 1'
-                }]}
-            )
+                }]
+            }
 
             res = self.client.get('/suppliers/services')
             assert_equal(res.status_code, 200)
@@ -83,13 +81,13 @@ class TestListServices(BaseApplicationTest):
         with self.app.test_client():
             self.login()
 
-            data_api_client.find_services = Mock(
-                return_value={'services': [{
+            data_api_client.find_services.return_value = {
+                'services': [{
                     'serviceName': 'Service name 123',
                     'status': 'published',
                     'id': '123'
-                }]}
-            )
+                }]
+            }
 
             res = self.client.get('/suppliers/services')
             assert_equal(res.status_code, 200)

--- a/tests/app/main/test_suppliers.py
+++ b/tests/app/main/test_suppliers.py
@@ -2,7 +2,6 @@ from dmutils.apiclient import HTTPError
 from dmutils.email import MandrillException
 import mock
 from flask import session
-from mock import Mock
 from nose.tools import assert_equal, assert_true, assert_in, assert_false
 from tests.app.helpers import BaseApplicationTest
 from lxml import html
@@ -163,15 +162,13 @@ class TestSupplierDashboardLogin(BaseApplicationTest):
         get_current_suppliers_users.side_effect = get_user
         with self.app.test_client():
             self.login()
-            data_api_client.authenticate_user = Mock(
-                return_value=(self.user(
-                    123, "email@email.com", 1234, "Supplier Name", "Name")))
+            data_api_client.authenticate_user.return_value = self.user(
+                123, "email@email.com", 1234, "Supplier Name", "Name")
 
-            data_api_client.get_user = Mock(
-                return_value=(self.user(
-                    123, "email@email.com", 1234, "Supplier Name", "Name")))
+            data_api_client.get_user.return_value = self.user(
+                123, "email@email.com", 1234, "Supplier Name", "Name")
 
-            data_api_client.get_supplier = Mock(side_effect=get_supplier)
+            data_api_client.get_supplier.side_effect = get_supplier
 
             self.client.post("/suppliers/login", data={
                 "email_address": "valid@email.com",

--- a/tests/app/test_application.py
+++ b/tests/app/test_application.py
@@ -1,10 +1,7 @@
 # coding=utf-8
 
 import mock
-from mock import Mock
 from nose.tools import assert_equal, assert_true
-from app import data_api_client
-from requests import ConnectionError
 from .helpers import BaseApplicationTest
 from dmutils.apiclient.errors import HTTPError
 
@@ -42,13 +39,12 @@ class TestApplication(BaseApplicationTest):
             "enquiries@digitalmarketplace.service.gov.uk</a>"
             in res.get_data(as_text=True))
 
-    def test_503(self):
+    @mock.patch('app.main.views.services.data_api_client')
+    def test_503(self, data_api_client):
         with self.app.test_client():
             self.login()
 
-            data_api_client.get_supplier = Mock(
-                side_effect=HTTPError('API is down')
-            )
+            data_api_client.get_supplier.side_effect = HTTPError('API is down')
             self.app.config['DEBUG'] = False
 
             res = self.client.get('/suppliers')


### PR DESCRIPTION
Importing the `data_api_client` and patching an individual method (in `test_application.py`) wasn't a great idea, so I've removed that.
I've also removed `Mock`s in a few places so as to be more consistent across the tests.

The supplier app has changed since [story on Pivotal](https://www.pivotaltracker.com/story/show/97111136) related to this was written.  The tests weren't failing when I started this, but the solution wasn't a very sustainable one.