### PR TITLE
Allow the JavaScript tests to run in CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,10 +77,17 @@ Note: `npm run frontend-install` is run automatically as a post-install task whe
 
 ### Run the tests
 
+To run the Python tests:
+
 ```
 ./scripts/run_tests.sh
 ```
 
+To run the JavaScript tests:
+
+```
+npm test
+```
 
 ### Run the server
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -5,6 +5,7 @@ var sass = require('gulp-sass');
 var filelog = require('gulp-filelog');
 var include = require('gulp-include');
 var colours = require('colors/safe');
+var jasmine = require('gulp-jasmine-phantom');
 
 // Paths
 var environment;
@@ -237,6 +238,25 @@ gulp.task(
     sspContentRoot, 'app/content'
   )
 );
+
+gulp.task('test', function () {
+  var manifest = require(repoRoot + 'spec/javascripts/manifest.js').manifest;
+
+  manifest.support = manifest.support.map(function (val) {
+    return val.replace(/^(\.\.\/){3}/, '');
+  });
+  manifest.test = manifest.test.map(function (val) {
+    return val.replace(/^\.\.\//, 'spec/javascripts/');
+  });
+
+  return gulp.src(manifest.test)
+    .pipe(jasmine({
+      'jasmine': '2.0',
+      'integration': true,
+      'abortOnFail': true,
+      'vendor': manifest.support
+    }));
+});
 
 gulp.task('watch', ['build:development'], function () {
   var jsWatcher = gulp.watch([ assetsFolder + '/**/*.js' ], ['js']);

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "gulp-sass": "1.3.3",
     "gulp-shell": "0.2.9",
     "gulp-uglifyjs": "0.6.0",
-    "gulp-jasmine-phantom": "2.0.1",
+    "gulp-jasmine-phantom": "git://github.com/alphagov/gulp-jasmine-phantom#87dccbefcac66ef5670ed714de4d4600139a5ff5",
     "colors": "1.1.2"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "gulp-sass": "1.3.3",
     "gulp-shell": "0.2.9",
     "gulp-uglifyjs": "0.6.0",
-    "gulp-jasmine-phantom": "git://github.com/alphagov/gulp-jasmine-phantom#87dccbefcac66ef5670ed714de4d4600139a5ff5",
+    "gulp-jasmine-phantom": "git://github.com/alphagov/gulp-jasmine-phantom#8debcde0e457eff62bc5e736f20b482d896cd396",
     "colors": "1.1.2"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "frontend-build:development": "./node_modules/gulp/bin/gulp.js build:development",
     "frontend-build:production": "./node_modules/gulp/bin/gulp.js build:production",
     "frontend-build:watch": "./node_modules/gulp/bin/gulp.js watch",
+    "test": "./node_modules/gulp/bin/gulp.js test",
     "postinstall": "npm run frontend-install && npm run frontend-build:production"
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "gulp-sass": "1.3.3",
     "gulp-shell": "0.2.9",
     "gulp-uglifyjs": "0.6.0",
+    "gulp-jasmine-phantom": "2.0.1",
     "colors": "1.1.2"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "gulp-sass": "1.3.3",
     "gulp-shell": "0.2.9",
     "gulp-uglifyjs": "0.6.0",
-    "gulp-jasmine-phantom": "git://github.com/alphagov/gulp-jasmine-phantom#8debcde0e457eff62bc5e736f20b482d896cd396",
+    "gulp-jasmine-phantom": "git://github.com/alphagov/gulp-jasmine-phantom#203c1cb2c4e951ff6aac7f3022d0f61111c8d9f4",
     "colors": "1.1.2"
   },
   "scripts": {

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -34,3 +34,5 @@ display_result $? 1 "Build of front end static assets"
 
 nosetests -v -s --with-doctest
 display_result $? 3 "Unit tests"
+
+npm test

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -33,6 +33,7 @@ npm run --silent frontend-build:production
 display_result $? 1 "Build of front end static assets"
 
 nosetests -v -s --with-doctest
-display_result $? 3 "Unit tests"
+display_result $? 3 "Python Unit tests"
 
 npm test
+display_result $? 3 "JavaScript Unit tests"

--- a/spec/javascripts/manifest.js
+++ b/spec/javascripts/manifest.js
@@ -14,3 +14,7 @@ var manifest = {
     '../unit/AnalyticsSpec.js'
   ]
 };
+
+if (typeof exports !== 'undefined') {
+  exports.manifest = manifest;
+}


### PR DESCRIPTION
You can currently only run the JavaScript tests by loading the test runner in a browser.

This adds a Gulp task which uses PhantomJS to run the tests so it can be done from a command as well.

Travis apparently has PhantomJS as part of its environment: http://docs.travis-ci.com/user/ci-environment/#Headless-Browser-Testing-Tools

### Notes

There were a few problems getting the plugin to work with Travis, the details of which (and the reason we're pointing to a Github repo in the `package.json`) is explained here:

http://stackoverflow.com/questions/32461456/travis-ci-can-the-version-of-node-installed-on-all-vm-images-match-the-latest

and here:

https://github.com/alphagov/gulp-jasmine-phantom/pull/1