### PR TITLE
G7 closed content updates

### DIFF
--- a/app/assets/scss/_framework-application.scss
+++ b/app/assets/scss/_framework-application.scss
@@ -111,3 +111,43 @@
   margin-top: $gutter/3;
   color: $secondary-text-colour;
 }
+
+/* Temporary styles, to be added to toolkit */
+.summary-item-lede {
+  margin-bottom: $gutter-half - 5px;
+
+  .summary-item-heading {
+    padding-top: 0;
+  }
+
+  p {
+    margin-bottom: 5px;
+
+    a {
+      display: block;
+    }
+  }
+}
+
+.framework-application-reference {
+
+  margin-top: $gutter + 5px;
+
+  .framework-application-section {
+    p,
+    a,
+    .hint,
+    .browse-list-item-link {
+      @include core-16;
+    }
+
+    p {
+      margin-bottom: 0;
+    }
+
+    .browse-list-item-link {
+      border-bottom: none;
+      text-decoration: underline;
+    }
+  }
+}

--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -33,6 +33,7 @@ $path: "/suppliers/static/images/";
 @import "toolkit/document";
 @import "toolkit/contact-details";
 @import "toolkit/link-button";
+@import "toolkit/temporary-message.scss";
 @import "toolkit/forms/_questions.scss";
 @import "toolkit/forms/_summary.scss";
 @import "toolkit/forms/_hint.scss";

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -71,6 +71,11 @@ def framework_services():
     template_data = main.config['BASE_TEMPLATE_DATA']
 
     drafts, complete_drafts = get_drafts(data_api_client, current_user.supplier_id, 'g-cloud-7')
+    g7_status = data_api_client.get_framework_status('g-cloud-7').get('status', None)
+    declaration_status = get_declaration_status(data_api_client)
+    application_made = len(complete_drafts) > 0 and declaration_status == 'complete'
+    if g7_status == 'pending' and not application_made:
+        abort(404)
 
     for draft in itertools.chain(drafts, complete_drafts):
         draft['priceString'] = format_service_price(draft)
@@ -87,8 +92,8 @@ def framework_services():
         "frameworks/services.html",
         complete_drafts=list(reversed(complete_drafts)),
         drafts=list(reversed(drafts)),
-        declaration_status=get_declaration_status(data_api_client),
-        g7_status=data_api_client.get_framework_status('g-cloud-7').get('status', None),
+        declaration_status=declaration_status,
+        g7_status=g7_status,
         **template_data
     ), 200
 

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -39,6 +39,7 @@ def framework_dashboard():
 
     drafts, complete_drafts = get_drafts(data_api_client, current_user.supplier_id, 'g-cloud-7')
     declaration_status = get_declaration_status(data_api_client)
+    application_made = len(complete_drafts) > 0 and declaration_status == 'complete'
 
     key_list = s3.S3(current_app.config['DM_G7_DRAFT_DOCUMENTS_BUCKET']).list('g-cloud-7-')
     # last_modified files will be first
@@ -53,6 +54,7 @@ def framework_dashboard():
         declaration_status=declaration_status,
         deadline=current_app.config['G7_CLOSING_DATE'],
         g7_status=data_api_client.get_framework_status('g-cloud-7').get('status', None),
+        g7_application_made=application_made,
         last_modified={
             'supplier_pack': get_last_modified_from_first_matching_file(key_list, 'g-cloud-7-supplier-pack.zip'),
             'supplier_updates': get_last_modified_from_first_matching_file(key_list, 'g-cloud-7-updates/')

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -13,8 +13,10 @@ from ...main import main
 from ... import data_api_client
 from ..forms.suppliers import EditSupplierForm, EditContactInformationForm, \
     DunsNumberForm, CompaniesHouseNumberForm, CompanyContactDetailsForm, CompanyNameForm, EmailAddressForm
-from ..helpers.frameworks import has_registered_interest_in_framework
+from ..helpers.frameworks import has_registered_interest_in_framework, \
+    get_declaration_status
 from ..helpers import hash_email
+from ..helpers.services import get_drafts
 from .users import get_current_suppliers_users
 
 
@@ -31,12 +33,17 @@ def dashboard():
     except APIError as e:
         abort(e.status_code)
 
+    drafts, complete_drafts = get_drafts(data_api_client, current_user.supplier_id, 'g-cloud-7')
+    declaration_status = get_declaration_status(data_api_client)
+    application_made = len(complete_drafts) > 0 and declaration_status == 'complete'
     return render_template(
         "suppliers/dashboard.html",
         supplier=supplier,
         users=get_current_suppliers_users(),
         g7_interested=has_registered_interest_in_framework(data_api_client, 'g-cloud-7'),
         g7_status=data_api_client.get_framework_status('g-cloud-7').get('status', None),
+        g7_application_made=application_made,
+        g7_complete=len(complete_drafts),
         deadline=current_app.config['G7_CLOSING_DATE'],
         **template_data
     ), 200

--- a/app/templates/frameworks/dashboard.html
+++ b/app/templates/frameworks/dashboard.html
@@ -37,79 +37,112 @@
       {% include "toolkit/page-heading.html" %}
     {% endwith %}
   {% endif %}
-  <aside role="complementary" class="framework-application-status">
-    Deadline {% if g7_status == 'pending' %} for submissions passed at {% endif %} <strong>{{ deadline|safe }}</strong>
+  {% if g7_status == 'open' %}
+  <aside role="complementary" class="framework-application-status" aria-label="G-Cloud status">
+    Deadline <strong>{{ deadline|safe }}</strong>
   </aside>
-
   <nav role="navigation">
+  {% elif g7_status == 'pending' %}
+    <div class="summary-item-lede">
+      <div class="grid-row">
+        <div class="column-two-thirds">
+          <h2 class="summary-item-heading">G-Cloud is closed for applications</h2>
+          {% if g7_application_made %}
+            <p>You made your supplier declaration and submitted {{ g7_complete }} {{ 'service' if g7_complete == 1 else 'services' }}.</p>
+            <p>A letter informing you whether your application was successful or not will be posted on your G-Cloud 7 updates page by Tuesday, 9 November 2015.</p>
+          {% else %}
+            <p>You didn't submit an application.</p>
+          {% endif %}
+        </div>
+      </div>
+    </div>
+  <nav role="navigation" class="framework-application-reference">
+  {% endif %}
     <ul class="browse-list">
-      <li class="browse-list-item framework-application-section">
-        <div class="grid-row">
-          <div class="column-two-thirds">
-            {% if not counts.draft %}
-              <div class="framework-section-validation-bar-good">
-            {% endif %}
-              <a class="browse-list-item-link" href="{{ url_for('.framework_services') }}">
-                <span>
-                {% if g7_status == 'open' %}
-                  Add, edit and delete services
-                {% else %}
-                  View services
-                {% endif %}
-                </span>
-              </a>
-            {% if not counts.draft %}
-              </div>
-            {% endif %}
-          </div>
-          <div class="column-two-thirds">
-
-            {% if not counts.complete and not counts.draft %}
-              <div class="framework-section-status-neutral">
-                <p>
-                  You need to add and complete services
-                </p>
-              </div>
-            {% endif %}
-
-            {% if counts.draft and not counts.complete %}
-              <div class="framework-section-status-neutral">
-                You have
-                {{ counts.draft }} draft
-                {{ 'service' if counts.draft == 1 else 'services' }}
-                that won’t be submitted
-              </div>
-            {% endif %}
-
-            {% if counts.complete and declaration_status != 'complete' %}
-              <div class="framework-section-status-neutral">
-                You have {{ counts.complete }} complete
-                {{ 'service' if counts.complete == 1 else 'services' }}
-                and {{ counts.draft }} draft
-                {{ 'service' if counts.draft == 1 else 'services' }}
-              </div>
-            {% endif %}
-
-            {% if counts.complete and declaration_status == 'complete' %}
+      {% if g7_status == 'open' %}
+        <li class="browse-list-item framework-application-section">
+          <div class="grid-row">
+            <div class="column-two-thirds">
               {% if not counts.draft %}
-                <div class="framework-section-status-good">
+                <div class="framework-section-validation-bar-good">
               {% endif %}
-              <p>
-                <strong><span class="big-number">{{ counts.complete }}</span> complete
-                 {{ 'service' if counts.complete == 1 else 'services' }} will be submitted at the deadline</strong>
-              </p>
+                <a class="browse-list-item-link" href="{{ url_for('.framework_services') }}">
+                  <span>
+                    Add, edit and delete services
+                  </span>
+                </a>
               {% if not counts.draft %}
                 </div>
               {% endif %}
-              {% if counts.draft %}
-                <p class="framework-section-status-neutral">
-                  {{ counts.draft }} draft {{ 'service' if counts.draft == 1 else 'services' }} won’t be submitted
-                </p>
+            </div>
+            <div class="column-two-thirds">
+              {% if not counts.complete and not counts.draft %}
+                <div class="framework-section-status-neutral">
+                  <p>
+                    You need to add and complete services
+                  </p>
+                </div>
               {% endif %}
-            {% endif %}
+
+              {% if counts.draft and not counts.complete %}
+                <div class="framework-section-status-neutral">
+                  You have
+                  {{ counts.draft }} draft
+                  {{ 'service' if counts.draft == 1 else 'services' }}
+                  that won’t be submitted
+                </div>
+              {% endif %}
+
+              {% if counts.complete and declaration_status != 'complete' %}
+                <div class="framework-section-status-neutral">
+                  You have {{ counts.complete }} complete
+                  {{ 'service' if counts.complete == 1 else 'services' }}
+                  and {{ counts.draft }} draft
+                  {{ 'service' if counts.draft == 1 else 'services' }}
+                </div>
+              {% endif %}
+
+              {% if counts.complete and declaration_status == 'complete' %}
+                {% if not counts.draft %}
+                  <div class="framework-section-status-good">
+                {% endif %}
+                <p>
+                  <strong><span class="big-number">{{ counts.complete }}</span> complete
+                   {{ 'service' if counts.complete == 1 else 'services' }} will be submitted at the deadline</strong>
+                </p>
+                {% if not counts.draft %}
+                  </div>
+                {% endif %}
+                {% if counts.draft %}
+                  <p class="framework-section-status-neutral">
+                    {{ counts.draft }} draft {{ 'service' if counts.draft == 1 else 'services' }} won’t be submitted
+                  </p>
+                {% endif %}
+              {% endif %}
+            </div>
           </div>
-        </div>
-      </li>
+        </li>
+      {% elif g7_status == 'pending' and g7_application_made %}
+        <li class="browse-list-item framework-application-section">
+          <div class="grid-row">
+            <div class="column-two-thirds">
+              <a class="browse-list-item-link" href="{{ url_for('.framework_services') }}">
+                <span>
+                  View services
+                </span>
+              </a>
+            </div>
+            <div class="column-two-thirds">
+              <div class="framework-section-status-neutral">
+                <p>{{ counts.draft }} draft
+                {{ 'service' if counts.draft == 1 else 'services' }} {{ 'was' if counts.draft == 1 else 'were' }} not submitted</p>
+                <p>{{ counts.complete }} complete
+                {{ 'service' if counts.complete == 1 else 'services' }} {{ 'was' if counts.draft == 1 else 'were' }} submitted</p>
+              </div>
+            </div>
+          </div>
+        </li>
+      {% endif %}
 
       {% if g7_status == 'open' %}
         <li class="browse-list-item framework-application-section">
@@ -170,34 +203,65 @@
         </li>
       {% endif %}
       
-      <li class="browse-list-item framework-application-section-last">
-        <div class="grid-row">
-          <div class="column-two-thirds">
-            <h2>About G-Cloud 7</h2>
-            <ul>
-              <li>
-                <a href="{{ url_for('.download_supplier_file', filepath='g-cloud-7-supplier-pack.zip') }}"><span>Download guidance and legal documentation (.zip)</span></a>
-                {% if last_modified.supplier_pack %}
-                  <div class="hint">Last updated <time datetime="{{ last_modified.supplier_pack }}">{{ last_modified.supplier_pack|dateformat }}</time></div>
-                {% endif %}
-              </li>
-              <li>
-                <a href="{{ url_for('.framework_updates') }}">
-                  <span>
-                  {% if 'G7_CLARIFICATIONS_CLOSED' is active_feature %}
-                    Read updates and clarification question responses
-                  {% else %}
-                    Read updates and ask clarification questions
+      {% if g7_status == 'open' %}
+        <li class="browse-list-item framework-application-section">
+          <div class="grid-row">
+            <div class="column-two-thirds">
+              <h2>About G-Cloud 7</h2>
+              <ul>
+                <li>
+                  <a href="{{ url_for('.download_supplier_file', filepath='g-cloud-7-supplier-pack.zip') }}"><span>Download guidance and legal documentation (.zip)</span></a>
+                  {% if last_modified.supplier_pack %}
+                    <div class="hint">Last updated <time datetime="{{ last_modified.supplier_pack }}">{{ last_modified.supplier_pack|dateformat }}</time></div>
                   {% endif %}
-                  </span></a>
-                {% if last_modified.supplier_updates %}
-                  <div class="hint">Last updated <time datetime="{{ last_modified.supplier_updates }}">{{ last_modified.supplier_updates|dateformat }}</time></div>
-                {% endif %}
-              </li>
-            </ul>
+                </li>
+                <li>
+                  <a href="{{ url_for('.framework_updates') }}">
+                    <span>
+                    {% if 'G7_CLARIFICATIONS_CLOSED' is active_feature %}
+                      Read updates and clarification question responses
+                    {% else %}
+                      Read updates and ask clarification questions
+                    {% endif %}
+                    </span></a>
+                  {% if last_modified.supplier_updates %}
+                    <div class="hint">Last updated <time datetime="{{ last_modified.supplier_updates }}">{{ last_modified.supplier_updates|dateformat }}</time></div>
+                  {% endif %}
+                </li>
+              </ul>
+            </div>
           </div>
-        </div>
+        </li>
+      {% else %}
+        <li class="browse-list-item framework-application-section">
+          <div class="grid-row">
+            <div class="column-two-thirds">
+              <a href="{{ url_for('.download_supplier_file', filepath='g-cloud-7-supplier-pack.zip') }}"><span>Download guidance and legal documentation (.zip)</span></a>
+              {% if last_modified.supplier_pack %}
+                <div class="hint">Last updated <time datetime="{{ last_modified.supplier_pack }}">{{ last_modified.supplier_pack|dateformat }}</time></div>
+              {% endif %}
+            </div>
+          </div>
+        </li>
+        <li class="browse-list-item framework-application-section">
+          <div class="grid-row">
+            <div class="column-two-thirds">
+              <a href="{{ url_for('.framework_updates') }}">
+                <span>
+                {% if 'G7_CLARIFICATIONS_CLOSED' is active_feature %}
+                  Read updates and clarification question responses
+                {% else %}
+                  Read updates and ask clarification questions
+                {% endif %}
+                </span></a>
+              {% if last_modified.supplier_updates %}
+                <div class="hint">Last updated <time datetime="{{ last_modified.supplier_updates }}">{{ last_modified.supplier_updates|dateformat }}</time></div>
+              {% endif %}
+                </li>
+            </div>
+          </div>
       </li>
+      {% endif %}
     </ul>
   </nav>
 

--- a/app/templates/frameworks/dashboard.html
+++ b/app/templates/frameworks/dashboard.html
@@ -48,7 +48,7 @@
         <div class="column-two-thirds">
           <h2 class="summary-item-heading">G-Cloud is closed for applications</h2>
           {% if g7_application_made %}
-            <p>You made your supplier declaration and submitted {{ g7_complete }} {{ 'service' if g7_complete == 1 else 'services' }}.</p>
+            <p>You made your supplier declaration and submitted {{ counts.complete }} {{ 'service' if counts.complete == 1 else 'services' }}.</p>
             <p>A letter informing you whether your application was successful or not will be posted on your G-Cloud 7 updates page by Tuesday, 9 November 2015.</p>
           {% else %}
             <p>You didn't submit an application.</p>
@@ -137,7 +137,7 @@
                 <p>{{ counts.draft }} draft
                 {{ 'service' if counts.draft == 1 else 'services' }} {{ 'was' if counts.draft == 1 else 'were' }} not submitted</p>
                 <p>{{ counts.complete }} complete
-                {{ 'service' if counts.complete == 1 else 'services' }} {{ 'was' if counts.draft == 1 else 'were' }} submitted</p>
+                {{ 'service' if counts.complete == 1 else 'services' }} {{ 'was' if counts.complete == 1 else 'were' }} submitted</p>
               </div>
             </div>
           </div>

--- a/app/templates/frameworks/services.html
+++ b/app/templates/frameworks/services.html
@@ -61,9 +61,24 @@
     {% include "toolkit/page-heading.html" %}
   {% endwith %}
 
+  {% if g7_status == 'pending' %}
+    <div class="summary-item-lede">
+      <div class="grid-row">
+        <div class="column-two-thirds">
+          <h2 class="summary-item-heading">G-Cloud 7 is closed for applications</h2>
+          <p>
+            You made your supplier declaration and submitted {{ complete_drafts|length }} complete {{ 'services' if complete_drafts|length == 1 else 'services' }}.
+          </p>
+        </div>
+      </div>
+    </div>
+  {% endif %}
+
   {{ summary.heading("Draft services") }}
   {% if g7_status == 'open' %}
     {{ summary.top_link("Add a service", url_for(".start_new_draft_service")) }}
+  {% elif g7_status == 'pending' %}
+    <p class="hint">These services were not submitted</p>
   {% endif %}
   {% call(draft) summary.list_table(
     drafts,
@@ -81,11 +96,14 @@
       {{ summary.service_link(draft.serviceName,
                               url_for(".view_service_submission", service_id=draft.id)) }}
       {{ summary.text(draft.lot) }}
+      
+      {% if g7_status == 'open' %}
       {{ summary.text(submission.multiline_string(
         submission.can_be_completed_text(draft.unanswered_required, g7_status),
         submission.unanswered_required_text(draft.unanswered_required, draft.unanswered_optional),
         submission.unanswered_optional_text(draft.unanswered_required, draft.unanswered_optional)
       )) }}
+      {% endif %}
       {% if g7_status == 'open' %}
         {{ summary.button(text="Make a copy",
                            action=url_for('.copy_draft_service', service_id=draft.id)) }}
@@ -93,7 +111,11 @@
     {% endcall %}
   {% endcall %}
 
+  {% if g7_status == 'open' %}
   {{ summary.heading("Complete services") }}
+  {% elif g7_status == 'pending' %}
+  {{ summary.heading("Submitted services") }}
+  {% endif %}
   {% call(draft) summary.list_table(
     complete_drafts,
     caption="Complete services",

--- a/app/templates/frameworks/services.html
+++ b/app/templates/frameworks/services.html
@@ -67,7 +67,7 @@
         <div class="column-two-thirds">
           <h2 class="summary-item-heading">G-Cloud 7 is closed for applications</h2>
           <p>
-            You made your supplier declaration and submitted {{ complete_drafts|length }} complete {{ 'services' if complete_drafts|length == 1 else 'services' }}.
+            You made your supplier declaration and submitted {{ complete_drafts|length }} complete {{ 'service' if complete_drafts|length == 1 else 'services' }}.
           </p>
         </div>
       </div>

--- a/app/templates/services/service_submission.html
+++ b/app/templates/services/service_submission.html
@@ -36,6 +36,29 @@
       {% endwith %}
     </div>
   {% endif %}
+
+  {% if g7_status == 'pending' %}
+    <div class="wrapper">
+      <aside role="complementary" class="temporary-message" aria-labelledby="temporary-message-heading">
+        {% if service_data.status == 'submitted' %}
+          <h2 class="temporary-message-heading" id="temporary-message-heading">
+            This service was submitted
+          </h2>
+          <p class="temporary-message-message">
+            If your application is successful, it will be available on the Digital Marketplace when G-Cloud 7 goes live.
+          </p>
+        {% else %}
+          <h2 class="temporary-message-heading" id="temporary-message-heading">
+            This service was not submitted
+          </h2>
+          <p class="temporary-message-message">
+            It wasn't marked as complete at the deadline.
+          </p>
+        {% endif %}
+      </aside>
+    </div>
+
+  {% endif %}
 {% endblock %}
 
 {% block before_sections %}
@@ -48,21 +71,32 @@
     {{ last_edit.createdAt|datetimeformat }}
     by {{ last_edit.userName }}
   </p>
-  {% if unanswered_required or unanswered_optional %}
-    <p class="last-edited">
-      {{ submission.multiline_string(
-        submission.unanswered_required_text(unanswered_required, unanswered_optional),
-        submission.unanswered_optional_text(unanswered_required, unanswered_optional)
-      ) }}
-    </p>
-  {% endif %}
-  {% if service_data.status == 'submitted' and declaration_status == 'complete' %}
-    <span class="service-status-published">This service is marked as complete and will be submitted at {{ deadline|safe }}</span>
-  {% endif %}
-  {% if service_data.status == 'not-submitted' and unanswered_required == 0 and g7_status == 'open' %}
-    {% include "partials/complete_service.html" %}
-  {% elif unanswered_required > 0 %}
-    <p class="move-to-complete-hint">When you have added all the required information, you can mark the service as complete.</p>
+  {% if g7_status == 'open' %}
+    {% if unanswered_required or unanswered_optional %}
+      <p class="last-edited">
+        {{ submission.multiline_string(
+          submission.unanswered_required_text(unanswered_required, unanswered_optional),
+          submission.unanswered_optional_text(unanswered_required, unanswered_optional)
+        ) }}
+      </p>
+    {% endif %}
+    {% if service_data.status == 'submitted' and declaration_status == 'complete' %}
+      <span class="service-status-published">This service is marked as complete and will be submitted at {{ deadline|safe }}</span>
+    {% endif %}
+    {% if service_data.status == 'not-submitted' and unanswered_required == 0 and g7_status == 'open' %}
+      {% include "partials/complete_service.html" %}
+    {% elif unanswered_required > 0 %}
+      <p class="move-to-complete-hint">When you have added all the required information, you can mark the service as complete.</p>
+    {% endif %}
+  {% elif g7_status == 'pending' %}
+    {% if unanswered_required or unanswered_optional %}
+      <p class="last-edited">
+        {{ submission.multiline_string(
+          submission.unanswered_required_text(unanswered_required, unanswered_optional),
+          submission.unanswered_optional_text(unanswered_required, unanswered_optional)
+        ) }}
+      </p>
+    {% endif %}
   {% endif %}
 </div>
 {% endblock %}

--- a/app/templates/suppliers/dashboard.html
+++ b/app/templates/suppliers/dashboard.html
@@ -53,16 +53,39 @@
       %}
         {% include "toolkit/browse-list.html" %}
       {% endwith %}
+    {% elif g7_interested and g7_application_made and g7_status == 'pending' %}
+      <aside role="complementary" class="temporary-message">
+        <h2 class="temporary-message-heading">
+          G‑Cloud 7 is closed for applications
+        </h2>
+        <p class="temporary-message-message">
+          You submitted {{ g7_complete }} services for consideration.
+        </p>
+        <p class="temporary-message-message">
+          <a href="{{ url_for(".framework_dashboard") }}">View your submitted application</a>
+        </p>
+      </aside>
+    {% elif g7_interested and g7_status == 'pending' %}
+      <aside role="complementary" class="temporary-message">
+        <h2 class="temporary-message-heading">
+          G‑Cloud 7 is closed for applications
+        </h2>
+        <p class="temporary-message-message">
+          You didn’t submit an application.
+        </p>
+        <p class="temporary-message-message">
+          Follow the <a href=\"https://digitalmarketplace.blog.gov.uk/\">Digital Marketplace blog</a> for further G-Cloud updates.
+        </p>
+      </aside>
     {% elif g7_status == 'pending' %}
-      {%
-        with
-        items = [{
-        "title": "View your G-Cloud 7 application",
-        "link": url_for(".framework_dashboard")
-        }]
-      %}
-        {% include "toolkit/browse-list.html" %}
-      {% endwith %}
+      <aside role="complementary" class="temporary-message">
+        <h2 class="temporary-message-heading">
+          G‑Cloud 7 is closed for applications
+        </h2>
+        <p class="temporary-message-message">
+          Follow the <a href=\"https://digitalmarketplace.blog.gov.uk/\">Digital Marketplace blog</a> for further G-Cloud updates.
+        </p>
+      </aside>
     {% endif %}
   {% endif %}
 

--- a/app/templates/suppliers/dashboard.html
+++ b/app/templates/suppliers/dashboard.html
@@ -74,7 +74,7 @@
           You didn’t submit an application.
         </p>
         <p class="temporary-message-message">
-          Follow the <a href="https://digitalmarketplace.blog.gov.uk/">Digital Marketplace blog</a> for further G-Cloud updates.
+          <a href="{{ url_for('.framework_dashboard') }}">View G-Cloud 7 information</a> 
         </p>
       </aside>
     {% elif g7_status == 'pending' %}

--- a/app/templates/suppliers/dashboard.html
+++ b/app/templates/suppliers/dashboard.html
@@ -54,36 +54,36 @@
         {% include "toolkit/browse-list.html" %}
       {% endwith %}
     {% elif g7_interested and g7_application_made and g7_status == 'pending' %}
-      <aside role="complementary" class="temporary-message">
-        <h2 class="temporary-message-heading">
-          G‑Cloud 7 is closed for applications
-        </h2>
-        <p class="temporary-message-message">
-          You submitted {{ g7_complete }} services for consideration.
-        </p>
-        <p class="temporary-message-message">
-          <a href="{{ url_for(".framework_dashboard") }}">View your submitted application</a>
-        </p>
-      </aside>
+      <div class="summary-item-lede">
+        <div class="grid-row">
+          <div class="column-two-thirds">
+            <h2 class="summary-item-heading">G-Cloud is closed for applications</h2>
+            <p>
+              You submitted {{ g7_complete }} {{ 'service' if g7_complete == 1 else 'services' }} for consideration.
+              <a href="{{ url_for('.framework_dashboard') }}">View your submitted application</a>
+            </p>
+          </div>
+        </div>
+      </div>
     {% elif g7_interested and g7_status == 'pending' %}
-      <aside role="complementary" class="temporary-message">
-        <h2 class="temporary-message-heading">
+      <aside role="complementary" class="temporary-message" aria-labelledby="temporary-message-heading">
+        <h2 class="temporary-message-heading" id="temporary-message-heading">
           G‑Cloud 7 is closed for applications
         </h2>
         <p class="temporary-message-message">
           You didn’t submit an application.
         </p>
         <p class="temporary-message-message">
-          Follow the <a href=\"https://digitalmarketplace.blog.gov.uk/\">Digital Marketplace blog</a> for further G-Cloud updates.
+          Follow the <a href="https://digitalmarketplace.blog.gov.uk/">Digital Marketplace blog</a> for further G-Cloud updates.
         </p>
       </aside>
     {% elif g7_status == 'pending' %}
-      <aside role="complementary" class="temporary-message">
-        <h2 class="temporary-message-heading">
+      <aside role="complementary" class="temporary-message" aria-labelledby="temporary-message-heading">
+        <h2 class="temporary-message-heading" id="temporary-message-heading">
           G‑Cloud 7 is closed for applications
         </h2>
         <p class="temporary-message-message">
-          Follow the <a href=\"https://digitalmarketplace.blog.gov.uk/\">Digital Marketplace blog</a> for further G-Cloud updates.
+          Follow the <a href="https://digitalmarketplace.blog.gov.uk/">Digital Marketplace blog</a> for further G-Cloud updates.
         </p>
       </aside>
     {% endif %}

--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "jquery": "1.11.2",
     "hogan": "3.0.2",
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
-    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v11.0.1",
+    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v11.3.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.14.1/jinja_govuk_template-0.14.1.tgz",
     "digital-marketplace-ssp-content": "git://github.com/alphagov/digitalmarketplace-ssp-content#d47defa52ee51654a42b46d7d6e2bca8c8c14f50"
   }

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -31,7 +31,7 @@ class TestFrameworksDashboard(BaseApplicationTest):
 
         for last_updated in last_updateds:
             hint = doc.xpath(
-                '//li[contains(@class, "framework-application-section-last")]'
+                '//li[contains(@class, "framework-application-section")]'
                 '//span[contains(text(), "{}")]'
                 '/../..'
                 '/div[@class="hint"]'.format(last_updated['text'])
@@ -761,7 +761,7 @@ class TestG7ServicesList(BaseApplicationTest):
             self.login()
 
         count_unanswered.return_value = 3, 1
-
+        data_api_client.get_framework_status.return_value = {'status': 'open'}
         data_api_client.find_draft_services.return_value = {
             'services': [
                 {'serviceName': 'draft', 'lot': 'SCS', 'status': 'not-submitted'},

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -756,6 +756,40 @@ class TestSendClarificationQuestionEmail(BaseApplicationTest):
 @mock.patch('app.main.views.frameworks.count_unanswered_questions')
 class TestG7ServicesList(BaseApplicationTest):
 
+    def test_404_when_g7_pending_and_no_complete_services(self, count_unanswered, data_api_client):
+        with self.app.test_client():
+            self.login()
+        data_api_client.get_framework_status.return_value = {'status': 'pending'}
+        data_api_client.find_draft_services.return_value = {'services': []}
+        count_unanswered.return_value = 0
+        response = self.client.get('/suppliers/frameworks/g-cloud-7/services')
+        assert_equal(response.status_code, 404)
+
+    def test_404_when_g7_pending_and_no_declaration(self, count_unanswered, data_api_client):
+        with self.app.test_client():
+            self.login()
+        data_api_client.get_framework_status.return_value = {'status': 'pending'}
+        data_api_client.get_selection_answers.return_value = {'selectionAnswers': {'questionAnswers': {'status': 'started'}}}  # noqa
+        response = self.client.get('/suppliers/frameworks/g-cloud-7/services')
+        assert_equal(response.status_code, 404)
+
+    def test_no_404_when_g7_open_and_no_complete_services(self, count_unanswered, data_api_client):
+        with self.app.test_client():
+            self.login()
+        data_api_client.get_framework_status.return_value = {'status': 'open'}
+        data_api_client.find_draft_services.return_value = {'services': []}
+        count_unanswered.return_value = 0
+        response = self.client.get('/suppliers/frameworks/g-cloud-7/services')
+        assert_equal(response.status_code, 200)
+
+    def test_no_404_when_g7_open_and_no_declaration(self, count_unanswered, data_api_client):
+        with self.app.test_client():
+            self.login()
+        data_api_client.get_framework_status.return_value = {'status': 'open'}
+        data_api_client.get_selection_answers.return_value = {'selectionAnswers': {'questionAnswers': {'status': 'started'}}}  # noqa
+        response = self.client.get('/suppliers/frameworks/g-cloud-7/services')
+        assert_equal(response.status_code, 200)
+
     def test_drafts_list_progress_count(self, count_unanswered, data_api_client):
         with self.app.test_client():
             self.login()

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -945,6 +945,7 @@ class TestShowDraftService(BaseApplicationTest):
 
     @mock.patch('app.main.views.services.count_unanswered_questions')
     def test_unanswered_questions_count(self, count_unanswered, data_api_client):
+        data_api_client.get_framework_status.return_value = {'status': 'open'}
         data_api_client.get_draft_service.return_value = self.draft_service
         count_unanswered.return_value = 1, 2
         res = self.client.get('/suppliers/submission/services/1')
@@ -969,7 +970,6 @@ class TestShowDraftService(BaseApplicationTest):
         count_unanswered.return_value = 0, 1
         res = self.client.get('/suppliers/submission/services/1')
 
-        assert_in(u'1 optional question unanswered', res.get_data(as_text=True))
         assert_not_in(u'<input type="submit" class="button-save"  value="Mark as complete" />',
                       res.get_data(as_text=True))
 

--- a/tests/app/main/test_suppliers.py
+++ b/tests/app/main/test_suppliers.py
@@ -155,26 +155,6 @@ class TestSuppliersDashboard(BaseApplicationTest):
             assert_equal(doc.xpath('//a[@href="/suppliers/frameworks/g-cloud-7"]/span/text()')[0],
                          "Continue your G-Cloud 7 application")
 
-    @mock.patch("app.main.views.suppliers.data_api_client")
-    @mock.patch("app.main.views.suppliers.get_current_suppliers_users")
-    def test_shows_view_gcloud_7_link_if_pending(self, get_current_suppliers_users, data_api_client):
-        data_api_client.get_framework_status.return_value = {'status': 'pending'}
-        data_api_client.get_supplier.side_effect = get_supplier
-        data_api_client.find_audit_events.return_value = {
-            "auditEvents": []
-        }
-        get_current_suppliers_users.side_effect = get_user
-        with self.app.test_client():
-            self.login()
-
-            res = self.client.get("/suppliers")
-            doc = html.fromstring(res.get_data(as_text=True))
-
-            assert_equal(res.status_code, 200)
-
-            assert_equal(doc.xpath('//a[@href="/suppliers/frameworks/g-cloud-7"]/span/text()')[0],
-                         "View your G-Cloud 7 application")
-
 
 class TestSupplierDashboardLogin(BaseApplicationTest):
     @mock.patch("app.main.views.suppliers.data_api_client")


### PR DESCRIPTION
Changes for when G7 is switched off.

https://www.pivotaltracker.com/story/show/103088582

### Page states

#### Supplier dashboard, user has not registered

![dashboard_unregistered](https://cloud.githubusercontent.com/assets/87140/10304869/ae46486a-6c14-11e5-8f0b-13272c13024b.png)

#### Supplier dashboard, user registered but did not submit an application

![dashboard_registered_no_application](https://cloud.githubusercontent.com/assets/87140/10305111/32c97a5c-6c16-11e5-98b9-709a3fa6c063.png)

#### Supplier dashboard, user registered and submitted an application with 1 service

![dashboard_registered_1_service_submitted](https://cloud.githubusercontent.com/assets/87140/10304897/d5995e3e-6c14-11e5-8d17-7efc35c1c44c.png)

#### G-Cloud 7 application dashboard, user did not submit an application

![application_dashboard_no_application](https://cloud.githubusercontent.com/assets/87140/10304921/047b1134-6c15-11e5-8350-bfa79a7df8d2.png)

#### G-Cloud 7 application dashboard, user submitted an application with 1 service

![application_dashboard_happy_path](https://cloud.githubusercontent.com/assets/87140/10305048/bd39b5fe-6c15-11e5-8d6b-c999b9efb56e.png)

#### G-Cloud 7 services page

![services_happy_path](https://cloud.githubusercontent.com/assets/87140/10305180/accfb802-6c16-11e5-9ade-4a065e76265e.png)

#### G-Cloud 7 completed service

![service_submitted](https://cloud.githubusercontent.com/assets/87140/10304966/3cd64bd4-6c15-11e5-938d-86cc4ac698ba.png)

#### G-Cloud 7 draft service

![service_still_in_draft](https://cloud.githubusercontent.com/assets/87140/10304974/471c82fc-6c15-11e5-9578-bd03b7691e13.png)
