### PR TITLE
Add a second submit button when editing drafts

### DIFF
--- a/app/assets/scss/_forms.scss
+++ b/app/assets/scss/_forms.scss
@@ -1,6 +1,6 @@
 @include media(tablet) {
-  form button.button-save {
-    margin-top: ($gutter * 1.5);
+  form input.button-save {
+    margin-top: 55px;
   }
 }
 

--- a/app/assets/scss/_return-link.scss
+++ b/app/assets/scss/_return-link.scss
@@ -2,3 +2,8 @@
   @include heading-27;
   margin-bottom: 25px;
 }
+
+.next-page-message {
+  color: $secondary-text-colour;
+  margin: -10px 0 $gutter 0;
+}

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -395,13 +395,22 @@ def edit_service_submission(service_id, section_id):
     if section is None or not section.editable:
         abort(404)
 
+    next_section_name = None
+
+    if content.get_next_editable_section_id(section_id):
+        next_section_name = content.get_section(
+            content.get_next_editable_section_id(section_id)
+        ).name
+
     draft = section.unformat_data(draft)
 
     return render_template(
         "services/edit_submission_section.html",
         section=section,
+        next_section_name=next_section_name,
         service_data=draft,
         service_id=service_id,
+        return_to_summary=bool(request.args.get('return_to_summary')),
         **main.config['BASE_TEMPLATE_DATA']
     )
 
@@ -458,7 +467,7 @@ def update_section_submission(service_id, section_id):
     return_to_summary = bool(request.args.get('return_to_summary'))
     next_section = content.get_next_editable_section_id(section_id)
 
-    if next_section and not return_to_summary:
+    if next_section and not return_to_summary and request.form.get('continue_to_next_section'):
         return redirect(url_for(".edit_service_submission", service_id=service_id, section_id=next_section))
     else:
         return redirect(url_for(".view_service_submission", service_id=service_id))

--- a/app/templates/services/edit_section.html
+++ b/app/templates/services/edit_section.html
@@ -31,8 +31,8 @@
     label="Save and return to service",
     type="save"
   %}
-  {% include "toolkit/button.html" %}
+    {% include "toolkit/button.html" %}
   {% endwith %}
 {% endblock %}
 
-{% block return_to_service %}{{ url_for(".edit_service", service_id=service_id) }}{% endblock %}
+{% block return_to_service_link %}{{ url_for(".edit_service", service_id=service_id) }}{% endblock %}

--- a/app/templates/services/edit_submission_section.html
+++ b/app/templates/services/edit_submission_section.html
@@ -30,27 +30,37 @@
 {% endblock %}
 
 {% block save_button %}
-  {% if request.args.get('return_to_summary') %}
+
+  {% if next_section_name and not return_to_summary %}
     {%
       with
-      label="Save and return to service",
+      label="Save and continue",
+      name = "continue_to_next_section",
       type="save"
     %}
-    {% include "toolkit/button.html" %}
+      {% include "toolkit/button.html" %}
+    {% endwith %}
+    <p class="next-page-message">
+      Next: {{ next_section_name }}
+    </p>
+    {%
+      with
+      type = "secondary",
+      label = "Save and return to service overview",
+      name = "return_to_overview"
+    %}
+      {% include "toolkit/button.html" %}
     {% endwith %}
   {% else %}
     {%
       with
       label="Save and continue",
-      type="save"
+      type="save",
+      name = "return_to_overview"
     %}
-    {% include "toolkit/button.html" %}
+      {% include "toolkit/button.html" %}
     {% endwith %}
   {% endif %}
-{% endblock %}
 
-{% block return_to_service_link %}
-  {% if service_data['serviceName'] %}
-  <a href="{{ url_for(".view_service_submission", service_id=service_id) }}">Return to service summary</a>
-  {% endif %}
 {% endblock %}
+{% block return_to_service_link %} {% endblock %}

--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "jquery": "1.11.2",
     "hogan": "3.0.2",
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
-    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v8.5.1",
+    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v9.0.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.14.1/jinja_govuk_template-0.14.1.tgz",
     "digital-marketplace-ssp-content": "git://github.com/alphagov/digitalmarketplace-ssp-content#cf7bb6f370560fa5a69f81d3a5d06e45b4922c02"
   }

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -732,7 +732,9 @@ class TestEditDraftService(BaseApplicationTest):
 
         res = self.client.post(
             '/suppliers/submission/services/1/edit/service_description',
-            data={})
+            data={
+                'continue_to_next_section': 'Save and continue'
+            })
 
         assert_equal(302, res.status_code)
         assert_equal('http://localhost/suppliers/submission/services/1/edit/service_type',
@@ -756,6 +758,18 @@ class TestEditDraftService(BaseApplicationTest):
 
         res = self.client.post(
             '/suppliers/submission/services/1/edit/service_description?return_to_summary=1',
+            data={})
+
+        assert_equal(302, res.status_code)
+        assert_equal('http://localhost/suppliers/submission/services/1',
+                     res.headers['Location'])
+
+    def test_update_redirects_to_edit_submission_if_grey_button_clicked(self, data_api_client, s3):
+        data_api_client.get_draft_service.return_value = self.empty_draft
+        data_api_client.update_draft_service.return_value = None
+
+        res = self.client.post(
+            '/suppliers/submission/services/1/edit/service_description',
             data={})
 
         assert_equal(302, res.status_code)
@@ -886,7 +900,7 @@ class TestShowDraftService(BaseApplicationTest):
         res = self.client.get('/suppliers/submission/services/1')
 
         assert_in(u'1 optional question unanswered', res.get_data(as_text=True))
-        assert_in(u'<button class="button-save">Mark as complete</button>',
+        assert_in(u'<input type="submit" class="button-save"  value="Mark as complete" />',
                   res.get_data(as_text=True))
 
 


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/355079/9522319/1e89be94-4ccc-11e5-9496-564d39ca1f2d.png)

--

This PR give users the explicit choice of whether to:
- save and continue to the next page of questions
- or save and return to the 'service overview' page

It does this by naming each button, and redirecting based on which button is clicked. To do this required bringing in https://github.com/alphagov/digitalmarketplace-frontend-toolkit/pull/146, which is why some of the tests/CSS have needed to change.

