### PR TITLE
BUGFIX: Need to have the JSONLogFile set for logs

### DIFF
--- a/.ebextensions/cwl-logs-apache-access.config
+++ b/.ebextensions/cwl-logs-apache-access.config
@@ -29,6 +29,7 @@ Mappings:
   CWLogs:
     AccessLogs:
       LogFile: "/var/log/httpd/cwl_access_log"
+      JSONLogFile: "/var/log/httpd/cwl_access_log.json"
       TimestampFormat: "%d/%b/%Y:%H:%M:%S %z"
       LogGroupName: {"Fn::GetOptionSetting": {"OptionName": "LogGroupName"}}
       JSONLogGroupName: {"Fn::GetOptionSetting": {"OptionName": "JSONLogGroupName"}}


### PR DESCRIPTION
CloudWatch logs configuration needs to have the JSONLogFile variable set
as it's being used later in the file.