### PR TITLE
[#102983572] Remove validation of VAT number

### DIFF
--- a/app/main/helpers/frameworks.py
+++ b/app/main/helpers/frameworks.py
@@ -10,7 +10,6 @@ from werkzeug.datastructures import ImmutableOrderedMultiDict
 
 
 EMAIL_REGEX = r'^[^@^\s]+@[^@^\.^\s]+(\.[^@^\.^\s]+)+$'
-VAT_NUMBER_REGEX = r'^(\S{9}|\S{12})$'
 TEXT_FIELD_CHARACTER_LIMIT = 5000
 OPTIONAL_FIELDS = set([
     "SQ1-1p-i", "SQ1-1p-ii", "SQ1-1p-iii", "SQ1-1p-iv",
@@ -123,8 +122,6 @@ def get_character_limit_errors(content, answers):
 
 def get_formatting_errors(answers):
     errors_map = {}
-    if not re.match(VAT_NUMBER_REGEX, answers.get('SQ1-1h', '')):
-        errors_map['SQ1-1h'] = 'invalid_format'
     if not re.match(EMAIL_REGEX, answers.get('SQ1-1o', '')):
         errors_map['SQ1-1o'] = 'invalid_format'
     if not re.match(EMAIL_REGEX, answers.get('SQ1-2b', '')):

--- a/tests/app/main/helpers/test_frameworks.py
+++ b/tests/app/main/helpers/test_frameworks.py
@@ -224,14 +224,6 @@ def test_invalid_email_addresses_cause_errors():
                  )
 
 
-def test_invalid_vat_number_causes_error():
-    content = declaration_content.get_builder()
-    submission = FULL_G7_SUBMISSION.copy()
-
-    submission['SQ1-1h'] = 'invalid'
-    assert_equal(get_all_errors(content, submission), {'SQ1-1h': 'invalid_format'})
-
-
 def test_character_limit_errors():
     cases = [
         ("SQ1-1a", 5000),


### PR DESCRIPTION
See: https://www.pivotaltracker.com/story/show/102983572

Our rules were too strict for non-UK companies, so we're not going to validate this field any more.