### PR TITLE
Upgrade to dmutils 9.0.0

### DIFF
--- a/app/main/helpers/frameworks.py
+++ b/app/main/helpers/frameworks.py
@@ -185,19 +185,19 @@ def get_first_question_index(content, section):
 
 def get_declaration_status(data_api_client):
     try:
-        answers = data_api_client.get_selection_answers(
+        declaration = data_api_client.get_supplier_declaration(
             current_user.supplier_id, 'g-cloud-7'
-        )['selectionAnswers']['questionAnswers']
+        )['declaration']
     except APIError as e:
         if e.status_code == 404:
             return 'unstarted'
         else:
             abort(e.status_code)
 
-    if not answers:
+    if not declaration:
         return 'unstarted'
     else:
-        return answers.get('status', 'unstarted')
+        return declaration.get('status', 'unstarted')
 
 
 def g_cloud_7_is_open_or_404(data_api_client):

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -116,9 +116,8 @@ def framework_supplier_declaration(section_id):
     is_last_page = section_id == content.sections[-1]['id']
 
     try:
-        response = data_api_client.get_selection_answers(
-            current_user.supplier_id, 'g-cloud-7')
-        latest_answers = response['selectionAnswers']['questionAnswers']
+        response = data_api_client.get_supplier_declaration(current_user.supplier_id, 'g-cloud-7')
+        latest_answers = response['declaration']
     except APIError as e:
         if e.status_code != 404:
             abort(e.status_code)
@@ -136,7 +135,7 @@ def framework_supplier_declaration(section_id):
             else:
                 latest_answers.update({"status": "complete"})
             try:
-                data_api_client.answer_selection_questions(
+                data_api_client.set_supplier_declaration(
                     current_user.supplier_id,
                     'g-cloud-7',
                     latest_answers,

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ Flask-Script==2.0.5
 Flask-WTF==0.12
 
 git+https://github.com/madzak/python-json-logger.git@v0.1.3#egg=python-json-logger==v0.1.3
-git+https://github.com/alphagov/digitalmarketplace-utils.git@8.6.0#egg=digitalmarketplace-utils==8.6.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@9.0.0#egg=digitalmarketplace-utils==9.0.0
 
 markdown==2.6.2
 


### PR DESCRIPTION
This brings in alphagov/digitalmarketplace-utils#178 which changes the `DataAPIClient` to match the language we use around the supplier declaration.

## :sparkles: This has been tested locally with the functional tests :sparkles: 

Using the SSP tests with the framework set to 'open'.