### PR TITLE
Remove ‘Account’ from above page title

### DIFF
--- a/app/templates/auth/login.html
+++ b/app/templates/auth/login.html
@@ -52,7 +52,6 @@
 
 {% with
   heading = "Log in to the Digital Marketplace",
-  context = "Account"
 %}
   {% include "toolkit/page-heading.html" %}
 {% endwith %}

--- a/app/templates/auth/login.html
+++ b/app/templates/auth/login.html
@@ -51,7 +51,7 @@
 {% endif %}
 
 {% with
-  heading = "Log in to the Digital Marketplace",
+  heading = "Log in to the Digital Marketplace"
 %}
   {% include "toolkit/page-heading.html" %}
 {% endwith %}


### PR DESCRIPTION
Unnecessary, so shouldn't be there.

Removing highlighted:

<img width="1050" alt="screen shot 2015-08-26 at 22 30 27 copy" src="https://cloud.githubusercontent.com/assets/8417288/9522672/cc67f746-4ccd-11e5-801b-3820a0d4251d.png">
 

