### PR TITLE
Add fields to apache access log

### DIFF
--- a/.ebextensions/apache_log.config
+++ b/.ebextensions/apache_log.config
@@ -7,5 +7,5 @@ files:
       LogFormat "apache-access supplier-frontend \"%{DM-Request-ID}o\" %h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" cloudwatchlogs
       CustomLog logs/cwl_access_log cloudwatchlogs
 
-      LogFormat "{ \"application\": \"supplier-frontend\", \"logType\": \"apache-access\", \"requestId\": \"%{DM-Request-ID}o\", \"remoteHost\": \"%h\", \"remoteLogname\": \"%l\", \"user\": \"%u\", \"time\": \"%t\", \"request\": \"%r\", \"status\": %>s, \"size\": %b, \"referer\": \"%{Referer}i\", \"userAgent\": \"%{User-Agent}i\"}" cloudwatchjsonlogs
+      LogFormat "{ \"application\": \"supplier-frontend\", \"logType\": \"apache-access\", \"requestId\": \"%{DM-Request-ID}o\", \"remoteHost\": \"%h\", \"remoteLogname\": \"%l\", \"user\": \"%u\", \"time\": \"%t\", \"request\": \"%r\", \"status\": %>s, \"size\": %b, \"referer\": \"%{Referer}i\", \"userAgent\": \"%{User-Agent}i\", \"requestTimeMicro\": %D, \"requestPath\": \"%U\"}" cloudwatchjsonlogs
       CustomLog logs/cwl_access_log.json cloudwatchjsonlogs


### PR DESCRIPTION
Add `requestTimeMicro` (the time a request took in microseconds) and `requestPath` (the request path without the query string) to the apache access logs.

`requestPath` is useful for metric filters against a specific page.

`requestTimeMicro` is justified here https://github.com/alphagov/digitalmarketplace-api/commit/9ec62be7f51997e7876e056bbb0236fc6fee5f7e

I have only added these to the JSON logs as they are the format we are moving towards and making changes to the plain text logs requires a bit more thought.

https://httpd.apache.org/docs/2.2/mod/mod_log_config.html#formats