### PR TITLE
[#101512016] Clarification question response emails

### DIFF
--- a/app/templates/emails/clarification_question_submitted.html
+++ b/app/templates/emails/clarification_question_submitted.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head lang="en">
+    <meta charset="UTF-8">
+</head>
+<body>
+Hello {{ user_name }},
+<br /><br />
+Thanks for sending your G-Cloud 7 clarification question. All clarification questions and answers will be published regularly on the Digital Marketplace G-Cloud 7 updates page.
+<br /><br />
+You’ll receive an email when new clarification answers are posted. The Crown Commercial Service will not respond to you individually.
+<br /><br />
+Here is a copy of the question that you sent:<br />
+"{{ message }}"
+<br /><br />
+This is an automated message. Email <a href="mailto:enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.service.gov.uk</a> if you need help.
+<br /><br />
+Thanks,
+<br /><br />
+The Digital Marketplace team
+</body>
+</html>

--- a/config.py
+++ b/config.py
@@ -32,6 +32,10 @@ class Config(object):
     INVITE_EMAIL_FROM = 'enquiries@digitalmarketplace.service.gov.uk'
     INVITE_EMAIL_SUBJECT = 'Your Digital Marketplace invitation'
 
+    CLARIFICATION_EMAIL_NAME = 'Digital Marketplace Admin'
+    CLARIFICATION_EMAIL_FROM = 'do-not-reply@digitalmarketplace.service.gov.uk'
+    CLARIFICATION_EMAIL_SUBJECT = 'Thanks for your clarification question'
+
     CREATE_USER_SUBJECT = 'Create your Digital Marketplace account'
     SECRET_KEY = os.getenv('DM_PASSWORD_SECRET_KEY')
     SHARED_EMAIL_KEY = os.getenv('DM_SHARED_EMAIL_KEY')
@@ -80,6 +84,7 @@ class Test(Config):
     SERVER_NAME = 'localhost'
     DM_MANDRILL_API_KEY = 'MANDRILL'
     SHARED_EMAIL_KEY = "KEY"
+    DM_CLARIFICATION_QUESTION_EMAIL = 'digitalmarketplace@mailinator.com'
 
     FEATURE_FLAGS_EDIT_SERVICE_PAGE = enabled_since('2015-06-03')
     FEATURE_FLAGS_SUPPLIER_DASHBOARD = enabled_since('2015-06-10')


### PR DESCRIPTION
See: https://www.pivotaltracker.com/story/show/101512016

This sends an email to the user who submitted a clarification question, to confirm that we have received it.  The email looks like this:
![screen shot 2015-08-26 at 13 40 33](https://cloud.githubusercontent.com/assets/6525554/9494239/d12aeeb8-4bfc-11e5-9408-c45d758e7f02.png)


I also tested the do-not-reply email address, which seems to do the job:
![screen shot 2015-08-26 at 15 51 32](https://cloud.githubusercontent.com/assets/6525554/9496890/6ed91286-4c0a-11e5-9e07-e8b680f1d8aa.png)
