### PR TITLE
README fix: point to a page that exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ More generally, the command to start the server is:
 python application.py runserver
 ```
 
-The supplier frontend runs on port 5003. Use the app at [http://127.0.0.1:5003/](http://127.0.0.1:5003/)
+The supplier frontend runs on port 5003. Use the app at [http://127.0.0.1:5003/suppliers](http://127.0.0.1:5003/suppliers)
 
 ### Using FeatureFlags
 


### PR DESCRIPTION
Similar to [this](https://github.com/alphagov/digitalmarketplace-admin-frontend/pull/138) pull request for admin-frontend, and as per @allait's comment, it is a good idea to point new developers to a page that actually exists rather than 404s.