### PR TITLE
Add link to supplier A–Z

### DIFF
--- a/app/templates/_footer_categories.html
+++ b/app/templates/_footer_categories.html
@@ -29,6 +29,9 @@
       <li>
         <a href="https://www.gov.uk/government/organisations/crown-commercial-service" rel="external">Crown Commercial Service</a>
       </li>
+      <li>
+        <a class="home" href="/g-cloud/suppliers">G-Cloud supplier A-Z</a>
+      </li>
     </ul>
   </div>
   <div class="footer-suppliers">


### PR DESCRIPTION
Since this ([soon won't be](https://github.com/alphagov/digitalmarketplace-buyer-frontend/pull/150)) behind a feature flag we can reliably assume, in this app, that it exists and therefore link to it.