### PR TITLE
Tweak copy to match updated version in story

### DIFF
--- a/app/templates/frameworks/updates.html
+++ b/app/templates/frameworks/updates.html
@@ -113,7 +113,7 @@
         large=true,
         question = "Ask a question about your G-Cloud 7 application",
         name = clarification_question_name,
-        hint = "If you have any questions about your G-Cloud 7 application, you can ask them here. You'll receive a private response from the Crown Commercial Service. (Maximum 5000 characters per question.)",
+        hint = "If you have any questions about your G-Cloud 7 application, you can ask them here. You'll get a private reply from the Crown Commercial Service. (Maximum 5000 characters per question.)",
         error = error_message,
         value = clarification_question_value
       %}


### PR DESCRIPTION
This is what happens when the story description gets updated after you've already copy-and-pasted the required content out of the story.