### PR TITLE
Move routes around to include framework slug

### DIFF
--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -1,4 +1,5 @@
 import itertools
+from datetime import datetime
 
 from flask import render_template, request, abort, flash, redirect, url_for, current_app
 from flask_login import login_required, current_user
@@ -10,6 +11,7 @@ from dmutils import flask_featureflags
 from dmutils.email import send_email, MandrillException
 from dmutils.formats import format_service_price
 from dmutils import s3
+from dmutils.deprecation import deprecated
 
 from ... import data_api_client
 from ...main import main, content_loader
@@ -195,6 +197,22 @@ def download_supplier_file(framework_slug, filepath):
         abort(404)
 
     return redirect(url)
+
+
+@main.route('/frameworks/<any("g-cloud-7"):framework_slug>/<path:filepath>.zip', methods=['GET'])
+@deprecated(dies_at=datetime(2015, 11, 9))
+def g7_download_zip_redirect_zip(framework_slug, filepath):
+    return redirect(url_for('.download_supplier_file',
+                            framework_slug='g-cloud-7',
+                            filepath='{}.zip'.format(filepath)), 301)
+
+
+@main.route('/frameworks/<any("g-cloud-7"):framework_slug>/<path:filepath>.pdf', methods=['GET'])
+@deprecated(dies_at=datetime(2015, 11, 9))
+def g7_download_zip_redirect_pdf(framework_slug, filepath):
+    return redirect(url_for('.download_supplier_file',
+                            framework_slug='g-cloud-7',
+                            filepath='{}.pdf'.format(filepath)), 301)
 
 
 @main.route('/frameworks/<framework_slug>/updates', methods=['GET'])

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -185,7 +185,7 @@ def framework_supplier_declaration(framework_slug, section_id=None):
     ), status_code
 
 
-@main.route('/frameworks/<framework_slug>/<path:filepath>', methods=['GET'])
+@main.route('/frameworks/<framework_slug>/files/<path:filepath>', methods=['GET'])
 @login_required
 @flask_featureflags.is_active_feature('GCLOUD7_OPEN')
 def download_supplier_file(framework_slug, filepath):

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -293,11 +293,11 @@ def copy_draft_service(framework_slug, service_id):
                             return_to_summary=1))
 
 
-@main.route('/submission/services/<string:service_id>/complete', methods=['POST'])
+@main.route('/frameworks/<framework_slug>/submissions/<service_id>/complete', methods=['POST'])
 @login_required
 @flask_featureflags.is_active_feature('GCLOUD7_OPEN')
-def complete_draft_service(service_id):
-    framework = data_api_client.get_framework('g-cloud-7')['frameworks']
+def complete_draft_service(framework_slug, service_id):
+    framework = data_api_client.get_framework(framework_slug)['frameworks']
     if framework['status'] != 'open':
         abort(404)
     draft = data_api_client.get_draft_service(service_id).get('services')
@@ -322,11 +322,11 @@ def complete_draft_service(service_id):
                     lot=draft['lot'].lower()))
 
 
-@main.route('/submission/services/<string:service_id>/delete', methods=['POST'])
+@main.route('/frameworks/<framework_slug>/submissions/<service_id>/delete', methods=['POST'])
 @login_required
 @flask_featureflags.is_active_feature('GCLOUD7_OPEN')
-def delete_draft_service(service_id):
-    framework = data_api_client.get_framework('g-cloud-7')['frameworks']
+def delete_draft_service(framework_slug, service_id):
+    framework = data_api_client.get_framework(framework_slug)['frameworks']
     if framework['status'] != 'open':
         abort(404)
     draft = data_api_client.get_draft_service(service_id).get('services')

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -171,7 +171,7 @@ def update_section(service_id, section_id):
 #  ####################  CREATING NEW DRAFT SERVICES ##########################
 
 
-@main.route('/submission/<framework_slug>/create', methods=['GET'])
+@main.route('/frameworks/<framework_slug>/submissions/create', methods=['GET'])
 @login_required
 @flask_featureflags.is_active_feature('GCLOUD7_OPEN')
 def start_new_draft_service(framework_slug):
@@ -200,7 +200,7 @@ def start_new_draft_service(framework_slug):
     ), 200
 
 
-@main.route('/submission/<framework_slug>/create', methods=['POST'])
+@main.route('/frameworks/<framework_slug>/submissions/create', methods=['POST'])
 @login_required
 @flask_featureflags.is_active_feature('GCLOUD7_OPEN')
 def create_new_draft_service(framework_slug):

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -345,6 +345,7 @@ def delete_draft_service(service_id):
         return redirect(url_for(".framework_services", framework_slug=framework['slug']))
     else:
         return redirect(url_for(".view_service_submission",
+                                framework_slug=framework['slug'],
                                 service_id=service_id,
                                 delete_requested=True)
                         )
@@ -366,11 +367,11 @@ def service_submission_document(framework_slug, supplier_id, document_name):
     return redirect(s3_url)
 
 
-@main.route('/submission/services/<string:service_id>', methods=['GET'])
+@main.route('/frameworks/<framework_slug>/submissions/<service_id>', methods=['GET'])
 @login_required
 @flask_featureflags.is_active_feature('GCLOUD7_OPEN')
-def view_service_submission(service_id):
-    framework = data_api_client.get_framework('g-cloud-7')['frameworks']
+def view_service_submission(framework_slug, service_id):
+    framework = data_api_client.get_framework(framework_slug)['frameworks']
     try:
         data = data_api_client.get_draft_service(service_id)
         draft, last_edit = data['services'], data['auditEvents']
@@ -381,7 +382,7 @@ def view_service_submission(service_id):
         abort(404)
 
     draft['priceString'] = format_service_price(draft)
-    content = content_loader.get_builder('g-cloud-7', 'edit_submission').filter(draft)
+    content = content_loader.get_builder(framework['slug'], 'edit_submission').filter(draft)
 
     sections = get_service_attributes(draft, content)
 
@@ -504,7 +505,7 @@ def update_section_submission(service_id, section_id):
     if next_section and not return_to_summary and request.form.get('continue_to_next_section'):
         return redirect(url_for(".edit_service_submission", service_id=service_id, section_id=next_section))
     else:
-        return redirect(url_for(".view_service_submission", service_id=service_id))
+        return redirect(url_for(".view_service_submission", framework_slug=framework['slug'], service_id=service_id))
 
 
 def _update_service_status(service, error_message=None):

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -350,7 +350,7 @@ def delete_draft_service(service_id):
                         )
 
 
-@main.route('/submission/documents/<string:framework_slug>/<int:supplier_id>/<string:document_name>', methods=['GET'])
+@main.route('/frameworks/<framework_slug>/submissions/documents/<int:supplier_id>/<document_name>', methods=['GET'])
 @login_required
 @flask_featureflags.is_active_feature('GCLOUD7_OPEN')
 def service_submission_document(framework_slug, supplier_id, document_name):

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -264,11 +264,11 @@ def create_new_draft_service(framework_slug):
     )
 
 
-@main.route('/submission/services/<string:service_id>/copy', methods=['POST'])
+@main.route('/frameworks/<framework_slug>/submissions/<service_id>/copy', methods=['POST'])
 @login_required
 @flask_featureflags.is_active_feature('GCLOUD7_OPEN')
-def copy_draft_service(service_id):
-    framework = data_api_client.get_framework('g-cloud-7')['frameworks']
+def copy_draft_service(framework_slug, service_id):
+    framework = data_api_client.get_framework(framework_slug)['frameworks']
     if framework['status'] != 'open':
         abort(404)
     draft = data_api_client.get_draft_service(service_id).get('services')

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -35,13 +35,14 @@ def dashboard():
 
     drafts, complete_drafts = get_drafts(data_api_client, current_user.supplier_id, 'g-cloud-7')
     declaration_status = get_declaration_status(data_api_client, 'g-cloud-7')
+    framework = data_api_client.get_framework('g-cloud-7')['frameworks']
     application_made = len(complete_drafts) > 0 and declaration_status == 'complete'
     return render_template(
         "suppliers/dashboard.html",
         supplier=supplier,
         users=get_current_suppliers_users(),
         g7_interested=has_registered_interest_in_framework(data_api_client, 'g-cloud-7'),
-        g7_status=data_api_client.get_framework_status('g-cloud-7').get('status', None),
+        g7_status=framework['status'],
         g7_application_made=application_made,
         g7_complete=len(complete_drafts),
         deadline=current_app.config['G7_CLOSING_DATE'],

--- a/app/templates/frameworks/dashboard.html
+++ b/app/templates/frameworks/dashboard.html
@@ -216,7 +216,7 @@
                   {% endif %}
                 </li>
                 <li>
-                  <a href="{{ url_for('.framework_updates') }}">
+                  <a href="{{ url_for('.framework_updates', framework_slug=framework.slug) }}">
                     <span>
                     {% if 'G7_CLARIFICATIONS_CLOSED' is active_feature %}
                       Read updates and clarification question responses
@@ -246,7 +246,7 @@
         <li class="browse-list-item framework-application-section">
           <div class="grid-row">
             <div class="column-two-thirds">
-              <a href="{{ url_for('.framework_updates') }}">
+              <a href="{{ url_for('.framework_updates', framework_slug=framework.slug) }}">
                 <span>
                 {% if 'G7_CLARIFICATIONS_CLOSED' is active_feature %}
                   Read updates and clarification question responses

--- a/app/templates/frameworks/services.html
+++ b/app/templates/frameworks/services.html
@@ -106,7 +106,7 @@
       {% endif %}
       {% if framework.status == 'open' %}
         {{ summary.button(text="Make a copy",
-                           action=url_for('.copy_draft_service', service_id=draft.id)) }}
+                           action=url_for('.copy_draft_service', framework_slug=framework.slug, service_id=draft.id)) }}
       {% endif %}
     {% endcall %}
   {% endcall %}

--- a/app/templates/frameworks/services.html
+++ b/app/templates/frameworks/services.html
@@ -94,7 +94,7 @@
   ) %}
     {% call summary.row() %}
       {{ summary.service_link(draft.serviceName,
-                              url_for(".view_service_submission", service_id=draft.id)) }}
+                              url_for(".view_service_submission", framework_slug=framework.slug, service_id=draft.id)) }}
       {{ summary.text(draft.lot) }}
       
       {% if framework.status == 'open' %}
@@ -130,7 +130,7 @@
   ) %}
     {% call summary.row() %}
       {{ summary.service_link(draft.serviceName,
-                              url_for(".view_service_submission", service_id=draft.id)) }}
+                              url_for(".view_service_submission", framework_slug=framework.slug, service_id=draft.id)) }}
       {{ summary.text(draft.lot) }}
       {{ summary.text(
         submission.unanswered_optional_text(draft.unanswered_required, draft.unanswered_optional)

--- a/app/templates/frameworks/updates.html
+++ b/app/templates/frameworks/updates.html
@@ -15,8 +15,8 @@
         "label": "Your account",
       },
       {
-        "link": url_for(".framework_dashboard", framework_slug='g-cloud-7'),
-        "label": "Apply to G-Cloud 7",
+        "link": url_for(".framework_dashboard", framework_slug=framework.slug),
+        "label": "Apply to " + framework.name,
       }
     ]
   %}
@@ -88,7 +88,7 @@
           {% call summary.row() %}
             {{ summary.field_name(item.last_modified|dateformat) }}
             {% call summary.field() %}
-               <a href="{{ url_for('.download_supplier_file', filepath=item.path, framework_slug='g-cloud-7') }}" class="document-link-with-icon">
+               <a href="{{ url_for('.download_supplier_file', filepath=item.path, framework_slug=framework.slug) }}" class="document-link-with-icon">
                 <span class='document-icon'>{{ item.ext }}<span> document:</span></span>
                 {{ item.filename }}
             {% endcall %}
@@ -129,7 +129,7 @@
           {% include "toolkit/button.html" %}
           {% endwith %}
         
-          <a href="{{ url_for('.framework_dashboard', framework_slug='g-cloud-7') }}">Return to G-Cloud 7 application</a>
+          <a href="{{ url_for('.framework_dashboard', framework_slug=framework.slug) }}">Return to {{ framework.name }} application</a>
 
         </div>
       </div>
@@ -161,7 +161,7 @@
               {% include "toolkit/button.html" %}
             {% endwith %}
       
-            <a href="{{ url_for('.framework_dashboard', framework_slug='g-cloud-7') }}">Return to G-Cloud 7 application</a>
+            <a href="{{ url_for('.framework_dashboard', framework_slug=framework.slug) }}">Return to {{ framework.name }} application</a>
 
           </div>
         </div>

--- a/app/templates/partials/complete_service.html
+++ b/app/templates/partials/complete_service.html
@@ -1,4 +1,4 @@
-<form action="{{ url_for('.complete_draft_service', service_id=service_id) }}" method="POST">
+<form action="{{ url_for('.complete_draft_service', framework_slug=framework.slug, service_id=service_id) }}" method="POST">
   <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
   {% with type = "save", label = "Mark as complete" %}
     {% include "toolkit/button.html" %}

--- a/app/templates/services/_base_service_page.html
+++ b/app/templates/services/_base_service_page.html
@@ -34,8 +34,8 @@
             {% call summary.row(complete=False) %}
               {{ summary.field_name(question.label) }}
               {% call summary.field() %}
-                {% if g7_status == 'open' %}
-                  <a href="{{ url_for(".edit_service_submission", service_id=service_id, section_id=section.id) }}">Answer required</a>
+                {% if framework and framework.status == 'open' %}
+                  <a href="{{ url_for(".edit_service_submission", framework_slug=framework.slug, service_id=service_id, section_id=section.id) }}">Answer required</a>
                 {% else %}
                   Not answered
                 {% endif %}

--- a/app/templates/services/edit_submission_section.html
+++ b/app/templates/services/edit_submission_section.html
@@ -20,7 +20,7 @@
         "label": "Services"
       },
       {
-        "link": url_for(".view_service_submission", service_id=service_id),
+        "link": url_for(".view_service_submission", framework_slug=framework.slug, service_id=service_id),
         "label": service_data['serviceName']
       }
     ]

--- a/app/templates/services/service_submission.html
+++ b/app/templates/services/service_submission.html
@@ -104,7 +104,7 @@
 {% block before_heading %}
   {% if delete_requested %}
     <div class="column-one-whole">
-      <form action="{{ url_for('.delete_draft_service', service_id=service_id ) }}" method="POST">
+      <form action="{{ url_for('.delete_draft_service', framework_slug=framework.slug, service_id=service_id ) }}" method="POST">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
         <input type="hidden" name="delete_confirmed" value="true" />
         <div class="banner-destructive-with-action">
@@ -139,7 +139,7 @@
           </div>
         {% endif %}
         {% if framework.status == 'open' %}
-        <form action="{{ url_for('.delete_draft_service', service_id=service_id ) }}" method="POST">
+        <form action="{{ url_for('.delete_draft_service', framework_slug=framework.slug, service_id=service_id ) }}" method="POST">
           <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
           {% with type = "destructive", label = "Delete this service" %}
             {% include "toolkit/button.html" %}

--- a/app/templates/services/service_submission.html
+++ b/app/templates/services/service_submission.html
@@ -14,18 +14,18 @@
         "label": "Your account"
       },
       {
-        "link": url_for(".framework_dashboard", framework_slug="g-cloud-7"),
-        "label": "Apply to G-Cloud 7"
+        "link": url_for(".framework_dashboard", framework_slug=framework.slug),
+        "label": "Apply to " + framework.name
       },
       {
-        "link": url_for(".framework_services", framework_slug="g-cloud-7"),
+        "link": url_for(".framework_services", framework_slug=framework.slug),
         "label": "Services"
       }
     ]
   %}
     {% include "toolkit/breadcrumb.html" %}
   {% endwith %}
-  {% if service_data.status == 'submitted' and declaration_status != 'complete' and g7_status == 'open' %}
+  {% if service_data.status == 'submitted' and declaration_status != 'complete' and framework.status == 'open' %}
     <div class="wrapper">
       {%
         with
@@ -37,7 +37,7 @@
     </div>
   {% endif %}
 
-  {% if g7_status == 'pending' %}
+  {% if framework.status == 'pending' %}
     <div class="wrapper">
       <aside role="complementary" class="temporary-message" aria-labelledby="temporary-message-heading">
         {% if service_data.status == 'submitted' %}
@@ -71,7 +71,7 @@
     {{ last_edit.createdAt|datetimeformat }}
     by {{ last_edit.userName }}
   </p>
-  {% if g7_status == 'open' %}
+  {% if framework.status == 'open' %}
     {% if unanswered_required or unanswered_optional %}
       <p class="last-edited">
         {{ submission.multiline_string(
@@ -83,12 +83,12 @@
     {% if service_data.status == 'submitted' and declaration_status == 'complete' %}
       <span class="service-status-published">This service is marked as complete and will be submitted at {{ deadline|safe }}</span>
     {% endif %}
-    {% if service_data.status == 'not-submitted' and unanswered_required == 0 and g7_status == 'open' %}
+    {% if service_data.status == 'not-submitted' and unanswered_required == 0 and framework.status == 'open' %}
       {% include "partials/complete_service.html" %}
     {% elif unanswered_required > 0 %}
       <p class="move-to-complete-hint">When you have added all the required information, you can mark the service as complete.</p>
     {% endif %}
-  {% elif g7_status == 'pending' %}
+  {% elif framework.status == 'pending' %}
     {% if unanswered_required or unanswered_optional %}
       <p class="last-edited">
         {{ submission.multiline_string(
@@ -120,8 +120,8 @@
 
 
 {% block edit_link %}
-  {% if g7_status == 'open' %}
-    {{ summary.top_link("Edit", url_for(".edit_service_submission", service_id=service_id, section_id=section.id)) }}
+  {% if framework.status == 'open' %}
+    {{ summary.top_link("Edit", url_for(".edit_service_submission", framework_slug=framework.slug, service_id=service_id, section_id=section.id)) }}
   {% endif %}
 {% endblock %}
 
@@ -133,12 +133,12 @@
         &nbsp;
       </div>
       <div class="column-one-third delete-draft-button">
-        {% if service_data.status == 'not-submitted' and unanswered_required == 0 and g7_status == 'open' %}
+        {% if service_data.status == 'not-submitted' and unanswered_required == 0 and framework.status == 'open' %}
           <div class="space-underneath">
             {% include "partials/complete_service.html" %}
           </div>
         {% endif %}
-        {% if g7_status == 'open' %}
+        {% if framework.status == 'open' %}
         <form action="{{ url_for('.delete_draft_service', service_id=service_id ) }}" method="POST">
           <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
           {% with type = "destructive", label = "Delete this service" %}

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -282,7 +282,7 @@ class TestFrameworkDocumentDownload(BaseApplicationTest):
         with self.app.test_client():
             self.login()
 
-            res = self.client.get('/suppliers/frameworks/g-cloud-7/example.pdf')
+            res = self.client.get('/suppliers/frameworks/g-cloud-7/files/example.pdf')
 
             assert_equal(res.status_code, 302)
             assert_equal(res.location, 'http://localhost/path?param=value')
@@ -296,7 +296,7 @@ class TestFrameworkDocumentDownload(BaseApplicationTest):
         with self.app.test_client():
             self.login()
 
-            res = self.client.get('/suppliers/frameworks/g-cloud-7/example.pdf')
+            res = self.client.get('/suppliers/frameworks/g-cloud-7/files/example.pdf')
 
             assert_equal(res.status_code, 404)
 
@@ -603,7 +603,7 @@ class TestFrameworkUpdatesPage(BaseApplicationTest):
                     assert_true(filename in filename_link.text_content())
                     assert_equal(
                         filename_link.get('href'),
-                        '/suppliers/frameworks/g-cloud-7/{}{}.{}'.format(
+                        '/suppliers/frameworks/g-cloud-7/files/{}{}.{}'.format(
                             section, filename.replace(' ', '%20'), ext
                         )
                     )
@@ -644,7 +644,7 @@ class TestFrameworkUpdatesPage(BaseApplicationTest):
                     assert_true(filename in filename_link.text_content())
                     assert_equal(
                         filename_link.get('href'),
-                        '/suppliers/frameworks/g-cloud-7/{}{}.{}'.format(
+                        '/suppliers/frameworks/g-cloud-7/files/{}{}.{}'.format(
                             section, filename.replace(' ', '%20'), ext
                         )
                     )

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -494,6 +494,7 @@ class TestSupplierDeclaration(BaseApplicationTest):
             assert not data_api_client.set_supplier_declaration.called
 
 
+@mock.patch('app.main.views.frameworks.data_api_client')
 @mock.patch('dmutils.s3.S3')
 class TestFrameworkUpdatesPage(BaseApplicationTest):
 
@@ -526,7 +527,8 @@ class TestFrameworkUpdatesPage(BaseApplicationTest):
                     in self.strip_all_whitespace(table_captions[index].text)
                 )
 
-    def test_should_be_a_503_if_connecting_to_amazon_fails(self, s3):
+    def test_should_be_a_503_if_connecting_to_amazon_fails(self, s3, data_api_client):
+        data_api_client.get_framework.return_value = self.framework('open')
         # if s3 throws a 500-level error
         s3.side_effect = S3ResponseError(500, 'Amazon has collapsed. The internet is over.')
 
@@ -543,7 +545,8 @@ class TestFrameworkUpdatesPage(BaseApplicationTest):
                 in self.strip_all_whitespace(response.get_data(as_text=True))
             )
 
-    def test_empty_messages_exist_if_no_files_returned(self, s3):
+    def test_empty_messages_exist_if_no_files_returned(self, s3, data_api_client):
+        data_api_client.get_framework.return_value = self.framework('open')
 
         with self.app.test_client():
             self.login()
@@ -565,7 +568,8 @@ class TestFrameworkUpdatesPage(BaseApplicationTest):
                     in self.strip_all_whitespace(response.get_data(as_text=True))
                 )
 
-    def test_the_tables_should_be_displayed_correctly(self, s3):
+    def test_the_tables_should_be_displayed_correctly(self, s3, data_api_client):
+        data_api_client.get_framework.return_value = self.framework('open')
 
         files = [
             ('g-cloud-7-updates/communications/', 'file 1', 'odt'),
@@ -608,7 +612,8 @@ class TestFrameworkUpdatesPage(BaseApplicationTest):
                         )
                     )
 
-    def test_names_with_the_section_name_in_them_will_display_correctly(self, s3):
+    def test_names_with_the_section_name_in_them_will_display_correctly(self, s3, data_api_client):
+        data_api_client.get_framework.return_value = self.framework('open')
 
         # for example: 'g-cloud-7-updates/clarifications/communications%20file.odf'
         files = [
@@ -711,9 +716,11 @@ class TestSendClarificationQuestionEmail(BaseApplicationTest):
                 ["g7-application-question"]
             )
 
+    @mock.patch('app.main.views.frameworks.data_api_client')
     @mock.patch('dmutils.s3.S3')
     @mock.patch('app.main.views.frameworks.send_email')
-    def test_should_not_send_email_if_invalid_clarification_question(self, send_email, s3):
+    def test_should_not_send_email_if_invalid_clarification_question(self, send_email, s3, data_api_client):
+        data_api_client.get_framework.return_value = self.framework('open')
 
         for invalid_clarification_question in [
             {
@@ -809,8 +816,10 @@ class TestSendClarificationQuestionEmail(BaseApplicationTest):
             object_id=1234,
             data={"question": clarification_question})
 
+    @mock.patch('app.main.views.frameworks.data_api_client')
     @mock.patch('app.main.views.frameworks.send_email')
-    def test_should_be_a_503_if_email_fails(self, send_email):
+    def test_should_be_a_503_if_email_fails(self, send_email, data_api_client):
+        data_api_client.get_framework.return_value = self.framework('open')
         send_email.side_effect = MandrillException("Arrrgh")
 
         clarification_question = 'This is a clarification question.'

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -300,6 +300,18 @@ class TestFrameworkDocumentDownload(BaseApplicationTest):
 
             assert_equal(res.status_code, 404)
 
+    def test_redirect_g7_document_downloads(self, s3):
+
+        for filename in ['foo.pdf', 'foo.zip', 'foo/bar.pdf']:
+            with self.app.test_client():
+                self.login()
+
+                res = self.client.get('/suppliers/frameworks/g-cloud-7/{}'.format(filename))
+
+                assert_equal(res.status_code, 301)
+                assert_equal(res.location,
+                             'http://localhost/suppliers/frameworks/g-cloud-7/files/{}'.format(filename))
+
 
 FULL_G7_SUBMISSION = {
     "status": "complete",

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -494,20 +494,20 @@ class TestCopyDraft(BaseApplicationTest):
         data_api_client.get_framework.return_value = self.framework(status='open')
         data_api_client.get_draft_service.return_value = {'services': self.draft}
 
-        res = self.client.post('/suppliers/submission/services/1/copy')
+        res = self.client.post('/suppliers/frameworks/g-cloud-7/submissions/1/copy')
         assert_equal(res.status_code, 302)
 
     def test_copy_draft_checks_supplier_id(self, data_api_client):
         self.draft['supplierId'] = 2
         data_api_client.get_draft_service.return_value = {'services': self.draft}
 
-        res = self.client.post('/suppliers/submission/services/1/copy')
+        res = self.client.post('/suppliers/frameworks/g-cloud-7/submissions/1/copy')
         assert_equal(res.status_code, 404)
 
     def test_cannot_copy_draft_if_not_open(self, data_api_client):
         data_api_client.get_framework.return_value = self.framework(status='other')
 
-        res = self.client.post('/suppliers/submission/services/1/copy')
+        res = self.client.post('/suppliers/frameworks/g-cloud-7/submissions/1/copy')
         assert_equal(res.status_code, 404)
 
 

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -404,7 +404,7 @@ class TestCreateDraftService(BaseApplicationTest):
             self.login()
         data_api_client.get_framework.return_value = self.framework(status='open')
 
-        res = self.client.get('/suppliers/submission/g-cloud-7/create')
+        res = self.client.get('/suppliers/frameworks/g-cloud-7/submissions/create')
         assert_equal(res.status_code, 200)
         assert_in("Create new service", res.get_data(as_text=True))
 
@@ -420,7 +420,7 @@ class TestCreateDraftService(BaseApplicationTest):
             self.login()
         data_api_client.get_framework.return_value = self.framework(status='other')
 
-        res = self.client.get('/suppliers/submission/g-cloud-7/create')
+        res = self.client.get('/suppliers/frameworks/g-cloud-7/submissions/create')
         assert_equal(res.status_code, 404)
 
     def _test_post_create_draft_service(self, if_error_expected, data_api_client):
@@ -442,7 +442,7 @@ class TestCreateDraftService(BaseApplicationTest):
         }
 
         res = self.client.post(
-            '/suppliers/submission/g-cloud-7/create'
+            '/suppliers/frameworks/g-cloud-7/submissions/create'
         )
 
         if if_error_expected:

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -804,7 +804,7 @@ class TestEditDraftService(BaseApplicationTest):
             data={})
 
         assert_equal(302, res.status_code)
-        assert_equal('http://localhost/suppliers/submission/services/1',
+        assert_equal('http://localhost/suppliers/frameworks/g-cloud-7/submissions/1',
                      res.headers['Location'])
 
     def test_update_redirects_to_edit_submission_if_return_to_summary(self, data_api_client, s3):
@@ -817,7 +817,7 @@ class TestEditDraftService(BaseApplicationTest):
             data={})
 
         assert_equal(302, res.status_code)
-        assert_equal('http://localhost/suppliers/submission/services/1',
+        assert_equal('http://localhost/suppliers/frameworks/g-cloud-7/submissions/1',
                      res.headers['Location'])
 
     def test_update_redirects_to_edit_submission_if_grey_button_clicked(self, data_api_client, s3):
@@ -830,7 +830,7 @@ class TestEditDraftService(BaseApplicationTest):
             data={})
 
         assert_equal(302, res.status_code)
-        assert_equal('http://localhost/suppliers/submission/services/1',
+        assert_equal('http://localhost/suppliers/frameworks/g-cloud-7/submissions/1',
                      res.headers['Location'])
 
     def test_update_with_answer_required_error(self, data_api_client, s3):
@@ -939,7 +939,7 @@ class TestShowDraftService(BaseApplicationTest):
 
     def test_service_price_is_correctly_formatted(self, data_api_client):
         data_api_client.get_draft_service.return_value = self.draft_service
-        res = self.client.get('/suppliers/submission/services/1')
+        res = self.client.get('/suppliers/frameworks/g-cloud-7/submissions/1')
         document = html.fromstring(res.get_data(as_text=True))
 
         assert_equal(res.status_code, 200)
@@ -954,7 +954,7 @@ class TestShowDraftService(BaseApplicationTest):
         data_api_client.get_framework.return_value = self.framework(status='open')
         data_api_client.get_draft_service.return_value = self.draft_service
         count_unanswered.return_value = 1, 2
-        res = self.client.get('/suppliers/submission/services/1')
+        res = self.client.get('/suppliers/frameworks/g-cloud-7/submissions/1')
 
         assert_true(u'3 unanswered questions' in res.get_data(as_text=True),
                     "'3 unanswered questions' not found in html")
@@ -964,7 +964,7 @@ class TestShowDraftService(BaseApplicationTest):
         data_api_client.get_framework.return_value = self.framework(status='open')
         data_api_client.get_draft_service.return_value = self.draft_service
         count_unanswered.return_value = 0, 1
-        res = self.client.get('/suppliers/submission/services/1')
+        res = self.client.get('/suppliers/frameworks/g-cloud-7/submissions/1')
 
         assert_in(u'1 optional question unanswered', res.get_data(as_text=True))
         assert_in(u'<input type="submit" class="button-save"  value="Mark as complete" />',
@@ -975,7 +975,7 @@ class TestShowDraftService(BaseApplicationTest):
         data_api_client.get_framework.return_value = self.framework(status='other')
         data_api_client.get_draft_service.return_value = self.draft_service
         count_unanswered.return_value = 0, 1
-        res = self.client.get('/suppliers/submission/services/1')
+        res = self.client.get('/suppliers/frameworks/g-cloud-7/submissions/1')
 
         assert_not_in(u'<input type="submit" class="button-save"  value="Mark as complete" />',
                       res.get_data(as_text=True))
@@ -985,7 +985,7 @@ class TestShowDraftService(BaseApplicationTest):
         data_api_client.get_framework.return_value = self.framework(status='pending')
         data_api_client.get_draft_service.return_value = self.draft_service
         count_unanswered.return_value = 3, 1
-        res = self.client.get('/suppliers/submission/services/1')
+        res = self.client.get('/suppliers/frameworks/g-cloud-7/submissions/1')
 
         doc = html.fromstring(res.get_data(as_text=True))
         message = doc.xpath('//aside[@class="temporary-message"]')
@@ -1001,7 +1001,7 @@ class TestShowDraftService(BaseApplicationTest):
         data_api_client.get_framework.return_value = self.framework(status='pending')
         data_api_client.get_draft_service.return_value = self.complete_service
         count_unanswered.return_value = 0, 1
-        res = self.client.get('/suppliers/submission/services/2')
+        res = self.client.get('/suppliers/frameworks/g-cloud-7/submissions/2')
 
         doc = html.fromstring(res.get_data(as_text=True))
         message = doc.xpath('//aside[@class="temporary-message"]')
@@ -1050,9 +1050,9 @@ class TestDeleteDraftService(BaseApplicationTest):
         assert_equal(res.status_code, 302)
         assert_equal(
             res.location,
-            'http://localhost/suppliers/submission/services/1?delete_requested=True'
+            'http://localhost/suppliers/frameworks/g-cloud-7/submissions/1?delete_requested=True'
         )
-        res2 = self.client.get('/suppliers/submission/services/1?delete_requested=True')
+        res2 = self.client.get('/suppliers/frameworks/g-cloud-7/submissions/1?delete_requested=True')
         assert_in(
             b"Are you sure you want to delete this service?", res2.get_data()
         )

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -535,7 +535,7 @@ class TestCompleteDraft(BaseApplicationTest):
         data_api_client.get_framework.return_value = self.framework(status='open')
         data_api_client.get_draft_service.return_value = {'services': self.draft}
 
-        res = self.client.post('/suppliers/submission/services/1/complete')
+        res = self.client.post('/suppliers/frameworks/g-cloud-7/submissions/1/complete')
         assert_equal(res.status_code, 302)
         assert_true('lot=scs' in res.location)
         assert_true('service_completed=1' in res.location)
@@ -545,13 +545,13 @@ class TestCompleteDraft(BaseApplicationTest):
         self.draft['supplierId'] = 2
         data_api_client.get_draft_service.return_value = {'services': self.draft}
 
-        res = self.client.post('/suppliers/submission/services/1/complete')
+        res = self.client.post('/suppliers/frameworks/g-cloud-7/submissions/1/complete')
         assert_equal(res.status_code, 404)
 
     def test_cannot_complete_draft_if_not_open(self, data_api_client):
         data_api_client.get_framework.return_value = self.framework(status='other')
 
-        res = self.client.post('/suppliers/submission/services/1/complete')
+        res = self.client.post('/suppliers/frameworks/g-cloud-7/submissions/1/complete')
         assert_equal(res.status_code, 404)
 
 
@@ -1045,7 +1045,7 @@ class TestDeleteDraftService(BaseApplicationTest):
         data_api_client.get_framework.return_value = self.framework(status='open')
         data_api_client.get_draft_service.return_value = self.draft_to_delete
         res = self.client.post(
-            '/suppliers/submission/services/1/delete',
+            '/suppliers/frameworks/g-cloud-7/submissions/1/delete',
             data={})
         assert_equal(res.status_code, 302)
         assert_equal(
@@ -1061,7 +1061,7 @@ class TestDeleteDraftService(BaseApplicationTest):
         data_api_client.get_framework.return_value = self.framework(status='other')
         data_api_client.get_draft_service.return_value = self.draft_to_delete
         res = self.client.post(
-            '/suppliers/submission/services/1/delete',
+            '/suppliers/frameworks/g-cloud-7/submissions/1/delete',
             data={})
         assert_equal(res.status_code, 404)
 
@@ -1069,7 +1069,7 @@ class TestDeleteDraftService(BaseApplicationTest):
         data_api_client.get_framework.return_value = self.framework(status='open')
         data_api_client.get_draft_service.return_value = self.draft_to_delete
         res = self.client.post(
-            '/suppliers/submission/services/1/delete',
+            '/suppliers/frameworks/g-cloud-7/submissions/1/delete',
             data={'delete_confirmed': 'true'})
 
         data_api_client.delete_draft_service.assert_called_with('1', 'email@email.com')
@@ -1084,7 +1084,7 @@ class TestDeleteDraftService(BaseApplicationTest):
         other_draft['services']['supplierId'] = 12345
         data_api_client.get_draft_service.return_value = other_draft
         res = self.client.post(
-            '/suppliers/submission/services/1/delete',
+            '/suppliers/frameworks/g-cloud-7/submissions/1/delete',
             data={'delete_confirmed': 'true'})
 
         assert_equal(res.status_code, 404)

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -582,7 +582,7 @@ class TestEditDraftService(BaseApplicationTest):
         data_api_client.get_framework.return_value = self.framework(status='open')
         data_api_client.get_draft_service.return_value = self.empty_draft
         res = self.client.post(
-            '/suppliers/submission/services/1/edit/service_description',
+            '/suppliers/frameworks/g-cloud-7/submissions/1/edit/service_description',
             data={
                 'serviceSummary': 'This is the service',
             })
@@ -602,7 +602,7 @@ class TestEditDraftService(BaseApplicationTest):
         data_api_client.get_draft_service.return_value = {'services': draft}
 
         res = self.client.post(
-            '/suppliers/submission/services/1/edit/service_description',
+            '/suppliers/frameworks/g-cloud-7/submissions/1/edit/service_description',
             data={
                 'serviceSummary': u"summary",
             })
@@ -616,7 +616,7 @@ class TestEditDraftService(BaseApplicationTest):
         data_api_client.get_framework.return_value = self.framework(status='open')
         data_api_client.get_draft_service.return_value = self.empty_draft
         res = self.client.post(
-            '/suppliers/submission/services/1/edit/service_description',
+            '/suppliers/frameworks/g-cloud-7/submissions/1/edit/service_description',
             data={
                 'serviceSummary': 'This is the service',
             })
@@ -627,12 +627,12 @@ class TestEditDraftService(BaseApplicationTest):
     def test_editing_readonly_section_is_not_allowed(self, data_api_client, s3):
         data_api_client.get_draft_service.return_value = self.empty_draft
 
-        res = self.client.get('/suppliers/submission/services/1/edit/service_attributes')
+        res = self.client.get('/suppliers/frameworks/g-cloud-7/submissions/1/edit/service_attributes')
         assert_equal(res.status_code, 404)
 
         data_api_client.get_draft_service.return_value = self.empty_draft
         res = self.client.post(
-            '/suppliers/submission/services/1/edit/service_attributes',
+            '/suppliers/frameworks/g-cloud-7/submissions/1/edit/service_attributes',
             data={
                 'lot': 'SCS',
             })
@@ -642,7 +642,7 @@ class TestEditDraftService(BaseApplicationTest):
         data_api_client.get_framework.return_value = self.framework(status='other')
         data_api_client.get_draft_service.return_value = self.empty_draft
         res = self.client.post(
-            '/suppliers/submission/services/1/edit/service_description',
+            '/suppliers/frameworks/g-cloud-7/submissions/1/edit/service_description',
             data={
                 'serviceSummary': 'This is the service',
             })
@@ -652,7 +652,7 @@ class TestEditDraftService(BaseApplicationTest):
         data_api_client.get_framework.return_value = self.framework(status='open')
         data_api_client.get_draft_service.return_value = self.empty_draft
         res = self.client.post(
-            '/suppliers/submission/services/1/edit/service_description',
+            '/suppliers/frameworks/g-cloud-7/submissions/1/edit/service_description',
             data={
                 'serviceFeatures': '',
             })
@@ -669,7 +669,7 @@ class TestEditDraftService(BaseApplicationTest):
         data_api_client.get_framework.return_value = self.framework(status='open')
         data_api_client.get_draft_service.return_value = draft
         response = self.client.get(
-            '/suppliers/submission/services/1/edit/service_definition'
+            '/suppliers/frameworks/g-cloud-7/submissions/1/edit/service_definition'
         )
         document = html.fromstring(response.get_data(as_text=True))
 
@@ -680,7 +680,7 @@ class TestEditDraftService(BaseApplicationTest):
         data_api_client.get_framework.return_value = self.framework(status='open')
         data_api_client.get_draft_service.return_value = self.empty_draft
         response = self.client.get(
-            '/suppliers/submission/services/1/edit/service_definition'
+            '/suppliers/frameworks/g-cloud-7/submissions/1/edit/service_definition'
         )
         document = html.fromstring(response.get_data(as_text=True))
 
@@ -692,7 +692,7 @@ class TestEditDraftService(BaseApplicationTest):
         data_api_client.get_draft_service.return_value = self.empty_draft
         with freeze_time('2015-01-02 03:04:05'):
             res = self.client.post(
-                '/suppliers/submission/services/1/edit/service_definition',
+                '/suppliers/frameworks/g-cloud-7/submissions/1/edit/service_definition',
                 data={
                     'serviceDefinitionDocumentURL': (StringIO(b'doc'), 'document.pdf'),
                 }
@@ -715,7 +715,7 @@ class TestEditDraftService(BaseApplicationTest):
         data_api_client.get_framework.return_value = self.framework(status='open')
         data_api_client.get_draft_service.return_value = self.empty_draft
         res = self.client.post(
-            '/suppliers/submission/services/1/edit/service_definition',
+            '/suppliers/frameworks/g-cloud-7/submissions/1/edit/service_definition',
             data={
                 'serviceDefinitionDocumentURL': (StringIO(b''), 'document.pdf'),
                 'unknownDocumentURL': (StringIO(b'doc'), 'document.pdf'),
@@ -734,7 +734,7 @@ class TestEditDraftService(BaseApplicationTest):
         data_api_client.get_framework.return_value = self.framework(status='open')
         data_api_client.get_draft_service.return_value = self.empty_draft
         res = self.client.post(
-            '/suppliers/submission/services/1/edit/service_definition',
+            '/suppliers/frameworks/g-cloud-7/submissions/1/edit/service_definition',
             data={
                 'serviceDefinitionDocumentURL': 'http://example.com/document.pdf',
             })
@@ -749,7 +749,7 @@ class TestEditDraftService(BaseApplicationTest):
         data_api_client.get_framework.return_value = self.framework(status='open')
         data_api_client.get_draft_service.return_value = self.empty_draft
         res = self.client.post(
-            '/suppliers/submission/services/1/edit/pricing',
+            '/suppliers/frameworks/g-cloud-7/submissions/1/edit/pricing',
             data={
                 'priceString': ["10.10", "11.10", "Person", "Second"],
             })
@@ -768,14 +768,14 @@ class TestEditDraftService(BaseApplicationTest):
 
     def test_edit_non_existent_draft_service_returns_404(self, data_api_client, s3):
         data_api_client.get_draft_service.side_effect = HTTPError(mock.Mock(status_code=404))
-        res = self.client.get('/suppliers/submission/services/1/edit/service_description')
+        res = self.client.get('/suppliers/frameworks/g-cloud-7/submissions/1/edit/service_description')
 
         assert_equal(res.status_code, 404)
 
     def test_edit_non_existent_draft_section_returns_404(self, data_api_client, s3):
         data_api_client.get_draft_service.return_value = self.empty_draft
         res = self.client.get(
-            '/suppliers/submission/services/1/edit/invalid_section'
+            '/suppliers/frameworks/g-cloud-7/submissions/1/edit/invalid_section'
         )
         assert_equal(404, res.status_code)
 
@@ -785,13 +785,13 @@ class TestEditDraftService(BaseApplicationTest):
         data_api_client.update_draft_service.return_value = None
 
         res = self.client.post(
-            '/suppliers/submission/services/1/edit/service_description',
+            '/suppliers/frameworks/g-cloud-7/submissions/1/edit/service_description',
             data={
                 'continue_to_next_section': 'Save and continue'
             })
 
         assert_equal(302, res.status_code)
-        assert_equal('http://localhost/suppliers/submission/services/1/edit/service_type',
+        assert_equal('http://localhost/suppliers/frameworks/g-cloud-7/submissions/1/edit/service_type',
                      res.headers['Location'])
 
     def test_update_redirects_to_edit_submission_if_no_next_editable_section(self, data_api_client, s3):
@@ -800,7 +800,7 @@ class TestEditDraftService(BaseApplicationTest):
         data_api_client.update_draft_service.return_value = None
 
         res = self.client.post(
-            '/suppliers/submission/services/1/edit/sfia_rate_card',
+            '/suppliers/frameworks/g-cloud-7/submissions/1/edit/sfia_rate_card',
             data={})
 
         assert_equal(302, res.status_code)
@@ -813,7 +813,7 @@ class TestEditDraftService(BaseApplicationTest):
         data_api_client.update_draft_service.return_value = None
 
         res = self.client.post(
-            '/suppliers/submission/services/1/edit/service_description?return_to_summary=1',
+            '/suppliers/frameworks/g-cloud-7/submissions/1/edit/service_description?return_to_summary=1',
             data={})
 
         assert_equal(302, res.status_code)
@@ -826,7 +826,7 @@ class TestEditDraftService(BaseApplicationTest):
         data_api_client.update_draft_service.return_value = None
 
         res = self.client.post(
-            '/suppliers/submission/services/1/edit/service_description',
+            '/suppliers/frameworks/g-cloud-7/submissions/1/edit/service_description',
             data={})
 
         assert_equal(302, res.status_code)
@@ -840,7 +840,7 @@ class TestEditDraftService(BaseApplicationTest):
             mock.Mock(status_code=400),
             {'serviceSummary': 'answer_required'})
         res = self.client.post(
-            '/suppliers/submission/services/1/edit/service_description',
+            '/suppliers/frameworks/g-cloud-7/submissions/1/edit/service_description',
             data={})
 
         assert_equal(res.status_code, 200)
@@ -856,7 +856,7 @@ class TestEditDraftService(BaseApplicationTest):
             mock.Mock(status_code=400),
             {'serviceSummary': 'under_50_words'})
         res = self.client.post(
-            '/suppliers/submission/services/1/edit/service_description',
+            '/suppliers/frameworks/g-cloud-7/submissions/1/edit/service_description',
             data={})
 
         assert_equal(res.status_code, 200)
@@ -881,7 +881,7 @@ class TestEditDraftService(BaseApplicationTest):
                 mock.Mock(status_code=400),
                 {field: error})
             res = self.client.post(
-                '/suppliers/submission/services/1/edit/pricing',
+                '/suppliers/frameworks/g-cloud-7/submissions/1/edit/pricing',
                 data={})
 
             assert_equal(res.status_code, 200)
@@ -891,14 +891,14 @@ class TestEditDraftService(BaseApplicationTest):
 
     def test_update_non_existent_draft_service_returns_404(self, data_api_client, s3):
         data_api_client.get_draft_service.side_effect = HTTPError(mock.Mock(status_code=404))
-        res = self.client.post('/suppliers/submission/services/1/edit/service_description')
+        res = self.client.post('/suppliers/frameworks/g-cloud-7/submissions/1/edit/service_description')
 
         assert_equal(res.status_code, 404)
 
     def test_update_non_existent_draft_section_returns_404(self, data_api_client, s3):
         data_api_client.get_draft_service.return_value = self.empty_draft
         res = self.client.post(
-            '/suppliers/submission/services/1/edit/invalid_section'
+            '/suppliers/frameworks/g-cloud-7/submissions/1/edit/invalid_section'
         )
         assert_equal(404, res.status_code)
 

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -1101,7 +1101,7 @@ class TestSubmissionDocuments(BaseApplicationTest):
         s3.return_value.get_signed_url.return_value = 'http://example.com/document.pdf'
 
         res = self.client.get(
-            '/suppliers/submission/documents/g-cloud-7/1234/document.pdf'
+            '/suppliers/frameworks/g-cloud-7/submissions/documents/1234/document.pdf'
         )
 
         assert_equal(res.status_code, 302)
@@ -1111,14 +1111,14 @@ class TestSubmissionDocuments(BaseApplicationTest):
         s3.return_value.get_signed_url.return_value = None
 
         res = self.client.get(
-            '/suppliers/submission/documents/g-cloud-7/1234/document.pdf'
+            '/suppliers/frameworks/g-cloud-7/submissions/documents/1234/document.pdf'
         )
 
         assert_equal(res.status_code, 404)
 
     def test_document_url_not_matching_user_supplier(self, s3):
         res = self.client.get(
-            '/suppliers/submission/documents/g-cloud-7/999/document.pdf'
+            '/suppliers/frameworks/g-cloud-7/submissions/documents/999/document.pdf'
         )
 
         assert_equal(res.status_code, 404)

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -938,6 +938,7 @@ class TestShowDraftService(BaseApplicationTest):
             self.login()
 
     def test_service_price_is_correctly_formatted(self, data_api_client):
+        data_api_client.get_framework.return_value = self.framework('open')
         data_api_client.get_draft_service.return_value = self.draft_service
         res = self.client.get('/suppliers/frameworks/g-cloud-7/submissions/1')
         document = html.fromstring(res.get_data(as_text=True))

--- a/tests/app/main/test_suppliers.py
+++ b/tests/app/main/test_suppliers.py
@@ -54,6 +54,7 @@ class TestSuppliersDashboard(BaseApplicationTest):
     @mock.patch("app.main.views.suppliers.data_api_client")
     @mock.patch("app.main.views.suppliers.get_current_suppliers_users")
     def test_shows_supplier_info(self, get_current_suppliers_users, data_api_client):
+        data_api_client.get_framework.return_value = self.framework('open')
         data_api_client.get_supplier.side_effect = get_supplier
         data_api_client.find_audit_events.return_value = {
             "auditEvents": []
@@ -117,7 +118,7 @@ class TestSuppliersDashboard(BaseApplicationTest):
     @mock.patch("app.main.views.suppliers.data_api_client")
     @mock.patch("app.main.views.suppliers.get_current_suppliers_users")
     def test_shows_gcloud_7_application_link(self, get_current_suppliers_users, data_api_client):
-        data_api_client.get_framework_status.return_value = {'status': 'open'}
+        data_api_client.get_framework.return_value = self.framework('open')
         data_api_client.get_supplier.side_effect = get_supplier
         data_api_client.find_audit_events.return_value = {
             "auditEvents": []
@@ -137,7 +138,7 @@ class TestSuppliersDashboard(BaseApplicationTest):
     @mock.patch("app.main.views.suppliers.data_api_client")
     @mock.patch("app.main.views.suppliers.get_current_suppliers_users")
     def test_shows_gcloud_7_continue_link(self, get_current_suppliers_users, data_api_client):
-        data_api_client.get_framework_status.return_value = {'status': 'open'}
+        data_api_client.get_framework.return_value = self.framework('open')
         data_api_client.get_supplier.side_effect = get_supplier
         data_api_client.find_audit_events.return_value = {
             "auditEvents": [{
@@ -160,7 +161,7 @@ class TestSuppliersDashboard(BaseApplicationTest):
     @mock.patch("app.main.views.suppliers.data_api_client")
     @mock.patch("app.main.views.suppliers.get_current_suppliers_users")
     def test_shows_gcloud_7_closed_message_if_pending_and_no_interest(self, get_current_suppliers_users, data_api_client):  # noqa
-        data_api_client.get_framework_status.return_value = {'status': 'pending'}
+        data_api_client.get_framework.return_value = self.framework('pending')
         data_api_client.get_supplier.side_effect = get_supplier
         data_api_client.find_audit_events.return_value = {
             "auditEvents": []
@@ -181,7 +182,7 @@ class TestSuppliersDashboard(BaseApplicationTest):
     @mock.patch("app.main.views.suppliers.data_api_client")
     @mock.patch("app.main.views.suppliers.get_current_suppliers_users")
     def test_shows_gcloud_7_closed_message_if_pending_and_no_application(self, get_current_suppliers_users, data_api_client):  # noqa
-        data_api_client.get_framework_status.return_value = {'status': 'pending'}
+        data_api_client.get_framework.return_value = self.framework('pending')
         data_api_client.get_supplier.side_effect = get_supplier
         data_api_client.find_audit_events.return_value = {
             "auditEvents": [{
@@ -213,7 +214,7 @@ class TestSuppliersDashboard(BaseApplicationTest):
     @mock.patch("app.main.views.suppliers.data_api_client")
     @mock.patch("app.main.views.suppliers.get_current_suppliers_users")
     def test_shows_gcloud_7_closed_message_if_pending_and_application_done(self, get_current_suppliers_users, data_api_client):  # noqa
-        data_api_client.get_framework_status.return_value = {'status': 'pending'}
+        data_api_client.get_framework.return_value = self.framework('pending')
         data_api_client.get_supplier.side_effect = get_supplier
         data_api_client.find_audit_events.return_value = {
             "auditEvents": [{


### PR DESCRIPTION
Move the routes around to follow the agreed new layout which includes framework slug in all framework specific routes.

The main goal of this change is to allow DOS to be supported by the route on the supplier frontend. A secondary goal has been to rationalise the routes to make grouping for analysis easier.

Old route | New route
------- | --------
`/frameworks/<framework_slug>/<filepath>` | `/frameworks/<framework_slug>/files/<filepath>`
`/frameworks/g-cloud-7/updates` | `/frameworks/<framework_slug>/updates`
`/submission/<framework_slug>/create` | `/frameworks/<framework_slug>/submissions/create`
`/submission/services/<service_id>/copy` | `/frameworks/<framework_slug>/submissions/<service_id>/copy`
`/submission/services/<service_id>/complete` | `/frameworks/<framework_slug>/submissions/<service_id>/complete`
`/submission/services/<service_id>/delete` | `/frameworks/<framework_slug>/submissions/<service_id>/delete`
`/submission/documents/<framework_slug>/<supplier_id>/<document_name>` | `/frameworks/<framework_slug>/submissions/documents/<supplier_id>/<document_name>`
`/submission/services/<service_id>` | `/frameworks/<framework_slug>/submissions/<service_id>`
`/submission/services/<service_id>/edit/<section_id>` | `/frameworks/<framework_slug>/submissions/<service_id>/edit/<section_id>`

:sparkles: The SSP functional tests have been run against this change :sparkles: 
