### PR TITLE
Error page content updated as per Roz suggestions.

### DIFF
--- a/app/templates/auth/update-user.html
+++ b/app/templates/auth/update-user.html
@@ -7,10 +7,10 @@
 {% if not token %}
 
 <header class="page-heading-smaller">
-  <h1>This link is invalid</h1>
+  <h1>Expired link</h1>
 </header>
 <p>
-    Check you’ve entered the correct link or ask the person who invited you to send a new invitation.
+    The link you used to create a contributor account may have expired. Check you’ve entered the correct link or ask the person who invited you to send a new invitation.
     If you still can’t create a contributor account, email <a href="mailto:enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.service.gov.uk</a>.
 </p>
 


### PR DESCRIPTION
Lots of people complaining that their link is "invalid" when probably it's expired.

Updates to the wording to help users understand what is going on.