### PR TITLE
Fix bug #105988832: Communications files erroring

### DIFF
--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -168,7 +168,8 @@ def framework_supplier_declaration(section_id):
 @login_required
 @flask_featureflags.is_active_feature('GCLOUD7_OPEN')
 def download_supplier_file(filepath):
-    url = get_draft_document_url(filepath)
+    uploader = s3.S3(current_app.config['DM_G7_DRAFT_DOCUMENTS_BUCKET'])
+    url = get_draft_document_url(uploader, filepath)
     if not url:
         abort(404)
 


### PR DESCRIPTION
When the signature of `get_draft_document_url` was changed the download supplier file route was not updated.