### PR TITLE
Change the nature of time.

### DIFF
--- a/app/templates/frameworks/dashboard.html
+++ b/app/templates/frameworks/dashboard.html
@@ -49,7 +49,7 @@
           <h2 class="summary-item-heading">G-Cloud 7 is closed for applications</h2>
           {% if g7_application_made %}
             <p>You made your supplier declaration and submitted {{ counts.complete }} {{ 'service' if counts.complete == 1 else 'services' }} for consideration.</p>
-            <p>A letter informing you whether your application was successful or not will be posted on your G-Cloud 7 updates page by Tuesday, 9 November 2015.</p>
+            <p>A letter informing you whether your application was successful or not will be posted on your G-Cloud 7 updates page by Monday, 9 November 2015.</p>
           {% else %}
             <p>You didn't submit an application.</p>
           {% endif %}


### PR DESCRIPTION
There is no Tuesday, November 9th 2015.  Not anymore.