### PR TITLE
Add JSON application logs and `login.success`

### DIFF
--- a/.ebextensions/cwl-logs-application.config
+++ b/.ebextensions/cwl-logs-application.config
@@ -4,8 +4,10 @@ Mappings:
     ApplicationLogs:
       LogDirectory: "/var/log/digitalmarketplace"
       LogFile: "/var/log/digitalmarketplace/application.log"
+      JSONLogFile: "/var/log/digitalmarketplace/application.log.json"
       TimestampFormat: "%Y-%m-%dT%H:%M:%S"
       LogGroupName: {"Fn::GetOptionSetting": {"OptionName": "LogGroupName"}}
+      JSONLogGroupName: {"Fn::GetOptionSetting": {"OptionName": "JSONLogGroupName"}}
       ApplicationName: {"Fn::GetOptionSetting": {"OptionName": "ApplicationName"}}
     FilterPatterns:
       LoginFailure: "[asctime, app_name=supplier-frontend, name, level, request_id, message = *login.fail*, ...]"
@@ -26,6 +28,12 @@ Resources:
                 log_stream_name = `{"Fn::Join": ["-", ["application", {"Fn::FindInMap":["CWLogs", "ApplicationLogs", "ApplicationName"]}]]}`
                 datetime_format = `{"Fn::FindInMap":["CWLogs", "ApplicationLogs", "TimestampFormat"]}`
                 multi_line_start_pattern = {datetime_format}
+
+                [application-logs-json]
+                file = `{"Fn::FindInMap":["CWLogs", "ApplicationLogs", "JSONLogFile"]}`
+                log_group_name = `{"Fn::FindInMap":["CWLogs", "ApplicationLogs", "JSONLogGroupName"]}`
+                log_stream_name = `{"Fn::Join": ["-", ["application", {"Fn::FindInMap":["CWLogs", "ApplicationLogs", "ApplicationName"]}]]}`
+                datetime_format = `{"Fn::FindInMap":["CWLogs", "ApplicationLogs", "TimestampFormat"]}`
 
                 [application-logs-combined]
                 file = `{"Fn::FindInMap":["CWLogs", "ApplicationLogs", "LogFile"]}`
@@ -109,7 +117,7 @@ container_commands:
     command: "mkdir -p /var/log/digitalmarketplace/"
   # if we don't create the file ourselves it gets owned by root
   02-create-file:
-    command: "touch /var/log/digitalmarketplace/application.log"
+    command: "touch /var/log/digitalmarketplace/application.log /var/log/digitalmarketplace/application.log.json"
   03-change-permissions:
     command: "chmod -R 777 /var/log/digitalmarketplace/"
   04-change-ownership:

--- a/app/main/views/login.py
+++ b/app/main/views/login.py
@@ -54,6 +54,7 @@ def process_login():
 
         user = User.from_json(user_json)
         login_user(user)
+        current_app.logger.info("login.success")
         if next_url and next_url.startswith('/suppliers'):
             return redirect(next_url)
 


### PR DESCRIPTION
## Add JSON application logs to CloudWatch
See: https://github.com/alphagov/digitalmarketplace-utils/pull/151

## Add login.success log message
This allows us to calculate a rate metric for login failures as apposed to the absolute number we currently have.