### PR TITLE
Change signup order

### DIFF
--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -287,60 +287,6 @@ def submit_company_contact_details():
         ), 400
 
 
-@main.route('/company-summary', methods=['GET'])
-def company_summary():
-    template_data = main.config['BASE_TEMPLATE_DATA']
-    return render_template(
-        "suppliers/company_summary.html",
-        **template_data
-    ), 200
-
-
-@main.route('/company-summary', methods=['POST'])
-def submit_company_summary():
-    template_data = main.config['BASE_TEMPLATE_DATA']
-
-    required_fields = [
-        "email_address",
-        "phone_number",
-        "contact_name",
-        "duns_number",
-        "company_name"
-    ]
-
-    missing_fields = [field for field in required_fields if field not in session]
-
-    if not missing_fields:
-        try:
-            supplier = {
-                "name": session["company_name"],
-                "dunsNumber": str(session["duns_number"]),
-                "contactInformation": [{
-                    "email": session["email_address"],
-                    "phoneNumber": session["phone_number"],
-                    "contactName": session["contact_name"]
-                }]
-            }
-
-            if session.get("companies_house_number", None):
-                supplier["companiesHouseNumber"] = session.get("companies_house_number")
-
-            supplier = data_api_client.create_supplier(supplier)
-            session.clear()
-            session['email_company_name'] = supplier['suppliers']['name']
-            session['email_supplier_id'] = supplier['suppliers']['id']
-            return redirect(url_for('.create_your_account'), 302)
-        except HTTPError as e:
-            current_app.logger.error(str(e))
-            abort(503)
-    else:
-        return render_template(
-            "suppliers/company_summary.html",
-            missing_fields=missing_fields,
-            **template_data
-        ), 400
-
-
 @main.route('/create-your-account', methods=['GET'])
 def create_your_account():
     current_app.logger.info(
@@ -427,6 +373,60 @@ def submit_create_your_account():
         return render_template(
             "suppliers/create_your_account.html",
             form=form,
+            **template_data
+        ), 400
+
+
+@main.route('/company-summary', methods=['GET'])
+def company_summary():
+    template_data = main.config['BASE_TEMPLATE_DATA']
+    return render_template(
+        "suppliers/company_summary.html",
+        **template_data
+    ), 200
+
+
+@main.route('/company-summary', methods=['POST'])
+def submit_company_summary():
+    template_data = main.config['BASE_TEMPLATE_DATA']
+
+    required_fields = [
+        "email_address",
+        "phone_number",
+        "contact_name",
+        "duns_number",
+        "company_name"
+    ]
+
+    missing_fields = [field for field in required_fields if field not in session]
+
+    if not missing_fields:
+        try:
+            supplier = {
+                "name": session["company_name"],
+                "dunsNumber": str(session["duns_number"]),
+                "contactInformation": [{
+                    "email": session["email_address"],
+                    "phoneNumber": session["phone_number"],
+                    "contactName": session["contact_name"]
+                }]
+            }
+
+            if session.get("companies_house_number", None):
+                supplier["companiesHouseNumber"] = session.get("companies_house_number")
+
+            supplier = data_api_client.create_supplier(supplier)
+            session.clear()
+            session['email_company_name'] = supplier['suppliers']['name']
+            session['email_supplier_id'] = supplier['suppliers']['id']
+            return redirect(url_for('.create_your_account'), 302)
+        except HTTPError as e:
+            current_app.logger.error(str(e))
+            abort(503)
+    else:
+        return render_template(
+            "suppliers/company_summary.html",
+            missing_fields=missing_fields,
             **template_data
         ), 400
 

--- a/app/templates/suppliers/companies_house_number.html
+++ b/app/templates/suppliers/companies_house_number.html
@@ -29,7 +29,7 @@
   <div class="grid-row">
     <div class="column-two-thirds">
       <div class="hint">
-        <p>This is a unique 8-character number given to you by Companies House.</p>
+        <p>This is a unique 8-character number given to your organisation by Companies House.</p>
         <p><a href="https://beta.companieshouse.gov.uk/" rel="external">Visit Companies House to get your number</a></p>
       </div>
       <form method="POST" action="{{ url_for('.companies_house_number') }}">

--- a/app/templates/suppliers/companies_house_number.html
+++ b/app/templates/suppliers/companies_house_number.html
@@ -1,7 +1,7 @@
 {% extends "_base_page.html" %}
 {% import "toolkit/summary-table.html" as summary %}
 
-{% block page_title %}Companies House - Create new supplier – Digital Marketplace{% endblock %}
+{% block page_title %}Companies House – Create new supplier – Digital Marketplace{% endblock %}
 
 {% block breadcrumb %}
 {%

--- a/app/templates/suppliers/company_contact_details.html
+++ b/app/templates/suppliers/company_contact_details.html
@@ -1,7 +1,7 @@
 {% extends "_base_page.html" %}
 {% import "toolkit/summary-table.html" as summary %}
 
-{% block page_title %}Company contact details - Create new supplier – Digital Marketplace{% endblock %}
+{% block page_title %}Company contact details – Create new supplier – Digital Marketplace{% endblock %}
 
 {% block breadcrumb %}
 {%

--- a/app/templates/suppliers/company_contact_details.html
+++ b/app/templates/suppliers/company_contact_details.html
@@ -61,10 +61,9 @@ with
 
             {%
                 with
-                    question = "Email address",
+                    question = "Contact email address",
                     name = "email_address",
                     value = form.email_address.data,
-                    hint = "This is the address that buyers will send their enquires to",
                     error = form.email_address.errors[0]
             %}
             {% include "toolkit/forms/textbox.html" %}
@@ -72,7 +71,7 @@ with
 
             {%
                 with
-                    question = "Phone number",
+                    question = "Contact phone number",
                     name = "phone_number",
                     value = form.phone_number.data,
                     error = form.phone_number.errors[0]

--- a/app/templates/suppliers/company_name.html
+++ b/app/templates/suppliers/company_name.html
@@ -27,9 +27,9 @@
   {% endwith %}
   <div class="grid-row">
     <div class="column-two-thirds">
-      <div class="hint">
-        <p>This is how buyers will see your company’s name on the Digital&nbsp;Marketplace.</p>
-      </div>
+      <p class="hint">
+        This is how buyers will see your company’s name on the Digital&nbsp;Marketplace.
+      </p>
       <form method="POST" action="{{ url_for('.company_name') }}">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
         {%

--- a/app/templates/suppliers/company_name.html
+++ b/app/templates/suppliers/company_name.html
@@ -1,7 +1,7 @@
 {% extends "_base_page.html" %}
 {% import "toolkit/summary-table.html" as summary %}
 
-{% block page_title %}Company name - Create new supplier – Digital Marketplace{% endblock %}
+{% block page_title %}Company name – Create new supplier – Digital Marketplace{% endblock %}
 
 {% block breadcrumb %}
 {%

--- a/app/templates/suppliers/company_summary.html
+++ b/app/templates/suppliers/company_summary.html
@@ -19,7 +19,7 @@
 {% block main_content %}
 
 {%
-  with heading = "Check your company information "
+  with heading = "Check your information "
 %}
 {% include "toolkit/page-heading.html" %}
 {% endwith %}
@@ -31,12 +31,12 @@
   {% if missing_fields|length > 0%}
   <div class="banner-warning-without-action">
     <p class="banner-message">
-      Please complete all fields
+      You must answer all the questions
     </p>
   </div>
   {% endif %}
 
-  {{ summary.heading('Your company') }}
+  {{ summary.heading('Your company details') }}
   {% call summary.mapping_table(
     caption="Summary table with content field as list",
     field_headings=[
@@ -77,7 +77,7 @@
   {% endcall %}
   {% endcall %}
 
-  {{ summary.heading('Your personal account') }}
+  {{ summary.heading('Your login details') }}
   {% call summary.mapping_table(
     caption="Summary table with content field as list",
     field_headings=[
@@ -98,7 +98,7 @@
   {%
     with
       type = "save",
-      label = "Create supplier account"
+      label = "Create account"
   %}
   {% include "toolkit/button.html" %}
   {% endwith %}

--- a/app/templates/suppliers/company_summary.html
+++ b/app/templates/suppliers/company_summary.html
@@ -1,7 +1,7 @@
 {% extends "_base_page.html" %}
 {% import "toolkit/summary-table.html" as summary %}
 
-{% block page_title %}Company summary - Create new supplier – Digital Marketplace{% endblock %}
+{% block page_title %}Check your information – Create new supplier – Digital Marketplace{% endblock %}
 
 {% block breadcrumb %}
 {%

--- a/app/templates/suppliers/company_summary.html
+++ b/app/templates/suppliers/company_summary.html
@@ -28,14 +28,15 @@
 
 <div class="company-information-summary">
 
-      {% if missing_fields|length > 0%}
-      <div class="banner-warning-without-action">
-        <p class="banner-message">
-          Please complete all fields
-        </p>
-      </div>
-      {% endif %}
+  {% if missing_fields|length > 0%}
+  <div class="banner-warning-without-action">
+    <p class="banner-message">
+      Please complete all fields
+    </p>
+  </div>
+  {% endif %}
 
+  {{ summary.heading('Your company') }}
   {% call summary.mapping_table(
     caption="Summary table with content field as list",
     field_headings=[
@@ -74,6 +75,22 @@
   {{ summary.text(session.get("phone_number", "You must answer this question.")) }}
   {{ summary.edit_link("Edit", url_for(".company_contact_details")) }}
   {% endcall %}
+  {% endcall %}
+
+  {{ summary.heading('Your personal account') }}
+  {% call summary.mapping_table(
+    caption="Summary table with content field as list",
+    field_headings=[
+      "Field name",
+      "Field value",
+    ],
+    field_headings_visible=False
+  ) %}
+    {% call summary.row(complete=session.get("account_email_address", None)) %}
+    {{ summary.field_name("Email address") }}
+    {{ summary.text(session.get("account_email_address", "You must answer this question.")) }}
+    {{ summary.edit_link("Edit", url_for(".create_your_account")) }}
+    {% endcall %}
   {% endcall %}
 </div>
 <form action="{{ url_for('.submit_company_summary')}}" method="POST">

--- a/app/templates/suppliers/create_new_supplier.html
+++ b/app/templates/suppliers/create_new_supplier.html
@@ -1,7 +1,7 @@
 {% extends "_base_page.html" %}
 {% import "toolkit/summary-table.html" as summary %}
 
-{% block page_title %}Create new supplier – Digital Marketplace{% endblock %}
+{% block page_title %}Create supplier account – Digital Marketplace{% endblock %}
 
 {% block breadcrumb %}
   {%

--- a/app/templates/suppliers/create_your_account.html
+++ b/app/templates/suppliers/create_your_account.html
@@ -44,7 +44,7 @@
         with
           question = "Your email address",
           name = "email_address",
-          value = form.email_address.data,
+          value = email_address,
           hint = "This is the address you will use to log in to the Digital Marketplace",
           error = form.email_address.errors[0]
       %}

--- a/app/templates/suppliers/create_your_account.html
+++ b/app/templates/suppliers/create_your_account.html
@@ -1,7 +1,7 @@
 {% extends "_base_page.html" %}
 {% import "toolkit/summary-table.html" as summary %}
 
-{% block page_title %}Companies House - Create new supplier – Digital Marketplace{% endblock %}
+{% block page_title %}Create login — Create new supplier – Digital Marketplace{% endblock %}
 
 {% block breadcrumb %}
 {%

--- a/app/templates/suppliers/create_your_account.html
+++ b/app/templates/suppliers/create_your_account.html
@@ -20,24 +20,14 @@
 
 {%
   with
-    heading = "Create your personal account"
+    heading = "Create login"
 %}
-{% include "toolkit/page-heading.html" %}
+  {% include "toolkit/page-heading.html" %}
 {% endwith %}
 
 <div class="grid-row">
   <div class="column-one-whole">
-    <p class="lede">
-      You’ve successfully created a supplier account. You need to create a
-      personal account so you can log in.
-    </p>
-    <p>Before you start, you should know that:</p>
-    <ul class="list-bullet">
-      <li>your personal account details will not be visible on the Digital Marketplace</li>
-      <li>you can add more accounts later</li>
-      <li>you’ll receive an email asking you to activate this account</li>
-      <li>the activation link expires after 7 days</li>
-    </ul>
+
     <form method="POST" action="{{ url_for('.submit_create_your_account') }}">
       <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
       {%
@@ -45,15 +35,15 @@
           question = "Your email address",
           name = "email_address",
           value = email_address,
-          hint = "This is the address you will use to log in to the Digital Marketplace",
           error = form.email_address.errors[0]
       %}
-      {% include "toolkit/forms/textbox.html" %}
+        {% include "toolkit/forms/textbox.html" %}
       {% endwith %}
+      <p>You'll use this address to log in. It won’t be publicly visible.</p>
       {%
         with
           type = "save",
-          label = "Create account"
+          label = "Continue"
       %}
       {% include "toolkit/button.html" %}
       {% endwith %}

--- a/app/templates/suppliers/create_your_account_complete.html
+++ b/app/templates/suppliers/create_your_account_complete.html
@@ -28,11 +28,10 @@
 
   <div class="grid-row">
     <div class="column-two-thirds">
-        <p>
-          An email has been sent to {{ email_address }}.
-          You’ll need to click on the link in the email to activate your account.
-        </p>
-        <p>Go back to the <a href="/">Digital Marketplace homepage.</a></p>
+      <p>
+        An email has been sent to {{ email_address }}.
+        You need to click on the link in the email to activate your account.
+      </p>
     </div>
   </div>
 </div>

--- a/app/templates/suppliers/create_your_account_complete.html
+++ b/app/templates/suppliers/create_your_account_complete.html
@@ -1,7 +1,7 @@
 {% extends "_base_page.html" %}
 {% import "toolkit/summary-table.html" as summary %}
 
-{% block page_title %}Companies House - Create new supplier – Digital Marketplace{% endblock %}
+{% block page_title %}Activate your account - Create new supplier – Digital Marketplace{% endblock %}
 
 {% block breadcrumb %}
 {%

--- a/app/templates/suppliers/dashboard.html
+++ b/app/templates/suppliers/dashboard.html
@@ -1,7 +1,7 @@
 {% extends "_base_page.html" %}
 {% import "toolkit/summary-table.html" as summary %}
 
-{% block page_title %}Supplier dashboard – Digital Marketplace{% endblock %}
+{% block page_title %}{{ current_user.supplier_name }} – Digital Marketplace{% endblock %}
 
 {% block breadcrumb %}
   {%

--- a/app/templates/suppliers/duns_number.html
+++ b/app/templates/suppliers/duns_number.html
@@ -40,7 +40,7 @@
   <div class="grid-row">
     <div class="column-two-thirds">
       <div class="hint">
-        <p>The Digital Marketplace uses your head office's 9-digit DUNS number to see if you’re already a supplier on the G-Cloud
+        <p>The Digital Marketplace uses your head office’s 9&#8209;digit DUNS number to see if you’re already a supplier on the G-Cloud
             framework.</p>
         <p><a href="http://www.dnb.co.uk/dandb-duns-number" rel="external">Find out how to get a DUNS number</a></p>
       </div>

--- a/app/templates/suppliers/duns_number.html
+++ b/app/templates/suppliers/duns_number.html
@@ -1,7 +1,7 @@
 {% extends "_base_page.html" %}
 {% import "toolkit/summary-table.html" as summary %}
 
-{% block page_title %}DUNS number - Create new supplier – Digital Marketplace{% endblock %}
+{% block page_title %}DUNS number – Create new supplier – Digital Marketplace{% endblock %}
 
 {% block breadcrumb %}
 {%

--- a/tests/app/main/test_suppliers.py
+++ b/tests/app/main/test_suppliers.py
@@ -653,7 +653,7 @@ class TestCreateSupplier(BaseApplicationTest):
         res = self.client.post("/suppliers/company-summary")
         assert_equal(res.status_code, 400)
         assert_equal(
-            'Please complete all fields' in res.get_data(as_text=True),
+            'You must answer all the questions' in res.get_data(as_text=True),
             True)
 
     @mock.patch("app.main.suppliers.data_api_client")
@@ -737,7 +737,7 @@ class TestCreateSupplier(BaseApplicationTest):
         assert_equal(res.status_code, 400)
         assert_equal(data_api_client.create_supplier.called, False)
         assert_equal(
-            'Please complete all fields' in res.get_data(as_text=True),
+            'You must answer all the questions' in res.get_data(as_text=True),
             True)
 
     @mock.patch("app.main.suppliers.data_api_client")
@@ -823,10 +823,7 @@ class TestCreateSupplier(BaseApplicationTest):
     @mock.patch("app.main.suppliers.generate_token")
     def test_should_be_an_error_if_incomplete_session_on_account_creation(self, generate_token, send_email):
         res = self.client.post(
-            "/suppliers/create-your-account",
-            data={
-                'email_address': "valid@email.com"
-            }
+            "/suppliers/company-summary"
         )
 
         assert_false(generate_token.called)


### PR DESCRIPTION
_These changes are based on:_
- _feedback that has come into enquiries@digitalmarketplace.service.gov.uk_
- _looking at the funnels in analytics_
- _some guerilla research that @ralph-hawkins and I did yesterday_



## Reorder account creation methods

This just changes the order in the code, so that the functional changes in subsequent commits will be easier to review. This pull request will be easier to review on a commit-by-commit basis.

## Move personal account page before summary page

![img_6793](https://cloud.githubusercontent.com/assets/355079/9760248/5e2a913a-56eb-11e5-9472-86288a70c209.jpeg)

We have had some users dropping out of the supplier creation process after they have clicked the green button on the summary page.

We posit that this is because:
- they think they're done at this point
- we don't do a good job of explaining why you need to enter an email address for the second time

This commit changes the order of the pages to put the summary last, and not create the supplier until we have both:
- the company details
- and the login details

It also adds a new section to the summary page showing the user the email address that they have entered for their login. This:
- reinforces that we have asked for two email addresses and that they are for different reasons
- allow them to go back and change their login address if they have made a typo

## Make content match new order

Some of the messages no longer made sense because they referred to parts of the process, the order of which has changed.

We also removed some messages which weren't immediately relevant to the user’s next steps. While the information they conveyed was important, it could be pushed down to the point at which it was most relevant.