### PR TITLE
Monitoring fixes

### DIFF
--- a/.ebextensions/cwl-logs-application.config
+++ b/.ebextensions/cwl-logs-application.config
@@ -82,7 +82,7 @@ Resources:
         "Fn::Join":
           - ""
           -
-            - "There have been too many failed logins on the supplier app.\n"
+            - "There have been too many failed logins on the supplier frontend.\n"
             - "Application: supplier-frontend\n"
             - "Stage and environment: "
             - {"Fn::FindInMap": ["CWLogs", "ApplicationLogs", "LogGroupName"]}


### PR DESCRIPTION
## Rename supplier app to be inline with other alarms

Other alarms use 'supplier frontend' rather than 'supplier app'. This change makes it easier to determining the application that has raised the alarm.

## Raise the failed logins threshold
This alarm is firing continuously on preview and regularly on staging and production. The intention of the alarm is to warn us of a possible attack, 10 requests in a minute is not indicative of that.