### PR TITLE
[#101379472] Highlight assurance questions for missing assurance answers

### DIFF
--- a/app/assets/scss/_assurance-question.scss
+++ b/app/assets/scss/_assurance-question.scss
@@ -10,3 +10,18 @@
   }
 
 }
+
+.assurance-question {
+
+  .validation-wrapper {
+    
+    margin-bottom: $gutter * 1.5;
+      
+    .question {
+      margin-top: 0;
+      margin-bottom: 0;
+    }
+    
+  }
+  
+}

--- a/app/main/helpers/services.py
+++ b/app/main/helpers/services.py
@@ -121,22 +121,27 @@ def upload_draft_documents(service, request_files, section):
 
 def get_section_error_messages(service_content, errors, lot):
     errors_map = {}
-    for error, message_key in errors.items():
-        if error == '_form':
+    for error_field, message_key in errors.items():
+        question_key = error_field
+        if error_field == '_form':
             abort(400, "Submitted data was not in a valid format")
-        else:
-            if error == 'serviceTypes':
-                error = 'serviceTypes{}'.format(lot)
-            elif error in PRICE_FIELDS:
-                message_key = _rewrite_pricing_error_key(error, message_key)
-                error = 'priceString'
-            validation_message = get_error_message(error, message_key, service_content)
-            question_id = service_content.get_question(error)['id']
-            errors_map[question_id] = {
-                'input_name': error,
-                'question': service_content.get_question(error)['question'],
-                'message': validation_message
-            }
+        elif error_field == 'serviceTypes':
+            error_field = 'serviceTypes{}'.format(lot)
+            question_key = error_field
+        elif error_field in PRICE_FIELDS:
+            message_key = _rewrite_pricing_error_key(error_field, message_key)
+            error_field = 'priceString'
+            question_key = error_field
+        elif message_key == 'assurance_required':
+            question_key = error_field + '--assurance'
+
+        validation_message = get_error_message(error_field, message_key, service_content)
+
+        errors_map[question_key] = {
+            'input_name': question_key,
+            'question': service_content.get_question(error_field)['question'],
+            'message': validation_message
+        }
     return errors_map
 
 

--- a/app/templates/services/_base_edit_section_page.html
+++ b/app/templates/services/_base_edit_section_page.html
@@ -39,7 +39,7 @@
             name=question.id,
             service_data=service_data,
             type=question.assuranceApproach,
-            errors={}
+            errors=errors if errors else {}
           ) }}
         </div>
       {% endif %}


### PR DESCRIPTION
See: https://www.pivotaltracker.com/story/show/101379472

Previously the main question was highlighted rather than the assurance part of the question.
This will make it clearer which part of the question is missing an answer.