### PR TITLE
[#105005134] Register for DOS

### DIFF
--- a/app/assets/scss/_framework-application.scss
+++ b/app/assets/scss/_framework-application.scss
@@ -118,13 +118,24 @@
 
   .summary-item-heading {
     padding-top: 0;
+    padding-right: 0;
   }
 
+  input.button-save { 
+    margin-top: 0px;
+    margin-bottom: 8px;
+  }
+
+  a {
+    @include bold-24;
+  }
+ 
   p {
     margin-bottom: 5px;
 
     a {
       display: block;
+      @include core-19;
     }
   }
 }

--- a/app/main/helpers/frameworks.py
+++ b/app/main/helpers/frameworks.py
@@ -1,6 +1,5 @@
 from flask import abort
 from flask_login import current_user
-from dmutils.audit import AuditTypes
 from dmutils.apiclient import APIError
 import re
 from operator import add
@@ -18,11 +17,12 @@ OPTIONAL_FIELDS = set([
 ])
 
 
-def has_registered_interest_in_framework(client, framework_slug):
-    frameworks = client.get_framework_interest(current_user.supplier_id)
-    if framework_slug in frameworks.get('frameworks', []):
-            return True
-    return False
+def frameworks_by_slug(client):
+    framework_list = client.find_frameworks().get("frameworks")
+    frameworks = {}
+    for framework in framework_list:
+        frameworks[framework['slug']] = framework
+    return frameworks
 
 
 def register_interest_in_framework(client, framework_slug):

--- a/app/main/helpers/frameworks.py
+++ b/app/main/helpers/frameworks.py
@@ -19,24 +19,14 @@ OPTIONAL_FIELDS = set([
 
 
 def has_registered_interest_in_framework(client, framework_slug):
-    audits = client.find_audit_events(
-        audit_type=AuditTypes.register_framework_interest,
-        object_type='suppliers',
-        object_id=current_user.supplier_id)
-    for audit in audits['auditEvents']:
-        if audit['data'].get('frameworkSlug') == framework_slug:
+    frameworks = client.get_framework_interest(current_user.supplier_id)
+    if framework_slug in frameworks.get('frameworks', []):
             return True
     return False
 
 
 def register_interest_in_framework(client, framework_slug):
-    if not has_registered_interest_in_framework(client, framework_slug):
-        client.create_audit_event(
-            audit_type=AuditTypes.register_framework_interest,
-            user=current_user.email_address,
-            object_type='suppliers',
-            object_id=current_user.supplier_id,
-            data={'frameworkSlug': framework_slug})
+    client.register_framework_interest(current_user.supplier_id, framework_slug, current_user.email_address)
 
 
 def get_last_modified_from_first_matching_file(key_list, path_starts_with):

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -18,7 +18,7 @@ from ...main import main, content_loader
 from ..helpers import hash_email
 from ..helpers.frameworks import get_error_messages_for_page, get_first_question_index, \
     get_error_messages, get_declaration_status, get_last_modified_from_first_matching_file, \
-    g_cloud_7_is_open_or_404, register_interest_in_framework
+    register_interest_in_framework
 from ..helpers.services import (
     get_draft_document_url, get_service_attributes, get_drafts,
     count_unanswered_questions
@@ -28,7 +28,7 @@ from ..helpers.services import (
 CLARIFICATION_QUESTION_NAME = 'clarification_question'
 
 
-@main.route('/frameworks/<framework_slug>', methods=['GET'])
+@main.route('/frameworks/<framework_slug>', methods=['GET', 'POST'])
 @login_required
 @flask_featureflags.is_active_feature('GCLOUD7_OPEN')
 def framework_dashboard(framework_slug):
@@ -36,10 +36,11 @@ def framework_dashboard(framework_slug):
     # TODO add a test for 404 if framework doesn't exist
     framework = data_api_client.get_framework(framework_slug)['frameworks']
 
-    try:
-        register_interest_in_framework(data_api_client, framework_slug)
-    except APIError as e:
-        abort(e.status_code)
+    if request.method == 'POST':
+        try:
+            register_interest_in_framework(data_api_client, framework_slug)
+        except APIError as e:
+            abort(e.status_code)
 
     drafts, complete_drafts = get_drafts(data_api_client, current_user.supplier_id, framework_slug)
     declaration_status = get_declaration_status(data_api_client, framework_slug)
@@ -137,6 +138,8 @@ def framework_supplier_declaration(framework_slug, section_id=None):
     except APIError as e:
         if e.status_code != 404:
             abort(e.status_code)
+
+    if latest_answers is None:
         latest_answers = {}
 
     if request.method == 'POST':

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -131,16 +131,15 @@ def framework_supplier_declaration(framework_slug, section_id=None):
         abort(404)
 
     is_last_page = section_id == content.sections[-1]['id']
+    latest_answers = {}
 
     try:
         response = data_api_client.get_supplier_declaration(current_user.supplier_id, framework_slug)
-        latest_answers = response['declaration']
+        if response['declaration']:
+            latest_answers = response['declaration']
     except APIError as e:
         if e.status_code != 404:
             abort(e.status_code)
-
-    if latest_answers is None:
-        latest_answers = {}
 
     if request.method == 'POST':
         answers = content.get_all_data(request.form)

--- a/app/templates/suppliers/_dos_messaging.html
+++ b/app/templates/suppliers/_dos_messaging.html
@@ -1,0 +1,29 @@
+{% if 'digital-outcomes-and-specialists' in registered_frameworks and frameworks.get('digital-outcomes-and-specialists', {}).get('status', None) == 'open' %}
+    <div class="summary-item-lede">
+        <h2 class="summary-item-heading">
+            {{ "Digital Outcomes and Specialists is open for applications until {}".format(deadline)|safe }}
+        </h2>
+        <a href="{{ url_for('.framework_dashboard', framework_slug='digital-outcomes-and-specialists') }}">Continue your application</a>
+    </div>
+    
+{% elif frameworks.get('digital-outcomes-and-specialists', {}).get('status', None) == 'open' %}
+    <form action="{{ url_for('.framework_dashboard', framework_slug='digital-outcomes-and-specialists') }}" method="POST">
+        <div class="summary-item-lede">
+            <h2 class="summary-item-heading">
+                {{ "Digital Outcomes and Specialists is open for applications until {}".format(deadline)|safe }}
+            </h2>
+        
+            {%
+            with
+                type = "save",
+                label = "Start application"
+            %}
+                {% include "toolkit/button.html" %}
+            {% endwith %}
+        
+            Starting your application means you’ll receive emails about the application process.
+        </div>
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+    </form>
+
+{% endif %}

--- a/app/templates/suppliers/_g7_messaging.html
+++ b/app/templates/suppliers/_g7_messaging.html
@@ -1,0 +1,63 @@
+{% if 'g-cloud-7' in registered_frameworks and frameworks['g-cloud-7'].get('status', None) == 'open' %}
+    {%
+    with
+        items = [{
+            "title": "Continue your G-Cloud 7 application",
+            "link": url_for(".framework_dashboard", framework_slug='g-cloud-7'),
+            "body": "Make your supplier declaration, add services and view G-Cloud 7 updates and clarification questions.",
+            "subtext": "Deadline for submissions: {}".format(deadline)
+        }]
+    %}
+        {% include "toolkit/browse-list.html" %}
+    {% endwith %}
+
+{% elif frameworks['g-cloud-7'].get('status', None) == 'open' %}
+    {%
+    with
+        items = [{
+        "title": "Register your interest in becoming a G-Cloud 7 supplier",
+        "link": url_for(".framework_dashboard", framework_slug='g-cloud-7'),
+        "body": "Read about G-Cloud 7, receive email updates and start the application process.",
+        "subtext": "Deadline for submissions: {}".format(deadline)
+        }]
+    %}
+        {% include "toolkit/browse-list.html" %}
+    {% endwith %}
+
+{% elif 'g-cloud-7' in registered_frameworks and g7_application_made and frameworks['g-cloud-7'].get('status', None) == 'pending' %}
+<div class="summary-item-lede">
+    <div class="grid-row">
+        <div class="column-two-thirds">
+            <h2 class="summary-item-heading">G-Cloud 7 is closed for applications</h2>
+            <p>
+                You submitted {{ g7_complete }} {{ 'service' if g7_complete == 1 else 'services' }} for consideration.
+                <a href="{{ url_for('.framework_dashboard', framework_slug='g-cloud-7') }}">View your submitted application</a>
+            </p>
+        </div>
+    </div>
+</div>
+
+{% elif 'g-cloud-7' in registered_frameworks and frameworks['g-cloud-7'].get('status', None) == 'pending' %}
+<aside role="complementary" class="temporary-message" aria-labelledby="temporary-message-heading">
+    <h2 class="temporary-message-heading" id="temporary-message-heading">
+        G‑Cloud 7 is closed for applications
+    </h2>
+    <p class="temporary-message-message">
+        You didn’t submit an application.
+    </p>
+    <p class="temporary-message-message">
+        <a href="{{ url_for('.framework_dashboard', framework_slug='g-cloud-7') }}">View G-Cloud 7 information</a>
+    </p>
+</aside>
+
+{% elif frameworks['g-cloud-7'].get('status', None) == 'pending' %}
+<aside role="complementary" class="temporary-message" aria-labelledby="temporary-message-heading">
+    <h2 class="temporary-message-heading" id="temporary-message-heading">
+        G‑Cloud 7 is closed for applications
+    </h2>
+    <p class="temporary-message-message">
+        Follow the <a href="https://digitalmarketplace.blog.gov.uk/">Digital Marketplace blog</a> for further G-Cloud updates.
+    </p>
+</aside>
+
+{% endif %}

--- a/app/templates/suppliers/_g7_messaging.html
+++ b/app/templates/suppliers/_g7_messaging.html
@@ -1,4 +1,4 @@
-{% if 'g-cloud-7' in registered_frameworks and frameworks['g-cloud-7'].get('status', None) == 'open' %}
+{% if 'g-cloud-7' in registered_frameworks and frameworks.get('g-cloud-7', {}).get('status', None) == 'open' %}
     {%
     with
         items = [{
@@ -11,7 +11,7 @@
         {% include "toolkit/browse-list.html" %}
     {% endwith %}
 
-{% elif frameworks['g-cloud-7'].get('status', None) == 'open' %}
+{% elif frameworks.get('g-cloud-7', {}).get('status', None) == 'open' %}
     {%
     with
         items = [{
@@ -24,7 +24,7 @@
         {% include "toolkit/browse-list.html" %}
     {% endwith %}
 
-{% elif 'g-cloud-7' in registered_frameworks and g7_application_made and frameworks['g-cloud-7'].get('status', None) == 'pending' %}
+{% elif 'g-cloud-7' in registered_frameworks and g7_application_made and frameworks.get('g-cloud-7', {}).get('status', None) == 'pending' %}
 <div class="summary-item-lede">
     <div class="grid-row">
         <div class="column-two-thirds">
@@ -37,7 +37,7 @@
     </div>
 </div>
 
-{% elif 'g-cloud-7' in registered_frameworks and frameworks['g-cloud-7'].get('status', None) == 'pending' %}
+{% elif 'g-cloud-7' in registered_frameworks and frameworks.get('g-cloud-7', {}).get('status', None) == 'pending' %}
 <aside role="complementary" class="temporary-message" aria-labelledby="temporary-message-heading">
     <h2 class="temporary-message-heading" id="temporary-message-heading">
         G‑Cloud 7 is closed for applications
@@ -50,7 +50,7 @@
     </p>
 </aside>
 
-{% elif frameworks['g-cloud-7'].get('status', None) == 'pending' %}
+{% elif frameworks.get('g-cloud-7', {}).get('status', None) == 'pending' %}
 <aside role="complementary" class="temporary-message" aria-labelledby="temporary-message-heading">
     <h2 class="temporary-message-heading" id="temporary-message-heading">
         G‑Cloud 7 is closed for applications

--- a/app/templates/suppliers/dashboard.html
+++ b/app/templates/suppliers/dashboard.html
@@ -28,66 +28,8 @@
     </div>
   </div>
 
-  {% if 'GCLOUD7_OPEN' is active_feature %}
-    {% if g7_interested and g7_status == 'open' %}
-      {%
-        with
-        items = [{
-          "title": "Continue your G-Cloud 7 application",
-          "link": url_for(".framework_dashboard", framework_slug='g-cloud-7'),
-          "body": "Make your supplier declaration, add services and view G-Cloud 7 updates and clarification questions.",
-          "subtext": "Deadline for submissions: {}".format(deadline)
-        }]
-      %}
-        {% include "toolkit/browse-list.html" %}
-      {% endwith %}
-    {% elif g7_status == 'open' %}
-      {%
-        with
-        items = [{
-          "title": "Register your interest in becoming a G-Cloud 7 supplier",
-          "link": url_for(".framework_dashboard", framework_slug='g-cloud-7'),
-          "body": "Read about G-Cloud 7, receive email updates and start the application process.",
-          "subtext": "Deadline for submissions: {}".format(deadline)
-        }]
-      %}
-        {% include "toolkit/browse-list.html" %}
-      {% endwith %}
-    {% elif g7_interested and g7_application_made and g7_status == 'pending' %}
-      <div class="summary-item-lede">
-        <div class="grid-row">
-          <div class="column-two-thirds">
-            <h2 class="summary-item-heading">G-Cloud 7 is closed for applications</h2>
-            <p>
-              You submitted {{ g7_complete }} {{ 'service' if g7_complete == 1 else 'services' }} for consideration.
-              <a href="{{ url_for('.framework_dashboard', framework_slug='g-cloud-7') }}">View your submitted application</a>
-            </p>
-          </div>
-        </div>
-      </div>
-    {% elif g7_interested and g7_status == 'pending' %}
-      <aside role="complementary" class="temporary-message" aria-labelledby="temporary-message-heading">
-        <h2 class="temporary-message-heading" id="temporary-message-heading">
-          G‑Cloud 7 is closed for applications
-        </h2>
-        <p class="temporary-message-message">
-          You didn’t submit an application.
-        </p>
-        <p class="temporary-message-message">
-          <a href="{{ url_for('.framework_dashboard', framework_slug='g-cloud-7') }}">View G-Cloud 7 information</a> 
-        </p>
-      </aside>
-    {% elif g7_status == 'pending' %}
-      <aside role="complementary" class="temporary-message" aria-labelledby="temporary-message-heading">
-        <h2 class="temporary-message-heading" id="temporary-message-heading">
-          G‑Cloud 7 is closed for applications
-        </h2>
-        <p class="temporary-message-message">
-          Follow the <a href="https://digitalmarketplace.blog.gov.uk/">Digital Marketplace blog</a> for further G-Cloud updates.
-        </p>
-      </aside>
-    {% endif %}
-  {% endif %}
+  {% include 'suppliers/_dos_messaging.html' %}
+  {% include 'suppliers/_g7_messaging.html' %}
 
   {{ summary.heading("Current services") }}
   {% if supplier.service_counts %}

--- a/config.py
+++ b/config.py
@@ -24,6 +24,7 @@ class Config(object):
     DM_MANDRILL_API_KEY = None
     DM_CLARIFICATION_QUESTION_EMAIL = 'digitalmarketplace@mailinator.com'
     G7_CLOSING_DATE = '3pm&nbsp;<abbr title="British Summer Time">BST</abbr>, 6 October 2015'
+    DOS_CLOSING_DATE = '14&nbsp;February&nbsp;2016'
 
     DM_G7_DRAFT_DOCUMENTS_BUCKET = None
     DM_G7_DRAFT_DOCUMENTS_URL = None

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ Flask-Script==2.0.5
 Flask-WTF==0.12
 
 git+https://github.com/madzak/python-json-logger.git@v0.1.3#egg=python-json-logger==v0.1.3
-git+https://github.com/alphagov/digitalmarketplace-utils.git@10.0.1#egg=digitalmarketplace-utils==10.0.1
+git+https://github.com/alphagov/digitalmarketplace-utils.git@10.5.0#egg=digitalmarketplace-utils==10.5.0
 
 markdown==2.6.2
 

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -53,14 +53,27 @@ class TestFrameworksDashboard(BaseApplicationTest):
 
             assert_equal(res.status_code, 200)
 
-    def test_interest_registered_in_framework(self, data_api_client, s3):
+    def test_interest_registered_in_framework_on_post(self, data_api_client, s3):
         with self.app.test_client():
             self.login()
 
-            res = self.client.get("/suppliers/frameworks/g-cloud-7")
+            res = self.client.post("/suppliers/frameworks/digital-outcomes-and-specialists")
 
             assert_equal(res.status_code, 200)
-            data_api_client.register_framework_interest.assert_called_once_with(1234, "g-cloud-7", "email@email.com")
+            data_api_client.register_framework_interest.assert_called_once_with(
+                1234,
+                "digital-outcomes-and-specialists",
+                "email@email.com"
+            )
+
+    def test_interest_not_registered_in_framework_on_get(self, data_api_client, s3):
+        with self.app.test_client():
+            self.login()
+
+            res = self.client.get("/suppliers/frameworks/digital-outcomes-and-specialists")
+
+            assert_equal(res.status_code, 200)
+            assert not data_api_client.register_framework_interest.called
 
     def test_shows_gcloud_7_closed_message_if_pending_and_no_application_done(self, data_api_client, s3):
         with self.app.test_client():

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -56,40 +56,18 @@ class TestFrameworksDashboard(BaseApplicationTest):
     def test_interest_registered_in_framework(self, data_api_client, s3):
         with self.app.test_client():
             self.login()
-            data_api_client.find_audit_events.return_value = {
-                "auditEvents": []
-            }
 
             res = self.client.get("/suppliers/frameworks/g-cloud-7")
 
             assert_equal(res.status_code, 200)
-            data_api_client.create_audit_event.assert_called_once_with(
-                audit_type=AuditTypes.register_framework_interest,
-                user="email@email.com",
-                object_type="suppliers",
-                object_id=1234,
-                data={"frameworkSlug": "g-cloud-7"})
-
-    def test_interest_in_framework_only_registered_once(self, data_api_client, s3):
-        with self.app.test_client():
-            self.login()
-            data_api_client.find_audit_events.return_value = {
-                "auditEvents": [{"data": {"frameworkSlug": "g-cloud-7"}}]
-            }
-
-            res = self.client.get("/suppliers/frameworks/g-cloud-7")
-
-            assert_equal(res.status_code, 200)
-            assert not data_api_client.create_audit_event.called
+            data_api_client.register_framework_interest.assert_called_once_with(1234, "g-cloud-7", "email@email.com")
 
     def test_shows_gcloud_7_closed_message_if_pending_and_no_application_done(self, data_api_client, s3):
         with self.app.test_client():
             self.login()
 
             data_api_client.get_framework.return_value = self.framework(status='pending')
-            data_api_client.find_audit_events.return_value = {
-                "auditEvents": [{"data": {"frameworkSlug": "g-cloud-7"}}]
-            }
+            data_api_client.get_framework_interest.return_value = {'frameworks': ['g-cloud-7']}
             data_api_client.find_draft_services.return_value = {
                 "services": [
                     {'serviceName': 'A service', 'status': 'not-submitted'}
@@ -112,9 +90,7 @@ class TestFrameworksDashboard(BaseApplicationTest):
             self.login()
 
             data_api_client.get_framework.return_value = self.framework(status='pending')
-            data_api_client.find_audit_events.return_value = {
-                "auditEvents": [{"data": {"frameworkSlug": "g-cloud-7"}}]
-            }
+            data_api_client.get_framework_interest.return_value = {'frameworks': ['g-cloud-7']}
             data_api_client.find_draft_services.return_value = {
                 "services": [
                     {'serviceName': 'A service', 'status': 'submitted'}

--- a/tests/app/main/test_suppliers.py
+++ b/tests/app/main/test_suppliers.py
@@ -140,13 +140,7 @@ class TestSuppliersDashboard(BaseApplicationTest):
     def test_shows_gcloud_7_continue_link(self, get_current_suppliers_users, data_api_client):
         data_api_client.get_framework.return_value = self.framework('open')
         data_api_client.get_supplier.side_effect = get_supplier
-        data_api_client.find_audit_events.return_value = {
-            "auditEvents": [{
-                "data": {
-                    "frameworkSlug": "g-cloud-7"
-                }
-            }]
-        }
+        data_api_client.get_framework_interest.return_value = {'frameworks': ['g-cloud-7']}
         get_current_suppliers_users.side_effect = get_user
         with self.app.test_client():
             self.login()
@@ -184,13 +178,7 @@ class TestSuppliersDashboard(BaseApplicationTest):
     def test_shows_gcloud_7_closed_message_if_pending_and_no_application(self, get_current_suppliers_users, data_api_client):  # noqa
         data_api_client.get_framework.return_value = self.framework('pending')
         data_api_client.get_supplier.side_effect = get_supplier
-        data_api_client.find_audit_events.return_value = {
-            "auditEvents": [{
-                "data": {
-                    "frameworkSlug": "g-cloud-7"
-                }
-            }]
-        }
+        data_api_client.get_framework_interest.return_value = {'frameworks': ['g-cloud-7']}
         data_api_client.find_draft_services.return_value = {
             "services": [
                 {'serviceName': 'A service', 'status': 'not-submitted'}
@@ -216,13 +204,8 @@ class TestSuppliersDashboard(BaseApplicationTest):
     def test_shows_gcloud_7_closed_message_if_pending_and_application_done(self, get_current_suppliers_users, data_api_client):  # noqa
         data_api_client.get_framework.return_value = self.framework('pending')
         data_api_client.get_supplier.side_effect = get_supplier
-        data_api_client.find_audit_events.return_value = {
-            "auditEvents": [{
-                "data": {
-                    "frameworkSlug": "g-cloud-7"
-                }
-            }]
-        }
+        data_api_client.get_framework_interest.return_value = {'frameworks': ['g-cloud-7']}
+
         # an application is made if at least one draft is complete and the declaration is complete
         data_api_client.find_draft_services.return_value = {
             "services": [

--- a/tests/app/main/test_suppliers.py
+++ b/tests/app/main/test_suppliers.py
@@ -9,6 +9,15 @@ from tests.app.helpers import BaseApplicationTest
 from lxml import html
 
 
+find_frameworks_return_value = {
+    "frameworks": [
+        {'status': 'live', 'slug': 'g-cloud-6'},
+        {'status': 'open', 'slug': 'digital-outcomes-and-specialists'},
+        {'status': 'open', 'slug': 'g-cloud-7'}
+    ]
+}
+
+
 def get_supplier(*args, **kwargs):
     return {"suppliers": {
         "id": 1234,
@@ -102,9 +111,7 @@ class TestSuppliersDashboard(BaseApplicationTest):
     @mock.patch("app.main.views.suppliers.get_current_suppliers_users")
     def test_shows_edit_buttons(self, get_current_suppliers_users, data_api_client):
         data_api_client.get_supplier.side_effect = get_supplier
-        data_api_client.find_audit_events.return_value = {
-            "auditEvents": []
-        }
+        data_api_client.find_frameworks.return_value = find_frameworks_return_value
         get_current_suppliers_users.side_effect = get_user
         with self.app.test_client():
             self.login()
@@ -120,9 +127,7 @@ class TestSuppliersDashboard(BaseApplicationTest):
     def test_shows_gcloud_7_application_link(self, get_current_suppliers_users, data_api_client):
         data_api_client.get_framework.return_value = self.framework('open')
         data_api_client.get_supplier.side_effect = get_supplier
-        data_api_client.find_audit_events.return_value = {
-            "auditEvents": []
-        }
+        data_api_client.find_frameworks.return_value = find_frameworks_return_value
         get_current_suppliers_users.side_effect = get_user
         with self.app.test_client():
             self.login()
@@ -141,6 +146,7 @@ class TestSuppliersDashboard(BaseApplicationTest):
         data_api_client.get_framework.return_value = self.framework('open')
         data_api_client.get_supplier.side_effect = get_supplier
         data_api_client.get_framework_interest.return_value = {'frameworks': ['g-cloud-7']}
+        data_api_client.find_frameworks.return_value = find_frameworks_return_value
         get_current_suppliers_users.side_effect = get_user
         with self.app.test_client():
             self.login()
@@ -157,8 +163,11 @@ class TestSuppliersDashboard(BaseApplicationTest):
     def test_shows_gcloud_7_closed_message_if_pending_and_no_interest(self, get_current_suppliers_users, data_api_client):  # noqa
         data_api_client.get_framework.return_value = self.framework('pending')
         data_api_client.get_supplier.side_effect = get_supplier
-        data_api_client.find_audit_events.return_value = {
-            "auditEvents": []
+        data_api_client.find_frameworks.return_value = {
+            "frameworks": [
+                {'status': 'coming', 'slug': 'digital-outcomes-and-specialists'},
+                {'status': 'pending', 'slug': 'g-cloud-7'}
+            ]
         }
         get_current_suppliers_users.side_effect = get_user
         with self.app.test_client():
@@ -179,6 +188,12 @@ class TestSuppliersDashboard(BaseApplicationTest):
         data_api_client.get_framework.return_value = self.framework('pending')
         data_api_client.get_supplier.side_effect = get_supplier
         data_api_client.get_framework_interest.return_value = {'frameworks': ['g-cloud-7']}
+        data_api_client.find_frameworks.return_value = {
+            "frameworks": [
+                {'status': 'coming', 'slug': 'digital-outcomes-and-specialists'},
+                {'status': 'pending', 'slug': 'g-cloud-7'}
+            ]
+        }
         data_api_client.find_draft_services.return_value = {
             "services": [
                 {'serviceName': 'A service', 'status': 'not-submitted'}
@@ -205,6 +220,12 @@ class TestSuppliersDashboard(BaseApplicationTest):
         data_api_client.get_framework.return_value = self.framework('pending')
         data_api_client.get_supplier.side_effect = get_supplier
         data_api_client.get_framework_interest.return_value = {'frameworks': ['g-cloud-7']}
+        data_api_client.find_frameworks.return_value = {
+            "frameworks": [
+                {'status': 'coming', 'slug': 'digital-outcomes-and-specialists'},
+                {'status': 'pending', 'slug': 'g-cloud-7'}
+            ]
+        }
 
         # an application is made if at least one draft is complete and the declaration is complete
         data_api_client.find_draft_services.return_value = {
@@ -231,6 +252,55 @@ class TestSuppliersDashboard(BaseApplicationTest):
             assert_in(u"View your submitted application",
                       heading[0].xpath('../p[1]/a/text()')[0])
 
+    @mock.patch("app.main.views.suppliers.data_api_client")
+    @mock.patch("app.main.views.suppliers.get_current_suppliers_users")
+    def test_shows_register_for_dos_button(self, get_current_suppliers_users, data_api_client):
+        data_api_client.get_framework_status.return_value = {'status': 'open'}
+        data_api_client.get_supplier.side_effect = get_supplier
+        data_api_client.find_frameworks.return_value = {
+            "frameworks": [
+                {'status': 'open', 'slug': 'digital-outcomes-and-specialists'},
+                {'status': 'live', 'slug': 'g-cloud-7'}
+            ]
+        }
+        get_current_suppliers_users.side_effect = get_user
+        with self.app.test_client():
+            self.login()
+
+            res = self.client.get("/suppliers")
+            doc = html.fromstring(res.get_data(as_text=True))
+
+            assert_equal(res.status_code, 200)
+
+            assert_in("Digital Outcomes and Specialists is open for applications",
+                      doc.xpath('//div[@class="summary-item-lede"]//h2[@class="summary-item-heading"]/text()')[0])
+            assert_equal("Start application", doc.xpath('//div[@class="summary-item-lede"]//input/@value')[0])
+
+    @mock.patch("app.main.views.suppliers.data_api_client")
+    @mock.patch("app.main.views.suppliers.get_current_suppliers_users")
+    def test_shows_continue_with_dos_link(self, get_current_suppliers_users, data_api_client):
+        data_api_client.get_framework_status.return_value = {'status': 'open'}
+        data_api_client.get_supplier.side_effect = get_supplier
+        data_api_client.get_framework_interest.return_value = {'frameworks': ['digital-outcomes-and-specialists']}
+        data_api_client.find_frameworks.return_value = {
+            "frameworks": [
+                {'status': 'open', 'slug': 'digital-outcomes-and-specialists'},
+                {'status': 'live', 'slug': 'g-cloud-7'}
+            ]
+        }
+        get_current_suppliers_users.side_effect = get_user
+        with self.app.test_client():
+            self.login()
+
+            res = self.client.get("/suppliers")
+            doc = html.fromstring(res.get_data(as_text=True))
+
+            assert_equal(res.status_code, 200)
+            assert_in("Digital Outcomes and Specialists is open for applications",
+                      doc.xpath('//div[@class="summary-item-lede"]//h2[@class="summary-item-heading"]/text()')[0])
+            assert_equal("Continue your application",
+                         doc.xpath('//div[@class="summary-item-lede"]//a/text()')[0])
+
 
 class TestSupplierDashboardLogin(BaseApplicationTest):
     @mock.patch("app.main.views.suppliers.data_api_client")
@@ -246,6 +316,8 @@ class TestSupplierDashboardLogin(BaseApplicationTest):
 
             data_api_client.get_user.return_value = self.user(
                 123, "email@email.com", 1234, "Supplier Name", "Name")
+
+            data_api_client.find_frameworks.return_value = find_frameworks_return_value
 
             data_api_client.get_supplier.side_effect = get_supplier
 


### PR DESCRIPTION
Completes this story: https://www.pivotaltracker.com/story/show/105005134

Further design for displaying both DOS and G-Cloud messages on the same page is forthcoming.  For now I have simply put the DOS messages above the existing G-Cloud 7 messages.

I have also changed registering interest to only happen on a POST request from the button in the "register interest" message - for G7 interest was registered with all GET requests to the framework dashboard. 

Also removes the dependency on `'GCLOUD7_OPEN' is active_feature` from the dashboard template - all messaging is now conditional on the status of the frameworks in the databse, not on a feature flag.

Prototype design for before registering:
http://dm-prototype.herokuapp.com/states/account?dos.framework=open&dos.application=null

Screenshot before registering:
![screen shot 2015-10-21 at 11 14 34](https://cloud.githubusercontent.com/assets/6525554/10634002/9c031cfe-77e6-11e5-8a8d-e34b21380fe6.png)


Prototype design for after registering: 
http://dm-prototype.herokuapp.com/states/account?dos.framework=open&dos.application=some

Screenshot after registering:
![screen shot 2015-10-21 at 11 15 01](https://cloud.githubusercontent.com/assets/6525554/10634008/a7236be8-77e6-11e5-8ed6-6a03be7477df.png)

Depends on:
- [x] https://github.com/alphagov/digitalmarketplace-api/pull/272
- [x] https://github.com/alphagov/digitalmarketplace-utils/pull/190