### PR TITLE
Add missing pageview tracking to analytics

### DIFF
--- a/app/assets/javascripts/_analytics.js
+++ b/app/assets/javascripts/_analytics.js
@@ -1,4 +1,5 @@
 //= include analytics/_register.js
+//= include analytics/_pageViews.js
 //= include analytics/_events.js
 //= include analytics/_virtualPageViews.js
 //= include analytics/_init.js

--- a/app/assets/javascripts/analytics/_init.js
+++ b/app/assets/javascripts/analytics/_init.js
@@ -3,6 +3,7 @@
 
   root.GOVUK.GDM.analytics.init = function () {
     this.register();
+    this.pageViews.init();
     this.virtualPageViews.init();
     this.events.init();
   };

--- a/app/assets/javascripts/analytics/_pageviews.js
+++ b/app/assets/javascripts/analytics/_pageviews.js
@@ -1,0 +1,7 @@
+(function (GOVUK) {
+  GOVUK.GDM.analytics.pageViews = {
+    'init': function () {
+      GOVUK.analytics.trackPageview();
+    }
+  };
+})(window.GOVUK);

--- a/spec/javascripts/manifest.js
+++ b/spec/javascripts/manifest.js
@@ -5,6 +5,7 @@ var manifest = {
     '../../../node_modules/govuk_frontend_toolkit/javascripts/govuk/analytics/google-analytics-universal-tracker.js',
     '../../../node_modules/govuk_frontend_toolkit/javascripts/govuk/analytics/analytics.js',
     '../../../app/assets/javascripts/analytics/_register.js',
+    '../../../app/assets/javascripts/analytics/_pageViews.js',
     '../../../app/assets/javascripts/analytics/_events.js',
     '../../../app/assets/javascripts/analytics/_virtualPageViews.js',
     '../../../app/assets/javascripts/analytics/_init.js'

--- a/spec/javascripts/unit/AnalyticsSpec.js
+++ b/spec/javascripts/unit/AnalyticsSpec.js
@@ -6,6 +6,23 @@ describe("GOVUK.Analytics", function () {
     spyOn(window, 'ga');
   });
 
+  describe('when initialised', function () {
+
+    it('should initialise pageviews, events and virtual pageviews', function () {
+      spyOn(window.GOVUK.GDM.analytics, 'register');
+      spyOn(window.GOVUK.GDM.analytics.pageViews, 'init');
+      spyOn(window.GOVUK.GDM.analytics.virtualPageViews, 'init');
+      spyOn(window.GOVUK.GDM.analytics.events, 'init');
+
+      window.GOVUK.GDM.analytics.init();
+
+      expect(window.GOVUK.GDM.analytics.register).toHaveBeenCalled();
+      expect(window.GOVUK.GDM.analytics.pageViews.init).toHaveBeenCalled();
+      expect(window.GOVUK.GDM.analytics.virtualPageViews.init).toHaveBeenCalled();
+      expect(window.GOVUK.GDM.analytics.events.init).toHaveBeenCalled();
+    });
+  });
+
   describe('when registered', function() {
     var universalSetupArguments;
 
@@ -19,6 +36,20 @@ describe("GOVUK.Analytics", function () {
       expect(universalSetupArguments[0]).toEqual(['create', trackerId, {
         'cookieDomain': document.domain
       }]);
+    });
+  });
+
+  describe('pageViews', function () {
+    beforeEach(function () {
+      window.ga.calls.reset();
+    });
+
+    it('should register a pageview when initialised', function () {
+      spyOn(window.GOVUK.GDM.analytics.pageViews, 'init').and.callThrough();
+
+      window.GOVUK.GDM.analytics.pageViews.init();
+
+      expect(window.ga.calls.argsFor(0)).toEqual(['send', 'pageview']);
     });
   });
 


### PR DESCRIPTION
This was missed out when the new functionality was added.

To run the tests, open `spec/javascripts/support/LocalTestRunner.html` in a browser.