### PR TITLE
Allow refresh on supplier account create completion

### DIFF
--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -440,6 +440,7 @@ def create_your_account_complete():
 
     email_address = session['email_sent_to']
     session.clear()
+    session['email_sent_to'] = email_address
     return render_template(
         "suppliers/create_your_account_complete.html",
         email_address=email_address,

--- a/tests/app/main/test_suppliers.py
+++ b/tests/app/main/test_suppliers.py
@@ -875,9 +875,25 @@ class TestCreateSupplier(BaseApplicationTest):
         with self.client as c:
             with c.session_transaction() as sess:
                 sess['email_sent_to'] = "my@email.com"
+                sess['other_stuff'] = True
 
             res = c.get("/suppliers/create-your-account-complete")
 
             assert_equal(res.status_code, 200)
             assert_true('An email has been sent to my@email.com' in res.get_data(as_text=True))
-            assert_false('email_sent_to' in session)
+            assert_false('other_stuff' in session)
+
+    def test_should_show_email_address_even_when_refreshed(self):
+        with self.client as c:
+            with c.session_transaction() as sess:
+                sess['email_sent_to'] = 'my-email@example.com'
+
+            res = c.get('/suppliers/create-your-account-complete')
+
+            assert_equal(res.status_code, 200)
+            assert_true('An email has been sent to my-email@example.com' in res.get_data(as_text=True))
+
+            res = c.get('/suppliers/create-your-account-complete')
+
+            assert_equal(res.status_code, 200)
+            assert_true('An email has been sent to my-email@example.com' in res.get_data(as_text=True))


### PR DESCRIPTION
We have been seeing exceptions in production for the supplier account creation complete view. It seems this is caused by a refresh because the entire session is cleared. Ensuring the `email_sent_to` field is re-added to the session means that at least this page can be refreshed.