### PR TITLE
Add grids to forms content

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -22,6 +22,14 @@
 
   var module;
 
+  if(typeof console === 'undefined') {
+    console = {
+      log: function () {},
+      time: function () {},
+      timeEnd: function () {}
+    };
+  }
+
   if (
     (GDM.debug = !window.location.href.match(/gov.uk/) && !window.jasmine)
   ) {

--- a/app/assets/scss/_supplier-declaration.scss
+++ b/app/assets/scss/_supplier-declaration.scss
@@ -28,14 +28,6 @@
     @include bold-19;
   }
 
-  .selection-button {
-
-    @include media(desktop) {
-      max-width: 66%;
-    }
-
-  }
-
   .validation-wrapper {
 
     overflow: visible;

--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -74,17 +74,6 @@ $path: "/suppliers/static/images/";
   margin: (1.5 * $gutter) 0 (2 * $gutter);
 }
 
-.question-heading,
-.question-heading-with-hint,
-.hint,
-.validation-message {
-
-  @include media(desktop) {
-    width: 66%;
-  }
-
-}
-
 .delete-draft-button {
 
   padding: $gutter 0 $gutter * 2 0;

--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -25,7 +25,7 @@ $path: "/suppliers/static/images/";
 @import "toolkit/_digital-marketplace-colours.scss";
 @import "toolkit/_buttons.scss";
 @import "toolkit/_breadcrumb.scss";
-@import "toolkit/_browse_list.scss";
+@import "toolkit/_browse-list.scss";
 @import "toolkit/_page-headings.scss";
 @import "toolkit/search/_search-result.scss";
 @import "toolkit/_notification-banners.scss";

--- a/app/templates/auth/create-user.html
+++ b/app/templates/auth/create-user.html
@@ -27,53 +27,57 @@
 
     <form autocomplete="off" action="{{ url_for('.submit_create_user', encoded_token=token) }}" method="POST" id="createUserForm">
 
-        {{ form.hidden_tag() }}
+        <div class="grid-row">
+            <div class="column-two-thirds">
+                {{ form.hidden_tag() }}
 
-        {% if form.name.errors %}
-        <div class="validation-wrapper">
-            {% endif %}
-            <div class="question">
-                {{ form.name.label(class="question-heading-with-hint") }}
-                <p class="hint">
-                    Enter the name to be referred to on the Digital Marketplace
-                </p>
                 {% if form.name.errors %}
-                <p class="validation-message" id="error-name-textbox">
-                    {% for error in form.name.errors %}{{ error }}{% endfor %}
-                </p>
+                <div class="validation-wrapper">
+                    {% endif %}
+                    <div class="question">
+                        {{ form.name.label(class="question-heading-with-hint") }}
+                        <p class="hint">
+                            Enter the name to be referred to on the Digital Marketplace
+                        </p>
+                        {% if form.name.errors %}
+                        <p class="validation-message" id="error-name-textbox">
+                            {% for error in form.name.errors %}{{ error }}{% endfor %}
+                        </p>
+                        {% endif %}
+                        {{ form.name(class="text-box", autocomplete="off") }}
+                    </div>
+                    {% if form.name.errors %}
+                </div>
                 {% endif %}
-                {{ form.name(class="text-box", autocomplete="off") }}
-            </div>
-            {% if form.name.errors %}
-        </div>
-        {% endif %}
 
-        {% if form.password.errors %}
-        <div class="validation-wrapper">
-    {% endif %}
-        <div class="question">
-            {{ form.password.label(class="question-heading-with-hint") }}
-            <p class="hint">
-              Must be between 10 and 50 characters
-            </p>
-            {% if form.password.errors %}
-            <p class="validation-message" id="error-password-textbox">
-                {% for error in form.password.errors %}{{ error }}{% endfor %}
-            </p>
+                {% if form.password.errors %}
+                <div class="validation-wrapper">
             {% endif %}
-            {{ form.password(class="text-box", autocomplete="off") }}
-        </div>
-    {% if form.password.errors %}
-        </div>
-    {% endif %}
+                <div class="question">
+                    {{ form.password.label(class="question-heading-with-hint") }}
+                    <p class="hint">
+                      Must be between 10 and 50 characters
+                    </p>
+                    {% if form.password.errors %}
+                    <p class="validation-message" id="error-password-textbox">
+                        {% for error in form.password.errors %}{{ error }}{% endfor %}
+                    </p>
+                    {% endif %}
+                    {{ form.password(class="text-box", autocomplete="off") }}
+                </div>
+            {% if form.password.errors %}
+                </div>
+            {% endif %}
 
-        {%
-          with
-          type = "save",
-          label = "Create contributor account"
-        %}
-          {% include "toolkit/button.html" %}
-        {% endwith %}
+            {%
+              with
+              type = "save",
+              label = "Create contributor account"
+            %}
+              {% include "toolkit/button.html" %}
+            {% endwith %}
+            </div>
+        </div>
     </form>
 
         </p>

--- a/app/templates/auth/login.html
+++ b/app/templates/auth/login.html
@@ -57,55 +57,59 @@
 {% endwith %}
 
 <form autocomplete="off" action="{{ url_for('.process_login', next=next) }}" method="POST">
+    <div class="grid-row">
+        <div class="column-two-thirds">
 
-    {{ form.hidden_tag() }}
+            {{ form.hidden_tag() }}
 
-    {% if form.email_address.errors %}
-        <div class="validation-wrapper">
-    {% endif %}
-        <div class="question">
-            {{ form.email_address.label(class="question-heading-with-hint") }}
-            <p class="hint">
-                Enter the email address you used to register with the Digital Marketplace
-            </p>
             {% if form.email_address.errors %}
-            <p class="validation-message" id="error-email-address-textbox">
-                {% for error in form.email_address.errors %}{{ error }}{% endfor %}
-            </p>
+                <div class="validation-wrapper">
             {% endif %}
-            {{ form.email_address(class="text-box", autocomplete="off") }}
-        </div>
-    {% if form.email_address.errors %}
-        </div>
-    {% endif %}
+                <div class="question">
+                    {{ form.email_address.label(class="question-heading-with-hint") }}
+                    <p class="hint">
+                        Enter the email address you used to register with the Digital Marketplace
+                    </p>
+                    {% if form.email_address.errors %}
+                    <p class="validation-message" id="error-email-address-textbox">
+                        {% for error in form.email_address.errors %}{{ error }}{% endfor %}
+                    </p>
+                    {% endif %}
+                    {{ form.email_address(class="text-box", autocomplete="off") }}
+                </div>
+            {% if form.email_address.errors %}
+                </div>
+            {% endif %}
 
-    {% if form.password.errors %}
-        <div class="validation-wrapper">
-    {% endif %}
-        <div class="question">
-            {{ form.password.label(class="question-heading") }}
             {% if form.password.errors %}
-            <p class="validation-message" id="error-password-textbox">
-                {% for error in form.password.errors %}{{ error }}{% endfor %}
-            </p>
+                <div class="validation-wrapper">
             {% endif %}
-            {{ form.password(class="text-box", autocomplete="off") }}
-        </div>
-    {% if form.password.errors %}
-        </div>
-    {% endif %}
+                <div class="question">
+                    {{ form.password.label(class="question-heading") }}
+                    {% if form.password.errors %}
+                    <p class="validation-message" id="error-password-textbox">
+                        {% for error in form.password.errors %}{{ error }}{% endfor %}
+                    </p>
+                    {% endif %}
+                    {{ form.password(class="text-box", autocomplete="off") }}
+                </div>
+            {% if form.password.errors %}
+                </div>
+            {% endif %}
 
-    {%
-      with
-      type = "save",
-      label = "Log in"
-    %}
-      {% include "toolkit/button.html" %}
-    {% endwith %}
-    <header class="page-heading-smaller">
-        <p class="context">
-            <a href="{{ url_for('.request_password_reset') }}">Forgotten password</a>
-        </p>
-    </header>
+            {%
+              with
+              type = "save",
+              label = "Log in"
+            %}
+              {% include "toolkit/button.html" %}
+            {% endwith %}
+            <header class="page-heading-smaller">
+                <p class="context">
+                    <a href="{{ url_for('.request_password_reset') }}">Forgotten password</a>
+                </p>
+            </header>
+        </div>
+    </div>
 </form>
 {% endblock %}

--- a/app/templates/auth/request-password-reset.html
+++ b/app/templates/auth/request-password-reset.html
@@ -43,34 +43,38 @@
 </p>
 
 <form autocomplete="off" action="{{ url_for('.request_password_reset') }}" method="POST" id="resetPasswordForm">
+    <div class="grid-row">
+        <div class="column-two-thirds">
 
-    {{ form.hidden_tag() }}
+            {{ form.hidden_tag() }}
 
-    {% if form.email_address.errors %}
-        <div class="validation-wrapper">
-    {% endif %}
-        <div class="question">
-            {{ form.email_address.label(class="question-heading-with-hint") }}
-            <p class="hint">
-                Enter the email address you used to register with the Digital Marketplace
-            </p>
             {% if form.email_address.errors %}
-            <p class="validation-message" id="error-email-address-textbox">
-                {% for error in form.email_address.errors %}{{ error }}{% endfor %}
-            </p>
+                <div class="validation-wrapper">
             {% endif %}
-            {{ form.email_address(class="text-box", autocomplete="off") }}
-        </div>
-    {% if form.email_address.errors %}
-        </div>
-    {% endif %}
+                <div class="question">
+                    {{ form.email_address.label(class="question-heading-with-hint") }}
+                    <p class="hint">
+                        Enter the email address you used to register with the Digital Marketplace
+                    </p>
+                    {% if form.email_address.errors %}
+                    <p class="validation-message" id="error-email-address-textbox">
+                        {% for error in form.email_address.errors %}{{ error }}{% endfor %}
+                    </p>
+                    {% endif %}
+                    {{ form.email_address(class="text-box", autocomplete="off") }}
+                </div>
+            {% if form.email_address.errors %}
+                </div>
+            {% endif %}
 
-    {%
-      with
-      type = "save",
-      label = "Send reset email"
-    %}
-      {% include "toolkit/button.html" %}
-    {% endwith %}
+            {%
+              with
+              type = "save",
+              label = "Send reset email"
+            %}
+              {% include "toolkit/button.html" %}
+            {% endwith %}
+        </div>
+    </div>
 </form>
 {% endblock %}

--- a/app/templates/auth/reset-password.html
+++ b/app/templates/auth/reset-password.html
@@ -26,52 +26,56 @@
 
 <form autocomplete="off" action="{{ url_for('.update_password', token=token) }}" method="POST">
 
-    {{ form.hidden_tag() }}
+    <div class="grid-row">
+        <div class="column-two-thirds">
+            {{ form.hidden_tag() }}
 
-    {% if form.password.errors %}
-        <div class="validation-wrapper">
-    {% endif %}
-        <div class="question">
-            {{ form.password.label(class="question-heading-with-hint") }}
-            <p class="hint">
-              Must be between 10 and 50 characters
-            </p>
             {% if form.password.errors %}
-            <p class="validation-message" id="error-password-textbox">
-                {% for error in form.password.errors %}{{ error }}{% endfor %}
-            </p>
+                <div class="validation-wrapper">
             {% endif %}
-            {{ form.password(class="text-box", autocomplete="off") }}
-        </div>
-    {% if form.password.errors %}
-        </div>
-    {% endif %}
+                <div class="question">
+                    {{ form.password.label(class="question-heading-with-hint") }}
+                    <p class="hint">
+                      Must be between 10 and 50 characters
+                    </p>
+                    {% if form.password.errors %}
+                    <p class="validation-message" id="error-password-textbox">
+                        {% for error in form.password.errors %}{{ error }}{% endfor %}
+                    </p>
+                    {% endif %}
+                    {{ form.password(class="text-box", autocomplete="off") }}
+                </div>
+            {% if form.password.errors %}
+                </div>
+            {% endif %}
 
-    {% if form.confirm_password.errors %}
-        <div class="validation-wrapper">
-    {% endif %}
-        <div class="question">
-            {{ form.confirm_password.label(class="question-heading-with-hint") }}
-            <p class="hint">
-                Repeat password used above
-            </p>
             {% if form.confirm_password.errors %}
-            <p class="validation-message" id="error-confirm-password-textbox">
-                {% for error in form.confirm_password.errors %}{{ error }}{% endfor %}
-            </p>
+                <div class="validation-wrapper">
             {% endif %}
-            {{ form.confirm_password(class="text-box", autocomplete="off") }}
-        </div>
-    {% if form.confirm_password.errors %}
-        </div>
-    {% endif %}
+                <div class="question">
+                    {{ form.confirm_password.label(class="question-heading-with-hint") }}
+                    <p class="hint">
+                        Repeat password used above
+                    </p>
+                    {% if form.confirm_password.errors %}
+                    <p class="validation-message" id="error-confirm-password-textbox">
+                        {% for error in form.confirm_password.errors %}{{ error }}{% endfor %}
+                    </p>
+                    {% endif %}
+                    {{ form.confirm_password(class="text-box", autocomplete="off") }}
+                </div>
+            {% if form.confirm_password.errors %}
+                </div>
+            {% endif %}
 
-    {%
-      with
-      type = "save",
-      label = "Reset password"
-    %}
-      {% include "toolkit/button.html" %}
-    {% endwith %}
+            {%
+              with
+              type = "save",
+              label = "Reset password"
+            %}
+              {% include "toolkit/button.html" %}
+            {% endwith %}
+        </div>
+    </div>
 </form>
 {% endblock %}

--- a/app/templates/auth/submit-email-address.html
+++ b/app/templates/auth/submit-email-address.html
@@ -60,34 +60,38 @@
 
   <form autocomplete="off" action="{{ url_for('.send_invite_user') }}" method="POST">
 
-      {{ form.hidden_tag() }}
+      <div class="grid-row">
+          <div class="column-two-thirds">
+              {{ form.hidden_tag() }}
 
-      {% if form.email_address.errors %}
-          <div class="validation-wrapper">
-      {% endif %}
-          <div class="question">
-              {{ form.email_address.label(class="question-heading-with-hint") }}
-              <p class="hint">
-                  An invite will be sent asking the recipient to register as a contributor.
-              </p>
               {% if form.email_address.errors %}
-              <p class="validation-message" id="error-email-address-textbox">
-                  {% for error in form.email_address.errors %}{{ error }}{% endfor %}
-              </p>
+                  <div class="validation-wrapper">
               {% endif %}
-              {{ form.email_address(class="text-box", autocomplete="off") }}
-          </div>
-      {% if form.email_address.errors %}
-          </div>
-      {% endif %}
+                  <div class="question">
+                      {{ form.email_address.label(class="question-heading-with-hint") }}
+                      <p class="hint">
+                          An invite will be sent asking the recipient to register as a contributor.
+                      </p>
+                      {% if form.email_address.errors %}
+                      <p class="validation-message" id="error-email-address-textbox">
+                          {% for error in form.email_address.errors %}{{ error }}{% endfor %}
+                      </p>
+                      {% endif %}
+                      {{ form.email_address(class="text-box", autocomplete="off") }}
+                  </div>
+              {% if form.email_address.errors %}
+                  </div>
+              {% endif %}
 
-      {%
-        with
-        type = "save",
-        label = "Send invite"
-      %}
-        {% include "toolkit/button.html" %}
-      {% endwith %}
+              {%
+                with
+                type = "save",
+                label = "Send invite"
+              %}
+                {% include "toolkit/button.html" %}
+              {% endwith %}
+          </div>
+      </div>
   </form>
 </div>
 

--- a/app/templates/frameworks/edit_declaration_section.html
+++ b/app/templates/frameworks/edit_declaration_section.html
@@ -42,46 +42,49 @@
   </p>
   <form method="post" class="supplier-declaration">
 
-    {% set question_index = [first_question_index] %}
-      {% with
-        heading = section.name,
-        smaller = true
-      %}
-        {% include 'toolkit/page-heading.html' %}
-      {% endwith %}
-      {% for question in section.questions %}
-        {% set _ = question_index.append(question_index.pop() + 1) %}
-        {% if errors and errors[question.id] %}
-          {{ forms[question.type](question, service_data, errors, question_number=question_index[0]) }}
-        {% else %}
-          {{ forms[question.type](question, service_data, {}, question_number=question_index[0]) }}
-        {% endif %}
-      {% endfor %}
+    <div class="grid-row">
+        <div class="column-two-thirds">
+            {% set question_index = [first_question_index] %}
+              {% with
+                heading = section.name,
+                smaller = true
+              %}
+                {% include 'toolkit/page-heading.html' %}
+              {% endwith %}
+              {% for question in section.questions %}
+                {% set _ = question_index.append(question_index.pop() + 1) %}
+                {% if errors and errors[question.id] %}
+                  {{ forms[question.type](question, service_data, errors, question_number=question_index[0]) }}
+                {% else %}
+                  {{ forms[question.type](question, service_data, {}, question_number=question_index[0]) }}
+                {% endif %}
+              {% endfor %}
 
-    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
-    {% if is_last_page %}
-      {%
-        with
-        label="Make declaration",
-        type="save"
-      %}
-        {% include "toolkit/button.html" %}
-      {% endwith %}
-      <p class="last-edited move-to-complete-hint">
-        You can edit the declaration until the application deadline.
-      </p>
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+            {% if is_last_page %}
+              {%
+                with
+                label="Make declaration",
+                type="save"
+              %}
+                {% include "toolkit/button.html" %}
+              {% endwith %}
+              <p class="last-edited move-to-complete-hint">
+                You can edit the declaration until the application deadline.
+              </p>
 
-    {% else %}
-      {%
-        with
-        label="Save and continue",
-        type="save"
-      %}
-        {% include "toolkit/button.html" %}
-      {% endwith %}
-    {% endif %}
+            {% else %}
+              {%
+                with
+                label="Save and continue",
+                type="save"
+              %}
+                {% include "toolkit/button.html" %}
+              {% endwith %}
+            {% endif %}
 
-    <a href="{{ url_for('.framework_dashboard') }}">Return to G-Cloud 7 application</a>
-
+            <a href="{{ url_for('.framework_dashboard') }}">Return to G-Cloud 7 application</a>
+          </div>
+      </div>
   </form>
 {% endblock %}

--- a/app/templates/frameworks/updates.html
+++ b/app/templates/frameworks/updates.html
@@ -107,56 +107,64 @@
 
   {% if 'G7_CLARIFICATIONS_CLOSED' is active_feature %}
     <form method="post">
-      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
-      {%
-        with
-        large=true,
-        question = "Ask a question about your G-Cloud 7 application",
-        name = clarification_question_name,
-        hint = "If you have any questions about your G-Cloud 7 application, you can ask them here. You'll get a private reply from the Crown Commercial Service. (Maximum 5000 characters per question.)",
-        error = error_message,
-        value = clarification_question_value
-      %}
-      {% include "toolkit/forms/textbox.html" %}
-      {% endwith %}
-      {%
-        with
-        label="Ask question",
-        type="save"
-      %}
-      {% include "toolkit/button.html" %}
-      {% endwith %}
-    
-      <a href="{{ url_for('.framework_dashboard') }}">Return to G-Cloud 7 application</a>
-    
+      <div class="grid-row">
+        <div class="column-two-thirds">
+          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+          {%
+            with
+            large=true,
+            question = "Ask a question about your G-Cloud 7 application",
+            name = clarification_question_name,
+            hint = "If you have any questions about your G-Cloud 7 application, you can ask them here. You'll get a private reply from the Crown Commercial Service. (Maximum 5000 characters per question.)",
+            error = error_message,
+            value = clarification_question_value
+          %}
+          {% include "toolkit/forms/textbox.html" %}
+          {% endwith %}
+          {%
+            with
+            label="Ask question",
+            type="save"
+          %}
+          {% include "toolkit/button.html" %}
+          {% endwith %}
+        
+          <a href="{{ url_for('.framework_dashboard') }}">Return to G-Cloud 7 application</a>
+
+        </div>
+      </div>
     </form>
   {% else %}
     <form method="post">
-      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
-        {%
-          with
-          large=true,
-          question = "Ask a G-Cloud 7 clarification question",
-          name = clarification_question_name,
-          hint = "You should ask any questions you have about G-Cloud 7 here. The Crown Commercial Service will not respond to you individually. All answers to clarification questions will be published here regularly. (Maximum 5000 characters per question.)",
-          error = error_message,
-          value = clarification_question_value
-        %}
-          {% include "toolkit/forms/textbox.html" %}
-        {% endwith %}
-        <p>
-          The deadline for clarification questions is 5pm <abbr title="British Summer Time">BST</abbr>, 22 September 2015. All responses will be published by 5pm <abbr title="British Summer Time">BST</abbr>, 29 September 2015.
-        </p>
-        {%
-          with
-          label="Ask question",
-          type="save"
-        %}
-          {% include "toolkit/button.html" %}
-        {% endwith %}
-  
-        <a href="{{ url_for('.framework_dashboard') }}">Return to G-Cloud 7 application</a>
-  
-    </form>
+      <div class="grid-row">
+        <div class="column-two-thirds">
+          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+            {%
+              with
+              large=true,
+              question = "Ask a G-Cloud 7 clarification question",
+              name = clarification_question_name,
+              hint = "You should ask any questions you have about G-Cloud 7 here. The Crown Commercial Service will not respond to you individually. All answers to clarification questions will be published here regularly. (Maximum 5000 characters per question.)",
+              error = error_message,
+              value = clarification_question_value
+            %}
+              {% include "toolkit/forms/textbox.html" %}
+            {% endwith %}
+            <p>
+              The deadline for clarification questions is 5pm <abbr title="British Summer Time">BST</abbr>, 22 September 2015. All responses will be published by 5pm <abbr title="British Summer Time">BST</abbr>, 29 September 2015.
+            </p>
+            {%
+              with
+              label="Ask question",
+              type="save"
+            %}
+              {% include "toolkit/button.html" %}
+            {% endwith %}
+      
+            <a href="{{ url_for('.framework_dashboard') }}">Return to G-Cloud 7 application</a>
+
+          </div>
+        </div>
+      </form>
   {% endif %}
 {% endblock %}

--- a/app/templates/services/_base_edit_section_page.html
+++ b/app/templates/services/_base_edit_section_page.html
@@ -27,30 +27,36 @@
 
   <form method="post" enctype="multipart/form-data">
 
-    {% for question in section.questions %}
-      {% if errors and errors[question.id] %}
-        {{ forms[question.type](question, service_data, errors) }}
-      {% else %}
-        {{ forms[question.type](question, service_data, {}) }}
-      {% endif %}
-      {% if question.assuranceApproach %}
-        <div class='assurance-question'>
-          {{ assurance_question(
-            name=question.id,
-            service_data=service_data,
-            type=question.assuranceApproach,
-            errors=errors if errors else {}
-          ) }}
-        </div>
-      {% endif %}
-    {% endfor %}
+    <div class="grid-row">
+      <div class="column-two-thirds">
 
-    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
-    {% block save_button %}{% endblock %}
+          {% for question in section.questions %}
+            {% if errors and errors[question.id] %}
+              {{ forms[question.type](question, service_data, errors) }}
+            {% else %}
+              {{ forms[question.type](question, service_data, {}) }}
+            {% endif %}
+            {% if question.assuranceApproach %}
+              <div class='assurance-question'>
+                {{ assurance_question(
+                  name=question.id,
+                  service_data=service_data,
+                  type=question.assuranceApproach,
+                  errors=errors if errors else {}
+                ) }}
+              </div>
+            {% endif %}
+          {% endfor %}
 
-    {% block return_to_service_link %}
-    <a href="{% block return_to_service %}{% endblock %}">Return to service summary</a>
-    {% endblock %}
+          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+          {% block save_button %}{% endblock %}
+
+          {% block return_to_service_link %}
+          <a href="{% block return_to_service %}{% endblock %}">Return to service summary</a>
+          {% endblock %}
+
+      </div>
+    </div>
 
   </form>
 {% endblock %}

--- a/app/templates/suppliers/create_new_supplier.html
+++ b/app/templates/suppliers/create_new_supplier.html
@@ -24,24 +24,28 @@
   %}
     {% include "toolkit/page-heading.html" %}
   {% endwith %}
-  <div class="check-list">
-    <p class="lead">To create a supplier account, you will need your company’s:</p>
-    <ul class="list-bullet">
-      <li>
-        <p>head office <span class="visual-emphasis">DUNS number</span></p>
-        <p>This can be found at <a href="http://www.dnb.co.uk/dandb-duns-number" rel="external">www.dnb.co.uk/dandb-duns-number</a></p>
-      </li>
-      <li>
-        <p><span class="visual-emphasis">Companies House number</span> (if you have one)</p>
-        <p>
-        This can be found at <a href="https://beta.companieshouse.gov.uk/help/welcome" rel="external">beta.companieshouse.gov.uk/help/welcome</a>
-        </p>
-      </li>
-      <li>
-        contact details
-      </li>
-    </ul>
-    <a href='{{ url_for(".duns_number") }}' class="button-save" role="button">Start</a>
+  <div class="grid-row">
+    <div class="column-two-thirds">
+      <div class="check-list">
+        <p class="lead">To create a supplier account, you will need your company’s:</p>
+        <ul class="list-bullet">
+          <li>
+            <p>head office <span class="visual-emphasis">DUNS number</span></p>
+            <p>This can be found at <a href="http://www.dnb.co.uk/dandb-duns-number" rel="external">www.dnb.co.uk/dandb-duns-number</a></p>
+          </li>
+          <li>
+            <p><span class="visual-emphasis">Companies House number</span> (if you have one)</p>
+            <p>
+            This can be found at <a href="https://beta.companieshouse.gov.uk/help/welcome" rel="external">beta.companieshouse.gov.uk/help/welcome</a>
+            </p>
+          </li>
+          <li>
+            contact details
+          </li>
+        </ul>
+        <a href='{{ url_for(".duns_number") }}' class="button-save" role="button">Start</a>
+      </div>
+    </div>
   </div>
 </div>
 {% endblock %}

--- a/app/templates/suppliers/create_your_account.html
+++ b/app/templates/suppliers/create_your_account.html
@@ -26,7 +26,7 @@
 {% endwith %}
 
 <div class="grid-row">
-  <div class="column-one-whole">
+  <div class="column-two-thirds">
 
     <form method="POST" action="{{ url_for('.submit_create_your_account') }}">
       <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>

--- a/app/templates/suppliers/edit_supplier.html
+++ b/app/templates/suppliers/edit_supplier.html
@@ -63,7 +63,7 @@
   <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
 
   <div class="grid-row">
-    <div class="column-one-whole">
+    <div class="column-two-thirds">
       {{ forms.question_textarea('description', 'Supplier summary', supplier_form.description.data, '50 words max', errors=supplier_form.description.errors, max_length_in_words=50) }}
 
       {{ forms.question_list_entry('clients', 'Clients', supplier_form.clients.data, '1 client per box, max 10 clients', errors=supplier_form.clients.errors, item_name='client', number_of_items=10) }}

--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "jquery": "1.11.2",
     "hogan": "3.0.2",
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
-    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v9.1.3",
+    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v11.0.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.14.1/jinja_govuk_template-0.14.1.tgz",
     "digital-marketplace-ssp-content": "git://github.com/alphagov/digitalmarketplace-ssp-content#3351a71d67e482a51bda3933ae9e6e1c120dac00"
   }


### PR DESCRIPTION
Wraps all form content in a two-thirds grid so their width is dictated by the grid instead of part of their styling.

Part of https://www.pivotaltracker.com/story/show/103093496

Brings in this work from the DM Toolkit: https://github.com/alphagov/digitalmarketplace-frontend-toolkit/pull/158

This pull request also includes a shim for the `console` object so browsers that don't support it won't throw an error when it is used.