### PR TITLE
Update password-reset error messages.

### DIFF
--- a/app/templates/auth/request-password-reset.html
+++ b/app/templates/auth/request-password-reset.html
@@ -18,11 +18,12 @@
                         we'll send a link to reset the password.
 
                         {% elif message == 'token_expired' %}
-                        This password reset link has expired because you requested it more than
-                        24 hours ago. Get a new one using the form below.
+                        This password reset link has expired. Enter your email address and we’ll send you a new one.
+                        Password reset links are only valid for 24 hours.
 
                         {% elif message == 'token_invalid' %}
-                        This password reset link is invalid. Get a new one using the form below.
+                        This password reset link is invalid. Enter your email address and we’ll send you a new one.
+                        Password reset links are only valid for 24 hours.
 
                         {% else %}
                         {{ message }}

--- a/app/templates/emails/reset_password_email.html
+++ b/app/templates/emails/reset_password_email.html
@@ -7,12 +7,12 @@
 <body>
 Hello,
 <br /><br />
-You recently asked to reset your Digital Marketplace password. 
+You recently asked to reset your Digital Marketplace password.
 <br /><br />
 {% if locked %}
-Unfortunately <strong>your account is now locked</strong>. Please contact
-<a href="mailto:enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.service.gov.uk</a>
-to unlock it.
+It looks like you failed to log in 5 times so your account has now been locked.
+Email <a href="mailto:enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.service.gov.uk</a> to unlock it.
+<br /><br />
 {% else %}
 You can change your password now using the link below:
 <br /><br />
@@ -21,12 +21,8 @@ You can change your password now using the link below:
 You must click this link within 24 hours of receiving this email.
 <br /><br />
 {% endif %}
-Please don't reply to this email - it's an automated message. If you need to 
-get in touch, you can reach us at 
-<a href="mailto:enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.service.gov.uk</a>
-<br /><br />
 Thanks,
 <br /><br />
-The Digital Marketplace Admin Team
+The Digital Marketplace Team
 </body>
 </html>

--- a/app/templates/emails/reset_password_email.html
+++ b/app/templates/emails/reset_password_email.html
@@ -23,6 +23,6 @@ You must click this link within 24 hours of receiving this email.
 {% endif %}
 Thanks,
 <br /><br />
-The Digital Marketplace Team
+The Digital Marketplace team
 </body>
 </html>


### PR DESCRIPTION
"[Some of the wording we're using in our user-facing messaged is not ideal](https://www.pivotaltracker.com/story/show/97612300)", and though some of it had been looked at, there were a few places left over that weren't.

We're not referring explicitly to forms any longer, but rather asking users to do something with the form.
Also, removed the bit about getting in touch from the password reset email unless getting in contact would be necessary.

[>> Story on Pivotal](https://www.pivotaltracker.com/story/show/97612300)