### PR TITLE
Fix bug whereby token fields not passed to template

### DIFF
--- a/app/main/views/login.py
+++ b/app/main/views/login.py
@@ -272,7 +272,7 @@ def submit_create_user(encoded_token):
             form=form,
             token=None,
             email_address=None,
-            supplier=None,
+            supplier_name=None,
             **template_data), 400
     else:
         if form.validate_on_submit():
@@ -295,8 +295,8 @@ def submit_create_user(encoded_token):
                 valid_token=False,
                 form=form,
                 token=encoded_token,
-                email_address=None,
-                supplier=None,
+                email_address=token.get('email_address'),
+                supplier_name=token.get('supplier_name'),
                 **template_data), 400
 
 

--- a/app/templates/auth/create-user.html
+++ b/app/templates/auth/create-user.html
@@ -17,7 +17,7 @@
 {%
   with
   smaller = true,
-  heading = "Create contributor account for  " ~ supplier_name,
+  heading = "Create contributor account for " ~ supplier_name,
   context = email_address
 %}
   {% include "toolkit/page-heading.html" %}

--- a/tests/app/main/test_login.py
+++ b/tests/app/main/test_login.py
@@ -837,6 +837,12 @@ class TestInviteUser(BaseApplicationTest):
             assert_true(
                 "Passwords must be between 10 and 50 characters" in res.get_data(as_text=True)
             )
+            assert_true(
+                "Create contributor account for Supplier Name" in res.get_data(as_text=True)
+            )
+            assert_true(
+                "testme@email.com" in res.get_data(as_text=True)
+            )
 
     @mock.patch('app.main.views.login.data_api_client')
     def test_should_create_user_if_user_does_not_exist(self, data_api_client):


### PR DESCRIPTION
When the validation fails I was passing None to the template instead of the values from the token we needed to render the page correctly