### PR TITLE
Change password reset message.

### DIFF
--- a/app/templates/auth/request-password-reset.html
+++ b/app/templates/auth/request-password-reset.html
@@ -14,7 +14,7 @@
             {% endif %}
                     <p class="banner-message">
                         {% if message == 'email_sent' %}
-                        If the email address you've entered belongs to a supplier account
+                        If the email address you've entered belongs to a supplier account,
                         we'll send a link to reset the password.
 
                         {% elif message == 'token_expired' %}

--- a/app/templates/auth/request-password-reset.html
+++ b/app/templates/auth/request-password-reset.html
@@ -14,8 +14,8 @@
             {% endif %}
                     <p class="banner-message">
                         {% if message == 'email_sent' %}
-                        If the email address you've entered is valid we'll send you a link
-                        to reset your password.
+                        If the email address you've entered belongs to a supplier account
+                        we'll send a link to reset the password.
 
                         {% elif message == 'token_expired' %}
                         This password reset link has expired because you requested it more than


### PR DESCRIPTION
Previous password reset message lied to users.
Emails have to be associated with supplier accounts -- validity is necessary but not sufficient.