### PR TITLE
Change upload document display

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,6 +1,6 @@
 import re
 
-from datetime import timedelta
+from datetime import timedelta, datetime
 from flask import Flask, request, redirect, session, Markup
 from flask_login import LoginManager
 from flask_wtf.csrf import CsrfProtect
@@ -17,6 +17,12 @@ data_api_client = apiclient.DataAPIClient()
 login_manager = LoginManager()
 feature_flags = flask_featureflags.FeatureFlag()
 csrf = CsrfProtect()
+
+
+def parse_document_upload_time(data):
+    match = re.search("(\d{4}-\d{2}-\d{2}-\d{2}\d{2})\..{2,3}$", data)
+    if match:
+        return datetime.strptime(match.group(1), "%Y-%m-%d-%H%M")
 
 
 def create_app(config_name):
@@ -58,6 +64,8 @@ def create_app(config_name):
     @application.template_filter('markdown')
     def markdown_filter(data):
         return Markup(markdown(data))
+
+    application.add_template_filter(parse_document_upload_time)
 
     return application
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,6 +1,6 @@
 import re
 
-from datetime import timedelta, datetime
+from datetime import timedelta
 from flask import Flask, request, redirect, session, Markup
 from flask_login import LoginManager
 from flask_wtf.csrf import CsrfProtect
@@ -19,10 +19,7 @@ feature_flags = flask_featureflags.FeatureFlag()
 csrf = CsrfProtect()
 
 
-def parse_document_upload_time(data):
-    match = re.search("(\d{4}-\d{2}-\d{2}-\d{2}\d{2})\..{2,3}$", data)
-    if match:
-        return datetime.strptime(match.group(1), "%Y-%m-%d-%H%M")
+from app.main.helpers.services import parse_document_upload_time
 
 
 def create_app(config_name):

--- a/app/templates/macros/toolkit_forms.html
+++ b/app/templates/macros/toolkit_forms.html
@@ -97,7 +97,9 @@
     question=question_content.question|markdown,
     hint=(question_content.hint or '')|markdown,
     name=question_content.id,
-    value=service_data[question_content.id],
+    value="Document uploaded {}".format(
+      service_data[question_content.id]|parse_document_upload_time|datetimeformat
+    ),
     error=errors.get(question_content.id)['message'],
     question_number=question_number
   %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ Flask-Login==0.2.11
 Flask-Script==2.0.5
 Flask-WTF==0.11
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@6.2.2#egg=digitalmarketplace-utils==6.2.2
+git+https://github.com/alphagov/digitalmarketplace-utils.git@6.5.0#egg=digitalmarketplace-utils==6.5.0
 markdown==2.6.2
 
 requests==2.5.1


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/101692502

Change how the previously uploaded file is displayed on the upload form so that rather than showing a long URL we show a message saying when the file was uploaded.

This is implemented in the Jinja2 macro to avoid changing the draft data in place (and thus lying about the value is) and to avoid doing the formatting in the frontend toolkit (which doesn't have access to the
required template filters).

## Before
![screen shot 2015-08-26 at 08 40 09](https://cloud.githubusercontent.com/assets/14287/9487956/23208518-4bce-11e5-91b5-3fa3ad412640.png)

## After
![screen shot 2015-08-26 at 08 41 29](https://cloud.githubusercontent.com/assets/14287/9487984/4ae035ee-4bce-11e5-98d7-5c063e1da885.png)


## Refactor service helpers
Move `unformat_section_data` to `dmutils.content_loader`:
This continues the work of moving content section related functions into `dmutils`. This removes the need for any question type checking functions in the frontend app any more.

Pass `service_content` into `get_section_error_messages`:
Along with the previous change this removes the dependency on `new_service_content`.

Move `parse_document_upload_time` into helpers:
It is a service helper of a sort.
