### PR TITLE
[#101903480] Enable G7 on Staging

### DIFF
--- a/config.py
+++ b/config.py
@@ -122,7 +122,7 @@ class Production(Live):
 
 class Staging(Production):
     FEATURE_FLAGS_USER_DASHBOARD = enabled_since('2015-08-19')
-
+    FEATURE_FLAGS_GCLOUD7_OPEN = enabled_since('2015-08-26')
 
 configs = {
     'development': Development,


### PR DESCRIPTION
See: https://www.pivotaltracker.com/story/show/101903480

The Frameworks table is already updated to have G7 `open`, so this should be all that's required to turn on G7 features in staging.