### PR TITLE
Give the JS tests their own exit status

### DIFF
--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -36,4 +36,4 @@ nosetests -v -s --with-doctest
 display_result $? 3 "Python Unit tests"
 
 npm test
-display_result $? 3 "JavaScript Unit tests"
+display_result $? 4 "JavaScript Unit tests"


### PR DESCRIPTION
It's useful to have something that points to the
testsuite that's being run, as mentioned in:

https://github.com/alphagov/digitalmarketplace-buyer-frontend/pull/159#discussion_r39135917

This is now in the buyers app so we should also have it here.