### PR TITLE
[#102167826] Fix invitation link behaviour

### DIFF
--- a/app/main/views/login.py
+++ b/app/main/views/login.py
@@ -195,7 +195,14 @@ def create_user(encoded_token):
 
     if token is None:
         current_app.logger.warning("createuser.token_invalid: %s", encoded_token)
-        _token_error("auth/create-user.html", form=form, template_data=template_data)
+        flash('token_invalid', 'error')
+        return render_template(
+            "auth/create-user.html",
+            form=form,
+            token=None,
+            email_address=None,
+            supplier_name=None,
+            **template_data), 400
 
     else:
         user_json = data_api_client.get_user(email_address=token.get("email_address"))
@@ -255,7 +262,13 @@ def submit_update_user(encoded_token):
     token = decode_invitation_token(encoded_token)
     if token is None:
         current_app.logger.warning("createuser.token_invalid: %s", encoded_token)
-        _token_error("auth/update-user.html", template_data=template_data)
+        flash('token_invalid', 'error')
+        return render_template(
+            "auth/update-user.html",
+            token=None,
+            email_address=None,
+            supplier_name=None,
+            **template_data), 400
 
     else:
         user_json = data_api_client.get_user(email_address=token.get("email_address"))
@@ -285,7 +298,14 @@ def submit_create_user(encoded_token):
     token = decode_invitation_token(encoded_token)
     if token is None:
         current_app.logger.warning("createuser.token_invalid: %s", encoded_token)
-        _token_error("auth/create-user.html", form=form, template_data=template_data)
+        flash('token_invalid', 'error')
+        return render_template(
+            "auth/create-user.html",
+            form=form,
+            token=None,
+            email_address=None,
+            supplier_name=None,
+            **template_data), 400
 
     else:
         if not form.validate_on_submit():
@@ -448,14 +468,3 @@ def decode_invitation_token(encoded_token):
 
 def token_created_before_password_last_changed(token_timestamp, user_timestamp):
     return token_timestamp < user_timestamp
-
-
-def _token_error(template_name=None, form=None, template_data=None):
-    flash('token_invalid', 'error')
-    return render_template(
-        template_name,
-        form=form,
-        token=None,
-        email_address=None,
-        supplier_name=None,
-        **template_data), 400

--- a/app/main/views/login.py
+++ b/app/main/views/login.py
@@ -219,22 +219,20 @@ def create_user(encoded_token):
                 **template_data), 200
 
         user = User.from_json(user_json)
-        is_buyer = user.role == 'buyer'
 
         # locked or inactive
         is_inactive_or_locked = 'inactive' if not user.active else 'locked' if user.is_locked() else False
 
         # supplier account exists (wrong supplier)
         is_registered_to_another_supplier = False
-        if not is_buyer and token.get("supplier_name") != user.supplier_name:
+        if user.role == 'supplier' and token.get("supplier_name") != user.supplier_name:
             is_registered_to_another_supplier = {
                 'supplier_who_sent_the_invitation': token.get("supplier_name"),
                 'supplier_registered_with_account': user.supplier_name,
             }
 
         # valid supplier account exists
-        if not is_buyer and not is_registered_to_another_supplier and not is_inactive_or_locked:
-
+        if user.role == 'supplier' and not is_registered_to_another_supplier and not is_inactive_or_locked:
             # valid supplier account exists and is logged in
             if not current_user.is_anonymous() and current_user.email_address == user.email_address:
                 return redirect(url_for('.dashboard'))

--- a/app/main/views/login.py
+++ b/app/main/views/login.py
@@ -209,7 +209,7 @@ def create_user(encoded_token):
 
         if not user_json:
 
-            # i. account does not exist -> create account
+            # account does not exist
             return render_template(
                 "auth/create-user.html",
                 form=form,
@@ -218,14 +218,13 @@ def create_user(encoded_token):
                 token=encoded_token,
                 **template_data), 200
 
-        # at this point, we know the user account exists
         user = User.from_json(user_json)
-
-        # ii. buyer account exists -> create account
-        # iii. supplier account exists -> message + login
         is_buyer = user.role == 'buyer'
 
-        # iv. supplier account exists (wrong supplier) -> message + login
+        # locked or inactive
+        is_inactive_or_locked = 'inactive' if not user.active else 'locked' if user.is_locked() else False
+
+        # supplier account exists (wrong supplier)
         is_registered_to_another_supplier = False
         if not is_buyer and token.get("supplier_name") != user.supplier_name:
             is_registered_to_another_supplier = {
@@ -233,14 +232,14 @@ def create_user(encoded_token):
                 'supplier_registered_with_account': user.supplier_name,
             }
 
-        # v. supplier account exists (and is logged in) -> supplier dashboard
-        if not current_user.is_anonymous() and current_user.email_address == user.email_address \
-                and not is_registered_to_another_supplier:
+        # valid supplier account exists
+        if not is_buyer and not is_registered_to_another_supplier and not is_inactive_or_locked:
 
-            return redirect(url_for('.dashboard'))
+            # valid supplier account exists and is logged in
+            if not current_user.is_anonymous() and current_user.email_address == user.email_address:
+                return redirect(url_for('.dashboard'))
 
-        # vi. locked or inactive -> message
-        is_locked_or_inactive = user.is_locked() or not user.is_active()
+            return redirect(url_for('.render_login'))
 
         return render_template(
             "auth/update-user.html",
@@ -249,9 +248,8 @@ def create_user(encoded_token):
             email_address=token['email_address'],
             supplier_name=token['supplier_name'],
             token=encoded_token,
-            is_locked_or_inactive=is_locked_or_inactive,
+            is_inactive_or_locked=is_inactive_or_locked,
             is_registered_to_another_supplier=is_registered_to_another_supplier,
-            is_buyer=is_buyer,
             **template_data), 200
 
 

--- a/app/templates/auth/login.html
+++ b/app/templates/auth/login.html
@@ -14,7 +14,7 @@
     {% endif %}
             {% if message == 'no_account' %}
               <p class="banner-message">
-                There was a problem with the account details you provided.
+                Make sure you've entered the right email address and password.
                 Accounts are locked after 5 failed attempts. If you think your
                 account has been locked, email
                 <a href="mailto:enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.service.gov.uk</a>.

--- a/app/templates/auth/login.html
+++ b/app/templates/auth/login.html
@@ -14,9 +14,9 @@
     {% endif %}
             {% if message == 'no_account' %}
               <p class="banner-message">
-                Sorry, we couldn't log you in with that username and password.
-                Accounts are locked after five failed attempts. If you think your
-                account has been locked, please contact
+                There was a problem with the account details you provided.
+                Accounts are locked after 5 failed attempts. If you think your
+                account has been locked, email
                 <a href="mailto:enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.service.gov.uk</a>.
               </p>
             {% elif message == 'password_updated' %}

--- a/app/templates/auth/update-user.html
+++ b/app/templates/auth/update-user.html
@@ -14,6 +14,14 @@
     Check you’ve entered the correct link or ask the person who invited you to send a new invitation.<br/>
     If you still can’t create a contributor account, email <a href="mailto:enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.service.gov.uk</a>.
 </p>
+{% elif user.role == 'admin' %}
+
+<header class="page-heading-smaller">
+  <h1>You have an administrator account.</h1>
+</header>
+<p>
+  Your account cannot be converted to a supplier account.
+</p>
 
 {% elif is_inactive_or_locked == 'inactive' %}
 

--- a/app/templates/auth/update-user.html
+++ b/app/templates/auth/update-user.html
@@ -15,34 +15,35 @@
     If you still can’t create a contributor account, email <a href="mailto:enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.service.gov.uk</a>.
 </p>
 
-{% elif is_locked_or_inactive %}
+{% elif is_inactive_or_locked == 'inactive' %}
 
 <header class="page-heading-smaller">
-  <h1>The account associated with this email address is inactive or locked.</h1>
+  <h1>Your account has been deactivated.</h1>
 </header>
 <p>
-    Please email <a href="mailto:enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.service.gov.uk</a> for help with setting up a new contributor account.
+    Email <a href="mailto:enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.service.gov.uk</a> to reactivate your account.
+</p>
+
+{% elif is_inactive_or_locked == 'locked' %}
+
+<header class="page-heading-smaller">
+  <h1>Your account has been locked.</h1>
+</header>
+<p>
+    Email <a href="mailto:enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.service.gov.uk</a> to unlock your account.
 </p>
 
 {% elif is_registered_to_another_supplier %}
 
 <header class="page-heading-smaller">
-  <h1>The account is already exists, but it is registered with a different supplier than the one who invited you.</h1>
+  <h1>The details you provided are registered with another supplier.</h1>
 </header>
-<p>You were invited by "{{ is_registered_to_another_supplier.supplier_who_sent_the_invitation }}"</p>
-<p>Your account is registered with "{{ is_registered_to_another_supplier.supplier_registered_with_account }}"</p>
+<p>You were invited by ‘{{ is_registered_to_another_supplier.supplier_who_sent_the_invitation }}‘</p>
+<p>Your account is registered with ‘{{ is_registered_to_another_supplier.supplier_registered_with_account }}’</p>
 <br>
 <p>
-    Login <a href="{{ url_for('.render_login') }}">here</a>, or, if this is not what you expected, email <a href="mailto:enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.service.gov.uk</a> for help with switching over your account.
-</p>
-
-{% elif not is_buyer %}
-
-<header class="page-heading-smaller">
-  <h1>This account already exists.</h1>
-</header>
-<p>
-    Login <a href="{{ url_for('.render_login') }}">here</a>.
+  <a href="{{ url_for('.render_login') }}">Log in</a> to your account with {{ is_registered_to_another_supplier.supplier_registered_with_account }} or email
+  <a href="mailto:enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.service.gov.uk</a> to change the organisation your account is registered with.
 </p>
 
 {% else %}

--- a/app/templates/auth/update-user.html
+++ b/app/templates/auth/update-user.html
@@ -42,8 +42,8 @@
 <p>Your account is registered with ‘{{ is_registered_to_another_supplier.supplier_registered_with_account }}’</p>
 <br>
 <p>
-  <a href="{{ url_for('.render_login') }}">Log in</a> to your account with {{ is_registered_to_another_supplier.supplier_registered_with_account }} or email
-  <a href="mailto:enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.service.gov.uk</a> to change the organisation your account is registered with.
+  <a href="{{ url_for('.render_login') }}">Log in</a> to your {{ is_registered_to_another_supplier.supplier_registered_with_account }} account or email
+  <a href="mailto:enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.service.gov.uk</a> to register your account with a different organisation.
 </p>
 
 {% else %}

--- a/app/templates/auth/update-user.html
+++ b/app/templates/auth/update-user.html
@@ -38,7 +38,7 @@
 <header class="page-heading-smaller">
   <h1>The details you provided are registered with another supplier.</h1>
 </header>
-<p>You were invited by ‘{{ is_registered_to_another_supplier.supplier_who_sent_the_invitation }}‘</p>
+<p>You were invited by ‘{{ is_registered_to_another_supplier.supplier_who_sent_the_invitation }}’</p>
 <p>Your account is registered with ‘{{ is_registered_to_another_supplier.supplier_registered_with_account }}’</p>
 <br>
 <p>

--- a/app/templates/auth/update-user.html
+++ b/app/templates/auth/update-user.html
@@ -15,13 +15,34 @@
     If you still can’t create a contributor account, email <a href="mailto:enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.service.gov.uk</a>.
 </p>
 
-{% elif invalid_user %}
+{% elif is_locked_or_inactive %}
 
 <header class="page-heading-smaller">
-  <h1>The account associated with this email address is inactive, locked, or already registered with a different supplier.</h1>
+  <h1>The account associated with this email address is inactive or locked.</h1>
 </header>
 <p>
     Please email <a href="mailto:enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.service.gov.uk</a> for help with setting up a new contributor account.
+</p>
+
+{% elif is_registered_to_another_supplier %}
+
+<header class="page-heading-smaller">
+  <h1>The account is already exists, but it is registered with a different supplier than the one who invited you.</h1>
+</header>
+<p>You were invited by "{{ is_registered_to_another_supplier.supplier_who_sent_the_invitation }}"</p>
+<p>Your account is registered with "{{ is_registered_to_another_supplier.supplier_registered_with_account }}"</p>
+<br>
+<p>
+    Login <a href="{{ url_for('.render_login') }}">here</a>, or, if this is not what you expected, email <a href="mailto:enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.service.gov.uk</a> for help with switching over your account.
+</p>
+
+{% elif not is_buyer %}
+
+<header class="page-heading-smaller">
+  <h1>This account already exists.</h1>
+</header>
+<p>
+    Login <a href="{{ url_for('.render_login') }}">here</a>.
 </p>
 
 {% else %}

--- a/tests/app/helpers.py
+++ b/tests/app/helpers.py
@@ -59,7 +59,6 @@ class BaseApplicationTest(object):
             "role": role,
             "locked": locked,
             'active': active,
-            "active": active,
             'passwordChangedAt': password_changed_at
         }
 

--- a/tests/app/main/test_login.py
+++ b/tests/app/main/test_login.py
@@ -99,7 +99,7 @@ class TestLogin(BaseApplicationTest):
             'password': '1234567890'
         })
         assert_in(
-            self.strip_all_whitespace("Sorry, we couldn't log you in"),
+            self.strip_all_whitespace("There was a problem with the account details you provided"),
             self.strip_all_whitespace(res.get_data(as_text=True)))
         assert_equal(res.status_code, 403)
 
@@ -943,13 +943,12 @@ class TestInviteUser(BaseApplicationTest):
 
             assert_equal(res.status_code, 200)
             assert_in(
-                "The account associated with this email address is inactive, "
-                "locked, or already registered with a different supplier",
+                "Your account has been locked",
                 res.get_data(as_text=True)
             )
             assert_in(
-                'Please email <a href="mailto:enquiries@digitalmarketplace.service.gov.uk">'
-                'enquiries@digitalmarketplace.service.gov.uk</a> for help with setting up a new contributor account.',
+                'Email <a href="mailto:enquiries@digitalmarketplace.service.gov.uk">'
+                'enquiries@digitalmarketplace.service.gov.uk</a> to unlock your account.',
                 res.get_data(as_text=True)
             )
 
@@ -982,13 +981,12 @@ class TestInviteUser(BaseApplicationTest):
 
             assert_equal(res.status_code, 200)
             assert_in(
-                "The account associated with this email address is inactive, "
-                "locked, or already registered with a different supplier",
+                "Your account has been deactivated",
                 res.get_data(as_text=True)
             )
             assert_in(
-                'Please email <a href="mailto:enquiries@digitalmarketplace.service.gov.uk">'
-                'enquiries@digitalmarketplace.service.gov.uk</a> for help with setting up a new contributor account.',
+                'Email <a href="mailto:enquiries@digitalmarketplace.service.gov.uk">'
+                'enquiries@digitalmarketplace.service.gov.uk</a> to reactivate your account',
                 res.get_data(as_text=True)
             )
 
@@ -1019,17 +1017,8 @@ class TestInviteUser(BaseApplicationTest):
             res = self.client.get(
                 '/suppliers/create-user/{}'.format(token)
             )
-            assert_equal(res.status_code, 200)
-            assert_in(
-                "The account associated with this email address is inactive, "
-                "locked, or already registered with a different supplier",
-                res.get_data(as_text=True)
-            )
-            assert_in(
-                'Please email <a href="mailto:enquiries@digitalmarketplace.service.gov.uk">'
-                'enquiries@digitalmarketplace.service.gov.uk</a> for help with setting up a new contributor account.',
-                res.get_data(as_text=True)
-            )
+            assert_equal(res.status_code, 302)
+            assert_equal(res.location, 'http://localhost/suppliers/login')
 
     @mock.patch('app.main.views.login.data_api_client')
     def test_should_not_update_a_supplier_account(self, data_api_client):

--- a/tests/app/main/test_login.py
+++ b/tests/app/main/test_login.py
@@ -434,6 +434,22 @@ class TestLoginFormsNotAutofillable(BaseApplicationTest):
 
 class TestInviteUser(BaseApplicationTest):
 
+    def _generate_token(
+            self,
+            supplier_id=1234,
+            supplier_name='Supplier Name',
+            email_address='test@email.com',
+    ):
+        return generate_token(
+            {
+                'supplier_id': supplier_id,
+                'supplier_name': supplier_name,
+                'email_address': email_address
+            },
+            self.app.config['SHARED_EMAIL_KEY'],
+            self.app.config['INVITE_EMAIL_SALT']
+        )
+
     def test_should_be_an_error_for_invalid_email(self):
         with self.app.app_context():
             self.login()
@@ -647,37 +663,19 @@ class TestInviteUser(BaseApplicationTest):
 
             data_api_client.get_user.return_value = None
 
-            token = generate_token(
-                {
-                    'supplier_id': 1234,
-                    'supplier_name': 'Supplier Name',
-                    'email_address': 'testme@email.com'
-                },
-                self.app.config['SHARED_EMAIL_KEY'],
-                self.app.config['INVITE_EMAIL_SALT']
-            )
-
+            token = self._generate_token()
             res = self.client.get(
                 '/suppliers/create-user/{}'.format(token)
             )
 
             assert_equal(res.status_code, 200)
-            assert_true(
-                "Supplier Name"
-                in res.get_data(as_text=True)
-            )
-            assert_true(
-                "testme@email.com"
-                in res.get_data(as_text=True)
-            )
-            assert_true(
-                '<button class="button-save">Create contributor account</button>'
-                in res.get_data(as_text=True)
-            )
-            assert_true(
+            for message in [
+                "Supplier Name",
+                "test@email.com",
+                '<button class="button-save">Create contributor account</button>',
                 '<form autocomplete="off" action="/suppliers/create-user/{}" method="POST" id="createUserForm">'.format(token)  # noqa
-                in res.get_data(as_text=True)
-            )
+            ]:
+                assert_in(message, res.get_data(as_text=True))
 
     @mock.patch('app.main.views.login.data_api_client')
     def test_should_render_update_user_page_if_user_does_exist(self, data_api_client):
@@ -685,39 +683,24 @@ class TestInviteUser(BaseApplicationTest):
 
             data_api_client.get_user.return_value = self.user(
                 123,
-                'testme@email.com',
+                'test@email.com',
                 None,
                 None,
                 'Users name'
             )
 
-            token = generate_token(
-                {
-                    'supplier_id': 1234,
-                    'supplier_name': 'Supplier Name',
-                    'email_address': 'testme@email.com'
-                },
-                self.app.config['SHARED_EMAIL_KEY'],
-                self.app.config['INVITE_EMAIL_SALT']
-            )
-
+            token = self._generate_token()
             res = self.client.get(
                 '/suppliers/create-user/{}'.format(token)
             )
 
             assert_equal(res.status_code, 200)
-            assert_true(
-                "Supplier Name"
-                in res.get_data(as_text=True)
-            )
-            assert_true(
-                '<button class="button-save">Create contributor account</button>'
-                in res.get_data(as_text=True)
-            )
-            assert_true(
+            for message in [
+                "Supplier Name",
+                '<button class="button-save">Create contributor account</button>',
                 '<form autocomplete="off" action="/suppliers/update-user/{}" method="POST" id="updateUserForm">'.format(token)  # noqa
-                in res.get_data(as_text=True)
-            )
+            ]:
+                assert_in(message, res.get_data(as_text=True))
 
     def test_should_be_an_error_if_invalid_token_on_submit(self):
         with self.app.app_context():
@@ -754,42 +737,23 @@ class TestInviteUser(BaseApplicationTest):
     def test_should_be_an_error_if_missing_name_and_password(self):
         with self.app.app_context():
 
-            token = generate_token(
-                {
-                    'supplier_id': 1234,
-                    'supplier_name': 'Supplier Name',
-                    'email_address': 'testme@email.com'
-                },
-                self.app.config['SHARED_EMAIL_KEY'],
-                self.app.config['INVITE_EMAIL_SALT']
-            )
-
+            token = self._generate_token()
             res = self.client.post(
                 '/suppliers/create-user/{}'.format(token),
                 data={}
             )
 
             assert_equal(res.status_code, 400)
-            assert_true(
-                "Please enter a password" in res.get_data(as_text=True)
-            )
-            assert_true(
-                "Please enter a name" in res.get_data(as_text=True)
-            )
+            for message in [
+                "Please enter a name",
+                "Please enter a password"
+            ]:
+                assert_in(message, res.get_data(as_text=True))
 
     def test_should_be_an_error_if_too_short_name_and_password(self):
         with self.app.app_context():
 
-            token = generate_token(
-                {
-                    'supplier_id': 1234,
-                    'supplier_name': 'Supplier Name',
-                    'email_address': 'testme@email.com'
-                },
-                self.app.config['SHARED_EMAIL_KEY'],
-                self.app.config['INVITE_EMAIL_SALT']
-            )
-
+            token = self._generate_token()
             res = self.client.post(
                 '/suppliers/create-user/{}'.format(token),
                 data={
@@ -799,26 +763,16 @@ class TestInviteUser(BaseApplicationTest):
             )
 
             assert_equal(res.status_code, 400)
-            assert_true(
-                "Please enter a name" in res.get_data(as_text=True)
-            )
-            assert_true(
-                "Passwords must be between 10 and 50 characters" in res.get_data(as_text=True)
-            )
+            for message in [
+                "Please enter a name",
+                "Passwords must be between 10 and 50 characters"
+            ]:
+                assert_in(message, res.get_data(as_text=True))
 
     def test_should_be_an_error_if_too_long_name_and_password(self):
         with self.app.app_context():
 
-            token = generate_token(
-                {
-                    'supplier_id': 1234,
-                    'supplier_name': 'Supplier Name',
-                    'email_address': 'testme@email.com'
-                },
-                self.app.config['SHARED_EMAIL_KEY'],
-                self.app.config['INVITE_EMAIL_SALT']
-            )
-
+            token = self._generate_token()
             twofiftysix = "a" * 256
             fiftyone = "a" * 51
 
@@ -831,18 +785,13 @@ class TestInviteUser(BaseApplicationTest):
             )
 
             assert_equal(res.status_code, 400)
-            assert_true(
-                "Names must be between 1 and 255 characters" in res.get_data(as_text=True)
-            )
-            assert_true(
-                "Passwords must be between 10 and 50 characters" in res.get_data(as_text=True)
-            )
-            assert_true(
-                "Create contributor account for Supplier Name" in res.get_data(as_text=True)
-            )
-            assert_true(
-                "testme@email.com" in res.get_data(as_text=True)
-            )
+            for message in [
+                "Names must be between 1 and 255 characters",
+                "Passwords must be between 10 and 50 characters",
+                "Create contributor account for Supplier Name",
+                "test@email.com"
+            ]:
+                assert_in(message, res.get_data(as_text=True))
 
     @mock.patch('app.main.views.login.data_api_client')
     def test_should_render_update_user_page_with_locked_message_if_user_is_locked(self, data_api_client):
@@ -850,37 +799,24 @@ class TestInviteUser(BaseApplicationTest):
 
             data_api_client.get_user.return_value = self.user(
                 123,
-                'testme@email.com',
+                'test@email.com',
                 1234,
                 'Supplier Name',
                 'Users name',
                 locked=True
             )
 
-            token = generate_token(
-                {
-                    'supplier_id': 1234,
-                    'supplier_name': 'Supplier Name',
-                    'email_address': 'testme@email.com'
-                },
-                self.app.config['SHARED_EMAIL_KEY'],
-                self.app.config['INVITE_EMAIL_SALT']
-            )
-
+            token = self._generate_token()
             res = self.client.get(
                 '/suppliers/create-user/{}'.format(token)
             )
 
             assert_equal(res.status_code, 200)
-            assert_in(
+            for message in [
                 "Your account has been locked",
-                res.get_data(as_text=True)
-            )
-            assert_in(
-                'Email <a href="mailto:enquiries@digitalmarketplace.service.gov.uk">'
-                'enquiries@digitalmarketplace.service.gov.uk</a> to unlock your account.',
-                res.get_data(as_text=True)
-            )
+                'Email <a href="mailto:enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.service.gov.uk</a> to unlock your account'  # noqa
+            ]:
+                assert_in(message, res.get_data(as_text=True))
 
     @mock.patch('app.main.views.login.data_api_client')
     def test_should_render_update_user_page_with_inactive_message_if_user_is_not_active(self, data_api_client):
@@ -888,37 +824,24 @@ class TestInviteUser(BaseApplicationTest):
 
             data_api_client.get_user.return_value = self.user(
                 123,
-                'testme@email.com',
+                'test@email.com',
                 1234,
                 'Supplier Name',
                 'Users name',
                 active=False
             )
 
-            token = generate_token(
-                {
-                    'supplier_id': 1234,
-                    'supplier_name': 'Supplier Name',
-                    'email_address': 'testme@email.com'
-                },
-                self.app.config['SHARED_EMAIL_KEY'],
-                self.app.config['INVITE_EMAIL_SALT']
-            )
-
+            token = self._generate_token()
             res = self.client.get(
                 '/suppliers/create-user/{}'.format(token)
             )
 
             assert_equal(res.status_code, 200)
-            assert_in(
+            for message in [
                 "Your account has been deactivated",
-                res.get_data(as_text=True)
-            )
-            assert_in(
-                'Email <a href="mailto:enquiries@digitalmarketplace.service.gov.uk">'
-                'enquiries@digitalmarketplace.service.gov.uk</a> to reactivate your account',
-                res.get_data(as_text=True)
-            )
+                'Email <a href="mailto:enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.service.gov.uk</a> to reactivate your account'  # noqa
+            ]:
+                assert_in(message, res.get_data(as_text=True))
 
     @mock.patch('app.main.views.login.data_api_client')
     def test_should_render_update_user_page_with_wrong_supplier_message_if_invited_by_wrong_supplier(self, data_api_client):  # noqa
@@ -926,20 +849,16 @@ class TestInviteUser(BaseApplicationTest):
 
             data_api_client.get_user.return_value = self.user(
                 123,
-                'testme@email.com',
+                'test@email.com',
                 1234,
                 'Supplier Name',
                 'Users name'
             )
 
-            token = generate_token(
-                {
-                    'supplier_id': 9999,
-                    'supplier_name': 'Different Supplier Name',
-                    'email_address': 'different_supplier@email.com'
-                },
-                self.app.config['SHARED_EMAIL_KEY'],
-                self.app.config['INVITE_EMAIL_SALT']
+            token = self._generate_token(
+                supplier_id=9999,
+                supplier_name='Different Supplier Name',
+                email_address='different_supplier@email.com'
             )
 
             res = self.client.get(
@@ -947,14 +866,11 @@ class TestInviteUser(BaseApplicationTest):
             )
 
             assert_equal(res.status_code, 200)
-            assert_in(
+            for message in [
                 "You were invited by ‘Different Supplier Name’",
-                res.get_data(as_text=True)
-            )
-            assert_in(
-                "Your account is registered with ‘Supplier Name’",
-                res.get_data(as_text=True)
-            )
+                "Your account is registered with ‘Supplier Name’"
+            ]:
+                assert_in(message, res.get_data(as_text=True))
 
     @mock.patch('app.main.views.login.data_api_client')
     def test_should_redirect_to_login_page_if_user_is_already_a_supplier(self, data_api_client):
@@ -965,21 +881,34 @@ class TestInviteUser(BaseApplicationTest):
                 'test@email.com',
                 1234,
                 'Supplier Name',
-                'Users name',
-                active=True,
-                locked=False
+                'Users name'
             )
 
-            token = generate_token(
-                {
-                    'supplier_id': 1234,
-                    'supplier_name': 'Supplier Name',
-                    'email_address': 'test@email.com'
-                },
-                self.app.config['SHARED_EMAIL_KEY'],
-                self.app.config['INVITE_EMAIL_SALT']
+            token = self._generate_token()
+            res = self.client.get(
+                '/suppliers/create-user/{}'.format(token),
+                follow_redirects=True
+            )
+            assert_equal(res.status_code, 200)
+            assert_in(
+                "Log in to the Digital Marketplace",
+                res.get_data(as_text=True)
             )
 
+    @mock.patch('app.main.views.login.data_api_client')
+    def test_should_redirect_to_login_page_if_logged_in_user_is_not_invited_user(self, data_api_client):
+        with self.app.app_context():
+
+            self.login()
+            data_api_client.get_user.return_value = self.user(
+                999,
+                'different_email@email.com',
+                1234,
+                'Supplier Name',
+                'Different users name'
+            )
+
+            token = self._generate_token()
             res = self.client.get(
                 '/suppliers/create-user/{}'.format(token),
                 follow_redirects=True
@@ -1000,21 +929,10 @@ class TestInviteUser(BaseApplicationTest):
                 'test@email.com',
                 1234,
                 'Supplier Name',
-                'Users name',
-                active=True,
-                locked=False
+                'Users name'
             )
 
-            token = generate_token(
-                {
-                    'supplier_id': 1234,
-                    'supplier_name': 'Supplier Name',
-                    'email_address': 'test@email.com'
-                },
-                self.app.config['SHARED_EMAIL_KEY'],
-                self.app.config['INVITE_EMAIL_SALT']
-            )
-
+            token = self._generate_token()
             res = self.client.get(
                 '/suppliers/create-user/{}'.format(token),
                 follow_redirects=True
@@ -1031,16 +949,7 @@ class TestInviteUser(BaseApplicationTest):
 
             data_api_client.get_user.return_value = None
 
-            token = generate_token(
-                {
-                    'supplier_id': 1234,
-                    'supplier_name': 'Supplier Name',
-                    'email_address': 'testme@email.com'
-                },
-                self.app.config['SHARED_EMAIL_KEY'],
-                self.app.config['INVITE_EMAIL_SALT']
-            )
-
+            token = self._generate_token()
             res = self.client.post(
                 '/suppliers/create-user/{}'.format(token),
                 data={
@@ -1052,7 +961,7 @@ class TestInviteUser(BaseApplicationTest):
             data_api_client.create_user.assert_called_once_with({
                 'role': 'supplier',
                 'password': 'validpassword',
-                'emailAddress': 'testme@email.com',
+                'emailAddress': 'test@email.com',
                 'name': 'valid name',
                 'supplierId': 1234
             })
@@ -1066,22 +975,13 @@ class TestInviteUser(BaseApplicationTest):
 
             data_api_client.get_user.return_value = self.user(
                 123,
-                'testme@email.com',
+                'test@email.com',
                 None,
                 None,
                 'Users name'
             )
 
-            token = generate_token(
-                {
-                    'supplier_id': 1234,
-                    'supplier_name': 'Supplier Name',
-                    'email_address': 'testme@email.com'
-                },
-                self.app.config['SHARED_EMAIL_KEY'],
-                self.app.config['INVITE_EMAIL_SALT']
-            )
-
+            token = self._generate_token()
             res = self.client.post(
                 '/suppliers/update-user/{}'.format(token)
             )
@@ -1101,23 +1001,14 @@ class TestInviteUser(BaseApplicationTest):
 
             data_api_client.get_user.return_value = self.user(
                 123,
-                'testme@email.com',
+                'test@email.com',
                 1234,
                 'Supplier Name',
                 'Users name',
                 active=True
             )
 
-            token = generate_token(
-                {
-                    'supplier_id': 1234,
-                    'supplier_name': 'Supplier Name',
-                    'email_address': 'testme@email.com'
-                },
-                self.app.config['SHARED_EMAIL_KEY'],
-                self.app.config['INVITE_EMAIL_SALT']
-            )
-
+            token = self._generate_token()
             res = self.client.post(
                 '/suppliers/update-user/{}'.format(token),
                 data={"password": "password1234", "name": "Joe Bloggs"}
@@ -1132,7 +1023,7 @@ class TestInviteUser(BaseApplicationTest):
 
             data_api_client.get_user.return_value = self.user(
                 123,
-                'testme@email.com',
+                'test@email.com',
                 None,
                 None,
                 'Users name',
@@ -1140,16 +1031,7 @@ class TestInviteUser(BaseApplicationTest):
                 role='admin'
             )
 
-            token = generate_token(
-                {
-                    'supplier_id': 1234,
-                    'supplier_name': 'Supplier Name',
-                    'email_address': 'testme@email.com'
-                },
-                self.app.config['SHARED_EMAIL_KEY'],
-                self.app.config['INVITE_EMAIL_SALT']
-            )
-
+            token = self._generate_token()
             res = self.client.post(
                 '/suppliers/update-user/{}'.format(token),
                 data={"password": "password1234", "name": "Joe Bloggs"}
@@ -1164,7 +1046,7 @@ class TestInviteUser(BaseApplicationTest):
 
             data_api_client.get_user.return_value = self.user(
                 123,
-                'testme@email.com',
+                'test@email.com',
                 None,
                 None,
                 'Users name',
@@ -1172,16 +1054,7 @@ class TestInviteUser(BaseApplicationTest):
                 locked=True
             )
 
-            token = generate_token(
-                {
-                    'supplier_id': 1234,
-                    'supplier_name': 'Supplier Name',
-                    'email_address': 'testme@email.com'
-                },
-                self.app.config['SHARED_EMAIL_KEY'],
-                self.app.config['INVITE_EMAIL_SALT']
-            )
-
+            token = self._generate_token()
             res = self.client.post(
                 '/suppliers/update-user/{}'.format(token),
                 data={"password": "password1234", "name": "Joe Bloggs"}
@@ -1196,7 +1069,7 @@ class TestInviteUser(BaseApplicationTest):
 
             data_api_client.get_user.return_value = self.user(
                 123,
-                'testme@email.com',
+                'test@email.com',
                 None,
                 None,
                 'Users name',
@@ -1204,16 +1077,7 @@ class TestInviteUser(BaseApplicationTest):
                 locked=False
             )
 
-            token = generate_token(
-                {
-                    'supplier_id': 1234,
-                    'supplier_name': 'Supplier Name',
-                    'email_address': 'testme@email.com'
-                },
-                self.app.config['SHARED_EMAIL_KEY'],
-                self.app.config['INVITE_EMAIL_SALT']
-            )
-
+            token = self._generate_token()
             res = self.client.post(
                 '/suppliers/update-user/{}'.format(token),
                 data={"password": "password1234", "name": "Joe Bloggs"}
@@ -1228,16 +1092,7 @@ class TestInviteUser(BaseApplicationTest):
 
             data_api_client.create_user.side_effect = HTTPError("bad email")
 
-            token = generate_token(
-                {
-                    'supplier_id': 1234,
-                    'supplier_name': 'Supplier Name',
-                    'email_address': 'testme@email.com'
-                },
-                self.app.config['SHARED_EMAIL_KEY'],
-                self.app.config['INVITE_EMAIL_SALT']
-            )
-
+            token = self._generate_token()
             res = self.client.post(
                 '/suppliers/create-user/{}'.format(token),
                 data={

--- a/tests/app/main/test_login.py
+++ b/tests/app/main/test_login.py
@@ -99,7 +99,7 @@ class TestLogin(BaseApplicationTest):
             'password': '1234567890'
         })
         assert_in(
-            self.strip_all_whitespace("There was a problem with the account details you provided"),
+            self.strip_all_whitespace("Make sure you've entered the right email address and password"),
             self.strip_all_whitespace(res.get_data(as_text=True)))
         assert_equal(res.status_code, 403)
 
@@ -790,6 +790,30 @@ class TestInviteUser(BaseApplicationTest):
                 "Passwords must be between 10 and 50 characters",
                 "Create contributor account for Supplier Name",
                 "test@email.com"
+            ]:
+                assert_in(message, res.get_data(as_text=True))
+
+    @mock.patch('app.main.views.login.data_api_client')
+    def test_should_render_update_user_page_with_admin_message_if_user_is_an_admin(self, data_api_client):
+        with self.app.app_context():
+
+            data_api_client.get_user.return_value = self.user(
+                123,
+                'test@email.com',
+                None,
+                None,
+                'Users name',
+                role='admin'
+            )
+
+            token = self._generate_token()
+            res = self.client.get(
+                '/suppliers/create-user/{}'.format(token)
+            )
+
+            assert_equal(res.status_code, 200)
+            for message in [
+                "You have an administrator account",
             ]:
                 assert_in(message, res.get_data(as_text=True))
 

--- a/tests/app/main/test_login.py
+++ b/tests/app/main/test_login.py
@@ -867,8 +867,8 @@ class TestInviteUser(BaseApplicationTest):
 
             assert_equal(res.status_code, 200)
             for message in [
-                "You were invited by ‘Different Supplier Name’",
-                "Your account is registered with ‘Supplier Name’"
+                u"You were invited by ‘Different Supplier Name’",
+                u"Your account is registered with ‘Supplier Name’"
             ]:
                 assert_in(message, res.get_data(as_text=True))
 


### PR DESCRIPTION
This pull request addresses incorrect messaging we were potentially sending to invite-link-clicking enthusiasts.

For example, if a new user

1. clicked an invite link
2. created an account
3. clicked the invite link again

they would end up on an error page telling them their account was locked or inactive, which it clearly wasn't. 

The following table should help: first column outlines a scenario, second column describes the result.  (Screenshots below.)

State of the user when they click a valid invite link | Result
------------ | -------------
Totally new user | sees the Create User Form
User with a Buyer account | sees the Update User Form (which converts a `buyer` account to a `supplier` account).
Locked user | sees an error message telling them they're locked
Deactivated user | sees an error message telling them they're deactivated
User registered to one supplier but invited by a different supplier | sees an error message telling them they're currently registered to one supplier but were invited by another
Valid supplier user (not logged in) | sees the Login page
Valid supplier user (logged in) | sees the supplier dashboard

All of the onscreen messages either went through @ralph-hawkins or @superroz.  There's a heavily-edited document hanging around if anyone wants to see it.

[>> Story in Pivotal](https://www.pivotaltracker.com/story/show/102167826)

***

# Screenshots 

### i. Totally new user 
![screen shot 2015-09-08 at 19 16 00](https://cloud.githubusercontent.com/assets/2454380/9743636/4c9c6f10-565f-11e5-8c6a-a3458d72f6e3.png)

### ii. User with a Buyer account
![screen shot 2015-09-08 at 19 14 55](https://cloud.githubusercontent.com/assets/2454380/9743610/360cdef6-565f-11e5-95b8-cc1f56b8f130.png)

### iii. Locked user
![screen shot 2015-09-08 at 19 20 04](https://cloud.githubusercontent.com/assets/2454380/9743660/5fc9ef86-565f-11e5-9f73-de66fa34d6ee.png)

### iv. Deactivated user 
![screen shot 2015-09-08 at 19 18 27](https://cloud.githubusercontent.com/assets/2454380/9743671/70d6ab20-565f-11e5-8c28-2b00362c613c.png)

### v. User registered to one supplier but invited by a different supplier 
![screen shot 2015-09-08 at 19 21 34](https://cloud.githubusercontent.com/assets/2454380/9743679/7babd84a-565f-11e5-9175-e72aafeb9b0d.png)

### vi. Valid supplier user (not logged in)
![screen shot 2015-09-08 at 19 17 44](https://cloud.githubusercontent.com/assets/2454380/9743665/6484b47a-565f-11e5-9b1a-0bb5c96008e4.png)

### vii. Valid supplier user (logged in)
![screen shot 2015-09-08 at 19 16 58](https://cloud.githubusercontent.com/assets/2454380/9743643/50af9f82-565f-11e5-994b-8a40c9d7bc04.png)

***

### \*bonus\* Slightly modified login error message \*/bonus\*
![screen shot 2015-09-08 at 19 29 10](https://cloud.githubusercontent.com/assets/2454380/9743791/0cdd27d8-5660-11e5-8b69-be8233420bc6.png)
