### PR TITLE
Add trailing commas and Yes-No answers

### DIFF
--- a/scripts/generate_questions_csv.py
+++ b/scripts/generate_questions_csv.py
@@ -34,9 +34,10 @@ def generate_csvs(target_directory):
         )
         with open('{}/g7-{}-questions.csv'.format(target_directory, lot), 'wb') as csvfile:
             writer = unicodecsv.writer(csvfile, delimiter=',', quotechar='"')
+            max_opts = max_options(content)+1
             header = ["Page title", "Question", "Hint"]
             header.extend(
-                ["Answer {}".format(i) for i in range(1, max_options(content)+1)]
+                ["Answer {}".format(i) for i in range(1, max_opts)]
             )
             writer.writerow(header)
             for section in content.sections:
@@ -47,6 +48,11 @@ def generate_csvs(target_directory):
                         question.get('hint')
                     ]
                     options = [option['label'] for option in question.get('options', []) if 'label' in option]
+                    if question.get('type') == 'boolean':
+                        options.append('Yes')
+                        options.append('No')
+                    while len(options) < max_opts-1:
+                        options.append("")
                     row.extend(options)
 
                     writer.writerow(row)


### PR DESCRIPTION
* The generated CSV files were missing answers for `boolean` type questions - now they are included.
* Lines with fewer options than the maximum are now right-padded with commas so that each line has the same number of columns.  This makes it look pretty in Github, and may help with importing into spreadsheets.