### PR TITLE
[#103779820] Improve messaging for removed users.

### DIFF
--- a/app/main/views/login.py
+++ b/app/main/views/login.py
@@ -300,7 +300,8 @@ def submit_update_user(encoded_token):
         data_api_client.update_user(
             user_id=user.id,
             supplier_id=token.get("supplier_id"),
-            role='supplier'
+            role='supplier',
+            updater=current_user.email_address
         )
         login_user(user)
         return redirect(url_for('.dashboard'))

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -85,8 +85,7 @@ def update_service_status(service_id):
     try:
         updated_service = data_api_client.update_service_status(
             service.get('id'), status,
-            current_user.email_address, "Status changed to '{0}'".format(
-                status))
+            current_user.email_address)
 
     except APIError:
 
@@ -153,8 +152,7 @@ def update_section(service_id, section_id):
         data_api_client.update_service(
             service_id,
             posted_data,
-            current_user.email_address,
-            "supplier app")
+            current_user.email_address)
     except HTTPError as e:
         errors_map = get_section_error_messages(new_service_content, e.message, service['lot'])
         if not posted_data.get('serviceName', None):

--- a/app/main/views/users.py
+++ b/app/main/views/users.py
@@ -74,7 +74,7 @@ def deactivate_user(user_id):
                 'to_deactivate': user_id})
         abort(404)
 
-    data_api_client.update_user(user_id=user_to_deactivate['id'], active=False)
+    data_api_client.update_user(user_id=user_to_deactivate['id'], active=False, updater=current_user.email_address)
 
     flash({
         'deactivate_user_name': user_to_deactivate['name'],

--- a/app/templates/users/list_users.html
+++ b/app/templates/users/list_users.html
@@ -26,7 +26,7 @@
       {% if messages %}
         {% for category, message in messages %}
           {% if message['deactivate_user_name'] and message['deactivate_user_email_address'] %}
-            {% set message = "{} ({}) has been removed as a contributor. They can be invited again at any time.".format(message['deactivate_user_name'], message['deactivate_user_email_address']) %}
+            {% set message = "{} ({}) has been removed as a contributor.".format(message['deactivate_user_name'], message['deactivate_user_email_address']) %}
           {% elif message == 'user_invited' %}
             {% set message = "Contributor invited" %}
           {% endif %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ Flask-Script==2.0.5
 Flask-WTF==0.12
 
 git+https://github.com/madzak/python-json-logger.git@v0.1.3#egg=python-json-logger==v0.1.3
-git+https://github.com/alphagov/digitalmarketplace-utils.git@6.9.2#egg=digitalmarketplace-utils==6.9.2
+git+https://github.com/alphagov/digitalmarketplace-utils.git@7.0.0#egg=digitalmarketplace-utils==7.0.0
 markdown==2.6.2
 
 # Required for SNI to work in requests

--- a/tests/app/main/test_login.py
+++ b/tests/app/main/test_login.py
@@ -997,7 +997,7 @@ class TestInviteUser(BaseApplicationTest):
     @mock.patch('app.main.views.login.data_api_client')
     def test_should_update_user_if_user_does_exist(self, data_api_client):
         with self.app.app_context():
-
+            self.login()
             data_api_client.get_user.return_value = self.user(
                 123,
                 'test@email.com',
@@ -1014,7 +1014,8 @@ class TestInviteUser(BaseApplicationTest):
             data_api_client.update_user.assert_called_once_with(
                 user_id=123,
                 supplier_id=1234,
-                role='supplier'
+                role='supplier',
+                updater="email@email.com"
             )
 
             assert_equal(res.status_code, 302)

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -301,7 +301,7 @@ class TestEditService(BaseApplicationTest):
         assert_equal(res.status_code, 302)
         data_api_client.update_service.assert_called_once_with(
             '1', {'serviceName': 'The service', 'serviceSummary': 'This is the service'},
-            'email@email.com', 'supplier app')
+            'email@email.com')
 
     def test_editing_readonly_section_is_not_allowed(self, data_api_client):
         data_api_client.get_service.return_value = self.empty_service
@@ -327,7 +327,7 @@ class TestEditService(BaseApplicationTest):
 
         assert_equal(res.status_code, 302)
         data_api_client.update_service.assert_called_one_with(
-            '1', dict(), 'email@email.com', 'supplier app')
+            '1', dict(), 'email@email.com')
 
     def test_edit_non_existent_service_returns_404(self, data_api_client):
         data_api_client.get_service.return_value = None


### PR DESCRIPTION
Part of this bug fix: https://www.pivotaltracker.com/story/show/103779820

When a supplier removed a user from their supplier account the message said that they could re-invite the user at any time.  This isn't entirely true, as Nicole will have to re-activate the user first.

Rather than spell this out in a lengthy flash message (as re-adding a removed user is an unlikely edge case), it's better to just confirm that the user has been removed.

Depends on: 
- [x] https://github.com/alphagov/digitalmarketplace-utils/pull/166/files
