### PR TITLE
G7 display agreements

### DIFF
--- a/app/assets/scss/_framework-application.scss
+++ b/app/assets/scss/_framework-application.scss
@@ -112,6 +112,11 @@
   color: $secondary-text-colour;
 }
 
+.framework-section {
+    padding: 20px 0 15px 0;
+    border-bottom: 1px solid #dee0e2;
+}
+
 /* Temporary styles, to be added to toolkit */
 .summary-item-lede {
   margin-bottom: $gutter-half - 5px;

--- a/app/main/helpers/frameworks.py
+++ b/app/main/helpers/frameworks.py
@@ -17,6 +17,10 @@ OPTIONAL_FIELDS = set([
 ])
 
 
+def get_agreement_document_path(framework_slug, supplier_id, document_name):
+    return '{0}/agreements/{1}/{1}-{2}'.format(framework_slug, supplier_id, document_name)
+
+
 def frameworks_by_slug(client):
     framework_list = client.find_frameworks().get("frameworks")
     frameworks = {}

--- a/app/main/helpers/frameworks.py
+++ b/app/main/helpers/frameworks.py
@@ -194,6 +194,32 @@ def get_declaration_status(data_api_client, framework_slug):
         return declaration.get('status', 'unstarted')
 
 
+def get_supplier_framework_info(data_api_client, framework_slug):
+    try:
+        return data_api_client.get_supplier_framework_info(
+            current_user.supplier_id, framework_slug
+        )['frameworkInterest']
+    except APIError as e:
+        if e.status_code == 404:
+            return None
+        else:
+            abort(e.status_code)
+
+
+def get_declaration_status_from_info(supplier_framework_info):
+    if supplier_framework_info is None:
+        return 'unstarted'
+    else:
+        return supplier_framework_info['declaration'].get('status', 'unstarted')
+
+
+def get_supplier_on_framework_from_info(supplier_framework_info):
+    if supplier_framework_info is None:
+        return False
+    else:
+        return bool(supplier_framework_info.get('onFramework'))
+
+
 def g_cloud_7_is_open_or_404(data_api_client):
     if data_api_client.get_framework_status('g-cloud-7').get('status', None) != 'open':
         abort(404)

--- a/app/main/helpers/frameworks.py
+++ b/app/main/helpers/frameworks.py
@@ -17,10 +17,6 @@ OPTIONAL_FIELDS = set([
 ])
 
 
-def get_agreement_document_path(framework_slug, supplier_id, document_name):
-    return '{0}/agreements/{1}/{1}-{2}'.format(framework_slug, supplier_id, document_name)
-
-
 def frameworks_by_slug(client):
     framework_list = client.find_frameworks().get("frameworks")
     frameworks = {}

--- a/app/main/helpers/services.py
+++ b/app/main/helpers/services.py
@@ -85,16 +85,6 @@ def get_draft_document_url(uploader, document_path):
         return url._replace(netloc=base_url.netloc, scheme=base_url.scheme).geturl()
 
 
-def get_document_url(uploader, document_path):
-    url = uploader.get_signed_url(document_path)
-    if url is not None:
-        if current_app.config['DM_ASSETS_URL'] is not None:
-            url = urlparse.urlparse(url)
-            base_url = urlparse.urlparse(current_app.config['DM_ASSETS_URL'])
-            url = url._replace(netloc=base_url.netloc, scheme=base_url.scheme).geturl()
-        return url
-
-
 def parse_document_upload_time(data):
     match = re.search("(\d{4}-\d{2}-\d{2}-\d{2}\d{2})\..{2,3}$", data)
     if match:

--- a/app/main/helpers/services.py
+++ b/app/main/helpers/services.py
@@ -85,6 +85,16 @@ def get_draft_document_url(uploader, document_path):
         return url._replace(netloc=base_url.netloc, scheme=base_url.scheme).geturl()
 
 
+def get_document_url(uploader, document_path):
+    url = uploader.get_signed_url(document_path)
+    if url is not None:
+        if current_app.config['DM_ASSETS_URL'] is not None:
+            url = urlparse.urlparse(url)
+            base_url = urlparse.urlparse(current_app.config['DM_ASSETS_URL'])
+            url = url._replace(netloc=base_url.netloc, scheme=base_url.scheme).geturl()
+        return url
+
+
 def parse_document_upload_time(data):
     match = re.search("(\d{4}-\d{2}-\d{2}-\d{2}\d{2})\..{2,3}$", data)
     if match:

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -18,10 +18,10 @@ from ...main import main, content_loader
 from ..helpers import hash_email
 from ..helpers.frameworks import get_error_messages_for_page, get_first_question_index, \
     get_error_messages, get_declaration_status, get_last_modified_from_first_matching_file, \
-    register_interest_in_framework
+    register_interest_in_framework, get_agreement_document_path
 from ..helpers.services import (
     get_draft_document_url, get_service_attributes, get_drafts,
-    count_unanswered_questions
+    count_unanswered_questions, get_document_url
 )
 
 
@@ -70,7 +70,6 @@ def framework_dashboard(framework_slug):
             'supplier_pack': get_last_modified_from_first_matching_file(key_list, 'g-cloud-7-supplier-pack.zip'),
             'supplier_updates': get_last_modified_from_first_matching_file(key_list, 'g-cloud-7-updates/')
         },
-
         **template_data
     ), 200
 
@@ -199,6 +198,19 @@ def framework_supplier_declaration(framework_slug, section_id=None):
 def download_supplier_file(framework_slug, filepath):
     uploader = s3.S3(current_app.config['DM_G7_DRAFT_DOCUMENTS_BUCKET'])
     url = get_draft_document_url(uploader, filepath)
+    if not url:
+        abort(404)
+
+    return redirect(url)
+
+
+@main.route('/frameworks/<framework_slug>/agreements/<document_name>',
+            methods=['GET'])
+@login_required
+def download_agreement_file(framework_slug, document_name):
+    agreements_bucket = s3.S3(current_app.config['DM_AGREEMENTS_BUCKET'])
+    path = get_agreement_document_path(framework_slug, current_user.supplier_id, document_name)
+    url = get_document_url(agreements_bucket, path)
     if not url:
         abort(404)
 

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -36,8 +36,6 @@ CLARIFICATION_QUESTION_NAME = 'clarification_question'
 def framework_dashboard(framework_slug):
     template_data = main.config['BASE_TEMPLATE_DATA']
     framework = data_api_client.get_framework(framework_slug)['frameworks']
-    if not framework:
-        abort(404)
 
     if request.method == 'POST':
         try:

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -18,7 +18,8 @@ from ...main import main, content_loader
 from ..helpers import hash_email
 from ..helpers.frameworks import get_error_messages_for_page, get_first_question_index, \
     get_error_messages, get_declaration_status, get_last_modified_from_first_matching_file, \
-    register_interest_in_framework, get_agreement_document_path
+    register_interest_in_framework, get_agreement_document_path, get_supplier_framework_info, \
+    get_supplier_on_framework_from_info, get_declaration_status_from_info
 from ..helpers.services import (
     get_draft_document_url, get_service_attributes, get_drafts,
     count_unanswered_questions, get_document_url
@@ -44,7 +45,11 @@ def framework_dashboard(framework_slug):
             abort(e.status_code)
 
     drafts, complete_drafts = get_drafts(data_api_client, current_user.supplier_id, framework_slug)
-    declaration_status = get_declaration_status(data_api_client, framework_slug)
+
+    supplier_framework_info = get_supplier_framework_info(data_api_client, framework_slug)
+    declaration_status = get_declaration_status_from_info(supplier_framework_info)
+    supplier_is_on_framework = get_supplier_on_framework_from_info(supplier_framework_info)
+
     application_made = len(complete_drafts) > 0 and declaration_status == 'complete'
 
     # TODO: change to new format
@@ -65,6 +70,7 @@ def framework_dashboard(framework_slug):
         deadline=current_app.config['G7_CLOSING_DATE'],
         framework=framework,
         application_made=application_made,
+        supplier_is_on_framework=supplier_is_on_framework,
         last_modified={
             # TODO: s3 stuff above
             'supplier_pack': get_last_modified_from_first_matching_file(key_list, 'g-cloud-7-supplier-pack.zip'),

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -395,13 +395,21 @@ def framework_agreement(framework_slug):
 
     template_data = main.config['BASE_TEMPLATE_DATA']
 
-    supplier_framework = data_api_client.get_supplier_framework_info(current_user.supplier_id, framework_slug)
-    if not supplier_framework['frameworkInterest']['onFramework']:
+    supplier_framework = data_api_client.get_supplier_framework_info(
+        current_user.supplier_id, framework_slug
+    )['frameworkInterest']
+    if not supplier_framework['onFramework']:
         abort(404)
 
     return render_template(
         "frameworks/agreement.html",
         framework=framework,
-        agreement_returned=False,
+        supplier_framework=supplier_framework,
         **template_data
     ), 200
+
+
+@main.route('/frameworks/<framework_slug>/agreement', methods=['POST'])
+@login_required
+def upload_framework_agreement(framework_slug):
+    pass

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -210,8 +210,7 @@ def download_supplier_file(framework_slug, filepath):
     return redirect(url)
 
 
-@main.route('/frameworks/<framework_slug>/agreements/<document_name>',
-            methods=['GET'])
+@main.route('/frameworks/<framework_slug>/agreements/<document_name>', methods=['GET'])
 @login_required
 def download_agreement_file(framework_slug, document_name):
     agreements_bucket = s3.S3(current_app.config['DM_AGREEMENTS_BUCKET'])
@@ -391,12 +390,15 @@ def framework_updates_email_clarification_question(framework_slug):
 @login_required
 def framework_agreement(framework_slug):
     framework = data_api_client.get_framework(framework_slug)['frameworks']
-    if not (framework['status'] == 'pending' or framework['status'] == 'live'):
+    if framework['status'] not in ['standstill', 'live']:
         abort(404)
 
     template_data = main.config['BASE_TEMPLATE_DATA']
 
     supplier_framework = data_api_client.get_supplier_framework_info(current_user.supplier_id, framework_slug)
+    if not supplier_framework['frameworkInterest']['onFramework']:
+        abort(404)
+
     return render_template(
         "frameworks/agreement.html",
         framework=framework,

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -366,3 +366,21 @@ def framework_updates_email_clarification_question(framework_slug):
 
     flash('message_sent', 'success')
     return framework_updates(framework['slug'])
+
+
+@main.route('/frameworks/<framework_slug>/agreement', methods=['GET'])
+@login_required
+def framework_agreement(framework_slug):
+    framework = data_api_client.get_framework(framework_slug)['frameworks']
+    if not (framework['status'] == 'pending' or framework['status'] == 'live'):
+        abort(404)
+
+    template_data = main.config['BASE_TEMPLATE_DATA']
+
+    supplier_framework = data_api_client.get_supplier_framework_info(current_user.supplier_id, framework_slug)
+    return render_template(
+        "frameworks/agreement.html",
+        framework=framework,
+        agreement_returned=False,
+        **template_data
+    ), 200

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -12,17 +12,18 @@ from dmutils.email import send_email, MandrillException
 from dmutils.formats import format_service_price
 from dmutils import s3
 from dmutils.deprecation import deprecated
+from dmutils.documents import get_agreement_document_path, get_signed_url
 
 from ... import data_api_client
 from ...main import main, content_loader
 from ..helpers import hash_email
 from ..helpers.frameworks import get_error_messages_for_page, get_first_question_index, \
     get_error_messages, get_declaration_status, get_last_modified_from_first_matching_file, \
-    register_interest_in_framework, get_agreement_document_path, get_supplier_framework_info, \
+    register_interest_in_framework, get_supplier_framework_info, \
     get_supplier_on_framework_from_info, get_declaration_status_from_info
 from ..helpers.services import (
     get_draft_document_url, get_service_attributes, get_drafts,
-    count_unanswered_questions, get_document_url
+    count_unanswered_questions
 )
 
 
@@ -215,7 +216,7 @@ def download_supplier_file(framework_slug, filepath):
 def download_agreement_file(framework_slug, document_name):
     agreements_bucket = s3.S3(current_app.config['DM_AGREEMENTS_BUCKET'])
     path = get_agreement_document_path(framework_slug, current_user.supplier_id, document_name)
-    url = get_document_url(agreements_bucket, path)
+    url = get_signed_url(agreements_bucket, path, current_app.config['DM_ASSETS_URL'])
     if not url:
         abort(404)
 

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -33,8 +33,9 @@ CLARIFICATION_QUESTION_NAME = 'clarification_question'
 @flask_featureflags.is_active_feature('GCLOUD7_OPEN')
 def framework_dashboard(framework_slug):
     template_data = main.config['BASE_TEMPLATE_DATA']
-    # TODO add a test for 404 if framework doesn't exist
     framework = data_api_client.get_framework(framework_slug)['frameworks']
+    if not framework:
+        abort(404)
 
     if request.method == 'POST':
         try:

--- a/app/templates/emails/framework_agreement_uploaded.html
+++ b/app/templates/emails/framework_agreement_uploaded.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head lang="en">
+    <meta charset="UTF-8">
+</head>
+<body>
+<h2>{{ framework_name }} framework agreement uploaded</h2>
+<br />
+Supplier name: {{ supplier_name }}
+<br />
+Supplier ID: {{ supplier_id }}
+<br />
+User name: {{ user_name }}
+</body>
+</html>

--- a/app/templates/frameworks/agreement.html
+++ b/app/templates/frameworks/agreement.html
@@ -58,7 +58,7 @@ with items = [
         
         <div class="padding-bottom framework-section">
             <h3>2. Read your framework agreement</h3>
-            <p>If you have a question about your framework agreement, <a href="#">contact CCS</a>.</p>
+            <p>If you have a question about your framework agreement, <a href="{{ url_for('.framework_updates', framework_slug=framework.slug) }}">contact CCS</a>.</p>
         </div>
 
         <div class="padding-bottom framework-section">
@@ -66,7 +66,7 @@ with items = [
             <p class='padding-bottom-small'>To digitally sign your framework agreement, you need to:</p>
             <ol class='number-list indent-list-large loose-list padding-bottom-small'>
               <li>Use <strong>Adobe Reader</strong> to open your {{ framework.name }} framework agreement. 
-                    You can download it for free from the <a href="https://get.adobe.com/uk/reader/">Adobe Acrobat Reader</a> website.</li>
+                    You can download it for free from the <a rel="external" href="https://get.adobe.com/uk/reader/">Adobe Acrobat Reader</a> website.</li>
 
                 <li>Go to page 15 and click the signature box under the title ‘Signed duly authorised for and on behalf of the supplier’.</li>
 

--- a/app/templates/frameworks/agreement.html
+++ b/app/templates/frameworks/agreement.html
@@ -1,0 +1,134 @@
+{% extends "_base_page.html" %}
+
+{% block page_title %}{{ framework.name }} Framework Agreement– Digital Marketplace{% endblock %}
+
+{% block breadcrumb %}
+{%
+with items = [
+    {
+        "link": "/",
+        "label": "Digital Marketplace",
+    },
+    {
+        "link": url_for(".dashboard"),
+        "label": "Your account",
+    },
+    {
+        "link": url_for(".framework_dashboard", framework_slug=framework.slug),
+        "label": "Your {} application".format(framework.name),
+    }
+]
+%}
+{% include "toolkit/breadcrumb.html" %}
+{% endwith %}
+{% endblock %}
+
+{% block main_content %}
+    <div class='column-two-thirds large-paragraph'>
+        {% with
+            heading = "Sign your " + framework.name + " framework agreement",
+            smaller = True,
+            with_breadcrumb = True
+        %}
+            {% include "toolkit/page-heading.html" %}
+        {% endwith %}
+    </div>
+
+    <div class='column-two-thirds large-paragraph'>
+        <div class="padding-bottom-small">
+            <p>Your agreement will need to be signed by both you and the Crown Commercial Service (CCS) 
+                before you can sell {{ framework.name }} services.</p>
+        </div>
+
+        <div class="padding-bottom framework-section">
+            <h3>1. Download your framework agreement</h3>
+            {%
+            with
+                items = [
+                    {
+                    "file_type": "PDF",
+                    "link": "#",
+                    "title": "Download framework agreement (PDF, 216KB)"
+                    },
+                ]
+            %}
+            {% include "toolkit/documents.html" %}
+            {% endwith %}
+        </div>
+        
+        <div class="padding-bottom framework-section">
+            <h3>2. Read your framework agreement</h3>
+            <p>If you have a question about your framework agreement, <a href="#">contact CCS</a>.</p>
+        </div>
+
+        <div class="padding-bottom framework-section">
+            <h3>3. Sign your framework agreement</h3>
+            <p class='padding-bottom-small'>To digitally sign your framework agreement, you need to:</p>
+            <ol class='number-list indent-list-large loose-list padding-bottom-small'>
+                <li>Use <strong>Adobe Reader</strong> to open your G-Cloud 7 framework agreement. 
+                    You can download it for free from the <a href="https://get.adobe.com/uk/reader/">Adobe Acrobat Reader</a> website.</li>
+
+                <li>Go to page 15 and click the signature box under the title ‘Signed duly authorised for and on behalf of the supplier’.</li>
+
+                <li>Use an existing digital ID or create a new one.</li>
+
+                <li>Enter your name, email and organisation details.</li>
+
+                <li>Enter and confirm your new password. </li>
+
+                <li>Enter your password and click ‘Sign’.</li>
+
+                <li>Save your document to add your digital ID to the signature box.</li>
+
+                <li>Upload and return your signed framework agreement via the Digital Marketplace.</li>
+
+            </ol>
+            <p class='padding-bottom-small'>
+                If you can’t digitally sign your framework agreement:
+            </p>
+            <ol class='number-list indent-list-large loose-list padding-bottom-small'>
+                <li>Print and sign page 15.</li>
+                <li>Scan the page and save as PDF, JPG or PNG.</li>
+                <li>Upload and return your signed framework agreement via the Digital&nbsp;Marketplace.</li>
+            </ol>
+            <p>
+                Please don’t send paper copies to the CCS.
+            </p>
+        </div>
+        
+        <div class="padding-bottom framework-section">
+            <form method="post">
+                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+                <h3>4. Upload your signed framework agreement</h3>
+                {% if agreement_returned %}
+                    {%
+                    with
+                    question = "Please replace the file you previously uploaded",
+                    name = "question-2",
+                    value = "1234123412341234-pricing-document.pdf",
+                    hint = "Hint comprising further information about the question"
+                    %}
+                    {% include "toolkit/forms/upload.html" %}
+                    {% endwith %}
+                {% else %}
+                    {%
+                    with
+                    name = "question-1"
+                    %}
+                    {% include "toolkit/forms/upload.html" %}
+                    {% endwith %}
+                {% endif %}
+    
+                {%
+                with
+                type = "save",
+                label = "Send document to CCS"
+                %}
+                {% include "toolkit/button.html" %}
+                {% endwith %}
+            </form>
+        </div>
+        
+        <a href="{{url_for('.framework_dashboard', framework_slug=framework.slug)}}">Return to your G-Cloud application</a>
+    </div>
+{% endblock %}

--- a/app/templates/frameworks/agreement.html
+++ b/app/templates/frameworks/agreement.html
@@ -47,7 +47,7 @@ with items = [
                 items = [
                     {
                     "file_type": "PDF",
-                    "link": "#",
+                    "link": url_for('.download_agreement_file', framework_slug=framework.slug, document_name='framework-agreement.pdf'),
                     "title": "Download framework agreement (PDF, 216KB)"
                     },
                 ]

--- a/app/templates/frameworks/agreement.html
+++ b/app/templates/frameworks/agreement.html
@@ -97,23 +97,21 @@ with items = [
         </div>
         
         <div class="padding-bottom framework-section">
-            <form method="post">
+            <form method="post" action="{{ url_for(".upload_framework_agreement", framework_slug=framework.slug) }}">
                 <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
                 <h3>4. Upload your signed framework agreement</h3>
-                {% if agreement_returned %}
+                {% if supplier_framework.agreementReturned %}
                     {%
                     with
                     question = "Please replace the file you previously uploaded",
-                    name = "question-2",
-                    value = "1234123412341234-pricing-document.pdf",
-                    hint = "Hint comprising further information about the question"
+                    name = "agreement"
                     %}
                     {% include "toolkit/forms/upload.html" %}
                     {% endwith %}
                 {% else %}
                     {%
                     with
-                    name = "question-1"
+                    name = "agreement"
                     %}
                     {% include "toolkit/forms/upload.html" %}
                     {% endwith %}

--- a/app/templates/frameworks/agreement.html
+++ b/app/templates/frameworks/agreement.html
@@ -1,6 +1,6 @@
 {% extends "_base_page.html" %}
 
-{% block page_title %}{{ framework.name }} Framework Agreement– Digital Marketplace{% endblock %}
+{% block page_title %}{{ framework.name }} Framework Agreement – Digital Marketplace{% endblock %}
 
 {% block breadcrumb %}
 {%
@@ -65,7 +65,7 @@ with items = [
             <h3>3. Sign your framework agreement</h3>
             <p class='padding-bottom-small'>To digitally sign your framework agreement, you need to:</p>
             <ol class='number-list indent-list-large loose-list padding-bottom-small'>
-                <li>Use <strong>Adobe Reader</strong> to open your G-Cloud 7 framework agreement. 
+              <li>Use <strong>Adobe Reader</strong> to open your {{ framework.name }} framework agreement. 
                     You can download it for free from the <a href="https://get.adobe.com/uk/reader/">Adobe Acrobat Reader</a> website.</li>
 
                 <li>Go to page 15 and click the signature box under the title ‘Signed duly authorised for and on behalf of the supplier’.</li>
@@ -127,6 +127,6 @@ with items = [
             </form>
         </div>
         
-        <a href="{{url_for('.framework_dashboard', framework_slug=framework.slug)}}">Return to your G-Cloud application</a>
+        <a href="{{url_for('.framework_dashboard', framework_slug=framework.slug)}}">Return to your {{ framework.name }} application</a>
     </div>
 {% endblock %}

--- a/app/templates/frameworks/dashboard.html
+++ b/app/templates/frameworks/dashboard.html
@@ -56,7 +56,18 @@
         </div>
       </div>
     </div>
-  <nav role="navigation" class="framework-application-reference">
+  {% elif framework.status == 'standstill' %}
+    <div class="summary-item-lede">
+      <div class="grid-row">
+        <div class="column-two-thirds">
+          {% if application_made %}
+            <p>You made your supplier declaration and submitted {{ counts.complete }} {{ 'service' if counts.complete == 1 else 'services' }}.</p>
+          {% else %}
+            <p>You didn't submit an application.</p>
+          {% endif %}
+        </div>
+      </div>
+    </div>
   {% endif %}
     <ul class="browse-list">
 
@@ -64,7 +75,9 @@
         <li class="browse-list-item framework-application-section">
           <div class="grid-row">
             <div class="column-two-thirds">
-              <a href="{{ url_for('.download_agreement_file', framework_slug=framework.slug, document_name='result-letter.pdf') }}">Download your application result letter</a>
+              <a class="browse-list-item-link" href="{{ url_for('.download_agreement_file', framework_slug=framework.slug, document_name='result-letter.pdf') }}">
+                <span>Download your application result letter</span>
+              </a>
               <p>This letter informs you if your {{ framework.name }} has been successful.</p>
             </div>
           </div>
@@ -73,7 +86,9 @@
         <li class="browse-list-item framework-application-section">
           <div class="grid-row">
             <div class="column-two-thirds">
-              <a href="{{ url_for('.framework_agreement', framework_slug=framework.slug) }}">Sign and return your framework agreement</a>
+              <a class="browse-list-item-link" href="{{ url_for('.framework_agreement', framework_slug=framework.slug) }}">
+                <span>Sign and return your framework agreement</span>
+              </a>
               <p>Your agreement will need to be signed by both you and the Crown Commercial Service before you can sell {{framework.name}} services.</p>
             </div>
           </div>
@@ -144,15 +159,11 @@
             </div>
           </div>
         </li>
-      {% elif framework.status == 'pending' and application_made %}
+      {% elif framework.status in ['pending', 'standstill'] and application_made %}
         <li class="browse-list-item framework-application-section">
           <div class="grid-row">
             <div class="column-two-thirds">
-              <a class="browse-list-item-link" href="{{ url_for('.framework_services', framework_slug=framework.slug) }}">
-                <span>
-                  View services
-                </span>
-              </a>
+              <a href="{{ url_for('.framework_services', framework_slug=framework.slug) }}">View services</a>
             </div>
             <div class="column-two-thirds">
               <div class="framework-section-status-neutral">

--- a/app/templates/frameworks/dashboard.html
+++ b/app/templates/frameworks/dashboard.html
@@ -59,6 +59,18 @@
   <nav role="navigation" class="framework-application-reference">
   {% endif %}
     <ul class="browse-list">
+
+      {% if framework.status == 'standstill' and application_made %}
+        <li class="browse-list-item framework-application-section">
+          <div class="grid-row">
+            <div class="column-two-thirds">
+              <a href="{{ url_for('.download_agreement_file', framework_slug=framework.slug, document_name='result-letter.pdf') }}">Download your application result letter</a>
+              <p>This letter informs you if your {{ framework.name }} has been successful.</p>
+            </div>
+          </div>
+        </li>
+      {% endif %}
+
       {% if framework.status == 'open' %}
         <li class="browse-list-item framework-application-section">
           <div class="grid-row">

--- a/app/templates/frameworks/dashboard.html
+++ b/app/templates/frameworks/dashboard.html
@@ -78,7 +78,7 @@
               <a class="browse-list-item-link" href="{{ url_for('.download_agreement_file', framework_slug=framework.slug, document_name='result-letter.pdf') }}">
                 <span>Download your application result letter</span>
               </a>
-              <p>This letter informs you if your {{ framework.name }} has been successful.</p>
+              <p>This letter informs you if your {{ framework.name }} application has been successful.</p>
             </div>
           </div>
         </li>

--- a/app/templates/frameworks/dashboard.html
+++ b/app/templates/frameworks/dashboard.html
@@ -69,6 +69,16 @@
             </div>
           </div>
         </li>
+        {% if supplier_is_on_framework %}
+        <li class="browse-list-item framework-application-section">
+          <div class="grid-row">
+            <div class="column-two-thirds">
+              <a href="{{ url_for('.framework_agreement', framework_slug=framework.slug) }}">Sign and return your framework agreement</a>
+              <p>Your agreement will need to be signed by both you and the Crown Commercial Service before you can sell {{framework.name}} services.</p>
+            </div>
+          </div>
+        </li>
+        {% endif %}
       {% endif %}
 
       {% if framework.status == 'open' %}

--- a/config.py
+++ b/config.py
@@ -29,6 +29,10 @@ class Config(object):
     DM_G7_DRAFT_DOCUMENTS_BUCKET = None
     DM_G7_DRAFT_DOCUMENTS_URL = None
 
+    DM_AGREEMENTS_BUCKET = None
+    DM_COMMUNICATIONS_BUCKET = None
+    DM_ASSETS_URL = None
+
     DEBUG = False
 
     RESET_PASSWORD_EMAIL_NAME = 'Digital Marketplace Admin'

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,8 @@ werkzeug==0.10.4
 git+https://github.com/madzak/python-json-logger.git@v0.1.3#egg=python-json-logger==v0.1.3
 git+https://github.com/alphagov/digitalmarketplace-utils.git@11.4.0#egg=digitalmarketplace-utils==11.4.0
 
+markdown==2.6.2
+
 # Required for SNI to work in requests
 pyOpenSSL==0.14
 ndg-httpsclient==0.3.3

--- a/tests/app/helpers.py
+++ b/tests/app/helpers.py
@@ -7,6 +7,81 @@ from datetime import datetime, timedelta
 from dmutils.formats import DATETIME_FORMAT
 
 
+FULL_G7_SUBMISSION = {
+    "status": "complete",
+    "PR1": "true",
+    "PR2": "true",
+    "PR3": "true",
+    "PR4": "true",
+    "PR5": "true",
+    "SQ1-1i-i": "true",
+    "SQ2-1abcd": "true",
+    "SQ2-1e": "true",
+    "SQ2-1f": "true",
+    "SQ2-1ghijklmn": "true",
+    "SQ2-2a": "true",
+    "SQ3-1a": "true",
+    "SQ3-1b": "true",
+    "SQ3-1c": "true",
+    "SQ3-1d": "true",
+    "SQ3-1e": "true",
+    "SQ3-1f": "true",
+    "SQ3-1g": "true",
+    "SQ3-1h-i": "true",
+    "SQ3-1h-ii": "true",
+    "SQ3-1i-i": "true",
+    "SQ3-1i-ii": "true",
+    "SQ3-1j": "true",
+    "SQ3-1k": "Blah",
+    "SQ4-1a": "true",
+    "SQ4-1b": "true",
+    "SQ5-2a": "true",
+    "SQD2b": "true",
+    "SQD2d": "true",
+    "SQ1-1a": "Blah",
+    "SQ1-1b": "Blah",
+    "SQ1-1cii": "Blah",
+    "SQ1-1d": "Blah",
+    "SQ1-1e": "Blah",
+    "SQ1-1h": "999999999",
+    "SQ1-1i-ii": "Blah",
+    "SQ1-1j-ii": "Blah",
+    "SQ1-1k": "Blah",
+    "SQ1-1n": "Blah",
+    "SQ1-1o": "Blah",
+    "SQ1-2a": "Blah",
+    "SQ1-2b": "Blah",
+    "SQ2-2b": "Blah",
+    "SQ4-1c": "Blah",
+    "SQD2c": "Blah",
+    "SQD2e": "Blah",
+    "SQ1-1ci": "public limited company",
+    "SQ1-1j-i": "licensed?",
+    "SQ1-1m": "micro",
+    "SQ1-3": "on-demand self-service. blah blah",
+    "SQ5-1a": u"Yes – your organisation has, blah blah",
+    "SQC2": [
+        "race?",
+        "sexual orientation?",
+        "disability?",
+        "age equality?",
+        "religion or belief?",
+        "gender (sex)?",
+        "gender reassignment?",
+        "marriage or civil partnership?",
+        "pregnancy or maternity?",
+        "human rights?"
+    ],
+    "SQC3": "true",
+    "SQA2": "true",
+    "SQA3": "true",
+    "SQA4": "true",
+    "SQA5": "true",
+    "AQA3": "true",
+    "SQE2a": ["as a prime contractor, using third parties (subcontractors) to provide some services"]
+}
+
+
 class BaseApplicationTest(object):
     def setup(self):
         self.app = create_app('test')
@@ -99,6 +174,20 @@ class BaseApplicationTest(object):
                 'status': status,
                 'name': name,
                 'slug': slug
+            }
+        }
+
+    @staticmethod
+    def supplier_framework(declaration=None, status=None, on_framework=False, agreement_returned=False):
+        if declaration is None:
+            declaration = FULL_G7_SUBMISSION.copy()
+        if status is not None:
+            declaration['status'] = status
+        return {
+            'frameworkInterest': {
+                'declaration': declaration,
+                'onFramework': on_framework,
+                'agreementReturned': agreement_returned,
             }
         }
 

--- a/tests/app/helpers.py
+++ b/tests/app/helpers.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import re
 from mock import patch
 from app import create_app

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -47,6 +47,7 @@ class TestFrameworksDashboard(BaseApplicationTest):
 
     def test_shows(self, data_api_client, s3):
         with self.app.test_client():
+            data_api_client.get_framework.return_value = self.framework(status='open')
             self.login()
 
             res = self.client.get("/suppliers/frameworks/g-cloud-7")
@@ -259,6 +260,15 @@ class TestFrameworksDashboard(BaseApplicationTest):
             ]
 
             self._assert_last_updated_times(doc, last_updateds)
+
+    def test_returns_404_if_framework_does_not_exist(self, data_api_client, s3):
+        with self.app.test_client():
+            self.login()
+            data_api_client.get_framework.return_value = {'frameworks': {}}
+
+            res = self.client.get('/suppliers/frameworks/does-not-exist')
+
+            assert_equal(res.status_code, 404)
 
 
 @mock.patch('dmutils.s3.S3')

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -8,7 +8,7 @@ from dmutils.audit import AuditTypes
 from dmutils.email import MandrillException
 from dmutils.s3 import S3ResponseError
 
-from ..helpers import BaseApplicationTest
+from ..helpers import BaseApplicationTest, FULL_G7_SUBMISSION
 
 
 def _return_fake_s3_file_dict(directory, filename, ext, last_modified=None, size=None):
@@ -110,14 +110,11 @@ class TestFrameworksDashboard(BaseApplicationTest):
                     {'serviceName': 'A service', 'status': 'submitted'}
                 ]
             }
-            data_api_client.get_supplier_framework_info.return_value = {
-                "frameworkInterest": {
-                    "declaration": FULL_G7_SUBMISSION}}
+            data_api_client.get_supplier_framework_info.return_value = self.supplier_framework()
 
             res = self.client.get("/suppliers/frameworks/g-cloud-7")
 
             doc = html.fromstring(res.get_data(as_text=True))
-
             heading = doc.xpath('//div[@class="summary-item-lede"]//h2[@class="summary-item-heading"]')
             assert_true(len(heading) > 0)
             assert_in(u"G-Cloud 7 is closed for applications",
@@ -132,9 +129,7 @@ class TestFrameworksDashboard(BaseApplicationTest):
             self.login()
 
             data_api_client.get_framework.return_value = self.framework(status='open')
-            data_api_client.get_supplier_framework_info.return_value = {
-                "frameworkInterest": {
-                    "declaration": FULL_G7_SUBMISSION}}
+            data_api_client.get_supplier_framework_info.return_value = self.supplier_framework()
 
             res = self.client.get("/suppliers/frameworks/g-cloud-7")
 
@@ -153,12 +148,10 @@ class TestFrameworksDashboard(BaseApplicationTest):
             del submission['SQ2-1e']
             del submission['SQ2-1f']
             del submission['SQ2-1ghijklmn']
-            submission.update({"status": "started"})
 
             data_api_client.get_framework.return_value = self.framework(status='open')
-            data_api_client.get_supplier_framework_info.return_value = {
-                "frameworkInterest": {
-                    "declaration": submission}}
+            data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
+                declaration=submission, status='started')
 
             res = self.client.get("/suppliers/frameworks/g-cloud-7")
 
@@ -282,9 +275,7 @@ class TestFrameworksDashboard(BaseApplicationTest):
                     {'serviceName': 'A service', 'status': 'submitted'}
                 ]
             }
-            data_api_client.get_supplier_framework_info.return_value = {
-                "frameworkInterest": {
-                    "declaration": FULL_G7_SUBMISSION}}
+            data_api_client.get_supplier_framework_info.return_value = self.supplier_framework()
 
             res = self.client.get("/suppliers/frameworks/g-cloud-7")
 
@@ -303,9 +294,7 @@ class TestFrameworksDashboard(BaseApplicationTest):
                     {'serviceName': 'A service', 'status': 'submitted'}
                 ]
             }
-            data_api_client.get_supplier_framework_info.return_value = {
-                "frameworkInterest": {
-                    "declaration": FULL_G7_SUBMISSION}}
+            data_api_client.get_supplier_framework_info.return_value = self.supplier_framework()
 
             res = self.client.get("/suppliers/frameworks/g-cloud-7")
 
@@ -324,9 +313,7 @@ class TestFrameworksDashboard(BaseApplicationTest):
                     {'serviceName': 'A service', 'status': 'not-submitted'}
                 ]
             }
-            data_api_client.get_supplier_framework_info.return_value = {
-                "frameworkInterest": {
-                    "declaration": FULL_G7_SUBMISSION}}
+            data_api_client.get_supplier_framework_info.return_value = self.supplier_framework()
 
             res = self.client.get("/suppliers/frameworks/g-cloud-7")
 
@@ -345,9 +332,8 @@ class TestFrameworksDashboard(BaseApplicationTest):
                     {'serviceName': 'A service', 'status': 'submitted'}
                 ]
             }
-            data_api_client.get_supplier_framework_info.return_value = {
-                "frameworkInterest": {
-                    "declaration": FULL_G7_SUBMISSION, "onFramework": True}}
+            data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
+                on_framework=True)
 
             res = self.client.get("/suppliers/frameworks/g-cloud-7")
 
@@ -366,9 +352,8 @@ class TestFrameworksDashboard(BaseApplicationTest):
                     {'serviceName': 'A service', 'status': 'submitted'}
                 ]
             }
-            data_api_client.get_supplier_framework_info.return_value = {
-                "frameworkInterest": {
-                    "declaration": FULL_G7_SUBMISSION, "onFramework": False}}
+            data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
+                on_framework=False)
 
             res = self.client.get("/suppliers/frameworks/g-cloud-7")
 
@@ -384,9 +369,8 @@ class TestFrameworkAgreement(BaseApplicationTest):
             self.login()
 
             data_api_client.get_framework.return_value = self.framework(status='standstill')
-            data_api_client.get_supplier_framework_info.return_value = {
-                "frameworkInterest": {
-                    "declaration": FULL_G7_SUBMISSION, "onFramework": True}}
+            data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
+                on_framework=True)
 
             res = self.client.get("/suppliers/frameworks/g-cloud-7/agreement")
 
@@ -397,9 +381,8 @@ class TestFrameworkAgreement(BaseApplicationTest):
             self.login()
 
             data_api_client.get_framework.return_value = self.framework(status='open')
-            data_api_client.get_supplier_framework_info.return_value = {
-                "frameworkInterest": {
-                    "declaration": FULL_G7_SUBMISSION, "onFramework": True}}
+            data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
+                on_framework=True)
 
             res = self.client.get("/suppliers/frameworks/g-cloud-7/agreement")
 
@@ -410,9 +393,8 @@ class TestFrameworkAgreement(BaseApplicationTest):
             self.login()
 
             data_api_client.get_framework.return_value = self.framework(status='standstill')
-            data_api_client.get_supplier_framework_info.return_value = {
-                "frameworkInterest": {
-                    "declaration": FULL_G7_SUBMISSION, "onFramework": False}}
+            data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
+                on_framework=False)
 
             res = self.client.get("/suppliers/frameworks/g-cloud-7/agreement")
 
@@ -423,10 +405,9 @@ class TestFrameworkAgreement(BaseApplicationTest):
             self.login()
 
             data_api_client.get_framework.return_value = self.framework(status='standstill')
-            data_api_client.get_supplier_framework_info.return_value = {
-                'frameworkInterest': {
-                    'declaration': FULL_G7_SUBMISSION, 'onFramework': True, 'agreementReturned': True
-                }}
+            data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
+                on_framework=True, agreement_returned=True
+            )
 
             res = self.client.get('/suppliers/frameworks/g-cloud-7/agreement')
             data = res.get_data(as_text=True)
@@ -444,10 +425,8 @@ class TestFrameworkAgreement(BaseApplicationTest):
             self.login()
 
             data_api_client.get_framework.return_value = self.framework(status='standstill')
-            data_api_client.get_supplier_framework_info.return_value = {
-                'frameworkInterest': {
-                    'declaration': FULL_G7_SUBMISSION, 'onFramework': True, 'agreementReturned': False
-                }}
+            data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
+                on_framework=True)
 
             res = self.client.get('/suppliers/frameworks/g-cloud-7/agreement')
             data = res.get_data(as_text=True)
@@ -532,81 +511,6 @@ class TestFrameworkDocumentDownload(BaseApplicationTest):
                 assert_equal(res.status_code, 301)
                 assert_equal(res.location,
                              'http://localhost/suppliers/frameworks/g-cloud-7/files/{}'.format(filename))
-
-
-FULL_G7_SUBMISSION = {
-    "status": "complete",
-    "PR1": "true",
-    "PR2": "true",
-    "PR3": "true",
-    "PR4": "true",
-    "PR5": "true",
-    "SQ1-1i-i": "true",
-    "SQ2-1abcd": "true",
-    "SQ2-1e": "true",
-    "SQ2-1f": "true",
-    "SQ2-1ghijklmn": "true",
-    "SQ2-2a": "true",
-    "SQ3-1a": "true",
-    "SQ3-1b": "true",
-    "SQ3-1c": "true",
-    "SQ3-1d": "true",
-    "SQ3-1e": "true",
-    "SQ3-1f": "true",
-    "SQ3-1g": "true",
-    "SQ3-1h-i": "true",
-    "SQ3-1h-ii": "true",
-    "SQ3-1i-i": "true",
-    "SQ3-1i-ii": "true",
-    "SQ3-1j": "true",
-    "SQ3-1k": "Blah",
-    "SQ4-1a": "true",
-    "SQ4-1b": "true",
-    "SQ5-2a": "true",
-    "SQD2b": "true",
-    "SQD2d": "true",
-    "SQ1-1a": "Blah",
-    "SQ1-1b": "Blah",
-    "SQ1-1cii": "Blah",
-    "SQ1-1d": "Blah",
-    "SQ1-1e": "Blah",
-    "SQ1-1h": "999999999",
-    "SQ1-1i-ii": "Blah",
-    "SQ1-1j-ii": "Blah",
-    "SQ1-1k": "Blah",
-    "SQ1-1n": "Blah",
-    "SQ1-1o": "Blah",
-    "SQ1-2a": "Blah",
-    "SQ1-2b": "Blah",
-    "SQ2-2b": "Blah",
-    "SQ4-1c": "Blah",
-    "SQD2c": "Blah",
-    "SQD2e": "Blah",
-    "SQ1-1ci": "public limited company",
-    "SQ1-1j-i": "licensed?",
-    "SQ1-1m": "micro",
-    "SQ1-3": "on-demand self-service. blah blah",
-    "SQ5-1a": u"Yes – your organisation has, blah blah",
-    "SQC2": [
-        "race?",
-        "sexual orientation?",
-        "disability?",
-        "age equality?",
-        "religion or belief?",
-        "gender (sex)?",
-        "gender reassignment?",
-        "marriage or civil partnership?",
-        "pregnancy or maternity?",
-        "human rights?"
-    ],
-    "SQC3": "true",
-    "SQA2": "true",
-    "SQA3": "true",
-    "SQA4": "true",
-    "SQA5": "true",
-    "AQA3": "true",
-    "SQE2a": ["as a prime contractor, using third parties (subcontractors) to provide some services"]
-}
 
 
 @mock.patch('app.main.views.frameworks.data_api_client', autospec=True)

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -619,7 +619,7 @@ class TestSupplierDeclaration(BaseApplicationTest):
         with self.app.test_client():
             self.login()
 
-            data_api_client.get_framework_status.return_value = {'status': 'other'}
+            data_api_client.get_framework.return_value = self.framework(status='other')
             data_api_client.get_supplier_declaration.return_value = {
                 "declaration": {"status": "started"}
             }
@@ -992,7 +992,7 @@ class TestG7ServicesList(BaseApplicationTest):
     def test_no_404_when_g7_open_and_no_complete_services(self, count_unanswered, data_api_client):
         with self.app.test_client():
             self.login()
-        data_api_client.get_framework_status.return_value = {'status': 'open'}
+        data_api_client.get_framework.return_value = self.framework(status='open')
         data_api_client.find_draft_services.return_value = {'services': []}
         count_unanswered.return_value = 0
         response = self.client.get('/suppliers/frameworks/g-cloud-7/services')
@@ -1001,7 +1001,8 @@ class TestG7ServicesList(BaseApplicationTest):
     def test_no_404_when_g7_open_and_no_declaration(self, count_unanswered, data_api_client):
         with self.app.test_client():
             self.login()
-        data_api_client.get_framework_status.return_value = {'status': 'open'}
+
+        data_api_client.get_framework.return_value = self.framework(status='open')
         data_api_client.get_supplier_declaration.return_value = {
             "declaration": {"status": "started"}
         }

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -258,7 +258,7 @@ class TestFrameworksDashboard(BaseApplicationTest):
     def test_returns_404_if_framework_does_not_exist(self, data_api_client, s3):
         with self.app.test_client():
             self.login()
-            data_api_client.get_framework.return_value = {'frameworks': {}}
+            data_api_client.get_framework.side_effect = APIError(mock.Mock(status_code=404))
 
             res = self.client.get('/suppliers/frameworks/does-not-exist')
 

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -110,8 +110,9 @@ class TestFrameworksDashboard(BaseApplicationTest):
                     {'serviceName': 'A service', 'status': 'submitted'}
                 ]
             }
-            data_api_client.get_supplier_declaration.return_value = \
-                {"declaration": FULL_G7_SUBMISSION}
+            data_api_client.get_supplier_framework_info.return_value = {
+                "frameworkInterest": {
+                    "declaration": FULL_G7_SUBMISSION}}
 
             res = self.client.get("/suppliers/frameworks/g-cloud-7")
 
@@ -131,9 +132,9 @@ class TestFrameworksDashboard(BaseApplicationTest):
             self.login()
 
             data_api_client.get_framework.return_value = self.framework(status='open')
-            data_api_client.get_supplier_declaration.return_value = {
-                "declaration": FULL_G7_SUBMISSION
-            }
+            data_api_client.get_supplier_framework_info.return_value = {
+                "frameworkInterest": {
+                    "declaration": FULL_G7_SUBMISSION}}
 
             res = self.client.get("/suppliers/frameworks/g-cloud-7")
 
@@ -155,9 +156,9 @@ class TestFrameworksDashboard(BaseApplicationTest):
             submission.update({"status": "started"})
 
             data_api_client.get_framework.return_value = self.framework(status='open')
-            data_api_client.get_supplier_declaration.return_value = {
-                "declaration": submission
-            }
+            data_api_client.get_supplier_framework_info.return_value = {
+                "frameworkInterest": {
+                    "declaration": submission}}
 
             res = self.client.get("/suppliers/frameworks/g-cloud-7")
 
@@ -171,7 +172,7 @@ class TestFrameworksDashboard(BaseApplicationTest):
             self.login()
 
             data_api_client.get_framework.return_value = self.framework(status='open')
-            data_api_client.get_supplier_declaration.side_effect = APIError(mock.Mock(status_code=404))
+            data_api_client.get_supplier_framework_info.side_effect = APIError(mock.Mock(status_code=404))
 
             res = self.client.get("/suppliers/frameworks/g-cloud-7")
 
@@ -281,8 +282,9 @@ class TestFrameworksDashboard(BaseApplicationTest):
                     {'serviceName': 'A service', 'status': 'submitted'}
                 ]
             }
-            data_api_client.get_supplier_declaration.return_value = \
-                {"declaration": FULL_G7_SUBMISSION}
+            data_api_client.get_supplier_framework_info.return_value = {
+                "frameworkInterest": {
+                    "declaration": FULL_G7_SUBMISSION}}
 
             res = self.client.get("/suppliers/frameworks/g-cloud-7")
 
@@ -301,8 +303,9 @@ class TestFrameworksDashboard(BaseApplicationTest):
                     {'serviceName': 'A service', 'status': 'submitted'}
                 ]
             }
-            data_api_client.get_supplier_declaration.return_value = \
-                {"declaration": FULL_G7_SUBMISSION}
+            data_api_client.get_supplier_framework_info.return_value = {
+                "frameworkInterest": {
+                    "declaration": FULL_G7_SUBMISSION}}
 
             res = self.client.get("/suppliers/frameworks/g-cloud-7")
 
@@ -321,14 +324,57 @@ class TestFrameworksDashboard(BaseApplicationTest):
                     {'serviceName': 'A service', 'status': 'not-submitted'}
                 ]
             }
-            data_api_client.get_supplier_declaration.return_value = \
-                {"declaration": FULL_G7_SUBMISSION}
+            data_api_client.get_supplier_framework_info.return_value = {
+                "frameworkInterest": {
+                    "declaration": FULL_G7_SUBMISSION}}
 
             res = self.client.get("/suppliers/frameworks/g-cloud-7")
 
             data = res.get_data(as_text=True)
 
             assert_not_in(u'Download your application result letter', data)
+
+    def test_link_to_framework_agreement_is_shown_if_supplier_is_on_framework(self, data_api_client, s3):
+        with self.app.test_client():
+            self.login()
+
+            data_api_client.get_framework.return_value = self.framework(status='standstill')
+            data_api_client.get_framework_interest.return_value = {'frameworks': ['g-cloud-7']}
+            data_api_client.find_draft_services.return_value = {
+                "services": [
+                    {'serviceName': 'A service', 'status': 'submitted'}
+                ]
+            }
+            data_api_client.get_supplier_framework_info.return_value = {
+                "frameworkInterest": {
+                    "declaration": FULL_G7_SUBMISSION, "onFramework": True}}
+
+            res = self.client.get("/suppliers/frameworks/g-cloud-7")
+
+            data = res.get_data(as_text=True)
+
+            assert_in(u'Sign and return your framework agreement', data)
+
+    def test_link_to_framework_agreement_is_shown_if_supplier_is_not_on_framework(self, data_api_client, s3):
+        with self.app.test_client():
+            self.login()
+
+            data_api_client.get_framework.return_value = self.framework(status='standstill')
+            data_api_client.get_framework_interest.return_value = {'frameworks': ['g-cloud-7']}
+            data_api_client.find_draft_services.return_value = {
+                "services": [
+                    {'serviceName': 'A service', 'status': 'submitted'}
+                ]
+            }
+            data_api_client.get_supplier_framework_info.return_value = {
+                "frameworkInterest": {
+                    "declaration": FULL_G7_SUBMISSION, "onFramework": False}}
+
+            res = self.client.get("/suppliers/frameworks/g-cloud-7")
+
+            data = res.get_data(as_text=True)
+
+            assert_not_in(u'Sign and return your framework agreement', data)
 
 
 @mock.patch('dmutils.s3.S3')


### PR DESCRIPTION
- Add an environment variable for the base assets URL since the assets domain is not just for documents.
- Build a path for an agreements document based on the framework slug and the supplier ID of the current user. The agreement documents contain the supplier ID (for easy referencing later) and also live in a directory named the supplier ID (for easy browsing of the bucket).
- Add a function to get a document URL that works in a similar way to the draft document URL function but only replaces the host and scheme with the asset URL if the environment variable is set. This allows the URLs to work in development even if a reverse proxy is not being used.
- Add link to framework agreement page. This replaces the declaration status API call on the framework dashboard with a call to the supplier framework info endpoint that includes both the declaration status and the flags for whether a supplier is on the framework and they have returned their signed agreement.

## Depends on
- [x] Sign off by Cath
- [x] Sign off by Ralph
- [ ] :sparkles: functional tests :sparkles: 
- [x] https://github.com/alphagov/digitalmarketplace-aws/pull/159
- [x] https://github.com/alphagov/digitalmarketplace-utils/pull/201