### PR TITLE
Save if changed

### DIFF
--- a/app/main/helpers/services.py
+++ b/app/main/helpers/services.py
@@ -180,3 +180,10 @@ def parse_document_upload_time(data):
     match = re.search("(\d{4}-\d{2}-\d{2}-\d{2}\d{2})\..{2,3}$", data)
     if match:
         return datetime.strptime(match.group(1), "%Y-%m-%d-%H%M")
+
+
+def has_changes_to_save(section, draft, update_data):
+    return (
+        any(draft.get(key) != update_data[key] for key in update_data) or
+        any(question['id'] not in draft for question in section.questions)
+    )

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -7,7 +7,8 @@ from ..helpers.services import (
     get_section_error_messages,
     is_service_modifiable, is_service_associated_with_supplier,
     upload_draft_documents, get_service_attributes,
-    get_draft_document_url, count_unanswered_questions
+    get_draft_document_url, count_unanswered_questions,
+    has_changes_to_save
 )
 from ..helpers.frameworks import get_declaration_status
 from ... import data_api_client, flask_featureflags
@@ -443,6 +444,7 @@ def update_section_submission(service_id, section_id):
     else:
         update_data.update(uploaded_documents)
 
+    if not errors and has_changes_to_save(section, draft, update_data):
         try:
             data_api_client.update_draft_service(
                 service_id,

--- a/app/templates/services/service_submission.html
+++ b/app/templates/services/service_submission.html
@@ -85,7 +85,7 @@
 {% endblock %}
 
 {% block edit_link %}
-  {{ summary.top_link("Edit", url_for(".edit_service_submission", service_id=service_id, section_id=section.id, return_to_summary=1)) }}
+  {{ summary.top_link("Edit", url_for(".edit_service_submission", service_id=service_id, section_id=section.id)) }}
 {% endblock %}
 
 {% block after_sections %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ Flask-Login==0.2.11
 Flask-Script==2.0.5
 Flask-WTF==0.11
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@6.5.0#egg=digitalmarketplace-utils==6.5.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@6.5.1#egg=digitalmarketplace-utils==6.5.1
 markdown==2.6.2
 
 requests==2.5.1

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -576,6 +576,20 @@ class TestEditDraftService(BaseApplicationTest):
             page_questions=['serviceSummary']
         )
 
+    def test_update_without_changes_is_not_sent_to_the_api(self, data_api_client, s3):
+        draft = self.empty_draft['services'].copy()
+        draft.update({'serviceSummary': u"summary"})
+        data_api_client.get_draft_service.return_value = {'services': draft}
+
+        res = self.client.post(
+            '/suppliers/submission/services/1/edit/service_description',
+            data={
+                'serviceSummary': u"summary",
+            })
+
+        assert_equal(res.status_code, 302)
+        assert_false(data_api_client.update_draft_service.called)
+
     def test_S3_should_not_be_instantiated_if_there_are_no_files(self, data_api_client, s3):
         data_api_client.get_draft_service.return_value = self.empty_draft
         res = self.client.post(


### PR DESCRIPTION
#### Revert to "Save and continue" after clicking "Edit" in service summary
[#102058034](https://www.pivotaltracker.com/story/show/102058034)

We're keeping "Save and return to summary" only for service name edits
after "Make a copy".

#### Only send draft update request to API if any fields were changed
There's an expectation that some suppliers will use the section
editing flows to check filled in questions. When every update
sends a request to the API there's a risk that this would lead
to lost writes if other users are editing the same service at
the same time.

To avoid this we check if any of the submitted fields are different
from existing service data and only send the API update request if
fields were changed.

This works for input fields, but not for empty checkboxes, radios and
file uploads. Since they are not part of the posted data when no value
is selected, they don't trigger the "field change" event, which means
that the request is not sent to the API and there's no "answer required"
error shown.

To keep the "answer required" checks performed by the API we look for
the section questions in the service data and send the posted data to
the API if any of the keys are missing, even if there were no changes
made.

#### Update dmutils to 6.5.1
Allows removing previous priceMax value