### PR TITLE
Give all submit buttons a submit attribute

### DIFF
--- a/app/templates/auth/create-user.html
+++ b/app/templates/auth/create-user.html
@@ -67,7 +67,13 @@
         </div>
     {% endif %}
 
-        <button type="submit" class="button-save">Create contributor account</button>
+        {%
+          with
+          type = "save",
+          label = "Create contributor account"
+        %}
+          {% include "toolkit/button.html" %}
+        {% endwith %}
     </form>
 
         </p>

--- a/app/templates/auth/create-user.html
+++ b/app/templates/auth/create-user.html
@@ -67,7 +67,7 @@
         </div>
     {% endif %}
 
-        <button class="button-save">Create contributor account</button>
+        <button type="submit" class="button-save">Create contributor account</button>
     </form>
 
         </p>

--- a/app/templates/auth/login.html
+++ b/app/templates/auth/login.html
@@ -95,7 +95,13 @@
         </div>
     {% endif %}
 
-    <button type="submit" class="button-save">Log in</button>
+    {%
+      with
+      type = "save",
+      label = "Log in"
+    %}
+      {% include "toolkit/button.html" %}
+    {% endwith %}
     <header class="page-heading-smaller">
         <p class="context">
             <a href="{{ url_for('.request_password_reset') }}">Forgotten password</a>

--- a/app/templates/auth/login.html
+++ b/app/templates/auth/login.html
@@ -95,7 +95,7 @@
         </div>
     {% endif %}
 
-    <button class="button-save">Log in</button>
+    <button type="submit" class="button-save">Log in</button>
     <header class="page-heading-smaller">
         <p class="context">
             <a href="{{ url_for('.request_password_reset') }}">Forgotten password</a>

--- a/app/templates/auth/request-password-reset.html
+++ b/app/templates/auth/request-password-reset.html
@@ -64,6 +64,12 @@
         </div>
     {% endif %}
 
-    <button type="submit" class="button-save">Send reset email</button>
+    {%
+      with
+      type = "save",
+      label = "Send reset email"
+    %}
+      {% include "toolkit/button.html" %}
+    {% endwith %}
 </form>
 {% endblock %}

--- a/app/templates/auth/request-password-reset.html
+++ b/app/templates/auth/request-password-reset.html
@@ -64,6 +64,6 @@
         </div>
     {% endif %}
 
-    <button class="button-save">Send reset email</button>
+    <button type="submit" class="button-save">Send reset email</button>
 </form>
 {% endblock %}

--- a/app/templates/auth/reset-password.html
+++ b/app/templates/auth/reset-password.html
@@ -66,6 +66,12 @@
         </div>
     {% endif %}
 
-    <button type="submit" class="button-save">Reset password</button>
+    {%
+      with
+      type = "save",
+      label = "Reset password"
+    %}
+      {% include "toolkit/button.html" %}
+    {% endwith %}
 </form>
 {% endblock %}

--- a/app/templates/auth/reset-password.html
+++ b/app/templates/auth/reset-password.html
@@ -66,6 +66,6 @@
         </div>
     {% endif %}
 
-    <button class="button-save">Reset password</button>
+    <button type="submit" class="button-save">Reset password</button>
 </form>
 {% endblock %}

--- a/app/templates/auth/submit-email-address.html
+++ b/app/templates/auth/submit-email-address.html
@@ -81,7 +81,7 @@
           </div>
       {% endif %}
 
-      <button class="button-save">Send invite</button>
+      <button type="submit" class="button-save">Send invite</button>
   </form>
 </div>
 

--- a/app/templates/auth/submit-email-address.html
+++ b/app/templates/auth/submit-email-address.html
@@ -81,7 +81,13 @@
           </div>
       {% endif %}
 
-      <button type="submit" class="button-save">Send invite</button>
+      {%
+        with
+        type = "save",
+        label = "Send invite"
+      %}
+        {% include "toolkit/button.html" %}
+      {% endwith %}
   </form>
 </div>
 

--- a/app/templates/auth/update-user.html
+++ b/app/templates/auth/update-user.html
@@ -67,7 +67,7 @@
 
     <form autocomplete="off" action="{{ url_for('.submit_update_user', encoded_token=token) }}" method="POST" id="updateUserForm">
         {{ form.hidden_tag() }}
-        <button class="button-save">Create contributor account</button>
+        <button type="submit" class="button-save">Create contributor account</button>
     </form>
 
         </p>

--- a/app/templates/auth/update-user.html
+++ b/app/templates/auth/update-user.html
@@ -67,7 +67,13 @@
 
     <form autocomplete="off" action="{{ url_for('.submit_update_user', encoded_token=token) }}" method="POST" id="updateUserForm">
         {{ form.hidden_tag() }}
-        <button type="submit" class="button-save">Create contributor account</button>
+        {%
+          with
+          type = "save",
+          label = "Create contributor account"
+        %}
+          {% include "toolkit/button.html" %}
+        {% endwith %}
     </form>
 
         </p>

--- a/app/templates/services/service_submission.html
+++ b/app/templates/services/service_submission.html
@@ -77,7 +77,7 @@
           <p class="banner-message">
             Are you sure you want to delete this service?
           </p>
-          <button class="button-destructive banner-action">Yes, delete &ldquo;{{ service_data['serviceName'] }}&rdquo;</button>
+          <button type="submit" class="button-destructive banner-action">Yes, delete &ldquo;{{ service_data['serviceName'] }}&rdquo;</button>
         </div>
       </form>
     </div>

--- a/app/templates/suppliers/edit_supplier.html
+++ b/app/templates/suppliers/edit_supplier.html
@@ -63,7 +63,7 @@
   <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
 
   <div class="grid-row">
-    <div class="column-two-thirds">
+    <div class="column-one-whole">
       {{ forms.question_textarea('description', 'Supplier summary', supplier_form.description.data, '50 words max', errors=supplier_form.description.errors, max_length_in_words=50) }}
 
       {{ forms.question_list_entry('clients', 'Clients', supplier_form.clients.data, '1 client per box, max 10 clients', errors=supplier_form.clients.errors, item_name='client', number_of_items=10) }}
@@ -92,7 +92,13 @@
     </div>
   </div>
 
-  <button type="submit" class="button-save" type="submit">Save and return</button>
+  {%
+    with
+    type = "save",
+    label = "Save and return"
+  %}
+    {% include "toolkit/button.html" %}
+  {% endwith %}
   <p>
     <a href="{{ url_for('.dashboard') }}">Return without saving</a>
   </p>

--- a/app/templates/suppliers/edit_supplier.html
+++ b/app/templates/suppliers/edit_supplier.html
@@ -63,7 +63,7 @@
   <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
 
   <div class="grid-row">
-    <div class="column-one-whole">
+    <div class="column-two-thirds">
       {{ forms.question_textarea('description', 'Supplier summary', supplier_form.description.data, '50 words max', errors=supplier_form.description.errors, max_length_in_words=50) }}
 
       {{ forms.question_list_entry('clients', 'Clients', supplier_form.clients.data, '1 client per box, max 10 clients', errors=supplier_form.clients.errors, item_name='client', number_of_items=10) }}
@@ -92,7 +92,7 @@
     </div>
   </div>
 
-  <button class="button-save" type="submit">Save and return</button>
+  <button type="submit" class="button-save" type="submit">Save and return</button>
   <p>
     <a href="{{ url_for('.dashboard') }}">Return without saving</a>
   </p>

--- a/tests/app/main/test_login.py
+++ b/tests/app/main/test_login.py
@@ -672,7 +672,7 @@ class TestInviteUser(BaseApplicationTest):
             for message in [
                 "Supplier Name",
                 "test@email.com",
-                '<button class="button-save">Create contributor account</button>',
+                '<button type="submit" class="button-save">Create contributor account</button>',
                 '<form autocomplete="off" action="/suppliers/create-user/{}" method="POST" id="createUserForm">'.format(token)  # noqa
             ]:
                 assert_in(message, res.get_data(as_text=True))
@@ -697,7 +697,7 @@ class TestInviteUser(BaseApplicationTest):
             assert_equal(res.status_code, 200)
             for message in [
                 "Supplier Name",
-                '<button class="button-save">Create contributor account</button>',
+                '<button type="submit" class="button-save">Create contributor account</button>',
                 '<form autocomplete="off" action="/suppliers/update-user/{}" method="POST" id="updateUserForm">'.format(token)  # noqa
             ]:
                 assert_in(message, res.get_data(as_text=True))

--- a/tests/app/main/test_login.py
+++ b/tests/app/main/test_login.py
@@ -392,7 +392,8 @@ class TestLoginFormsNotAutofillable(BaseApplicationTest):
             non_hidden_inputs = form.xpath('//input[@type!="hidden"]')
 
             for input in non_hidden_inputs:
-                assert_equal("off", input.get('autocomplete'))
+                if input.get('type') != 'submit':
+                    assert_equal("off", input.get('autocomplete'))
 
     def test_login_form_and_inputs_not_autofillable(self):
         self._forms_and_inputs_not_autofillable(
@@ -672,7 +673,7 @@ class TestInviteUser(BaseApplicationTest):
             for message in [
                 "Supplier Name",
                 "test@email.com",
-                '<button type="submit" class="button-save">Create contributor account</button>',
+                '<input type="submit" class="button-save"  value="Create contributor account" />',
                 '<form autocomplete="off" action="/suppliers/create-user/{}" method="POST" id="createUserForm">'.format(token)  # noqa
             ]:
                 assert_in(message, res.get_data(as_text=True))
@@ -697,7 +698,7 @@ class TestInviteUser(BaseApplicationTest):
             assert_equal(res.status_code, 200)
             for message in [
                 "Supplier Name",
-                '<button type="submit" class="button-save">Create contributor account</button>',
+                '<input type="submit" class="button-save"  value="Create contributor account" />',
                 '<form autocomplete="off" action="/suppliers/update-user/{}" method="POST" id="updateUserForm">'.format(token)  # noqa
             ]:
                 assert_in(message, res.get_data(as_text=True))
@@ -717,7 +718,7 @@ class TestInviteUser(BaseApplicationTest):
                 u"Check you’ve entered the correct link or ask the person who invited you to send a new invitation." in res.get_data(as_text=True)  # noqa
             )
             assert_false(
-                '<button class="button-save">Create contributor account</button>' in res.get_data(as_text=True)
+                '<input type="submit" class="button-save"  value="Create contributor account" />' in res.get_data(as_text=True)  # noqa
             )
 
     def test_should_be_an_error_if_invalid_token_on_update(self):
@@ -731,7 +732,7 @@ class TestInviteUser(BaseApplicationTest):
                 u"Check you’ve entered the correct link or ask the person who invited you to send a new invitation." in res.get_data(as_text=True)  # noqa
             )
             assert_false(
-                '<button class="button-save">Update user</button>' in res.get_data(as_text=True)  # noqa
+                '<input type="submit" class="button-save"  value="Update user" />' in res.get_data(as_text=True)  # noqa
             )
 
     def test_should_be_an_error_if_missing_name_and_password(self):


### PR DESCRIPTION
IE7 needs submit buttons to have an attribute of `type="submit"` for them to work and a lot of ours don't.

This fixes that by adding the necessary attribute where needed.