### PR TITLE
[#102066014] More required declaration answers

### DIFF
--- a/app/main/helpers/frameworks.py
+++ b/app/main/helpers/frameworks.py
@@ -73,7 +73,7 @@ def get_required_fields(all_fields, answers):
         required_fields.add('SQ3-1k')
 
     # If you answered No to question 26 (established in the UK)
-    if answers.get('SQ5-2a') is False:
+    if 'SQ5-2a' in answers and not answers['SQ5-2a']:
         required_fields.add('SQ1-1i-i')
         required_fields.add('SQ1-1j-i')
 

--- a/app/main/helpers/frameworks.py
+++ b/app/main/helpers/frameworks.py
@@ -47,6 +47,7 @@ def get_required_fields(all_fields, answers):
     required_fields = set(all_fields)
     #  Remove optional fields
     required_fields -= OPTIONAL_FIELDS
+
     #  If you answered other to question 19 (trading status)
     if answers.get('SQ1-1ci') == 'other (please specify)':
         required_fields.add('SQ1-1cii')
@@ -72,7 +73,7 @@ def get_required_fields(all_fields, answers):
         required_fields.add('SQ3-1k')
 
     # If you answered No to question 26 (established in the UK)
-    if not answers.get('SQ5-2a'):
+    if answers.get('SQ5-2a') is False:
         required_fields.add('SQ1-1i-i')
         required_fields.add('SQ1-1j-i')
 

--- a/bower.json
+++ b/bower.json
@@ -7,6 +7,6 @@
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
     "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v9.0.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.14.1/jinja_govuk_template-0.14.1.tgz",
-    "digital-marketplace-ssp-content": "git://github.com/alphagov/digitalmarketplace-ssp-content#6c4858f8c1d71f4e8ab0b55c1e828bc64a4a0699"
+    "digital-marketplace-ssp-content": "git://github.com/alphagov/digitalmarketplace-ssp-content#7613af9c0b9448d98fa60688bf5d61b1a09a437d"
   }
 }

--- a/tests/app/main/helpers/test_frameworks.py
+++ b/tests/app/main/helpers/test_frameworks.py
@@ -39,10 +39,13 @@ FULL_G7_SUBMISSION = {
     "SQ1-1b": "Blah",
     "SQ1-1cii": "Blah",
     "SQ1-1d": "Blah",
+    "SQ1-1d-i": "Blah",
+    "SQ1-1d-ii": "Blah",
     "SQ1-1e": "Blah",
     "SQ1-1h": "999999999",
     "SQ1-1i-ii": "Blah",
     "SQ1-1j-ii": "Blah",
+    "SQ1-1p-i": "Blah",
     "SQ1-1k": "Blah",
     "SQ1-1n": "Blah",
     "SQ1-1o": "valid@email.com",
@@ -98,7 +101,7 @@ def test_error_if_required_text_field_is_empty():
 def test_no_error_if_optional_field_is_missing():
     content = declaration_content.get_builder()
     submission = FULL_G7_SUBMISSION.copy()
-    del submission['SQ1-1e']
+    del submission['SQ1-1p-i']
 
     assert_equal(get_all_errors(content, submission), {})
 


### PR DESCRIPTION
See: https://www.pivotaltracker.com/story/show/102066014

Following discussions with CCS these fields are now required in the declaration: SQ1-1b, SQ1-1d-i, SQ1-1d-ii, SQ1-1e

SQ1-1b wasn't optional before anyway, but the other three were and this makes them required.

Also fixes a small validation bug - previously using `if not ...` on the `SQ5-2a` field returned true for either `None` or `False`, but the required fields should only be added to the errors for the `False` case, and not for the `None` case.  So using `is False` is the right test.