### PR TITLE
[#102562916] Assertions repopulated on edit pages

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "jquery": "1.11.2",
     "hogan": "3.0.2",
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
-    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v9.1.1",
+    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v9.1.2",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.14.1/jinja_govuk_template-0.14.1.tgz",
     "digital-marketplace-ssp-content": "git://github.com/alphagov/digitalmarketplace-ssp-content#92818a67caf476da2e8ff1cd53ead632c162e1dd"
   }

--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "jquery": "1.11.2",
     "hogan": "3.0.2",
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
-    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v9.1.2",
+    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v9.1.3",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.14.1/jinja_govuk_template-0.14.1.tgz",
     "digital-marketplace-ssp-content": "git://github.com/alphagov/digitalmarketplace-ssp-content#92818a67caf476da2e8ff1cd53ead632c162e1dd"
   }

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ Flask-Script==2.0.5
 Flask-WTF==0.12
 
 git+https://github.com/madzak/python-json-logger.git@v0.1.3#egg=python-json-logger==v0.1.3
-git+https://github.com/alphagov/digitalmarketplace-utils.git@6.7.1#egg=digitalmarketplace-utils==6.7.1
+git+https://github.com/alphagov/digitalmarketplace-utils.git@6.8.1#egg=digitalmarketplace-utils==6.8.1
 markdown==2.6.2
 
 # Required for SNI to work in requests


### PR DESCRIPTION
See https://www.pivotaltracker.com/story/show/102562916

This brings in the changes necessary to repopulate assertion answers with their values - both on validation error and when editing previously completed pages.

Depends on:
- [x] https://github.com/alphagov/digitalmarketplace-api/pull/238
- [x] https://github.com/alphagov/digitalmarketplace-frontend-toolkit/pull/151
- [x]  https://github.com/alphagov/digitalmarketplace-utils/pull/158
