### PR TITLE
Track when users click buttons

### DIFF
--- a/app/assets/javascripts/analytics/_events.js
+++ b/app/assets/javascripts/analytics/_events.js
@@ -98,6 +98,10 @@
     return ( positionTop > $root.scrollTop() && positionTop < ($root.scrollTop() + $root.height()) );
   };
 
+  GOVUK.GDM.analytics.isQuestionPage = function(url) {
+    return !!url.match(/suppliers\/submission\/services\/([\d]+)\/edit\/([^/]+)$/);
+  };
+
   GOVUK.GDM.analytics.events = {
     'registerLinkClick': function (e) {
       var $target = $(e.target),
@@ -128,14 +132,15 @@
     },
     'registerSubmitButtonClick': function () {
 
-      var label = window.location.href;
+      var currentURL = root.location.href;
 
-      if (label.match(/^(https|http){1}/) === null) {
-        label = 'http://example.com';
-      }
+      if (
+        currentURL.match(/^(https|http){1}/) &&
+        !GOVUK.GDM.analytics.isQuestionPage(currentURL)
+      ) return;
 
       GOVUK.analytics.trackEvent(
-        'button', this.value, {'label': label}
+        'button', this.value, {'label': document.title}
       );
     },
     'ScrollTracker': ScrollTracker,

--- a/app/assets/javascripts/analytics/_events.js
+++ b/app/assets/javascripts/analytics/_events.js
@@ -126,10 +126,26 @@
       }
       GOVUK.analytics.trackEvent(category, action);
     },
+    'registerSubmitButtonClick': function () {
+
+      var label = window.location.href;
+
+      if (label.match(/^(https|http){1}/) === null) {
+        label = 'http://example.com';
+      }
+
+      GOVUK.analytics.trackEvent(
+        'button', this.value, {'label': label}
+      );
+    },
     'ScrollTracker': ScrollTracker,
     'init': function () {
-      $('body').on('click', 'a', this.registerLinkClick);
+
+      $('body')
+        .on('click', 'a', this.registerLinkClick)
+        .on('click', 'input[type=submit]', this.registerSubmitButtonClick);
       var scrollTracker = new this.ScrollTracker(CONFIG);
+
     }
   };
 })(window, window.GOVUK);

--- a/app/assets/javascripts/analytics/_events.js
+++ b/app/assets/javascripts/analytics/_events.js
@@ -21,7 +21,7 @@
 
     $(root).scroll($.proxy(this.onScroll, this));
     this.trackVisibleNodes();
-  };
+  }
 
   ScrollTracker.prototype.getConfigForCurrentPath = function getConfigForCurrentPath(sitewideConfig) {
     for (var path in sitewideConfig) {
@@ -31,12 +31,12 @@
 
   ScrollTracker.prototype.buildNodes = function buildNodes(config) {
     var nodes = [];
-    var nodeConstructor, nodeData;
+    var NodeConstructor, nodeData;
 
     for (var i=0; i<config.length; i++) {
-      nodeConstructor = ScrollTracker[config[i][0] + "Node"];
+      NodeConstructor = ScrollTracker[config[i][0] + "Node"];
       nodeData = config[i][1];
-      nodes.push(new nodeConstructor(nodeData));
+      nodes.push(new NodeConstructor(nodeData));
     }
 
     return nodes;
@@ -90,7 +90,7 @@
   ScrollTracker.HeadingNode.prototype.isVisible = function isVisible() {
     if ( !this.$element ) return false;
     return this.elementIsVisible(this.$element);
-  }
+  };
 
   ScrollTracker.HeadingNode.prototype.elementIsVisible = function elementIsVisible($element) {
     var $root = $(root);
@@ -108,7 +108,7 @@
           currentHost = root.location.hostname,
           currentHostRegExp = (currentHost !== '') ? new RegExp(currentHost) : /^$/g; // this ccode can run in an environment without a host, ie. a html file
 
-      /* 
+      /*
          File type matching based on those in:
          https://github.com/alphagov/digitalmarketplace-utils/blob/8251d45f47593bd73c5e3b993e1734b5ee505b4b/dmutils/documents.py#L105
       */

--- a/spec/javascripts/unit/AnalyticsSpec.js
+++ b/spec/javascripts/unit/AnalyticsSpec.js
@@ -93,9 +93,32 @@ describe("GOVUK.Analytics", function () {
     });
   });
 
+  describe('button tracking', function () {
+    var mockButton;
+
+    beforeEach(function () {
+      mockButton = document.createElement('input');
+      mockButton.setAttribute('type', 'submit');
+      window.ga.calls.reset();
+    });
+
+    it('sends the right event when a submit button is clicked', function() {
+      mockButton.setAttribute('value', 'Save and continue');
+      console.info(mockButton.value);
+      GOVUK.GDM.analytics.events.registerSubmitButtonClick.call(mockButton);
+      expect(window.ga.calls.first().args).toEqual(['send', {
+          'hitType': 'event',
+          'eventCategory': 'button',
+          'eventAction': 'Save and continue',
+          'eventLabel': 'http://example.com'
+        }
+      ]);
+    });
+  });
+
   describe('virtual page views', function () {
     beforeEach(function () {
-      
+
       window.ga.calls.reset();
     });
 

--- a/spec/javascripts/unit/AnalyticsSpec.js
+++ b/spec/javascripts/unit/AnalyticsSpec.js
@@ -63,7 +63,7 @@ describe("GOVUK.Analytics", function () {
 
     it('sends the right event when an internal link is clicked', function() {
       mockLink.appendChild(document.createTextNode('Suppliers guide'));
-      mockLink.href = window.location.hostname + '/suppliers/frameworks/g-cloud-7/download-supplier-pack'
+      mockLink.href = window.location.hostname + '/suppliers/frameworks/g-cloud-7/download-supplier-pack';
       GOVUK.GDM.analytics.events.registerLinkClick({ 'target': mockLink });
       expect(window.ga.calls.first().args).toEqual(['send', {
         'hitType': 'event',
@@ -104,16 +104,37 @@ describe("GOVUK.Analytics", function () {
 
     it('sends the right event when a submit button is clicked', function() {
       mockButton.setAttribute('value', 'Save and continue');
-      console.info(mockButton.value);
+      document.title = 'Features and benefits';
       GOVUK.GDM.analytics.events.registerSubmitButtonClick.call(mockButton);
       expect(window.ga.calls.first().args).toEqual(['send', {
           'hitType': 'event',
           'eventCategory': 'button',
           'eventAction': 'Save and continue',
-          'eventLabel': 'http://example.com'
+          'eventLabel': 'Features and benefits'
         }
       ]);
     });
+
+    it('knows if the user is on a service page', function () {
+
+      expect(
+        GOVUK.GDM.analytics.isQuestionPage("http://example.com/suppliers/submission/services/7478/edit/service_name")
+      ).toEqual(true);
+
+      expect(
+        GOVUK.GDM.analytics.isQuestionPage("http://example.com/suppliers/submission/services/7478")
+      ).toEqual(false);
+
+      expect(
+        GOVUK.GDM.analytics.isQuestionPage("http://example.com/suppliers/frameworks/g-cloud-7/services")
+      ).toEqual(false);
+
+      expect(
+        GOVUK.GDM.analytics.isQuestionPage("file:///Users/Jo/gds/suppliers/spec.html")
+      ).toEqual(false);
+
+    });
+
   });
 
   describe('virtual page views', function () {
@@ -142,7 +163,7 @@ describe("GOVUK.Analytics", function () {
           mockControl = document.createElement('label');
 
       radio.type = 'radio';
-      radio.value = 'iaas'
+      radio.value = 'iaas';
       mockControl.appendChild(radio);
 
       GOVUK.GDM.analytics.virtualPageViews.createANewService.registerLotSelection({


### PR DESCRIPTION
It would be very useful to know, for example, the split between how many users are clicking the 'save and continue' button and how many are clicking the 'save and return to service overview'.

This commit adds code similar to the link tracking code to fire an event when any button is clicked.

By recording the text of the button and the URL of the page that the user is on we can filter the data to work out what's going on.