### PR TITLE
[#103088520] Close G7 submissions

### DIFF
--- a/app/main/helpers/frameworks.py
+++ b/app/main/helpers/frameworks.py
@@ -199,6 +199,7 @@ def get_declaration_status(data_api_client):
     else:
         return answers.get('status', 'unstarted')
 
+
 def g_cloud_7_is_open_or_404(data_api_client):
     if data_api_client.get_framework_status('g-cloud-7').get('status', None) != 'open':
         abort(404)

--- a/app/main/helpers/frameworks.py
+++ b/app/main/helpers/frameworks.py
@@ -198,3 +198,7 @@ def get_declaration_status(data_api_client):
         return 'unstarted'
     else:
         return answers.get('status', 'unstarted')
+
+def g_cloud_7_is_open_or_404(data_api_client):
+    if data_api_client.get_framework_status('g-cloud-7').get('status', None) != 'open':
+        abort(404)

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -11,17 +11,16 @@ from dmutils.email import send_email, MandrillException
 from dmutils.formats import format_service_price
 from dmutils import s3
 
-from ...main import main, declaration_content, new_service_content
-from ..helpers.frameworks import get_error_messages_for_page, get_first_question_index, \
-    get_error_messages, get_declaration_status, get_last_modified_from_first_matching_file
-
 from ... import data_api_client
+from ...main import main, declaration_content, new_service_content
+from ..helpers import hash_email
+from ..helpers.frameworks import get_error_messages_for_page, get_first_question_index, \
+    get_error_messages, get_declaration_status, get_last_modified_from_first_matching_file, \
+    g_cloud_7_is_open_or_404, register_interest_in_framework
 from ..helpers.services import (
     get_draft_document_url, get_service_attributes, get_drafts,
     count_unanswered_questions
 )
-from ..helpers.frameworks import register_interest_in_framework
-from ..helpers import hash_email
 
 
 CLARIFICATION_QUESTION_NAME = 'clarification_question'
@@ -97,8 +96,7 @@ def framework_services():
 @login_required
 @flask_featureflags.is_active_feature('GCLOUD7_OPEN')
 def framework_supplier_declaration(section_id):
-    if data_api_client.get_framework_status('g-cloud-7').get('status', None) != 'open':
-        abort(404)
+    g_cloud_7_is_open_or_404(data_api_client)
 
     template_data = main.config['BASE_TEMPLATE_DATA']
     content = declaration_content.get_builder()

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -87,6 +87,7 @@ def framework_services():
         complete_drafts=list(reversed(complete_drafts)),
         drafts=list(reversed(drafts)),
         declaration_status=get_declaration_status(data_api_client),
+        g7_status=data_api_client.get_framework_status('g-cloud-7').get('status', None),
         **template_data
     ), 200
 

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -53,6 +53,7 @@ def framework_dashboard():
         },
         declaration_status=declaration_status,
         deadline=current_app.config['G7_CLOSING_DATE'],
+        g7_status=data_api_client.get_framework_status('g-cloud-7').get('status', None),
         last_modified={
             'supplier_pack': get_last_modified_from_first_matching_file(key_list, 'g-cloud-7-supplier-pack.zip'),
             'supplier_updates': get_last_modified_from_first_matching_file(key_list, 'g-cloud-7-updates/')

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -96,6 +96,9 @@ def framework_services():
 @login_required
 @flask_featureflags.is_active_feature('GCLOUD7_OPEN')
 def framework_supplier_declaration(section_id):
+    if data_api_client.get_framework_status('g-cloud-7').get('status', None) != 'open':
+        abort(404)
+
     template_data = main.config['BASE_TEMPLATE_DATA']
     content = declaration_content.get_builder()
     status_code = 200

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -379,6 +379,7 @@ def view_service_submission(service_id):
         unanswered_optional=unanswered_optional,
         delete_requested=delete_requested,
         declaration_status=get_declaration_status(data_api_client),
+        g7_status=data_api_client.get_framework_status('g-cloud-7').get('status', None),
         deadline=current_app.config['G7_CLOSING_DATE'],
         **main.config['BASE_TEMPLATE_DATA']), 200
 

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -2,6 +2,7 @@ from flask_login import login_required, current_user
 from flask import render_template, request, redirect, url_for, abort, flash, \
     current_app
 
+from ... import data_api_client, flask_featureflags
 from ...main import main, existing_service_content, new_service_content
 from ..helpers.services import (
     get_section_error_messages,
@@ -10,8 +11,8 @@ from ..helpers.services import (
     get_draft_document_url, count_unanswered_questions,
     has_changes_to_save, get_next_section_name
 )
-from ..helpers.frameworks import get_declaration_status
-from ... import data_api_client, flask_featureflags
+from ..helpers.frameworks import get_declaration_status, g_cloud_7_is_open_or_404
+
 from dmutils.apiclient import APIError, HTTPError
 from dmutils.formats import format_service_price
 
@@ -176,6 +177,7 @@ def start_new_draft_service():
     """
     Page to kick off creation of a new (G7) service.
     """
+    g_cloud_7_is_open_or_404(data_api_client)
     template_data = main.config['BASE_TEMPLATE_DATA']
 
     question = new_service_content.get_question('lot')
@@ -200,6 +202,7 @@ def create_new_draft_service():
     """
     Hits up the data API to create a new draft (G7) service.
     """
+    g_cloud_7_is_open_or_404(data_api_client)
     lot = request.form.get('lot', None)
 
     if not lot:
@@ -256,6 +259,7 @@ def create_new_draft_service():
 @login_required
 @flask_featureflags.is_active_feature('GCLOUD7_OPEN')
 def copy_draft_service(service_id):
+    g_cloud_7_is_open_or_404(data_api_client)
     draft = data_api_client.get_draft_service(service_id).get('services')
 
     if not is_service_associated_with_supplier(draft):
@@ -280,6 +284,7 @@ def copy_draft_service(service_id):
 @login_required
 @flask_featureflags.is_active_feature('GCLOUD7_OPEN')
 def complete_draft_service(service_id):
+    g_cloud_7_is_open_or_404(data_api_client)
     draft = data_api_client.get_draft_service(service_id).get('services')
 
     if not is_service_associated_with_supplier(draft):
@@ -305,6 +310,7 @@ def complete_draft_service(service_id):
 @login_required
 @flask_featureflags.is_active_feature('GCLOUD7_OPEN')
 def delete_draft_service(service_id):
+    g_cloud_7_is_open_or_404(data_api_client)
     draft = data_api_client.get_draft_service(service_id).get('services')
 
     if not is_service_associated_with_supplier(draft):
@@ -381,6 +387,7 @@ def view_service_submission(service_id):
 @login_required
 @flask_featureflags.is_active_feature('GCLOUD7_OPEN')
 def edit_service_submission(service_id, section_id):
+    g_cloud_7_is_open_or_404(data_api_client)
     try:
         draft = data_api_client.get_draft_service(service_id)['services']
     except HTTPError as e:
@@ -411,6 +418,7 @@ def edit_service_submission(service_id, section_id):
 @login_required
 @flask_featureflags.is_active_feature('GCLOUD7_OPEN')
 def update_section_submission(service_id, section_id):
+    g_cloud_7_is_open_or_404(data_api_client)
     try:
         draft = data_api_client.get_draft_service(service_id)['services']
     except HTTPError as e:

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -30,12 +30,12 @@ def dashboard():
         supplier['contact'] = supplier['contactInformation'][0]
     except APIError as e:
         abort(e.status_code)
-
     return render_template(
         "suppliers/dashboard.html",
         supplier=supplier,
         users=get_current_suppliers_users(),
         g7_interested=has_registered_interest_in_framework(data_api_client, 'g-cloud-7'),
+        g7_status=data_api_client.get_framework_status('g-cloud-7').get('status', None),
         deadline=current_app.config['G7_CLOSING_DATE'],
         **template_data
     ), 200

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -30,6 +30,7 @@ def dashboard():
         supplier['contact'] = supplier['contactInformation'][0]
     except APIError as e:
         abort(e.status_code)
+
     return render_template(
         "suppliers/dashboard.html",
         supplier=supplier,

--- a/app/templates/frameworks/dashboard.html
+++ b/app/templates/frameworks/dashboard.html
@@ -20,17 +20,25 @@
 {% endblock %}
 
 {% block main_content %}
-
-  {% with
-     heading = "Apply to G-Cloud 7",
-     smaller = True,
-     with_breadcrumb = True
-  %}
-    {% include "toolkit/page-heading.html" %}
-  {% endwith %}
-
+  {% if g7_status == 'open' %}
+    {% with
+       heading = "Apply to G-Cloud 7",
+       smaller = True,
+       with_breadcrumb = True
+    %}
+      {% include "toolkit/page-heading.html" %}
+    {% endwith %}
+  {% else %}
+    {% with
+      heading = "Your G-Cloud 7 application",
+      smaller = True,
+      with_breadcrumb = True
+    %}
+      {% include "toolkit/page-heading.html" %}
+    {% endwith %}
+  {% endif %}
   <aside role="complementary" class="framework-application-status">
-    Deadline <strong>{{ deadline|safe }}</strong>
+    Deadline {% if g7_status == 'pending' %} for submissions passed at {% endif %} <strong>{{ deadline|safe }}</strong>
   </aside>
 
   <nav role="navigation">
@@ -41,7 +49,15 @@
             {% if not counts.draft %}
               <div class="framework-section-validation-bar-good">
             {% endif %}
-              <a class="browse-list-item-link" href="{{ url_for('.framework_services') }}"><span>Add, edit and delete services</span></a>
+              <a class="browse-list-item-link" href="{{ url_for('.framework_services') }}">
+                <span>
+                {% if g7_status == 'open' %}
+                  Add, edit and delete services
+                {% else %}
+                  View services
+                {% endif %}
+                </span>
+              </a>
             {% if not counts.draft %}
               </div>
             {% endif %}
@@ -95,63 +111,65 @@
         </div>
       </li>
 
-      <li class="browse-list-item framework-application-section">
-        {% if declaration_status != 'complete' and counts.complete %}
-          <div class="framework-section-validation-bar">
-        {% endif %}
-        <div class="grid-row">
-          <div class="column-two-thirds">
-            <a class="browse-list-item-link" href="{{ url_for('.framework_supplier_declaration', section_id='g_cloud_7_essentials') }}">
-              {% if declaration_status == 'unstarted' %}
-                <span>Make supplier declaration</span>
-              {% else %}
-                <span>Edit supplier declaration</span>
+      {% if g7_status == 'open' %}
+        <li class="browse-list-item framework-application-section">
+          {% if declaration_status != 'complete' and counts.complete %}
+            <div class="framework-section-validation-bar">
+          {% endif %}
+          <div class="grid-row">
+            <div class="column-two-thirds">
+              <a class="browse-list-item-link" href="{{ url_for('.framework_supplier_declaration', section_id='g_cloud_7_essentials') }}">
+                {% if declaration_status == 'unstarted' %}
+                  <span>Make supplier declaration</span>
+                {% else %}
+                  <span>Edit supplier declaration</span>
+                {% endif %}
+              </a>
+              <p class="browse-list-item-body">
+                Agree to the terms of the bid, provide supplier information and
+                confirm&nbsp;eligibility.
+              </p>
+              {% if declaration_status == 'unstarted' and not counts.complete %}
+                <div class="framework-section-status-neutral">
+                  <p>
+                    You need to make the supplier declaration
+                  </p>
+                </div>
+              {% elif declaration_status == 'started' and not counts.complete %}
+                <div class="framework-section-status-neutral">
+                  <p>
+                    You need to finish making the supplier declaration
+                  </p>
+                </div>
+              {% elif declaration_status == 'unstarted' and counts.complete %}
+                <div class="framework-section-status-bad">
+                  <p>
+                    <strong>No services will be submitted because you haven’t made the
+                    supplier declaration</strong>
+                  </p>
+                </div>
+              {% elif declaration_status == 'started' and counts.complete %}
+                <div class="framework-section-status-bad">
+                  <p>
+                    <strong>No services will be submitted because you haven’t finished making the
+                    supplier declaration</strong>
+                  </p>
+                </div>
+              {% elif declaration_status == 'complete' %}
+                <div class="framework-section-status-good">
+                  <p>
+                    <strong>You’ve made the supplier declaration</strong>
+                  </p>
+                </div>
               {% endif %}
-            </a>
-            <p class="browse-list-item-body">
-              Agree to the terms of the bid, provide supplier information and
-              confirm&nbsp;eligibility.
-            </p>
-            {% if declaration_status == 'unstarted' and not counts.complete %}
-              <div class="framework-section-status-neutral">
-                <p>
-                  You need to make the supplier declaration
-                </p>
-              </div>
-            {% elif declaration_status == 'started' and not counts.complete %}
-              <div class="framework-section-status-neutral">
-                <p>
-                  You need to finish making the supplier declaration
-                </p>
-              </div>
-            {% elif declaration_status == 'unstarted' and counts.complete %}
-              <div class="framework-section-status-bad">
-                <p>
-                  <strong>No services will be submitted because you haven’t made the
-                  supplier declaration</strong>
-                </p>
-              </div>
-            {% elif declaration_status == 'started' and counts.complete %}
-              <div class="framework-section-status-bad">
-                <p>
-                  <strong>No services will be submitted because you haven’t finished making the
-                  supplier declaration</strong>
-                </p>
-              </div>
-            {% elif declaration_status == 'complete' %}
-              <div class="framework-section-status-good">
-                <p>
-                  <strong>You’ve made the supplier declaration</strong>
-                </p>
-              </div>
-            {% endif %}
+            </div>
           </div>
-        </div>
-        {% if declaration_status != 'complete' and counts.complete %}
-          </div>
-        {% endif %}
-      </li>
-
+          {% if declaration_status != 'complete' and counts.complete %}
+            </div>
+          {% endif %}
+        </li>
+      {% endif %}
+      
       <li class="browse-list-item framework-application-section-last">
         <div class="grid-row">
           <div class="column-two-thirds">

--- a/app/templates/frameworks/services.html
+++ b/app/templates/frameworks/services.html
@@ -43,7 +43,7 @@
     {% endfor %}
   {% endwith %}
 
-  {% if complete_drafts and declaration_status != 'complete' %}
+  {% if complete_drafts and declaration_status != 'complete' and g7_status == 'open' %}
     {%
       with
       message = 'You need to <a href="' + url_for('.framework_supplier_declaration', section_id='g_cloud_7_essentials') + '">make the supplier&nbsp;declaration</a> before any services can be submitted',
@@ -62,7 +62,9 @@
   {% endwith %}
 
   {{ summary.heading("Draft services") }}
-  {{ summary.top_link("Add a service", url_for(".start_new_draft_service")) }}
+  {% if g7_status == 'open' %}
+    {{ summary.top_link("Add a service", url_for(".start_new_draft_service")) }}
+  {% endif %}
   {% call(draft) summary.list_table(
     drafts,
     caption="Draft services",
@@ -71,7 +73,7 @@
         "Service name",
         "Lot",
         summary.hidden_field_heading("Progress"),
-        summary.hidden_field_heading("Clone service")
+        summary.hidden_field_heading("Make a copy")
     ],
     field_headings_visible=True
   ) %}
@@ -80,12 +82,14 @@
                               url_for(".view_service_submission", service_id=draft.id)) }}
       {{ summary.text(draft.lot) }}
       {{ summary.text(submission.multiline_string(
-        submission.can_be_completed_text(draft.unanswered_required),
+        submission.can_be_completed_text(draft.unanswered_required, g7_status),
         submission.unanswered_required_text(draft.unanswered_required, draft.unanswered_optional),
         submission.unanswered_optional_text(draft.unanswered_required, draft.unanswered_optional)
       )) }}
-      {{ summary.button(text="Make a copy",
-                         action=url_for('.copy_draft_service', service_id=draft.id)) }}
+      {% if g7_status == 'open' %}
+        {{ summary.button(text="Make a copy",
+                           action=url_for('.copy_draft_service', service_id=draft.id)) }}
+      {% endif %}
     {% endcall %}
   {% endcall %}
 
@@ -109,8 +113,10 @@
       {{ summary.text(
         submission.unanswered_optional_text(draft.unanswered_required, draft.unanswered_optional)
       ) }}
-      {{ summary.button(text="Make a copy",
-                         action=url_for('.copy_draft_service', service_id=draft.id)) }}
+      {% if g7_status == 'open' %}
+        {{ summary.button(text="Make a copy",
+                           action=url_for('.copy_draft_service', service_id=draft.id)) }}
+      {% endif %}
     {% endcall %}
   {% endcall %}
 

--- a/app/templates/macros/submission.html
+++ b/app/templates/macros/submission.html
@@ -22,8 +22,8 @@
 {% endmacro %}
 
 
-{% macro can_be_completed_text(unanswered_required) %}
-  {% if unanswered_required == 0%}
+{% macro can_be_completed_text(unanswered_required, g7_status) %}
+  {% if unanswered_required == 0 and g7_status == 'open' %}
     Service can be marked as complete
   {% endif %}
 {% endmacro %}

--- a/app/templates/services/_base_service_page.html
+++ b/app/templates/services/_base_service_page.html
@@ -34,7 +34,11 @@
             {% call summary.row(complete=False) %}
               {{ summary.field_name(question.label) }}
               {% call summary.field() %}
-                <a href="{{ url_for(".edit_service_submission", service_id=service_id, section_id=section.id) }}">Answer required</a>
+                {% if g7_status == 'open' %}
+                  <a href="{{ url_for(".edit_service_submission", service_id=service_id, section_id=section.id) }}">Answer required</a>
+                {% else %}
+                  Not answered
+                {% endif %}
               {% endcall %}
             {% endcall %}
           {% else %}

--- a/app/templates/services/service_submission.html
+++ b/app/templates/services/service_submission.html
@@ -25,7 +25,7 @@
   %}
     {% include "toolkit/breadcrumb.html" %}
   {% endwith %}
-  {% if service_data.status == 'submitted' and declaration_status != 'complete' %}
+  {% if service_data.status == 'submitted' and declaration_status != 'complete' and g7_status == 'open' %}
     <div class="wrapper">
       {%
         with

--- a/app/templates/services/service_submission.html
+++ b/app/templates/services/service_submission.html
@@ -59,7 +59,7 @@
   {% if service_data.status == 'submitted' and declaration_status == 'complete' %}
     <span class="service-status-published">This service is marked as complete and will be submitted at {{ deadline|safe }}</span>
   {% endif %}
-  {% if service_data.status == 'not-submitted' and unanswered_required == 0 %}
+  {% if service_data.status == 'not-submitted' and unanswered_required == 0 and g7_status == 'open' %}
     {% include "partials/complete_service.html" %}
   {% elif unanswered_required > 0 %}
     <p class="move-to-complete-hint">When you have added all the required information, you can mark the service as complete.</p>
@@ -84,9 +84,13 @@
   {% endif %}
 {% endblock %}
 
+
 {% block edit_link %}
-  {{ summary.top_link("Edit", url_for(".edit_service_submission", service_id=service_id, section_id=section.id)) }}
+  {% if g7_status == 'open' %}
+    {{ summary.top_link("Edit", url_for(".edit_service_submission", service_id=service_id, section_id=section.id)) }}
+  {% endif %}
 {% endblock %}
+
 
 {% block after_sections %}
   {% if not delete_requested %}
@@ -95,17 +99,19 @@
         &nbsp;
       </div>
       <div class="column-one-third delete-draft-button">
-        {% if service_data.status == 'not-submitted' and unanswered_required == 0 %}
+        {% if service_data.status == 'not-submitted' and unanswered_required == 0 and g7_status == 'open' %}
           <div class="space-underneath">
             {% include "partials/complete_service.html" %}
           </div>
         {% endif %}
+        {% if g7_status == 'open' %}
         <form action="{{ url_for('.delete_draft_service', service_id=service_id ) }}" method="POST">
           <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
           {% with type = "destructive", label = "Delete this service" %}
             {% include "toolkit/button.html" %}
           {% endwith %}
         </form>
+        {% endif %}
       </div>
     </div>
   {% endif %}

--- a/app/templates/suppliers/dashboard.html
+++ b/app/templates/suppliers/dashboard.html
@@ -29,7 +29,7 @@
   </div>
 
   {% if 'GCLOUD7_OPEN' is active_feature %}
-    {% if g7_interested %}
+    {% if g7_interested and g7_status == 'open' %}
       {%
         with
         items = [{
@@ -41,7 +41,7 @@
       %}
         {% include "toolkit/browse-list.html" %}
       {% endwith %}
-    {% else %}
+    {% elif g7_status == 'open' %}
       {%
         with
         items = [{
@@ -49,6 +49,16 @@
           "link": url_for(".framework_dashboard"),
           "body": "Read about G-Cloud 7, receive email updates and start the application process.",
           "subtext": "Deadline for submissions: {}".format(deadline)
+        }]
+      %}
+        {% include "toolkit/browse-list.html" %}
+      {% endwith %}
+    {% elif g7_status == 'pending' %}
+      {%
+        with
+        items = [{
+        "title": "View your G-Cloud 7 application",
+        "link": url_for(".framework_dashboard")
         }]
       %}
         {% include "toolkit/browse-list.html" %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ Flask-WTF==0.12
 
 git+https://github.com/madzak/python-json-logger.git@v0.1.3#egg=python-json-logger==v0.1.3
 git+https://github.com/alphagov/digitalmarketplace-utils.git@8.1.1#egg=digitalmarketplace-utils==8.1.1
+
 markdown==2.6.2
 
 # Required for SNI to work in requests

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -86,6 +86,7 @@ class TestFrameworksDashboard(BaseApplicationTest):
         with self.app.test_client():
             self.login()
 
+            data_api_client.get_framework_status.return_value = {'status': 'open'}
             data_api_client.get_selection_answers.return_value = \
                 {"selectionAnswers":
                     {"questionAnswers": FULL_G7_SUBMISSION}
@@ -110,6 +111,7 @@ class TestFrameworksDashboard(BaseApplicationTest):
             del submission['SQ2-1ghijklmn']
             submission.update({"status": "started"})
 
+            data_api_client.get_framework_status.return_value = {'status': 'open'}
             data_api_client.get_selection_answers.return_value = \
                 {"selectionAnswers":
                     {"questionAnswers": submission}
@@ -126,6 +128,7 @@ class TestFrameworksDashboard(BaseApplicationTest):
         with self.app.test_client():
             self.login()
 
+            data_api_client.get_framework_status.return_value = {'status': 'open'}
             data_api_client.get_selection_answers.side_effect = APIError(mock.Mock(status_code=404))
 
             res = self.client.get("/suppliers/frameworks/g-cloud-7")
@@ -298,6 +301,7 @@ class TestSupplierDeclaration(BaseApplicationTest):
         with self.app.test_client():
             self.login()
 
+            data_api_client.get_framework_status.return_value = {'status': 'open'}
             data_api_client.get_selection_answers.side_effect = APIError(mock.Mock(status_code=404))
 
             res = self.client.get(
@@ -314,6 +318,7 @@ class TestSupplierDeclaration(BaseApplicationTest):
         with self.app.test_client():
             self.login()
 
+            data_api_client.get_framework_status.return_value = {'status': 'open'}
             data_api_client.get_selection_answers.return_value = {
                 "selectionAnswers": {
                     "questionAnswers": {
@@ -334,6 +339,8 @@ class TestSupplierDeclaration(BaseApplicationTest):
     def test_post_valid_data(self, data_api_client):
         with self.app.test_client():
             self.login()
+
+            data_api_client.get_framework_status.return_value = {'status': 'open'}
             data_api_client.get_selection_answers.return_value = {
                 "selectionAnswers": {
                     "questionAnswers": {"status": "started"}
@@ -349,6 +356,8 @@ class TestSupplierDeclaration(BaseApplicationTest):
     def test_post_valid_data_to_complete_declaration(self, data_api_client):
         with self.app.test_client():
             self.login()
+
+            data_api_client.get_framework_status.return_value = {'status': 'open'}
             data_api_client.get_selection_answers.return_value = {
                 "selectionAnswers": {
                     "questionAnswers": {"status": "started"}
@@ -365,6 +374,8 @@ class TestSupplierDeclaration(BaseApplicationTest):
     def test_post_valid_data_with_api_failure(self, data_api_client):
         with self.app.test_client():
             self.login()
+
+            data_api_client.get_framework_status.return_value = {'status': 'open'}
             data_api_client.get_selection_answers.return_value = {
                 "selectionAnswers": {
                     "questionAnswers": {"status": "started"}
@@ -387,6 +398,7 @@ class TestSupplierDeclaration(BaseApplicationTest):
         with self.app.test_client():
             self.login()
 
+            data_api_client.get_framework_status.return_value = {'status': 'open'}
             get_error_messages_for_page.return_value = {'PR1': {'input_name': 'PR1', 'message': 'this is invalid'}}
 
             res = self.client.post(
@@ -750,6 +762,7 @@ class TestG7ServicesList(BaseApplicationTest):
 
         count_unanswered.return_value = 0, 1
 
+        apiclient.get_framework_status.return_value = {'status': 'open'}
         apiclient.find_draft_services.return_value = {
             'services': [
                 {'serviceName': 'draft', 'lot': 'SCS', 'status': 'not-submitted'},

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -408,6 +408,23 @@ class TestSupplierDeclaration(BaseApplicationTest):
             assert_equal(res.status_code, 400)
             assert not data_api_client.answer_selection_questions.called
 
+    def test_cannot_post_data_if_not_open(self, data_api_client):
+        with self.app.test_client():
+            self.login()
+
+            data_api_client.get_framework_status.return_value = {'status': 'other'}
+            data_api_client.get_selection_answers.return_value = {
+                "selectionAnswers": {
+                    "questionAnswers": {"status": "started"}
+                }
+            }
+            res = self.client.post(
+                '/suppliers/frameworks/g-cloud-7/declaration/g_cloud_7_essentials',
+                data=FULL_G7_SUBMISSION)
+
+            assert_equal(res.status_code, 404)
+            data_api_client.answer_selection_questions.assert_not_called()
+
 
 @mock.patch('dmutils.s3.S3')
 class TestFrameworkUpdatesPage(BaseApplicationTest):

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -739,13 +739,13 @@ class TestSendClarificationQuestionEmail(BaseApplicationTest):
 @mock.patch('app.main.views.frameworks.count_unanswered_questions')
 class TestG7ServicesList(BaseApplicationTest):
 
-    def test_drafts_list_progress_count(self, count_unanswered, apiclient):
+    def test_drafts_list_progress_count(self, count_unanswered, data_api_client):
         with self.app.test_client():
             self.login()
 
         count_unanswered.return_value = 3, 1
 
-        apiclient.find_draft_services.return_value = {
+        data_api_client.find_draft_services.return_value = {
             'services': [
                 {'serviceName': 'draft', 'lot': 'SCS', 'status': 'not-submitted'},
             ]
@@ -756,14 +756,14 @@ class TestG7ServicesList(BaseApplicationTest):
         assert_true(u'Service can be moved to complete' not in res.get_data(as_text=True))
         assert_in(u'4 unanswered questions', res.get_data(as_text=True))
 
-    def test_drafts_list_can_be_completed(self, count_unanswered, apiclient):
+    def test_drafts_list_can_be_completed(self, count_unanswered, data_api_client):
         with self.app.test_client():
             self.login()
 
         count_unanswered.return_value = 0, 1
 
-        apiclient.get_framework_status.return_value = {'status': 'open'}
-        apiclient.find_draft_services.return_value = {
+        data_api_client.get_framework_status.return_value = {'status': 'open'}
+        data_api_client.find_draft_services.return_value = {
             'services': [
                 {'serviceName': 'draft', 'lot': 'SCS', 'status': 'not-submitted'},
             ]
@@ -774,13 +774,13 @@ class TestG7ServicesList(BaseApplicationTest):
         assert_in(u'Service can be marked as complete', res.get_data(as_text=True))
         assert_in(u'1 optional question unanswered', res.get_data(as_text=True))
 
-    def test_drafts_list_completed(self, count_unanswered, apiclient):
+    def test_drafts_list_completed(self, count_unanswered, data_api_client):
         with self.app.test_client():
             self.login()
 
         count_unanswered.return_value = 0, 1
 
-        apiclient.find_draft_services.return_value = {
+        data_api_client.find_draft_services.return_value = {
             'services': [
                 {'serviceName': 'draft', 'lot': 'SCS', 'status': 'submitted'},
             ]

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -401,10 +401,10 @@ class TestCreateDraftService(BaseApplicationTest):
     def _format_for_request(phrase):
         return phrase.replace(' ', '+')
 
-    def test_get_create_draft_service_page(self, request, api_client):
+    def test_get_create_draft_service_page(self, request, data_api_client):
         with self.app.test_client():
             self.login()
-        api_client.get_framework_status.return_value = {'status': 'open'}
+        data_api_client.get_framework_status.return_value = {'status': 'open'}
 
         res = self.client.get('/suppliers/submission/g-cloud-7/create')
         assert_equal(res.status_code, 200)
@@ -417,12 +417,12 @@ class TestCreateDraftService(BaseApplicationTest):
 
         assert_not_in(self._validation_error, res.get_data(as_text=True))
 
-    def _test_post_create_draft_service(self, if_error_expected, api_client):
+    def _test_post_create_draft_service(self, if_error_expected, data_api_client):
         with self.app.test_client():
             self.login()
 
-        api_client.get_framework_status.return_value = {'status': 'open'}
-        api_client.create_new_draft_service.return_value = {
+        data_api_client.get_framework_status.return_value = {'status': 'open'}
+        data_api_client.create_new_draft_service.return_value = {
             'services': {
                 'id': 1,
                 'supplierId': 1234,
@@ -445,13 +445,13 @@ class TestCreateDraftService(BaseApplicationTest):
         else:
             assert_equal(res.status_code, 302)
 
-    def test_post_create_draft_service_with_lot_selected_succeeds(self, request, api_client):
+    def test_post_create_draft_service_with_lot_selected_succeeds(self, request, data_api_client):
         request.form.get.return_value = "SCS"
-        self._test_post_create_draft_service(if_error_expected=False, api_client=api_client)
+        self._test_post_create_draft_service(if_error_expected=False, api_client=data_api_client)
 
-    def test_post_create_draft_service_without_lot_selected_fails(self, request, api_client):
+    def test_post_create_draft_service_without_lot_selected_fails(self, request, data_api_client):
         request.form.get.return_value = None
-        self._test_post_create_draft_service(if_error_expected=True, api_client=api_client)
+        self._test_post_create_draft_service(if_error_expected=True, api_client=data_api_client)
 
 
 @mock.patch('app.main.views.services.data_api_client')
@@ -474,16 +474,16 @@ class TestCopyDraft(BaseApplicationTest):
             'updatedAt': "2015-06-29T15:26:07.650368Z"
         }
 
-    def test_copy_draft(self, api_client):
-        api_client.get_framework_status.return_value = {'status': 'open'}
-        api_client.get_draft_service.return_value = {'services': self.draft}
+    def test_copy_draft(self, data_api_client):
+        data_api_client.get_framework_status.return_value = {'status': 'open'}
+        data_api_client.get_draft_service.return_value = {'services': self.draft}
 
         res = self.client.post('/suppliers/submission/services/1/copy')
         assert_equal(res.status_code, 302)
 
-    def test_copy_draft_checks_supplier_id(self, api_client):
+    def test_copy_draft_checks_supplier_id(self, data_api_client):
         self.draft['supplierId'] = 2
-        api_client.get_draft_service.return_value = {'services': self.draft}
+        data_api_client.get_draft_service.return_value = {'services': self.draft}
 
         res = self.client.post('/suppliers/submission/services/1/copy')
         assert_equal(res.status_code, 404)
@@ -509,9 +509,9 @@ class TestCompleteDraft(BaseApplicationTest):
             'updatedAt': "2015-06-29T15:26:07.650368Z"
         }
 
-    def test_complete_draft(self, api_client):
-        api_client.get_framework_status.return_value = {'status': 'open'}
-        api_client.get_draft_service.return_value = {'services': self.draft}
+    def test_complete_draft(self, data_api_client):
+        data_api_client.get_framework_status.return_value = {'status': 'open'}
+        data_api_client.get_draft_service.return_value = {'services': self.draft}
 
         res = self.client.post('/suppliers/submission/services/1/complete')
         assert_equal(res.status_code, 302)
@@ -519,9 +519,9 @@ class TestCompleteDraft(BaseApplicationTest):
         assert_true('service_completed=1' in res.location)
         assert_true('/suppliers/frameworks/g-cloud-7/services' in res.location)
 
-    def test_complete_draft_checks_supplier_id(self, api_client):
+    def test_complete_draft_checks_supplier_id(self, data_api_client):
         self.draft['supplierId'] = 2
-        api_client.get_draft_service.return_value = {'services': self.draft}
+        data_api_client.get_draft_service.return_value = {'services': self.draft}
 
         res = self.client.post('/suppliers/submission/services/1/complete')
         assert_equal(res.status_code, 404)

--- a/tests/app/main/test_suppliers.py
+++ b/tests/app/main/test_suppliers.py
@@ -155,6 +155,26 @@ class TestSuppliersDashboard(BaseApplicationTest):
             assert_equal(doc.xpath('//a[@href="/suppliers/frameworks/g-cloud-7"]/span/text()')[0],
                          "Continue your G-Cloud 7 application")
 
+    @mock.patch("app.main.views.suppliers.data_api_client")
+    @mock.patch("app.main.views.suppliers.get_current_suppliers_users")
+    def test_shows_view_gcloud_7_link_if_pending(self, get_current_suppliers_users, data_api_client):
+        data_api_client.get_framework_status.return_value = {'status': 'pending'}
+        data_api_client.get_supplier.side_effect = get_supplier
+        data_api_client.find_audit_events.return_value = {
+            "auditEvents": []
+        }
+        get_current_suppliers_users.side_effect = get_user
+        with self.app.test_client():
+            self.login()
+
+            res = self.client.get("/suppliers")
+            doc = html.fromstring(res.get_data(as_text=True))
+
+            assert_equal(res.status_code, 200)
+
+            assert_equal(doc.xpath('//a[@href="/suppliers/frameworks/g-cloud-7"]/span/text()')[0],
+                         "View your G-Cloud 7 application")
+
 
 class TestSupplierDashboardLogin(BaseApplicationTest):
     @mock.patch("app.main.views.suppliers.data_api_client")

--- a/tests/app/main/test_suppliers.py
+++ b/tests/app/main/test_suppliers.py
@@ -115,6 +115,7 @@ class TestSuppliersDashboard(BaseApplicationTest):
     @mock.patch("app.main.views.suppliers.data_api_client")
     @mock.patch("app.main.views.suppliers.get_current_suppliers_users")
     def test_shows_gcloud_7_application_link(self, get_current_suppliers_users, data_api_client):
+        data_api_client.get_framework_status.return_value = {'status': 'open'}
         data_api_client.get_supplier.side_effect = get_supplier
         data_api_client.find_audit_events.return_value = {
             "auditEvents": []
@@ -134,6 +135,7 @@ class TestSuppliersDashboard(BaseApplicationTest):
     @mock.patch("app.main.views.suppliers.data_api_client")
     @mock.patch("app.main.views.suppliers.get_current_suppliers_users")
     def test_shows_gcloud_7_continue_link(self, get_current_suppliers_users, data_api_client):
+        data_api_client.get_framework_status.return_value = {'status': 'open'}
         data_api_client.get_supplier.side_effect = get_supplier
         data_api_client.find_audit_events.return_value = {
             "auditEvents": [{


### PR DESCRIPTION
See: https://www.pivotaltracker.com/story/show/103088520

There is a further story for @ralph-hawkins and/or @superroz to review the copy for G7-switchoff here: https://www.pivotaltracker.com/story/show/103088582

The copy changes in this pull-request are **TheDoubleK** specials.

The actual switch-off will be done by changing the `status` of the `g-cloud-7` framework from `open` to `pending`.  We should be able to merge and test this code on preview/staging by manually changing the database.  Once tested we should change the framework status back again, as the functional tests will fail once G7 submissions are closed.

With no change to the database then everything should be the same as it is now.
Once the framework is pending the following changes should be seen:

On `/suppliers`:
* The link to  "Continue your G-Cloud 7 application" / "Register your interest in becoming a G-Cloud 7 supplier" changes to "View your G-Cloud 7 application", without and sub-text or hint text.

![screen shot 2015-09-21 at 15 25 20](https://cloud.githubusercontent.com/assets/6525554/9995226/ee148134-6078-11e5-99c6-be41927e2467.png)

On `/suppliers/frameworks/g-cloud-7`:
* The heading "Apply to G-Cloud 7” changed to “Your G-Cloud 7 application” 
* The "Make/Edit supplier declaration" section is gone
* "Deadline 3pm BST, 6 October 2015" changed to "Deadline for submissions passed at 3pm BST, 6 October 2015"
* "Add, edit and delete services" link changed to "View services"

![screen shot 2015-09-21 at 10 20 01](https://cloud.githubusercontent.com/assets/6525554/9995241/0e6faf76-6079-11e5-9a94-145a802b30bf.png)

On `/suppliers/frameworks/g-cloud-7/services`:
* "You need to make the supplier declaration…" warning banner removed
* "Make a copy" buttons gone
* "Service can be marked as complete" text gone

![screen shot 2015-09-21 at 14 10 20](https://cloud.githubusercontent.com/assets/6525554/9995249/18c95d3c-6079-11e5-9873-9f803fb37d6a.png)

On `/suppliers/submission/services/<id>`:
Removed:
* “Mark as complete” button at the top of the page
* “Mark as complete” button at the bottom of the page
* “Delete this service” button from the bottom of the page
* “Edit” links from the right-hand side of each section heading

In addition to this all endpoints relating to editing the supplier declaration or making updates to services will return a 404 response once the framework is `pending`.

The required API and Utils changes required for this to work are already merged and live:
- [x] https://github.com/alphagov/digitalmarketplace-api/pull/248
- [x] https://github.com/alphagov/digitalmarketplace-utils/pull/163
