### PR TITLE
Make G7 routes support multi-framework

### DIFF
--- a/app/main/__init__.py
+++ b/app/main/__init__.py
@@ -7,6 +7,8 @@ content_loader = ContentLoader('app/content')
 content_loader.load_manifest('g-cloud-6', 'services', 'edit_service')
 content_loader.load_manifest('g-cloud-7', 'services', 'edit_submission')
 content_loader.load_manifest('g-cloud-7', 'declaration', 'declaration')
+content_loader.load_manifest('digital-outcomes-and-specialists', 'declaration', 'declaration')
+content_loader.load_manifest('digital-outcomes-and-specialists', 'services', 'edit_submission')
 
 
 @main.after_request

--- a/app/main/helpers/frameworks.py
+++ b/app/main/helpers/frameworks.py
@@ -183,10 +183,10 @@ def get_first_question_index(content, section):
     return questions_so_far
 
 
-def get_declaration_status(data_api_client):
+def get_declaration_status(data_api_client, framework_slug):
     try:
         declaration = data_api_client.get_supplier_declaration(
-            current_user.supplier_id, 'g-cloud-7'
+            current_user.supplier_id, framework_slug
         )['declaration']
     except APIError as e:
         if e.status_code == 404:

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -34,7 +34,7 @@ def dashboard():
         abort(e.status_code)
 
     drafts, complete_drafts = get_drafts(data_api_client, current_user.supplier_id, 'g-cloud-7')
-    declaration_status = get_declaration_status(data_api_client)
+    declaration_status = get_declaration_status(data_api_client, 'g-cloud-7')
     application_made = len(complete_drafts) > 0 and declaration_status == 'complete'
     return render_template(
         "suppliers/dashboard.html",

--- a/app/templates/frameworks/dashboard.html
+++ b/app/templates/frameworks/dashboard.html
@@ -1,6 +1,6 @@
 {% extends "_base_page.html" %}
 
-{% block page_title %}Apply to G-Cloud 7 – Digital Marketplace{% endblock %}
+{% block page_title %}Apply to {{ framework.name }} – Digital Marketplace{% endblock %}
 
 {% block breadcrumb %}
   {%
@@ -20,9 +20,9 @@
 {% endblock %}
 
 {% block main_content %}
-  {% if g7_status == 'open' %}
+  {% if framework.status == 'open' %}
     {% with
-       heading = "Apply to G-Cloud 7",
+       heading = "Apply to " + framework.name,
        smaller = True,
        with_breadcrumb = True
     %}
@@ -30,24 +30,24 @@
     {% endwith %}
   {% else %}
     {% with
-      heading = "Your G-Cloud 7 application",
+      heading = "Your " + framework.name + " application",
       smaller = True,
       with_breadcrumb = True
     %}
       {% include "toolkit/page-heading.html" %}
     {% endwith %}
   {% endif %}
-  {% if g7_status == 'open' %}
+  {% if framework.status == 'open' %}
   <aside role="complementary" class="framework-application-status" aria-label="G-Cloud status">
     Deadline <strong>{{ deadline|safe }}</strong>
   </aside>
   <nav role="navigation">
-  {% elif g7_status == 'pending' %}
+  {% elif framework.status == 'pending' %}
     <div class="summary-item-lede">
       <div class="grid-row">
         <div class="column-two-thirds">
-          <h2 class="summary-item-heading">G-Cloud 7 is closed for applications</h2>
-          {% if g7_application_made %}
+          <h2 class="summary-item-heading">{{ framework.name }} is closed for applications</h2>
+          {% if application_made %}
             <p>You made your supplier declaration and submitted {{ counts.complete }} {{ 'service' if counts.complete == 1 else 'services' }} for consideration.</p>
             <p>A letter informing you whether your application was successful or not will be posted on your G-Cloud 7 updates page by Monday, 9 November 2015.</p>
           {% else %}
@@ -59,14 +59,14 @@
   <nav role="navigation" class="framework-application-reference">
   {% endif %}
     <ul class="browse-list">
-      {% if g7_status == 'open' %}
+      {% if framework.status == 'open' %}
         <li class="browse-list-item framework-application-section">
           <div class="grid-row">
             <div class="column-two-thirds">
               {% if not counts.draft %}
                 <div class="framework-section-validation-bar-good">
               {% endif %}
-                <a class="browse-list-item-link" href="{{ url_for('.framework_services') }}">
+                <a class="browse-list-item-link" href="{{ url_for('.framework_services', framework_slug=framework.slug) }}">
                   <span>
                     Add, edit and delete services
                   </span>
@@ -122,11 +122,11 @@
             </div>
           </div>
         </li>
-      {% elif g7_status == 'pending' and g7_application_made %}
+      {% elif framework.status == 'pending' and application_made %}
         <li class="browse-list-item framework-application-section">
           <div class="grid-row">
             <div class="column-two-thirds">
-              <a class="browse-list-item-link" href="{{ url_for('.framework_services') }}">
+              <a class="browse-list-item-link" href="{{ url_for('.framework_services', framework_slug=framework.slug) }}">
                 <span>
                   View services
                 </span>
@@ -144,14 +144,14 @@
         </li>
       {% endif %}
 
-      {% if g7_status == 'open' %}
+      {% if framework.status == 'open' %}
         <li class="browse-list-item framework-application-section">
           {% if declaration_status != 'complete' and counts.complete %}
             <div class="framework-section-validation-bar">
           {% endif %}
           <div class="grid-row">
             <div class="column-two-thirds">
-              <a class="browse-list-item-link" href="{{ url_for('.framework_supplier_declaration', section_id='g_cloud_7_essentials') }}">
+              <a class="browse-list-item-link" href="{{ url_for('.framework_supplier_declaration', framework_slug=framework.slug, section_id='g_cloud_7_essentials') }}">
                 {% if declaration_status == 'unstarted' %}
                   <span>Make supplier declaration</span>
                 {% else %}
@@ -203,14 +203,14 @@
         </li>
       {% endif %}
       
-      {% if g7_status == 'open' %}
+      {% if framework.status == 'open' %}
         <li class="browse-list-item framework-application-section">
           <div class="grid-row">
             <div class="column-two-thirds">
-              <h2>About G-Cloud 7</h2>
+              <h2>About {{ framework.name }}</h2>
               <ul>
                 <li>
-                  <a href="{{ url_for('.download_supplier_file', filepath='g-cloud-7-supplier-pack.zip') }}"><span>Download guidance and legal documentation (.zip)</span></a>
+                  <a href="{{ url_for('.download_supplier_file', framework_slug=framework.slug, filepath='g-cloud-7-supplier-pack.zip') }}"><span>Download guidance and legal documentation (.zip)</span></a>
                   {% if last_modified.supplier_pack %}
                     <div class="hint">Last updated <time datetime="{{ last_modified.supplier_pack }}">{{ last_modified.supplier_pack|dateformat }}</time></div>
                   {% endif %}
@@ -236,7 +236,7 @@
         <li class="browse-list-item framework-application-section">
           <div class="grid-row">
             <div class="column-two-thirds">
-              <a href="{{ url_for('.download_supplier_file', filepath='g-cloud-7-supplier-pack.zip') }}"><span>Download guidance and legal documentation (.zip)</span></a>
+              <a href="{{ url_for('.download_supplier_file', filepath='g-cloud-7-supplier-pack.zip', framework_slug=framework.slug) }}"><span>Download guidance and legal documentation (.zip)</span></a>
               {% if last_modified.supplier_pack %}
                 <div class="hint">Last updated <time datetime="{{ last_modified.supplier_pack }}">{{ last_modified.supplier_pack|dateformat }}</time></div>
               {% endif %}

--- a/app/templates/frameworks/edit_declaration_section.html
+++ b/app/templates/frameworks/edit_declaration_section.html
@@ -1,7 +1,7 @@
 {% extends "_base_page.html" %}
 {% import "macros/toolkit_forms.html" as forms %}
 
-{% block page_title %}G-Cloud 7 supplier declaration – Digital Marketplace{% endblock %}
+{% block page_title %}{{ framework.name }} supplier declaration – Digital Marketplace{% endblock %}
 
 {% block breadcrumb %}
   {%
@@ -83,7 +83,7 @@
               {% endwith %}
             {% endif %}
 
-            <a href="{{ url_for('.framework_dashboard', framework_slug=framework.slug) }}">Return to G-Cloud 7 application</a>
+            <a href="{{ url_for('.framework_dashboard', framework_slug=framework.slug) }}">Return to {{ framework.name }} application</a>
           </div>
       </div>
   </form>

--- a/app/templates/frameworks/edit_declaration_section.html
+++ b/app/templates/frameworks/edit_declaration_section.html
@@ -15,8 +15,8 @@
         "label": current_user.supplier_name
       },
       {
-        "link": url_for(".framework_dashboard"),
-        "label": "Apply to G-Cloud 7"
+        "link": url_for(".framework_dashboard", framework_slug=framework.slug),
+        "label": "Apply to " + framework.name
       }
     ]
   %}
@@ -83,7 +83,7 @@
               {% endwith %}
             {% endif %}
 
-            <a href="{{ url_for('.framework_dashboard') }}">Return to G-Cloud 7 application</a>
+            <a href="{{ url_for('.framework_dashboard', framework_slug=framework.slug) }}">Return to G-Cloud 7 application</a>
           </div>
       </div>
   </form>

--- a/app/templates/frameworks/services.html
+++ b/app/templates/frameworks/services.html
@@ -2,7 +2,7 @@
 {% import "toolkit/summary-table.html" as summary %}
 {% import "macros/submission.html" as submission %}
 
-{% block page_title %}Apply to G-Cloud 7 – Digital Marketplace{% endblock %}
+{% block page_title %}Apply to {{ framework.name }} – Digital Marketplace{% endblock %}
 
 {% block breadcrumb %}
   {%
@@ -16,8 +16,8 @@
         "label": "Your account",
       },
       {
-        "link": url_for(".framework_dashboard"),
-        "label": "Apply to G-Cloud 7",
+        "link": url_for(".framework_dashboard", framework_slug=framework.slug),
+        "label": "Apply to " + framework.name,
       }
     ]
   %}
@@ -43,10 +43,10 @@
     {% endfor %}
   {% endwith %}
 
-  {% if complete_drafts and declaration_status != 'complete' and g7_status == 'open' %}
+  {% if complete_drafts and declaration_status != 'complete' and framework.status == 'open' %}
     {%
       with
-      message = 'You need to <a href="' + url_for('.framework_supplier_declaration', section_id='g_cloud_7_essentials') + '">make the supplier&nbsp;declaration</a> before any services can be submitted',
+      message = 'You need to <a href="' + url_for('.framework_supplier_declaration', framework_slug=framework.slug) + '">make the supplier&nbsp;declaration</a> before any services can be submitted',
       type = 'warning'
     %}
       {% include 'toolkit/notification-banner.html' %}
@@ -54,18 +54,18 @@
   {% endif %}
 
   {% with
-     heading = "G-Cloud 7 services",
+     heading = framework.name + " services",
      smaller = True,
      with_breadcrumb = True
   %}
     {% include "toolkit/page-heading.html" %}
   {% endwith %}
 
-  {% if g7_status == 'pending' %}
+  {% if framework.status == 'pending' %}
     <div class="summary-item-lede">
       <div class="grid-row">
         <div class="column-two-thirds">
-          <h2 class="summary-item-heading">G-Cloud 7 is closed for applications</h2>
+          <h2 class="summary-item-heading">{{ framework.name }} is closed for applications</h2>
           <p>
             You made your supplier declaration and submitted {{ complete_drafts|length }} complete {{ 'service' if complete_drafts|length == 1 else 'services' }}.
           </p>
@@ -75,9 +75,9 @@
   {% endif %}
 
   {{ summary.heading("Draft services") }}
-  {% if g7_status == 'open' %}
-    {{ summary.top_link("Add a service", url_for(".start_new_draft_service")) }}
-  {% elif g7_status == 'pending' %}
+  {% if framework.status == 'open' %}
+    {{ summary.top_link("Add a service", url_for(".start_new_draft_service", framework_slug=framework.slug)) }}
+  {% elif framework.status == 'pending' %}
     <p class="hint">These services were not submitted</p>
   {% endif %}
   {% call(draft) summary.list_table(
@@ -97,23 +97,23 @@
                               url_for(".view_service_submission", service_id=draft.id)) }}
       {{ summary.text(draft.lot) }}
       
-      {% if g7_status == 'open' %}
+      {% if framework.status == 'open' %}
       {{ summary.text(submission.multiline_string(
-        submission.can_be_completed_text(draft.unanswered_required, g7_status),
+        submission.can_be_completed_text(draft.unanswered_required, framework.status),
         submission.unanswered_required_text(draft.unanswered_required, draft.unanswered_optional),
         submission.unanswered_optional_text(draft.unanswered_required, draft.unanswered_optional)
       )) }}
       {% endif %}
-      {% if g7_status == 'open' %}
+      {% if framework.status == 'open' %}
         {{ summary.button(text="Make a copy",
                            action=url_for('.copy_draft_service', service_id=draft.id)) }}
       {% endif %}
     {% endcall %}
   {% endcall %}
 
-  {% if g7_status == 'open' %}
+  {% if framework.status == 'open' %}
   {{ summary.heading("Complete services") }}
-  {% elif g7_status == 'pending' %}
+  {% elif framework.status == 'pending' %}
   {{ summary.heading("Submitted services") }}
   {% endif %}
   {% call(draft) summary.list_table(
@@ -135,13 +135,13 @@
       {{ summary.text(
         submission.unanswered_optional_text(draft.unanswered_required, draft.unanswered_optional)
       ) }}
-      {% if g7_status == 'open' %}
+      {% if framework.status == 'open' %}
         {{ summary.button(text="Make a copy",
                            action=url_for('.copy_draft_service', service_id=draft.id)) }}
       {% endif %}
     {% endcall %}
   {% endcall %}
 
-  <a href="{{ url_for('.framework_dashboard') }}">Return to G-Cloud 7 application</a>
+  <a href="{{ url_for('.framework_dashboard', framework_slug=framework.slug) }}">Return to {{ framework.name }} application</a>
 
 {% endblock %}

--- a/app/templates/frameworks/updates.html
+++ b/app/templates/frameworks/updates.html
@@ -15,7 +15,7 @@
         "label": "Your account",
       },
       {
-        "link": url_for(".framework_dashboard"),
+        "link": url_for(".framework_dashboard", framework_slug='g-cloud-7'),
         "label": "Apply to G-Cloud 7",
       }
     ]
@@ -88,7 +88,7 @@
           {% call summary.row() %}
             {{ summary.field_name(item.last_modified|dateformat) }}
             {% call summary.field() %}
-               <a href="{{ url_for('.download_supplier_file', filepath=item.path) }}" class="document-link-with-icon">
+               <a href="{{ url_for('.download_supplier_file', filepath=item.path, framework_slug='g-cloud-7') }}" class="document-link-with-icon">
                 <span class='document-icon'>{{ item.ext }}<span> document:</span></span>
                 {{ item.filename }}
             {% endcall %}
@@ -129,7 +129,7 @@
           {% include "toolkit/button.html" %}
           {% endwith %}
         
-          <a href="{{ url_for('.framework_dashboard') }}">Return to G-Cloud 7 application</a>
+          <a href="{{ url_for('.framework_dashboard', framework_slug='g-cloud-7') }}">Return to G-Cloud 7 application</a>
 
         </div>
       </div>
@@ -161,7 +161,7 @@
               {% include "toolkit/button.html" %}
             {% endwith %}
       
-            <a href="{{ url_for('.framework_dashboard') }}">Return to G-Cloud 7 application</a>
+            <a href="{{ url_for('.framework_dashboard', framework_slug='g-cloud-7') }}">Return to G-Cloud 7 application</a>
 
           </div>
         </div>

--- a/app/templates/services/edit_submission_section.html
+++ b/app/templates/services/edit_submission_section.html
@@ -12,11 +12,11 @@
         "label": "Your account"
       },
       {
-        "link": url_for(".framework_dashboard"),
-        "label": "Apply to G-Cloud 7"
+        "link": url_for(".framework_dashboard", framework_slug=framework.slug),
+        "label": "Apply to " + framework.name
       },
       {
-        "link": url_for(".framework_services"),
+        "link": url_for(".framework_services", framework_slug=framework.slug),
         "label": "Services"
       },
       {

--- a/app/templates/services/service_submission.html
+++ b/app/templates/services/service_submission.html
@@ -14,11 +14,11 @@
         "label": "Your account"
       },
       {
-        "link": url_for(".framework_dashboard"),
+        "link": url_for(".framework_dashboard", framework_slug="g-cloud-7"),
         "label": "Apply to G-Cloud 7"
       },
       {
-        "link": url_for(".framework_services"),
+        "link": url_for(".framework_services", framework_slug="g-cloud-7"),
         "label": "Services"
       }
     ]

--- a/app/templates/suppliers/dashboard.html
+++ b/app/templates/suppliers/dashboard.html
@@ -34,7 +34,7 @@
         with
         items = [{
           "title": "Continue your G-Cloud 7 application",
-          "link": url_for(".framework_dashboard"),
+          "link": url_for(".framework_dashboard", framework_slug='g-cloud-7'),
           "body": "Make your supplier declaration, add services and view G-Cloud 7 updates and clarification questions.",
           "subtext": "Deadline for submissions: {}".format(deadline)
         }]
@@ -46,7 +46,7 @@
         with
         items = [{
           "title": "Register your interest in becoming a G-Cloud 7 supplier",
-          "link": url_for(".framework_dashboard"),
+          "link": url_for(".framework_dashboard", framework_slug='g-cloud-7'),
           "body": "Read about G-Cloud 7, receive email updates and start the application process.",
           "subtext": "Deadline for submissions: {}".format(deadline)
         }]
@@ -60,7 +60,7 @@
             <h2 class="summary-item-heading">G-Cloud 7 is closed for applications</h2>
             <p>
               You submitted {{ g7_complete }} {{ 'service' if g7_complete == 1 else 'services' }} for consideration.
-              <a href="{{ url_for('.framework_dashboard') }}">View your submitted application</a>
+              <a href="{{ url_for('.framework_dashboard', framework_slug='g-cloud-7') }}">View your submitted application</a>
             </p>
           </div>
         </div>
@@ -74,7 +74,7 @@
           You didn’t submit an application.
         </p>
         <p class="temporary-message-message">
-          <a href="{{ url_for('.framework_dashboard') }}">View G-Cloud 7 information</a> 
+          <a href="{{ url_for('.framework_dashboard', framework_slug='g-cloud-7') }}">View G-Cloud 7 information</a> 
         </p>
       </aside>
     {% elif g7_status == 'pending' %}

--- a/bower.json
+++ b/bower.json
@@ -7,6 +7,6 @@
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
     "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v11.3.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.14.1/jinja_govuk_template-0.14.1.tgz",
-    "digital-marketplace-ssp-content": "git://github.com/alphagov/digitalmarketplace-ssp-content#d47defa52ee51654a42b46d7d6e2bca8c8c14f50"
+    "digital-marketplace-ssp-content": "git://github.com/alphagov/digitalmarketplace-ssp-content#b1dd57d47a01807ac4aff2c4e693ed2680a19af3"
   }
 }

--- a/tests/app/helpers.py
+++ b/tests/app/helpers.py
@@ -92,6 +92,16 @@ class BaseApplicationTest(object):
             ]
         }
 
+    @staticmethod
+    def framework(status='open', name='G-Cloud 7', slug='g-cloud-7'):
+        return {
+            'frameworks': {
+                'status': status,
+                'name': name,
+                'slug': slug
+            }
+        }
+
     def teardown_login(self):
         if self.get_user_patch is not None:
             self.get_user_patch.stop()

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -86,7 +86,7 @@ class TestFrameworksDashboard(BaseApplicationTest):
         with self.app.test_client():
             self.login()
 
-            data_api_client.get_framework_status.return_value = {'status': 'pending'}
+            data_api_client.get_framework.return_value = self.framework(status='pending')
             data_api_client.find_audit_events.return_value = {
                 "auditEvents": [{"data": {"frameworkSlug": "g-cloud-7"}}]
             }
@@ -111,7 +111,7 @@ class TestFrameworksDashboard(BaseApplicationTest):
         with self.app.test_client():
             self.login()
 
-            data_api_client.get_framework_status.return_value = {'status': 'pending'}
+            data_api_client.get_framework.return_value = self.framework(status='pending')
             data_api_client.find_audit_events.return_value = {
                 "auditEvents": [{"data": {"frameworkSlug": "g-cloud-7"}}]
             }
@@ -140,7 +140,7 @@ class TestFrameworksDashboard(BaseApplicationTest):
         with self.app.test_client():
             self.login()
 
-            data_api_client.get_framework_status.return_value = {'status': 'open'}
+            data_api_client.get_framework.return_value = self.framework(status='open')
             data_api_client.get_supplier_declaration.return_value = {
                 "declaration": FULL_G7_SUBMISSION
             }
@@ -164,7 +164,7 @@ class TestFrameworksDashboard(BaseApplicationTest):
             del submission['SQ2-1ghijklmn']
             submission.update({"status": "started"})
 
-            data_api_client.get_framework_status.return_value = {'status': 'open'}
+            data_api_client.get_framework.return_value = self.framework(status='open')
             data_api_client.get_supplier_declaration.return_value = {
                 "declaration": submission
             }
@@ -180,7 +180,7 @@ class TestFrameworksDashboard(BaseApplicationTest):
         with self.app.test_client():
             self.login()
 
-            data_api_client.get_framework_status.return_value = {'status': 'open'}
+            data_api_client.get_framework.return_value = self.framework(status='open')
             data_api_client.get_supplier_declaration.side_effect = APIError(mock.Mock(status_code=404))
 
             res = self.client.get("/suppliers/frameworks/g-cloud-7")
@@ -382,7 +382,7 @@ class TestSupplierDeclaration(BaseApplicationTest):
         with self.app.test_client():
             self.login()
 
-            data_api_client.get_framework_status.return_value = {'status': 'open'}
+            data_api_client.get_framework.return_value = self.framework(status='open')
             data_api_client.get_supplier_declaration.side_effect = APIError(mock.Mock(status_code=404))
 
             res = self.client.get(
@@ -399,7 +399,7 @@ class TestSupplierDeclaration(BaseApplicationTest):
         with self.app.test_client():
             self.login()
 
-            data_api_client.get_framework_status.return_value = {'status': 'open'}
+            data_api_client.get_framework.return_value = self.framework(status='open')
             data_api_client.get_supplier_declaration.return_value = {
                 "declaration": {"status": "started", "PR1": False}
             }
@@ -416,7 +416,7 @@ class TestSupplierDeclaration(BaseApplicationTest):
         with self.app.test_client():
             self.login()
 
-            data_api_client.get_framework_status.return_value = {'status': 'open'}
+            data_api_client.get_framework.return_value = self.framework(status='open')
             data_api_client.get_supplier_declaration.return_value = {
                 "declaration": {"status": "started"}
             }
@@ -431,7 +431,7 @@ class TestSupplierDeclaration(BaseApplicationTest):
         with self.app.test_client():
             self.login()
 
-            data_api_client.get_framework_status.return_value = {'status': 'open'}
+            data_api_client.get_framework.return_value = self.framework(status='open')
             data_api_client.get_supplier_declaration.return_value = {
                 "declaration": {"status": "started"}
             }
@@ -447,7 +447,7 @@ class TestSupplierDeclaration(BaseApplicationTest):
         with self.app.test_client():
             self.login()
 
-            data_api_client.get_framework_status.return_value = {'status': 'open'}
+            data_api_client.get_framework.return_value = self.framework(status='open')
             data_api_client.get_supplier_declaration.return_value = {
                 "declaration": {"status": "started"}
             }
@@ -468,7 +468,7 @@ class TestSupplierDeclaration(BaseApplicationTest):
         with self.app.test_client():
             self.login()
 
-            data_api_client.get_framework_status.return_value = {'status': 'open'}
+            data_api_client.get_framework.return_value = self.framework(status='open')
             get_error_messages_for_page.return_value = {'PR1': {'input_name': 'PR1', 'message': 'this is invalid'}}
 
             res = self.client.post(
@@ -827,7 +827,7 @@ class TestG7ServicesList(BaseApplicationTest):
     def test_404_when_g7_pending_and_no_complete_services(self, count_unanswered, data_api_client):
         with self.app.test_client():
             self.login()
-        data_api_client.get_framework_status.return_value = {'status': 'pending'}
+        data_api_client.get_framework.return_value = self.framework(status='pending')
         data_api_client.find_draft_services.return_value = {'services': []}
         count_unanswered.return_value = 0
         response = self.client.get('/suppliers/frameworks/g-cloud-7/services')
@@ -836,7 +836,7 @@ class TestG7ServicesList(BaseApplicationTest):
     def test_404_when_g7_pending_and_no_declaration(self, count_unanswered, data_api_client):
         with self.app.test_client():
             self.login()
-        data_api_client.get_framework_status.return_value = {'status': 'pending'}
+        data_api_client.get_framework.return_value = self.framework(status='pending')
         data_api_client.get_supplier_declaration.return_value = {
             "declaration": {"status": "started"}
         }
@@ -865,7 +865,7 @@ class TestG7ServicesList(BaseApplicationTest):
     def test_shows_g7_message_if_pending_and_application_made(self, count_unanswered, data_api_client):
         with self.app.test_client():
             self.login()
-        data_api_client.get_framework_status.return_value = {'status': 'pending'}
+        data_api_client.get_framework.return_value = self.framework(status='pending')
         data_api_client.get_supplier_declaration.return_value = {'declaration': FULL_G7_SUBMISSION}  # noqa
         data_api_client.find_draft_services.return_value = {
             'services': [
@@ -890,7 +890,7 @@ class TestG7ServicesList(BaseApplicationTest):
             self.login()
 
         count_unanswered.return_value = 3, 1
-        data_api_client.get_framework_status.return_value = {'status': 'open'}
+        data_api_client.get_framework.return_value = self.framework(status='open')
         data_api_client.find_draft_services.return_value = {
             'services': [
                 {'serviceName': 'draft', 'lot': 'SCS', 'status': 'not-submitted'},
@@ -908,7 +908,7 @@ class TestG7ServicesList(BaseApplicationTest):
 
         count_unanswered.return_value = 0, 1
 
-        data_api_client.get_framework_status.return_value = {'status': 'open'}
+        data_api_client.get_framework.return_value = self.framework(status='open')
         data_api_client.find_draft_services.return_value = {
             'services': [
                 {'serviceName': 'draft', 'lot': 'SCS', 'status': 'not-submitted'},

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -402,7 +402,7 @@ class TestCreateDraftService(BaseApplicationTest):
     def test_get_create_draft_service_page_if_open(self, request, data_api_client):
         with self.app.test_client():
             self.login()
-        data_api_client.get_framework_status.return_value = {'status': 'open'}
+        data_api_client.get_framework.return_value = self.framework(status='open')
 
         res = self.client.get('/suppliers/submission/g-cloud-7/create')
         assert_equal(res.status_code, 200)
@@ -418,7 +418,7 @@ class TestCreateDraftService(BaseApplicationTest):
     def test_can_not_get_create_draft_service_page_if_not_open(self, request, data_api_client):
         with self.app.test_client():
             self.login()
-        data_api_client.get_framework_status.return_value = {'status': 'other'}
+        data_api_client.get_framework.return_value = self.framework(status='other')
 
         res = self.client.get('/suppliers/submission/g-cloud-7/create')
         assert_equal(res.status_code, 404)
@@ -427,7 +427,7 @@ class TestCreateDraftService(BaseApplicationTest):
         with self.app.test_client():
             self.login()
 
-        data_api_client.get_framework_status.return_value = {'status': 'open'}
+        data_api_client.get_framework.return_value = self.framework(status='open')
         data_api_client.create_new_draft_service.return_value = {
             'services': {
                 'id': 1,
@@ -463,7 +463,7 @@ class TestCreateDraftService(BaseApplicationTest):
         with self.app.test_client():
             self.login()
 
-        data_api_client.get_framework_status.return_value = {'status': 'other'}
+        data_api_client.get_framework.return_value = self.framework(status='other')
         res = self.client.post(
             '/suppliers/submission/g-cloud-7/create'
         )
@@ -491,7 +491,7 @@ class TestCopyDraft(BaseApplicationTest):
         }
 
     def test_copy_draft(self, data_api_client):
-        data_api_client.get_framework_status.return_value = {'status': 'open'}
+        data_api_client.get_framework.return_value = self.framework(status='open')
         data_api_client.get_draft_service.return_value = {'services': self.draft}
 
         res = self.client.post('/suppliers/submission/services/1/copy')
@@ -505,7 +505,7 @@ class TestCopyDraft(BaseApplicationTest):
         assert_equal(res.status_code, 404)
 
     def test_cannot_copy_draft_if_not_open(self, data_api_client):
-        data_api_client.get_framework_status.return_value = {'status': 'other'}
+        data_api_client.get_framework.return_value = self.framework(status='other')
 
         res = self.client.post('/suppliers/submission/services/1/copy')
         assert_equal(res.status_code, 404)
@@ -532,7 +532,7 @@ class TestCompleteDraft(BaseApplicationTest):
         }
 
     def test_complete_draft(self, data_api_client):
-        data_api_client.get_framework_status.return_value = {'status': 'open'}
+        data_api_client.get_framework.return_value = self.framework(status='open')
         data_api_client.get_draft_service.return_value = {'services': self.draft}
 
         res = self.client.post('/suppliers/submission/services/1/complete')
@@ -549,7 +549,7 @@ class TestCompleteDraft(BaseApplicationTest):
         assert_equal(res.status_code, 404)
 
     def test_cannot_complete_draft_if_not_open(self, data_api_client):
-        data_api_client.get_framework_status.return_value = {'status': 'other'}
+        data_api_client.get_framework.return_value = self.framework(status='other')
 
         res = self.client.post('/suppliers/submission/services/1/complete')
         assert_equal(res.status_code, 404)
@@ -579,7 +579,7 @@ class TestEditDraftService(BaseApplicationTest):
             self.login()
 
     def test_questions_for_this_draft_section_can_be_changed(self, data_api_client, s3):
-        data_api_client.get_framework_status.return_value = {'status': 'open'}
+        data_api_client.get_framework.return_value = self.framework(status='open')
         data_api_client.get_draft_service.return_value = self.empty_draft
         res = self.client.post(
             '/suppliers/submission/services/1/edit/service_description',
@@ -598,7 +598,7 @@ class TestEditDraftService(BaseApplicationTest):
     def test_update_without_changes_is_not_sent_to_the_api(self, data_api_client, s3):
         draft = self.empty_draft['services'].copy()
         draft.update({'serviceSummary': u"summary"})
-        data_api_client.get_framework_status.return_value = {'status': 'open'}
+        data_api_client.get_framework.return_value = self.framework(status='open')
         data_api_client.get_draft_service.return_value = {'services': draft}
 
         res = self.client.post(
@@ -613,7 +613,7 @@ class TestEditDraftService(BaseApplicationTest):
     def test_S3_should_not_be_called_if_there_are_no_files(self, data_api_client, s3):
         uploader = mock.Mock()
         s3.return_value = uploader
-        data_api_client.get_framework_status.return_value = {'status': 'open'}
+        data_api_client.get_framework.return_value = self.framework(status='open')
         data_api_client.get_draft_service.return_value = self.empty_draft
         res = self.client.post(
             '/suppliers/submission/services/1/edit/service_description',
@@ -639,7 +639,7 @@ class TestEditDraftService(BaseApplicationTest):
         assert_equal(res.status_code, 404)
 
     def test_draft_section_cannot_be_edited_if_not_open(self, data_api_client, s3):
-        data_api_client.get_framework_status.return_value = {'status': 'other'}
+        data_api_client.get_framework.return_value = self.framework(status='other')
         data_api_client.get_draft_service.return_value = self.empty_draft
         res = self.client.post(
             '/suppliers/submission/services/1/edit/service_description',
@@ -649,7 +649,7 @@ class TestEditDraftService(BaseApplicationTest):
         assert_equal(res.status_code, 404)
 
     def test_only_questions_for_this_draft_section_can_be_changed(self, data_api_client, s3):
-        data_api_client.get_framework_status.return_value = {'status': 'open'}
+        data_api_client.get_framework.return_value = self.framework(status='open')
         data_api_client.get_draft_service.return_value = self.empty_draft
         res = self.client.post(
             '/suppliers/submission/services/1/edit/service_description',
@@ -666,7 +666,7 @@ class TestEditDraftService(BaseApplicationTest):
     def test_display_file_upload_with_existing_file(self, data_api_client, s3):
         draft = copy.deepcopy(self.empty_draft)
         draft['services']['serviceDefinitionDocumentURL'] = 'http://localhost/fooo-2012-12-12-1212.pdf'
-        data_api_client.get_framework_status.return_value = {'status': 'open'}
+        data_api_client.get_framework.return_value = self.framework(status='open')
         data_api_client.get_draft_service.return_value = draft
         response = self.client.get(
             '/suppliers/submission/services/1/edit/service_definition'
@@ -677,7 +677,7 @@ class TestEditDraftService(BaseApplicationTest):
         assert_equal(len(document.cssselect('p.file-upload-existing-value')), 1)
 
     def test_display_file_upload_with_no_existing_file(self, data_api_client, s3):
-        data_api_client.get_framework_status.return_value = {'status': 'open'}
+        data_api_client.get_framework.return_value = self.framework(status='open')
         data_api_client.get_draft_service.return_value = self.empty_draft
         response = self.client.get(
             '/suppliers/submission/services/1/edit/service_definition'
@@ -688,7 +688,7 @@ class TestEditDraftService(BaseApplicationTest):
         assert_equal(len(document.cssselect('p.file-upload-existing-value')), 0)
 
     def test_file_upload(self, data_api_client, s3):
-        data_api_client.get_framework_status.return_value = {'status': 'open'}
+        data_api_client.get_framework.return_value = self.framework(status='open')
         data_api_client.get_draft_service.return_value = self.empty_draft
         with freeze_time('2015-01-02 03:04:05'):
             res = self.client.post(
@@ -712,7 +712,7 @@ class TestEditDraftService(BaseApplicationTest):
         )
 
     def test_file_upload_filters_empty_and_unknown_files(self, data_api_client, s3):
-        data_api_client.get_framework_status.return_value = {'status': 'open'}
+        data_api_client.get_framework.return_value = self.framework(status='open')
         data_api_client.get_draft_service.return_value = self.empty_draft
         res = self.client.post(
             '/suppliers/submission/services/1/edit/service_definition',
@@ -731,7 +731,7 @@ class TestEditDraftService(BaseApplicationTest):
         assert_false(s3.return_value.save.called)
 
     def test_upload_question_not_accepted_as_form_data(self, data_api_client, s3):
-        data_api_client.get_framework_status.return_value = {'status': 'open'}
+        data_api_client.get_framework.return_value = self.framework(status='open')
         data_api_client.get_draft_service.return_value = self.empty_draft
         res = self.client.post(
             '/suppliers/submission/services/1/edit/service_definition',
@@ -746,7 +746,7 @@ class TestEditDraftService(BaseApplicationTest):
         )
 
     def test_pricing_fields_are_added_correctly(self, data_api_client, s3):
-        data_api_client.get_framework_status.return_value = {'status': 'open'}
+        data_api_client.get_framework.return_value = self.framework(status='open')
         data_api_client.get_draft_service.return_value = self.empty_draft
         res = self.client.post(
             '/suppliers/submission/services/1/edit/pricing',
@@ -780,7 +780,7 @@ class TestEditDraftService(BaseApplicationTest):
         assert_equal(404, res.status_code)
 
     def test_update_redirects_to_next_editable_section(self, data_api_client, s3):
-        data_api_client.get_framework_status.return_value = {'status': 'open'}
+        data_api_client.get_framework.return_value = self.framework(status='open')
         data_api_client.get_draft_service.return_value = self.empty_draft
         data_api_client.update_draft_service.return_value = None
 
@@ -795,7 +795,7 @@ class TestEditDraftService(BaseApplicationTest):
                      res.headers['Location'])
 
     def test_update_redirects_to_edit_submission_if_no_next_editable_section(self, data_api_client, s3):
-        data_api_client.get_framework_status.return_value = {'status': 'open'}
+        data_api_client.get_framework.return_value = self.framework(status='open')
         data_api_client.get_draft_service.return_value = self.empty_draft
         data_api_client.update_draft_service.return_value = None
 
@@ -808,7 +808,7 @@ class TestEditDraftService(BaseApplicationTest):
                      res.headers['Location'])
 
     def test_update_redirects_to_edit_submission_if_return_to_summary(self, data_api_client, s3):
-        data_api_client.get_framework_status.return_value = {'status': 'open'}
+        data_api_client.get_framework.return_value = self.framework(status='open')
         data_api_client.get_draft_service.return_value = self.empty_draft
         data_api_client.update_draft_service.return_value = None
 
@@ -821,7 +821,7 @@ class TestEditDraftService(BaseApplicationTest):
                      res.headers['Location'])
 
     def test_update_redirects_to_edit_submission_if_grey_button_clicked(self, data_api_client, s3):
-        data_api_client.get_framework_status.return_value = {'status': 'open'}
+        data_api_client.get_framework.return_value = self.framework(status='open')
         data_api_client.get_draft_service.return_value = self.empty_draft
         data_api_client.update_draft_service.return_value = None
 
@@ -834,7 +834,7 @@ class TestEditDraftService(BaseApplicationTest):
                      res.headers['Location'])
 
     def test_update_with_answer_required_error(self, data_api_client, s3):
-        data_api_client.get_framework_status.return_value = {'status': 'open'}
+        data_api_client.get_framework.return_value = self.framework(status='open')
         data_api_client.get_draft_service.return_value = self.empty_draft
         data_api_client.update_draft_service.side_effect = HTTPError(
             mock.Mock(status_code=400),
@@ -850,7 +850,7 @@ class TestEditDraftService(BaseApplicationTest):
             document.xpath('//span[@id="error-serviceSummary"]/text()')[0].strip())
 
     def test_update_with_under_50_words_error(self, data_api_client, s3):
-        data_api_client.get_framework_status.return_value = {'status': 'open'}
+        data_api_client.get_framework.return_value = self.framework(status='open')
         data_api_client.get_draft_service.return_value = self.empty_draft
         data_api_client.update_draft_service.side_effect = HTTPError(
             mock.Mock(status_code=400),
@@ -875,7 +875,7 @@ class TestEditDraftService(BaseApplicationTest):
         ]
 
         for field, error, message in cases:
-            data_api_client.get_framework_status.return_value = {'status': 'open'}
+            data_api_client.get_framework.return_value = self.framework(status='open')
             data_api_client.get_draft_service.return_value = self.empty_draft
             data_api_client.update_draft_service.side_effect = HTTPError(
                 mock.Mock(status_code=400),
@@ -951,16 +951,17 @@ class TestShowDraftService(BaseApplicationTest):
 
     @mock.patch('app.main.views.services.count_unanswered_questions')
     def test_unanswered_questions_count(self, count_unanswered, data_api_client):
-        data_api_client.get_framework_status.return_value = {'status': 'open'}
+        data_api_client.get_framework.return_value = self.framework(status='open')
         data_api_client.get_draft_service.return_value = self.draft_service
         count_unanswered.return_value = 1, 2
         res = self.client.get('/suppliers/submission/services/1')
 
-        assert_in(u'3 unanswered questions', res.get_data(as_text=True))
+        assert_true(u'3 unanswered questions' in res.get_data(as_text=True),
+                    "'3 unanswered questions' not found in html")
 
     @mock.patch('app.main.views.services.count_unanswered_questions')
     def test_move_to_complete_button(self, count_unanswered, data_api_client):
-        data_api_client.get_framework_status.return_value = {'status': 'open'}
+        data_api_client.get_framework.return_value = self.framework(status='open')
         data_api_client.get_draft_service.return_value = self.draft_service
         count_unanswered.return_value = 0, 1
         res = self.client.get('/suppliers/submission/services/1')
@@ -971,7 +972,7 @@ class TestShowDraftService(BaseApplicationTest):
 
     @mock.patch('app.main.views.services.count_unanswered_questions')
     def test_no_move_to_complete_button_if_not_open(self, count_unanswered, data_api_client):
-        data_api_client.get_framework_status.return_value = {'status': 'other'}
+        data_api_client.get_framework.return_value = self.framework(status='other')
         data_api_client.get_draft_service.return_value = self.draft_service
         count_unanswered.return_value = 0, 1
         res = self.client.get('/suppliers/submission/services/1')
@@ -981,7 +982,7 @@ class TestShowDraftService(BaseApplicationTest):
 
     @mock.patch('app.main.views.services.count_unanswered_questions')
     def test_shows_g7_message_if_pending_and_service_is_in_draft(self, count_unanswered, data_api_client):
-        data_api_client.get_framework_status.return_value = {'status': 'pending'}
+        data_api_client.get_framework.return_value = self.framework(status='pending')
         data_api_client.get_draft_service.return_value = self.draft_service
         count_unanswered.return_value = 3, 1
         res = self.client.get('/suppliers/submission/services/1')
@@ -997,7 +998,7 @@ class TestShowDraftService(BaseApplicationTest):
 
     @mock.patch('app.main.views.services.count_unanswered_questions')
     def test_shows_g7_message_if_pending_and_service_is_complete(self, count_unanswered, data_api_client):
-        data_api_client.get_framework_status.return_value = {'status': 'pending'}
+        data_api_client.get_framework.return_value = self.framework(status='pending')
         data_api_client.get_draft_service.return_value = self.complete_service
         count_unanswered.return_value = 0, 1
         res = self.client.get('/suppliers/submission/services/2')
@@ -1041,7 +1042,7 @@ class TestDeleteDraftService(BaseApplicationTest):
             self.login()
 
     def test_delete_button_redirects_with_are_you_sure(self, data_api_client):
-        data_api_client.get_framework_status.return_value = {'status': 'open'}
+        data_api_client.get_framework.return_value = self.framework(status='open')
         data_api_client.get_draft_service.return_value = self.draft_to_delete
         res = self.client.post(
             '/suppliers/submission/services/1/delete',
@@ -1057,7 +1058,7 @@ class TestDeleteDraftService(BaseApplicationTest):
         )
 
     def test_cannot_delete_if_not_open(self, data_api_client):
-        data_api_client.get_framework_status.return_value = {'status': 'other'}
+        data_api_client.get_framework.return_value = self.framework(status='other')
         data_api_client.get_draft_service.return_value = self.draft_to_delete
         res = self.client.post(
             '/suppliers/submission/services/1/delete',
@@ -1065,7 +1066,7 @@ class TestDeleteDraftService(BaseApplicationTest):
         assert_equal(res.status_code, 404)
 
     def test_confirm_delete_button_deletes_and_redirects_to_dashboard(self, data_api_client):
-        data_api_client.get_framework_status.return_value = {'status': 'open'}
+        data_api_client.get_framework.return_value = self.framework(status='open')
         data_api_client.get_draft_service.return_value = self.draft_to_delete
         res = self.client.post(
             '/suppliers/submission/services/1/delete',


### PR DESCRIPTION
This change makes the routes that were hard coded to G-Cloud 7 support multiple frameworks. This change does not include moving any of the routes. This has been left for a later change as it will break far more tests.

This change has been tested with the functional test suite using both the @functional-test tag and the @ssp tag.

The list of routes is:
- /frameworks/<framework_slug>
- /frameworks/<framework_slug>/services
- /frameworks/<framework_slug>/declaration
- /frameworks/<framework_slug>/<path:filepath>
- /submission/<framework_slug>/create

The change consisted of a few steps:
- Replace `g-cloud-7` with `<framework_slug>` in the route
- Get the framework details from the data API - this 404s if it doesn't
  exist.
- Pass framework slug to `url_for` calls - some of them have just been hard
  coded as `g-cloud-7` for the moment.
- Update tests to mock `get_framework`.

The following changes are also contained:
- bump the frameworks content to bring in initial Digital Outcomes and Specialists (DOS) content
- add a '/frameworks/<framework_slug>/declaration' route which assumes a `section_id` of 1 so we don't need to put the section number in the URL for declaration start buttons