### PR TITLE
𝘗𝘙𝘖𝘗𝘖𝘚𝘈𝘓: Restart the app when content changes

### DIFF
--- a/application.py
+++ b/application.py
@@ -3,7 +3,23 @@
 import os
 import re
 from app import create_app
-from flask.ext.script import Manager, Server
+from flask.ext.script import Manager, Server as _Server
+
+
+def extra_files():
+    for dirname, dirs, files in os.walk('./app/content'):
+        for filename in files:
+            filename = os.path.join(dirname, filename)
+            if os.path.isfile(filename):
+                print(filename)
+                yield filename
+
+
+class Server(_Server):
+    def __init__(self, *args, **kwargs):
+        if kwargs.get('use_reloader', True):
+            kwargs.setdefault('extra_files', []).extend(extra_files())
+        super(Server, self).__init__(*args, **kwargs)
 
 application = create_app(
     os.getenv('DM_ENVIRONMENT') or 'development'

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -263,12 +263,14 @@ gulp.task('test', function () {
 gulp.task('watch', ['build:development'], function () {
   var jsWatcher = gulp.watch([ assetsFolder + '/**/*.js' ], ['js']);
   var cssWatcher = gulp.watch([ assetsFolder + '/**/*.scss' ], ['sass']);
+  var frameworkWatcher = gulp.watch([ bowerRoot + '/digitalmarketplace-frameworks' + '/**/*.yml' ], ['copy:frameworks']);
   var notice = function (event) {
     console.log('File ' + event.path + ' was ' + event.type + ' running tasks...');
   };
 
   cssWatcher.on('change', notice);
   jsWatcher.on('change', notice);
+  frameworkWatcher.on('change', notice);
 });
 
 gulp.task('set_environment_to_development', function (cb) {


### PR DESCRIPTION
_This is just hacked together, but it works. If we do it for real it should probably go in utils or something._

Any changes to files in `app/content` now cause the app to restart, in the same way that changing a `.py` file causes the app to restart.

This means:
- that when you `npm install` you don't need to restart the app
- you can quickly try out content changes locally and see the changes with just
  a refresh of the page