### PR TITLE
Bump utils to 6.7.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ Flask-Script==2.0.5
 Flask-WTF==0.11
 
 git+https://github.com/madzak/python-json-logger.git@v0.1.3#egg=python-json-logger==v0.1.3
-git+https://github.com/alphagov/digitalmarketplace-utils.git@6.7.0#egg=digitalmarketplace-utils==6.7.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@6.7.1#egg=digitalmarketplace-utils==6.7.1
 markdown==2.6.2
 
 requests==2.5.1


### PR DESCRIPTION
Brings in the fix for a unicode error from the
process that generates a fingerprint for the
static asset files:

https://github.com/alphagov/digitalmarketplace-utils/pull/155