### PR TITLE
Update Node modules

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,5 +1,5 @@
 var gulp = require('gulp');
-var uglify = require('gulp-uglifyjs');
+var uglify = require('gulp-uglify');
 var deleteFiles = require('del');
 var sass = require('gulp-sass');
 var filelog = require('gulp-filelog');
@@ -123,7 +123,6 @@ gulp.task('js', function () {
     .pipe(filelog('Compressing JavaScript files'))
     .pipe(include())
     .pipe(uglify(
-      jsDistributionFile,
       uglifyOptions[environment]
     ))
     .pipe(gulp.dest(jsDistributionFolder));

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -6,6 +6,7 @@ var filelog = require('gulp-filelog');
 var include = require('gulp-include');
 var colours = require('colors/safe');
 var jasmine = require('gulp-jasmine-phantom');
+var sourcemaps = require('gulp-sourcemaps');
 
 // Paths
 var environment;
@@ -122,9 +123,11 @@ gulp.task('js', function () {
   var stream = gulp.src(jsSourceFile)
     .pipe(filelog('Compressing JavaScript files'))
     .pipe(include())
+    .pipe(sourcemaps.init())
     .pipe(uglify(
       uglifyOptions[environment]
     ))
+    .pipe(sourcemaps.write('./maps'))
     .pipe(gulp.dest(jsDistributionFolder));
 
   stream.on('end', function () {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "gulp-sass": "1.3.3",
     "gulp-shell": "0.2.9",
     "gulp-uglify": "1.4.0",
+    "gulp-sourcemaps": "1.5.2",
     "gulp-jasmine-phantom": "git://github.com/alphagov/gulp-jasmine-phantom#203c1cb2c4e951ff6aac7f3022d0f61111c8d9f4",
     "colors": "1.1.2"
   },

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "gulp-include": "1.1.1",
     "gulp-sass": "1.3.3",
     "gulp-shell": "0.2.9",
-    "gulp-uglifyjs": "0.6.0",
+    "gulp-uglify": "1.4.0",
     "gulp-jasmine-phantom": "git://github.com/alphagov/gulp-jasmine-phantom#203c1cb2c4e951ff6aac7f3022d0f61111c8d9f4",
     "colors": "1.1.2"
   },

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "engine": "node >= 0.10.0",
   "dependencies": {
-    "bower": "1.3.12",
+    "bower": "1.5.2",
     "del": "1.1.1",
     "govuk_frontend_toolkit": "4.2.1",
     "gulp": "3.8.7",


### PR DESCRIPTION
Replaced the deprecated gulp-uglifyJS with gulp-uglify, as per the following warning message it was giving out:

`npm WARN deprecated gulp-uglifyjs@0.6.0: Since gulp-sourcemaps now works, use gulp-uglify instead`

While I was there I also updated Bower as it was also complaining of being a few releases behind and added sourcemaps to the JavaScript compression process.

If this is accepted I'll push it out to the other apps.