### PR TITLE
[#101483360] Display last modified dates on the G-Cloud 7 dashboard page

### DIFF
--- a/app/main/helpers/frameworks.py
+++ b/app/main/helpers/frameworks.py
@@ -43,6 +43,19 @@ def register_interest_in_framework(client, framework_slug):
             data={'frameworkSlug': framework_slug})
 
 
+def get_last_modified_from_first_matching_file(key_list, path_starts_with):
+    """
+    Takes a list of file keys and a string.
+    Returns the 'last_modified' timestamp for first file whose path starts with the passed-in string,
+    or None if no matching file is found.
+
+    :param key_list: list of file keys (from an s3 bucket)
+    :param path_starts_with: check for file paths which start with this string
+    :return: the timestamp of the first matching file key or None
+    """
+    return next((key for key in key_list if key.get('path').startswith(path_starts_with)), {}).get('last_modified')
+
+
 def get_required_fields(all_fields, answers):
     required_fields = set(all_fields)
     #  Remove optional fields

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -50,14 +50,12 @@ def framework_dashboard():
             "complete": len(complete_drafts),
         },
         declaration_status=declaration_status,
-<<<<<<< HEAD
         deadline=current_app.config['G7_CLOSING_DATE'],
-=======
         last_modified={
             'supplier_pack': get_last_modified_from_first_matching_file(key_list, 'g-cloud-7-supplier-pack.zip'),
             'supplier_updates': get_last_modified_from_first_matching_file(key_list, 'g-cloud-7-updates/')
         },
->>>>>>> Display last_modified times on g-cloud 7 dashboard
+
         **template_data
     ), 200
 

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -12,7 +12,7 @@ from dmutils import s3
 
 from ...main import main, declaration_content, new_service_content
 from ..helpers.frameworks import get_error_messages_for_page, get_first_question_index, \
-    get_error_messages, get_declaration_status
+    get_error_messages, get_declaration_status, get_last_modified_from_first_matching_file
 
 from ... import data_api_client
 from ..helpers.services import (
@@ -39,6 +39,10 @@ def framework_dashboard():
     drafts, complete_drafts = get_drafts(data_api_client, current_user.supplier_id, 'g-cloud-7')
     declaration_status = get_declaration_status(data_api_client)
 
+    key_list = s3.S3(current_app.config['DM_G7_DRAFT_DOCUMENTS_BUCKET']).list('g-cloud-7-')
+    # last_modified files will be first
+    key_list.reverse()
+
     return render_template(
         "frameworks/dashboard.html",
         counts={
@@ -46,7 +50,14 @@ def framework_dashboard():
             "complete": len(complete_drafts),
         },
         declaration_status=declaration_status,
+<<<<<<< HEAD
         deadline=current_app.config['G7_CLOSING_DATE'],
+=======
+        last_modified={
+            'supplier_pack': get_last_modified_from_first_matching_file(key_list, 'g-cloud-7-supplier-pack.zip'),
+            'supplier_updates': get_last_modified_from_first_matching_file(key_list, 'g-cloud-7-updates/')
+        },
+>>>>>>> Display last_modified times on g-cloud 7 dashboard
         **template_data
     ), 200
 

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -176,8 +176,7 @@ def framework_updates(error_message=None, default_textbox_value=None):
 
     template_data = main.config['BASE_TEMPLATE_DATA']
 
-    uploader = s3.S3(current_app.config['DM_G7_DRAFT_DOCUMENTS_BUCKET'])
-    file_list = uploader.list('g-cloud-7-updates/')
+    file_list = s3.S3(current_app.config['DM_G7_DRAFT_DOCUMENTS_BUCKET']).list('g-cloud-7-updates/')
 
     sections = [
         {

--- a/app/templates/frameworks/dashboard.html
+++ b/app/templates/frameworks/dashboard.html
@@ -159,9 +159,15 @@
             <ul>
               <li>
                 <a href="{{ url_for('.download_supplier_file', filepath='g-cloud-7-supplier-pack.zip') }}"><span>Download guidance and legal documentation (.zip)</span></a>
+                {% if last_modified.supplier_pack %}
+                  <div class="hint">Last updated <time datetime="{{ last_modified.supplier_pack }}">{{ last_modified.supplier_pack|dateformat }}</time></div>
+                {% endif %}
               </li>
               <li>
                 <a href="{{ url_for('.framework_updates') }}"><span>Read updates and ask clarification questions</span></a>
+                {% if last_modified.supplier_updates %}
+                  <div class="hint">Last updated <time datetime="{{ last_modified.supplier_updates }}">{{ last_modified.supplier_updates|dateformat }}</time></div>
+                {% endif %}
               </li>
             </ul>
           </div>

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ Flask-Login==0.2.11
 Flask-Script==2.0.5
 Flask-WTF==0.11
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@6.5.1#egg=digitalmarketplace-utils==6.5.1
+git+https://github.com/alphagov/digitalmarketplace-utils.git@6.5.2#egg=digitalmarketplace-utils==6.5.2
 markdown==2.6.2
 
 requests==2.5.1

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -11,9 +11,40 @@ from dmutils.s3 import S3ResponseError
 from ..helpers import BaseApplicationTest
 
 
+def _return_fake_s3_file_dict(directory, filename, ext, last_modified=None, size=None):
+
+    return {
+        'path': '{}{}.{}'.format(directory, filename, ext),
+        'filename': filename,
+        'ext': ext,
+        'last_modified': last_modified or '2015-08-17T14:00:00.000Z',
+        'size': size if size is not None else 1
+    }
+
+
 @mock.patch('dmutils.s3.S3')
 @mock.patch('app.main.views.frameworks.data_api_client')
 class TestFrameworksDashboard(BaseApplicationTest):
+
+    @staticmethod
+    def _assert_last_updated_times(doc, last_updateds):
+
+        for last_updated in last_updateds:
+            hint = doc.xpath(
+                '//li[contains(@class, "framework-application-section")]'
+                '//span[contains(text(), "{}")]'
+                '/../..'
+                '/p[@class="hint"]'.format(last_updated['text'])
+            )
+
+            if last_updated.get('time'):
+                time = hint[0].find('./time')
+                assert_equal(last_updated['time']['text'], time.text)
+                assert_equal(last_updated['time']['datetime'], time.get('datetime'))
+
+            else:
+                assert_equal(len(hint), 0)
+
     def test_shows(self, data_api_client, s3):
         with self.app.test_client():
             self.login()
@@ -103,6 +134,87 @@ class TestFrameworksDashboard(BaseApplicationTest):
             assert_equal(
                 len(doc.xpath('//p[contains(text(), "You need to make the supplier declaration")]')),
                 1)
+
+    def test_last_updated_exists_for_both_sections(self, data_api_client, s3):
+        files = [
+            ('g-cloud-7-updates/communications/', 'file 1', 'odt', '2015-01-01T14:00:00.000Z'),
+            ('g-cloud-7-updates/clarifications/', 'file 2', 'odt', '2015-02-02T14:00:00.000Z'),
+            ('', 'g-cloud-7-supplier-pack', 'zip', '2015-01-01T14:00:00.000Z'),
+        ]
+
+        s3.return_value.list.return_value = [
+            _return_fake_s3_file_dict(section, filename, ext, last_modified=last_modified)
+            for section, filename, ext, last_modified in files
+        ]
+
+        with self.app.test_client():
+            self.login()
+
+            res = self.client.get("/suppliers/frameworks/g-cloud-7")
+            doc = html.fromstring(res.get_data(as_text=True))
+            last_updateds = [
+                {
+                    'text': "Download supplier pack (.zip)",
+                    'time': {
+                        'text': 'Thursday 01 January 2015',
+                        'datetime': '2015-01-01T14:00:00.000Z'
+                    }
+                },
+                {
+                    'text': "Read G-Cloud 7 updates and ask clarification questions",
+                    'time': {
+                        'text': 'Monday 02 February 2015',
+                        'datetime': '2015-02-02T14:00:00.000Z'
+                    }
+                }
+            ]
+
+            self._assert_last_updated_times(doc, last_updateds)
+
+    def test_last_updated_exists_for_one_section(self, data_api_client, s3):
+        files = [
+            ('', 'g-cloud-7-supplier-pack', 'zip', '2015-01-01T14:00:00.000Z'),
+        ]
+
+        s3.return_value.list.return_value = [
+            _return_fake_s3_file_dict(section, filename, ext, last_modified=last_modified)
+            for section, filename, ext, last_modified in files
+        ]
+
+        with self.app.test_client():
+            self.login()
+
+            res = self.client.get("/suppliers/frameworks/g-cloud-7")
+            doc = html.fromstring(res.get_data(as_text=True))
+            last_updateds = [
+                {
+                    'text': "Download supplier pack (.zip)",
+                    'time': {
+                        'text': 'Thursday 01 January 2015',
+                        'datetime': '2015-01-01T14:00:00.000Z'
+                    }
+                },
+                {
+                    'text': "Read G-Cloud 7 updates and ask clarification questions"
+                }
+            ]
+
+            self._assert_last_updated_times(doc, last_updateds)
+
+    def test_last_updated_does_not_exist(self, data_api_client, s3):
+        s3.return_value.list.return_value = []
+
+        with self.app.test_client():
+            self.login()
+
+            res = self.client.get("/suppliers/frameworks/g-cloud-7")
+            doc = html.fromstring(res.get_data(as_text=True))
+            last_updateds = [
+                {'text': "Download supplier pack (.zip)"},
+                {'text': "Read G-Cloud 7 updates and ask clarification questions"}
+            ]
+
+            self._assert_last_updated_times(doc, last_updateds)
 
 
 FULL_G7_SUBMISSION = {
@@ -301,19 +413,6 @@ class TestFrameworkUpdatesPage(BaseApplicationTest):
                     in self.strip_all_whitespace(table_captions[index].text)
                 )
 
-    @staticmethod
-    def _return_fake_s3_file_dict(directory, file, last_modified=None, size=None):
-
-        filename, ext = os.path.splitext(file)
-
-        return {
-            'path': 'g-cloud-7-updates/{}/{}'.format(directory, file),
-            'filename': filename,
-            'ext': ext[:1],
-            'last_modified': last_modified or '2015-08-17T14:00:00.000Z',
-            'size': size if size is not None else 1
-        }
-
     def test_should_be_a_503_if_connecting_to_amazon_fails(self, s3):
         # if s3 throws a 500-level error
         s3.side_effect = S3ResponseError(500, 'Amazon has collapsed. The internet is over.')
@@ -355,17 +454,16 @@ class TestFrameworkUpdatesPage(BaseApplicationTest):
 
     def test_the_tables_should_be_displayed_correctly(self, s3):
 
-        filenames = [
-            ('communications', 'file 1', 'odt'),
-            ('communications', 'file 2', 'odt'),
-            ('clarifications', 'file 3', 'odt'),
-            ('clarifications', 'file 4', 'odt'),
+        files = [
+            ('g-cloud-7-updates/communications/', 'file 1', 'odt'),
+            ('g-cloud-7-updates/communications/', 'file 2', 'odt'),
+            ('g-cloud-7-updates/clarifications/', 'file 3', 'odt'),
+            ('g-cloud-7-updates/clarifications/', 'file 4', 'odt'),
         ]
 
         # the communications table is always before the clarifications table
         s3.return_value.list.return_value = [
-            self._return_fake_s3_file_dict(section, "{}.{}".format(filename, ext))
-            for section, filename, ext in filenames
+            _return_fake_s3_file_dict(section, filename, ext) for section, filename, ext in files
         ]
 
         with self.app.test_client():
@@ -386,28 +484,27 @@ class TestFrameworkUpdatesPage(BaseApplicationTest):
 
                 # test that the file names and urls are right
                 for row in item_rows:
-                    section, filename, ext = filenames.pop(0)
+                    section, filename, ext = files.pop(0)
                     filename_link = row.find('.//a[@class="document-link-with-icon"]')
 
                     assert_true(filename in filename_link.text_content())
                     assert_equal(
                         filename_link.get('href'),
-                        '/suppliers/frameworks/g-cloud-7/g-cloud-7-updates/{}/{}.{}'.format(
+                        '/suppliers/frameworks/g-cloud-7/{}{}.{}'.format(
                             section, filename.replace(' ', '%20'), ext
                         )
                     )
 
     def test_names_with_the_section_name_in_them_will_display_correctly(self, s3):
 
-        # for example: 'g-cloud-7-updates/clarifications/communications.odf'
-        filenames = [
-            ('communications', 'clarifications file', 'odt'),
-            ('clarifications', 'communications file', 'odt')
+        # for example: 'g-cloud-7-updates/clarifications/communications%20file.odf'
+        files = [
+            ('g-cloud-7-updates/communications/', 'clarifications file', 'odt'),
+            ('g-cloud-7-updates/clarifications/', 'communications file', 'odt')
         ]
 
         s3.return_value.list.return_value = [
-            self._return_fake_s3_file_dict(section, "{}.{}".format(filename, ext))
-            for section, filename, ext in filenames
+            _return_fake_s3_file_dict(section, filename, ext) for section, filename, ext in files
         ]
 
         with self.app.test_client():
@@ -428,13 +525,13 @@ class TestFrameworkUpdatesPage(BaseApplicationTest):
 
                 # test that the file names and urls are right
                 for row in item_rows:
-                    section, filename, ext = filenames.pop(0)
+                    section, filename, ext = files.pop(0)
                     filename_link = row.find('.//a[@class="document-link-with-icon"]')
 
                     assert_true(filename in filename_link.text_content())
                     assert_equal(
                         filename_link.get('href'),
-                        '/suppliers/frameworks/g-cloud-7/g-cloud-7-updates/{}/{}.{}'.format(
+                        '/suppliers/frameworks/g-cloud-7/{}{}.{}'.format(
                             section, filename.replace(' ', '%20'), ext
                         )
                     )

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -31,10 +31,10 @@ class TestFrameworksDashboard(BaseApplicationTest):
 
         for last_updated in last_updateds:
             hint = doc.xpath(
-                '//li[contains(@class, "framework-application-section")]'
+                '//li[contains(@class, "framework-application-section-last")]'
                 '//span[contains(text(), "{}")]'
                 '/../..'
-                '/p[@class="hint"]'.format(last_updated['text'])
+                '/div[@class="hint"]'.format(last_updated['text'])
             )
 
             if last_updated.get('time'):
@@ -154,14 +154,14 @@ class TestFrameworksDashboard(BaseApplicationTest):
             doc = html.fromstring(res.get_data(as_text=True))
             last_updateds = [
                 {
-                    'text': "Download supplier pack (.zip)",
+                    'text': "Download guidance and legal documentation (.zip)",
                     'time': {
                         'text': 'Thursday 01 January 2015',
                         'datetime': '2015-01-01T14:00:00.000Z'
                     }
                 },
                 {
-                    'text': "Read G-Cloud 7 updates and ask clarification questions",
+                    'text': "Read updates and ask clarification questions",
                     'time': {
                         'text': 'Monday 02 February 2015',
                         'datetime': '2015-02-02T14:00:00.000Z'
@@ -188,14 +188,14 @@ class TestFrameworksDashboard(BaseApplicationTest):
             doc = html.fromstring(res.get_data(as_text=True))
             last_updateds = [
                 {
-                    'text': "Download supplier pack (.zip)",
+                    'text': "Download guidance and legal documentation (.zip)",
                     'time': {
                         'text': 'Thursday 01 January 2015',
                         'datetime': '2015-01-01T14:00:00.000Z'
                     }
                 },
                 {
-                    'text': "Read G-Cloud 7 updates and ask clarification questions"
+                    'text': "Read updates and ask clarification questions"
                 }
             ]
 
@@ -210,8 +210,8 @@ class TestFrameworksDashboard(BaseApplicationTest):
             res = self.client.get("/suppliers/frameworks/g-cloud-7")
             doc = html.fromstring(res.get_data(as_text=True))
             last_updateds = [
-                {'text': "Download supplier pack (.zip)"},
-                {'text': "Read G-Cloud 7 updates and ask clarification questions"}
+                {'text': "Download guidance and legal documentation (.zip)"},
+                {'text': "Read updates and ask clarification questions"}
             ]
 
             self._assert_last_updated_times(doc, last_updateds)

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -11,9 +11,10 @@ from dmutils.s3 import S3ResponseError
 from ..helpers import BaseApplicationTest
 
 
+@mock.patch('dmutils.s3.S3')
 @mock.patch('app.main.views.frameworks.data_api_client')
 class TestFrameworksDashboard(BaseApplicationTest):
-    def test_shows(self, data_api_client):
+    def test_shows(self, data_api_client, s3):
         with self.app.test_client():
             self.login()
 
@@ -21,7 +22,7 @@ class TestFrameworksDashboard(BaseApplicationTest):
 
             assert_equal(res.status_code, 200)
 
-    def test_interest_registered_in_framework(self, data_api_client):
+    def test_interest_registered_in_framework(self, data_api_client, s3):
         with self.app.test_client():
             self.login()
             data_api_client.find_audit_events.return_value = {
@@ -38,7 +39,7 @@ class TestFrameworksDashboard(BaseApplicationTest):
                 object_id=1234,
                 data={"frameworkSlug": "g-cloud-7"})
 
-    def test_interest_in_framework_only_registered_once(self, data_api_client):
+    def test_interest_in_framework_only_registered_once(self, data_api_client, s3):
         with self.app.test_client():
             self.login()
             data_api_client.find_audit_events.return_value = {
@@ -50,7 +51,7 @@ class TestFrameworksDashboard(BaseApplicationTest):
             assert_equal(res.status_code, 200)
             assert not data_api_client.create_audit_event.called
 
-    def test_declaration_status_when_complete(self, data_api_client):
+    def test_declaration_status_when_complete(self, data_api_client, s3):
         with self.app.test_client():
             self.login()
 
@@ -66,7 +67,7 @@ class TestFrameworksDashboard(BaseApplicationTest):
                 len(doc.xpath(u'//p/strong[contains(text(), "You’ve made the supplier declaration")]')),
                 1)
 
-    def test_declaration_status_when_started(self, data_api_client):
+    def test_declaration_status_when_started(self, data_api_client, s3):
         with self.app.test_client():
             self.login()
 
@@ -90,7 +91,7 @@ class TestFrameworksDashboard(BaseApplicationTest):
                 len(doc.xpath('//p[contains(text(), "You need to finish making the supplier declaration")]')),  # noqa
                 1)
 
-    def test_declaration_status_when_not_complete(self, data_api_client):
+    def test_declaration_status_when_not_complete(self, data_api_client, s3):
         with self.app.test_client():
             self.login()
 

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -652,7 +652,6 @@ class TestEditDraftService(BaseApplicationTest):
         assert_equal(len(document.cssselect('p.file-upload-existing-value')), 0)
 
     def test_file_upload(self, data_api_client, s3):
-        s3.return_value = mock.Mock()
         data_api_client.get_draft_service.return_value = self.empty_draft
         with freeze_time('2015-01-02 03:04:05'):
             res = self.client.post(
@@ -993,7 +992,6 @@ class TestSubmissionDocuments(BaseApplicationTest):
             self.login()
 
     def test_document_url(self, s3):
-        s3.return_value = mock.Mock()
         s3.return_value.get_signed_url.return_value = 'http://example.com/document.pdf'
 
         res = self.client.get(
@@ -1004,7 +1002,6 @@ class TestSubmissionDocuments(BaseApplicationTest):
         assert_equal(res.headers['Location'], 'http://localhost/document.pdf')
 
     def test_missing_document_url(self, s3):
-        s3.return_value = mock.Mock()
         s3.return_value.get_signed_url.return_value = None
 
         res = self.client.get(
@@ -1014,8 +1011,6 @@ class TestSubmissionDocuments(BaseApplicationTest):
         assert_equal(res.status_code, 404)
 
     def test_document_url_not_matching_user_supplier(self, s3):
-        s3.return_value = mock.Mock()
-
         res = self.client.get(
             '/suppliers/submission/documents/g-cloud-7/999/document.pdf'
         )


### PR DESCRIPTION
This pull request adds a bit of contextual information to the G-Cloud 7 dashboard about when the supplier pack and the files on the updates page were last modified.

Spent a long time talking about date formats, but ultimately Cath said we wanted the year to be included, so I've gone with the [`DISPLAY_DATE_FORMAT`](https://github.com/alphagov/digitalmarketplace-utils/blob/master/dmutils/formats.py#L8) (ie, `Friday 28 August 2015`).

[>> Story on Pivotal](https://www.pivotaltracker.com/story/show/101483360)

***

### Before 
![screen shot 2015-08-28 at 11 47 50](https://cloud.githubusercontent.com/assets/2454380/9544877/253cb11e-4d7c-11e5-91a2-7e620ea87bf1.png)

### Now
![screen shot 2015-08-28 at 11 48 13](https://cloud.githubusercontent.com/assets/2454380/9544880/2a249b60-4d7c-11e5-8c5b-76eb0f13f797.png)