### PR TITLE
[#103193094] Prevent text being obscured on assurance validation error

### DIFF
--- a/app/assets/scss/_assurance-question.scss
+++ b/app/assets/scss/_assurance-question.scss
@@ -6,7 +6,6 @@
 
   .question-heading {
     @include core-19;
-    margin-top: -10px;
   }
 
 }


### PR DESCRIPTION
Fixes this bug: https://www.pivotaltracker.com/story/show/103193094

Before (Firefox):
![screen shot 2015-09-14 at 09 40 52](https://cloud.githubusercontent.com/assets/6525554/9845757/51563d32-5ac5-11e5-840c-459b74fe34f7.png)

After (Firefox):
![screen shot 2015-09-14 at 09 41 20](https://cloud.githubusercontent.com/assets/6525554/9845761/558beec4-5ac5-11e5-93a8-01fea934629d.png)
