### PR TITLE
[#104451064] BUGFIX (urgent): There may not be a logged-in user for user updates

### DIFF
--- a/app/main/views/login.py
+++ b/app/main/views/login.py
@@ -297,11 +297,16 @@ def submit_update_user(encoded_token):
                        'supplier_id': token.get('supplier_id')})
             abort(400, "should not update an existing supplier")
 
+        if current_user.is_anonymous():
+            updater = token.get("email_address")
+        else:
+            updater = current_user.email_address
+
         data_api_client.update_user(
             user_id=user.id,
             supplier_id=token.get("supplier_id"),
             role='supplier',
-            updater=current_user.email_address
+            updater=updater
         )
         login_user(user)
         return redirect(url_for('.dashboard'))

--- a/tests/app/main/test_login.py
+++ b/tests/app/main/test_login.py
@@ -1022,6 +1022,32 @@ class TestInviteUser(BaseApplicationTest):
             assert_equal(res.location, 'http://localhost/suppliers')
 
     @mock.patch('app.main.views.login.data_api_client')
+    def test_should_update_user_if_not_logged_in(self, data_api_client):
+        with self.app.app_context():
+            data_api_client.get_user.return_value = self.user(
+                123,
+                'test@email.com',
+                None,
+                None,
+                'Users name'
+            )
+
+            token = self._generate_token()
+            res = self.client.post(
+                '/suppliers/update-user/{}'.format(token)
+            )
+
+            data_api_client.update_user.assert_called_once_with(
+                user_id=123,
+                supplier_id=1234,
+                role='supplier',
+                updater="test@email.com"
+            )
+
+            assert_equal(res.status_code, 302)
+            assert_equal(res.location, 'http://localhost/suppliers')
+
+    @mock.patch('app.main.views.login.data_api_client')
     def test_should_not_update_a_supplier_account(self, data_api_client):
         with self.app.app_context():
 


### PR DESCRIPTION
This method was assuming that `current_user` exists, but this method doesn't require login and breaks if called without a `current_user`.

500s in the logs caused by:
```
'AnonymousUserMixin' object has no attribute 'email_address'
``` 