### PR TITLE
Remove remaining feature flags

### DIFF
--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -20,8 +20,6 @@ from .users import get_current_suppliers_users
 
 @main.route('')
 @login_required
-@flask_featureflags.is_active_feature('SUPPLIER_DASHBOARD',
-                                      redirect='.list_services')
 def dashboard():
     template_data = main.config['BASE_TEMPLATE_DATA']
 
@@ -45,7 +43,6 @@ def dashboard():
 
 @main.route('/edit', methods=['GET'])
 @login_required
-@flask_featureflags.is_active_feature('EDIT_SUPPLIER_PAGE')
 def edit_supplier(supplier_form=None, contact_form=None, error=None):
     template_data = main.config['BASE_TEMPLATE_DATA']
 
@@ -77,7 +74,6 @@ def edit_supplier(supplier_form=None, contact_form=None, error=None):
 
 @main.route('/edit', methods=['POST'])
 @login_required
-@flask_featureflags.is_active_feature('EDIT_SUPPLIER_PAGE')
 def update_supplier():
     # FieldList expects post parameter keys to have number suffixes
     # (eg client-0, client-1 ...), which is incompatible with how

--- a/app/main/views/users.py
+++ b/app/main/views/users.py
@@ -25,7 +25,6 @@ def get_current_suppliers_users():
 
 @main.route('/users')
 @login_required
-@flask_featureflags.is_active_feature('USER_DASHBOARD')
 def list_users():
 
     template_data = main.config['BASE_TEMPLATE_DATA']
@@ -39,7 +38,6 @@ def list_users():
 
 @main.route('/users/<int:user_id>/deactivate', methods=['POST'])
 @login_required
-@flask_featureflags.is_active_feature('USER_DASHBOARD')
 def deactivate_user(user_id):
 
     # check that id is not current user

--- a/app/templates/suppliers/dashboard.html
+++ b/app/templates/suppliers/dashboard.html
@@ -77,9 +77,7 @@
   {% endcall %}
 
   {{ summary.heading("Supplier information") }}
-  {% if 'EDIT_SUPPLIER_PAGE' is active_feature %}
-    {{ summary.top_link('Edit', url_for('.edit_supplier')) }}
-  {% endif %}
+  {{ summary.top_link('Edit', url_for('.edit_supplier')) }}
   {% call(item) summary.mapping_table(
     caption='Supplier information',
     field_headings=[
@@ -132,9 +130,7 @@
   {% endcall %}
 
   {{ summary.heading("Contributors") }}
-  {% if 'USER_DASHBOARD' is active_feature %}
-    {{ summary.top_link("Invite or remove", '/suppliers/users') }}
-  {% endif %}
+  {{ summary.top_link("Invite or remove", '/suppliers/users') }}
   {% call(item) summary.table(
     users,
     caption="Contributors",

--- a/config.py
+++ b/config.py
@@ -60,10 +60,7 @@ class Config(object):
     RAISE_ERROR_ON_MISSING_FEATURES = True
 
     FEATURE_FLAGS_EDIT_SERVICE_PAGE = False
-    FEATURE_FLAGS_SUPPLIER_DASHBOARD = False
-    FEATURE_FLAGS_EDIT_SUPPLIER_PAGE = False
     FEATURE_FLAGS_GCLOUD7_OPEN = False
-    FEATURE_FLAGS_USER_DASHBOARD = False
 
     # Logging
     DM_LOG_LEVEL = 'DEBUG'
@@ -93,10 +90,7 @@ class Test(Config):
     DM_CLARIFICATION_QUESTION_EMAIL = 'digitalmarketplace@mailinator.com'
 
     FEATURE_FLAGS_EDIT_SERVICE_PAGE = enabled_since('2015-06-03')
-    FEATURE_FLAGS_SUPPLIER_DASHBOARD = enabled_since('2015-06-10')
-    FEATURE_FLAGS_EDIT_SUPPLIER_PAGE = enabled_since('2015-06-18')
     FEATURE_FLAGS_GCLOUD7_OPEN = enabled_since('2015-06-18')
-    FEATURE_FLAGS_USER_DASHBOARD = enabled_since('2015-07-09')
 
 
 class Development(Config):
@@ -105,10 +99,7 @@ class Development(Config):
 
     # Dates not formatted like YYYY-(0)M-(0)D will fail
     FEATURE_FLAGS_EDIT_SERVICE_PAGE = enabled_since('2015-06-03')
-    FEATURE_FLAGS_SUPPLIER_DASHBOARD = enabled_since('2015-06-10')
-    FEATURE_FLAGS_EDIT_SUPPLIER_PAGE = enabled_since('2015-06-18')
     FEATURE_FLAGS_GCLOUD7_OPEN = enabled_since('2015-06-18')
-    FEATURE_FLAGS_USER_DASHBOARD = enabled_since('2015-07-09')
 
 
 class Live(Config):
@@ -119,21 +110,14 @@ class Live(Config):
 
 class Preview(Live):
     FEATURE_FLAGS_EDIT_SERVICE_PAGE = enabled_since('2015-06-03')
-    FEATURE_FLAGS_SUPPLIER_DASHBOARD = enabled_since('2015-06-10')
-    FEATURE_FLAGS_EDIT_SUPPLIER_PAGE = enabled_since('2015-06-18')
     FEATURE_FLAGS_GCLOUD7_OPEN = enabled_since('2015-06-18')
-    FEATURE_FLAGS_USER_DASHBOARD = enabled_since('2015-07-09')
 
 
 class Production(Live):
-    FEATURE_FLAGS_SUPPLIER_DASHBOARD = enabled_since('2015-06-10')
-    FEATURE_FLAGS_EDIT_SUPPLIER_PAGE = enabled_since('2015-06-18')
-    FEATURE_FLAGS_USER_DASHBOARD = enabled_since('2015-08-20')
     FEATURE_FLAGS_GCLOUD7_OPEN = enabled_since('2015-09-01')
 
 
 class Staging(Production):
-    FEATURE_FLAGS_USER_DASHBOARD = enabled_since('2015-08-19')
     FEATURE_FLAGS_GCLOUD7_OPEN = enabled_since('2015-08-26')
 
 configs = {


### PR DESCRIPTION
This commit removes feature flags which are now enabled on all environments, which are:
- `USER_DASHBOARD`
- `SUPPLIER_DASHBOARD`
- `EDIT_SUPPLIER_PAGE`

None of the other apps have feature flags which can be removed, therefore this completes [story 102080450](https://www.pivotaltracker.com/story/show/102080450).