### PR TITLE
Display error when entering existing email address

### DIFF
--- a/app/main/helpers/__init__.py
+++ b/app/main/helpers/__init__.py
@@ -8,3 +8,11 @@ def hash_email(email):
     m.update(email.encode('utf-8'))
 
     return base64.urlsafe_b64encode(m.digest())
+
+
+def is_existing_supplier_user(user):
+    if not user:
+        return False
+    if user['users'].get('role') is 'supplier':
+        return True
+    return False

--- a/app/main/views/login.py
+++ b/app/main/views/login.py
@@ -369,7 +369,11 @@ def invite_user():
 def send_invite_user():
     form = EmailAddressForm()
 
-    if form.validate_on_submit():
+    existing_user = data_api_client.get_user(
+        email_address=form.email_address.data
+    )
+
+    if form.validate_on_submit() and not existing_user:
         token = generate_token(
             {
                 "supplier_id": current_user.supplier_id,
@@ -416,6 +420,8 @@ def send_invite_user():
         flash('user_invited', 'success')
         return redirect(url_for('.list_users'))
     else:
+        if existing_user:
+            form.email_address.errors.append('An account already exists with this email address.')
         template_data = main.config['BASE_TEMPLATE_DATA']
         return render_template(
             "auth/submit-email-address.html",

--- a/app/main/views/login.py
+++ b/app/main/views/login.py
@@ -13,7 +13,7 @@ from dmutils.email import send_email, \
     generate_token, decode_token, MandrillException
 from .. import main
 from ..forms.auth_forms import LoginForm, EmailAddressForm, ChangePasswordForm, CreateUserForm
-from ..helpers import hash_email
+from ..helpers import hash_email, is_existing_supplier_user
 from ... import data_api_client
 
 
@@ -369,11 +369,11 @@ def invite_user():
 def send_invite_user():
     form = EmailAddressForm()
 
-    existing_user = data_api_client.get_user(
+    user = data_api_client.get_user(
         email_address=form.email_address.data
     )
 
-    if form.validate_on_submit() and not existing_user:
+    if form.validate_on_submit() and not is_existing_supplier_user(user):
         token = generate_token(
             {
                 "supplier_id": current_user.supplier_id,
@@ -420,7 +420,7 @@ def send_invite_user():
         flash('user_invited', 'success')
         return redirect(url_for('.list_users'))
     else:
-        if existing_user:
+        if is_existing_supplier_user(user):
             form.email_address.errors.append('An account already exists with this email address.')
         template_data = main.config['BASE_TEMPLATE_DATA']
         return render_template(

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -14,7 +14,7 @@ from ... import data_api_client
 from ..forms.suppliers import EditSupplierForm, EditContactInformationForm, \
     DunsNumberForm, CompaniesHouseNumberForm, CompanyContactDetailsForm, CompanyNameForm, EmailAddressForm
 from ..helpers.frameworks import has_registered_interest_in_framework
-from ..helpers import hash_email
+from ..helpers import hash_email, is_existing_supplier_user
 from .users import get_current_suppliers_users
 
 
@@ -324,11 +324,11 @@ def submit_create_your_account():
         email_address=form.email_address.data
     )
 
-    if form.validate_on_submit() and not existing_user:
+    if form.validate_on_submit() and not is_existing_supplier_user(existing_user):
         session['account_email_address'] = form.email_address.data
         return redirect(url_for(".company_summary"))
     else:
-        if existing_user:
+        if is_existing_supplier_user(existing_user):
             form.email_address.errors.append('An account already exists with this email address.')
         return render_template(
             "suppliers/create_your_account.html",

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -320,10 +320,16 @@ def submit_create_your_account():
     template_data = main.config['BASE_TEMPLATE_DATA']
     form = EmailAddressForm()
 
-    if form.validate_on_submit():
+    existing_user = data_api_client.get_user(
+        email_address=form.email_address.data
+    )
+
+    if form.validate_on_submit() and not existing_user:
         session['account_email_address'] = form.email_address.data
         return redirect(url_for(".company_summary"))
     else:
+        if existing_user:
+            form.email_address.errors.append('An account already exists with this email address.')
         return render_template(
             "suppliers/create_your_account.html",
             form=form,

--- a/tests/app/main/test_login.py
+++ b/tests/app/main/test_login.py
@@ -475,7 +475,10 @@ class TestInviteUser(BaseApplicationTest):
 
     @mock.patch('app.main.views.login.data_api_client')
     def test_should_be_an_error_for_existing_account(self, data_api_client):
-        data_api_client.get_user.return_value = {'users': {'emailAddress': 'test@example.com'}}
+        data_api_client.get_user.return_value = {'users': {
+            'emailAddress': 'test@example.com',
+            'role': 'supplier'
+        }}
         with self.app.app_context():
             self.login()
             res = self.client.post(

--- a/tests/app/main/test_login.py
+++ b/tests/app/main/test_login.py
@@ -474,10 +474,25 @@ class TestInviteUser(BaseApplicationTest):
             assert_equal(res.status_code, 400)
 
     @mock.patch('app.main.views.login.data_api_client')
+    def test_should_be_an_error_for_existing_account(self, data_api_client):
+        data_api_client.get_user.return_value = {'users': {'emailAddress': 'test@example.com'}}
+        with self.app.app_context():
+            self.login()
+            res = self.client.post(
+                '/suppliers/invite-user',
+                data={
+                    'email_address': 'test@example.com'
+                }
+            )
+            assert_in("An account already exists with this email address.", res.get_data(as_text=True))
+            assert_equal(res.status_code, 400)
+
+    @mock.patch('app.main.views.login.data_api_client')
     @mock.patch('app.main.views.login.send_email')
     def test_should_redirect_to_list_users_on_success_invite(self,
                                                              send_email,
                                                              data_api_client):
+        data_api_client.get_user.return_value = None
         with self.app.app_context():
             self.login()
             res = self.client.post(
@@ -496,6 +511,7 @@ class TestInviteUser(BaseApplicationTest):
                                                             send_email,
                                                             generate_token,
                                                             data_api_client):
+        data_api_client.get_user.return_value = None
         with self.app.app_context():
 
             self.app.config['SHARED_EMAIL_KEY'] = "KEY"
@@ -535,10 +551,12 @@ class TestInviteUser(BaseApplicationTest):
             assert not send_email.called
             assert not generate_token.called
 
+    @mock.patch('app.main.views.login.data_api_client')
     @mock.patch('app.main.views.login.send_email')
     def test_should_be_an_error_if_send_invitation_email_fails(
-            self, send_email
+            self, send_email, data_api_client
     ):
+        data_api_client.get_user.return_value = None
         with self.app.app_context():
             self.login()
 
@@ -556,6 +574,7 @@ class TestInviteUser(BaseApplicationTest):
     def test_should_call_send_invitation_email_with_correct_params(self,
                                                                    send_email,
                                                                    data_api_client):
+        data_api_client.get_user.return_value = None
         with self.app.app_context():
 
             self.login()
@@ -587,6 +606,7 @@ class TestInviteUser(BaseApplicationTest):
     def test_should_create_audit_event(self,
                                        send_email,
                                        data_api_client):
+        data_api_client.get_user.return_value = None
         with self.app.app_context():
             self.login()
 

--- a/tests/app/main/test_suppliers.py
+++ b/tests/app/main/test_suppliers.py
@@ -781,7 +781,10 @@ class TestCreateSupplier(BaseApplicationTest):
     @mock.patch("app.main.suppliers.data_api_client")
     def test_should_not_allow_existing_email_address(self, data_api_client):
 
-        data_api_client.get_user.return_value = {'users': {'emailAddress': 'test@example.com'}}
+        data_api_client.get_user.return_value = {'users': {
+            'emailAddress': 'test@example.com',
+            'role': 'supplier'
+        }}
         res = self.client.post(
             "/suppliers/create-your-account",
             data={
@@ -790,6 +793,21 @@ class TestCreateSupplier(BaseApplicationTest):
         )
         assert_equal(res.status_code, 400)
         assert_in("An account already exists with this email address.", res.get_data(as_text=True))
+
+    @mock.patch("app.main.suppliers.data_api_client")
+    def test_should_invite_existing_buyer(self, data_api_client):
+
+        data_api_client.get_user.return_value = {'users': {
+            'emailAddress': 'test@example.com',
+            'role': 'buyer'
+        }}
+        res = self.client.post(
+            "/suppliers/create-your-account",
+            data={
+                'email_address': 'test@example.com'
+            }
+        )
+        assert_equal(res.status_code, 302)
 
     @mock.patch("app.main.suppliers.data_api_client")
     @mock.patch("app.main.suppliers.send_email")

--- a/tests/app/main/test_suppliers.py
+++ b/tests/app/main/test_suppliers.py
@@ -779,6 +779,19 @@ class TestCreateSupplier(BaseApplicationTest):
         assert_true("You must provide a valid email address." in res.get_data(as_text=True))
 
     @mock.patch("app.main.suppliers.data_api_client")
+    def test_should_not_allow_existing_email_address(self, data_api_client):
+
+        data_api_client.get_user.return_value = {'users': {'emailAddress': 'test@example.com'}}
+        res = self.client.post(
+            "/suppliers/create-your-account",
+            data={
+                'email_address': 'test@example.com'
+            }
+        )
+        assert_equal(res.status_code, 400)
+        assert_in("An account already exists with this email address.", res.get_data(as_text=True))
+
+    @mock.patch("app.main.suppliers.data_api_client")
     @mock.patch("app.main.suppliers.send_email")
     @mock.patch("app.main.suppliers.generate_token")
     def test_should_allow_correct_email_address(self, generate_token, send_email, data_api_client):


### PR DESCRIPTION
<img width="827" alt="screen shot 2015-09-24 at 16 08 20" src="https://cloud.githubusercontent.com/assets/355079/10077738/80e4604e-62d9-11e5-93eb-08afae6fd053.png">

--

Just wrote all this sweet code and then had a thought: **is this a security hole because we're exposing which accounts exist?**

--

When a user enters an email address which is already associated account we should stop them.

This is relevant:
- when creating a new supplier account
- when inviting users to an existing supplier

--

@superroz How's the words?

--

Fulfils https://www.pivotaltracker.com/story/show/103066110