### PR TITLE
Improve and standardise logs

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -58,8 +58,8 @@ def create_app(config_name):
             return application.login_manager.unauthorized()
 
         application.logger.info(
-            u'csrf.invalid_token: Aborting request, user_id: %s', session['user_id']
-        )
+            u'csrf.invalid_token: Aborting request, user_id: {user_id}',
+            extra={'user_id': session['user_id']})
 
         abort(400, reason)
 

--- a/app/main/helpers/__init__.py
+++ b/app/main/helpers/__init__.py
@@ -1,0 +1,10 @@
+import hashlib
+import base64
+import six
+
+
+def hash_email(email):
+    m = hashlib.sha256()
+    m.update(email.encode('utf-8'))
+
+    return base64.urlsafe_b64encode(m.digest())

--- a/app/main/views/users.py
+++ b/app/main/views/users.py
@@ -45,10 +45,10 @@ def deactivate_user(user_id):
     # check that id is not current user
     if user_id == current_user.id:
         current_app.logger.error(
-            "deactivate_user cannot deactivate self, user_id={} supplier_id={}".format(
-                current_user.id, current_user.supplier_id
-            )
-        )
+            "deactivate_user cannot deactivate self, user_id={user_id} supplier_id={supplier_id}",
+            extra={
+                'user_id': current_user.id,
+                'supplier_id': current_user.supplier_id})
         abort(404)
 
     # check that user exists
@@ -57,10 +57,10 @@ def deactivate_user(user_id):
     if not user_to_deactivate or not user_to_deactivate.get('users'):
         current_app.logger.error(
             "deactivate_user user to deactivate not found, "
-            "user_id={} supplier_id={} user_id_to_deactivate={}".format(
-                current_user.id, current_user.supplier_id, user_id
-            )
-        )
+            "user_id={user_id} supplier_id={supplier_id} user_id_to_deactivate={to_deactivate}",
+            extra={
+                'user_id': current_user.id, 'supplier_id': current_user.supplier_id,
+                'to_deactivate': user_id})
         abort(404)
 
     user_to_deactivate = user_to_deactivate.get('users')
@@ -70,10 +70,10 @@ def deactivate_user(user_id):
             or user_to_deactivate['supplier']['supplierId'] != current_user.supplier_id:
         current_app.logger.error(
             "deactivate_user cannot deactivate another suppliers' users, "
-            "user_id={} supplier_id={} user_id_to_deactivate={}".format(
-                current_user.id, current_user.supplier_id, user_id
-            )
-        )
+            "user_id={user_id} supplier_id={supplier_id} user_id_to_deactivate={to_deactivate}",
+            extra={
+                'user_id': current_user.id, 'supplier_id': current_user.supplier_id,
+                'to_deactivate': user_id})
         abort(404)
 
     data_api_client.update_user(user_id=user_to_deactivate['id'], active=False)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ Flask-Script==2.0.5
 Flask-WTF==0.12
 
 git+https://github.com/madzak/python-json-logger.git@v0.1.3#egg=python-json-logger==v0.1.3
-git+https://github.com/alphagov/digitalmarketplace-utils.git@6.8.1#egg=digitalmarketplace-utils==6.8.1
+git+https://github.com/alphagov/digitalmarketplace-utils.git@6.9.0#egg=digitalmarketplace-utils==6.9.0
 markdown==2.6.2
 
 # Required for SNI to work in requests


### PR DESCRIPTION
This is a broad commit that does a few things.

Only put hashes of email addresses in logs. This means that we are not storing personal information in logs but we can search for log messages by email address if we hash the address locally first.

Extract variables out into extra parameters. The logging in dmutils has been changed to attempt to format log messages with the log record (containing all log variables). This means that if a log message is provided as a template and the variables provided in the extra dict then the message will be rendered correctly and the variables will be pulled out in the JSON logs.