### PR TITLE
Validation tweaks for none of the above

### DIFF
--- a/app/main/helpers/frameworks.py
+++ b/app/main/helpers/frameworks.py
@@ -66,8 +66,10 @@ def get_required_fields(all_fields, answers):
         required_fields.add('SQ1-1i-ii')
 
     #  If you answered 'licensed' or 'a member of a relevant organisation' in question 29
-    if len(answers.get('SQ1-1j-i', [])) > 0:
-        required_fields.add('SQ1-1j-ii')
+    answer_29 = answers.get('SQ1-1j-i', [])
+    if len(answer_29) > 0 and \
+            ('licensed' in answer_29 or 'a member of a relevant organisation' in answer_29):
+            required_fields.add('SQ1-1j-ii')
 
     # If you answered yes to either question 53 or 54 (tax returns)
     if answers.get('SQ4-1a', False) or answers.get('SQ4-1b', False):

--- a/bower.json
+++ b/bower.json
@@ -7,6 +7,6 @@
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
     "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v9.1.3",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.14.1/jinja_govuk_template-0.14.1.tgz",
-    "digital-marketplace-ssp-content": "git://github.com/alphagov/digitalmarketplace-ssp-content#aa1b1c41b8c6872c852ed6d6f38c4e26fefc6ed1"
+    "digital-marketplace-ssp-content": "git://github.com/alphagov/digitalmarketplace-ssp-content#3351a71d67e482a51bda3933ae9e6e1c120dac00"
   }
 }

--- a/tests/app/main/helpers/test_frameworks.py
+++ b/tests/app/main/helpers/test_frameworks.py
@@ -138,7 +138,7 @@ def test_licenced_details_error_depends_on_licenced():
     del submission['SQ1-1j-i']
     assert_equal(get_all_errors(content, submission), {})
 
-    submission['SQ1-1j-i'] = ["something"]
+    submission['SQ1-1j-i'] = ["licensed"]
     assert_equal(get_all_errors(content, submission), {'SQ1-1j-ii': 'answer_required'})
 
 


### PR DESCRIPTION
Adding 'none of the above' option means that the rules for the dependent question on that page need to be a bit smarter.

Also pulls in latest content with the 'none of the above' option.