### PR TITLE
G7 upload signed agreements

### DIFF
--- a/app/assets/scss/_framework-application.scss
+++ b/app/assets/scss/_framework-application.scss
@@ -124,7 +124,7 @@
   .question {
     margin: 0;
 
-    label {
+    .question-heading {
       position: absolute;
       left: -9999em;
     }

--- a/app/assets/scss/_framework-application.scss
+++ b/app/assets/scss/_framework-application.scss
@@ -112,9 +112,46 @@
   color: $secondary-text-colour;
 }
 
-.framework-section {
-    padding: 20px 0 15px 0;
-    border-bottom: 1px solid #dee0e2;
+%framework-agreement-section,
+.framework-agreement-section {
+  padding: 20px 0 15px 0;
+  border-top: 1px solid #dee0e2;
+
+  .document-list {
+    padding-bottom: 0;
+  }
+
+  .question {
+    margin: 0;
+
+    label {
+      position: absolute;
+      left: -9999em;
+    }
+  }
+
+  h3 {
+    margin-bottom: 5px;
+  }
+
+  .lead-in {
+    margin-bottom: 10px;
+  }
+
+  ol {
+    list-style: decimal;
+    margin-left: 1.5em;
+    margin-bottom: 10px;
+
+    li {
+      margin-bottom: 5px;
+    }
+  }
+}
+
+.framework-agreement-section-first {
+  @extend %framework-agreement-section;
+  border-top: none;
 }
 
 /* Temporary styles, to be added to toolkit */

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -428,13 +428,9 @@ def framework_agreement(framework_slug):
         abort(404)
 
     if supplier_framework['agreementReturned']:
-        agreements_bucket = s3.S3(current_app.config['DM_AGREEMENTS_BUCKET'])
-        path = get_agreement_document_path(
-            framework_slug, current_user.supplier_id, current_user.supplier_name, 'signed-framework-agreement.pdf')
-        last_modified = agreements_bucket.bucket.get_key(path).last_modified
-        last_modified = datetimeformat(date_parse(last_modified))
-    else:
-        last_modified = None
+        supplier_framework['agreementReturnedAt'] = datetimeformat(
+            date_parse(supplier_framework['agreementReturnedAt'])
+        )
 
     template_data = main.config['BASE_TEMPLATE_DATA']
 
@@ -442,7 +438,6 @@ def framework_agreement(framework_slug):
         "frameworks/agreement.html",
         framework=framework,
         supplier_framework=supplier_framework,
-        last_modified=last_modified,
         **template_data
     ), 200
 

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -429,7 +429,8 @@ def framework_agreement(framework_slug):
 
     if supplier_framework['agreementReturned']:
         agreements_bucket = s3.S3(current_app.config['DM_AGREEMENTS_BUCKET'])
-        path = get_agreement_document_path(framework_slug, current_user.supplier_id, 'signed-framework-agreement.pdf')
+        path = get_agreement_document_path(
+            framework_slug, current_user.supplier_id, current_user.supplier_name, 'signed-framework-agreement.pdf')
         last_modified = agreements_bucket.bucket.get_key(path).last_modified
         last_modified = datetimeformat(date_parse(last_modified))
     else:
@@ -477,7 +478,8 @@ def upload_framework_agreement(framework_slug):
         ), 400
 
     agreements_bucket = s3.S3(current_app.config['DM_AGREEMENTS_BUCKET'])
-    path = get_agreement_document_path(framework_slug, current_user.supplier_id, 'signed-framework-agreement.pdf')
+    path = get_agreement_document_path(
+        framework_slug, current_user.supplier_id, current_user.supplier_name, 'signed-framework-agreement.pdf')
     agreements_bucket.save(path, request.files['agreement'], acl='private')
 
     data_api_client.register_framework_agreement_returned(

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -460,8 +460,6 @@ def upload_framework_agreement(framework_slug):
     upload_error = None
     if not file_is_less_than_5mb(request.files['agreement']):
         upload_error = "Document must be less than 5Mb"
-    elif not request.files['agreement'].filename.endswith('.pdf'):
-        upload_error = "Document must be a PDF"
 
     if upload_error is not None:
         return render_template(

--- a/app/templates/emails/framework_agreement_uploaded.html
+++ b/app/templates/emails/framework_agreement_uploaded.html
@@ -6,10 +6,15 @@
 <body>
 <h2>{{ framework_name }} framework agreement uploaded</h2>
 <br />
+<p>
+  {{ supplier_name }} has uploaded their signed framework agreement.
+  You can download it from the admin console.
+</p>
+
 Supplier name: {{ supplier_name }}
 <br />
-Supplier ID: {{ supplier_id }}
-<br />
 User name: {{ user_name }}
+<br />
+Supplier ID: {{ supplier_id }}
 </body>
 </html>

--- a/app/templates/frameworks/agreement.html
+++ b/app/templates/frameworks/agreement.html
@@ -53,17 +53,14 @@ with items = [
 
         <div class="padding-bottom framework-agreement-section-first">
             <h2>1. Download your framework agreement</h2>
-            {% with
-                items = [
-                    {
-                    "file_type": "PDF",
-                    "link": url_for('.download_agreement_file', framework_slug=framework.slug, document_name='framework-agreement.pdf'),
-                    "title": "Download framework agreement (PDF, 216KB)"
-                    },
-                ]
-            %}
-            {% include "toolkit/documents.html" %}
-            {% endwith %}
+            <ul class='document-list'>
+                <li class='document-list-item'>
+                    <a href="{{ url_for('.download_agreement_file', framework_slug=framework.slug, document_name='framework-agreement.pdf') }}" class='document-link-with-icon' download>
+                      <span class='document-icon'>PDF<span> document:</span></span>
+                      Download framework agreement (PDF, 216KB)
+                    </a>
+                </li>
+            </ul>
         </div>
         
         <div class="padding-bottom framework-agreement-section">

--- a/app/templates/frameworks/agreement.html
+++ b/app/templates/frameworks/agreement.html
@@ -121,7 +121,6 @@ with items = [
                     question = "Upload your signed framework agreement",
                     file_type = "PDF",
                     name = "agreement",
-                    name = "agreement",
                     error = upload_error
                     %}
                     {% include "toolkit/forms/upload.html" %}

--- a/app/templates/frameworks/agreement.html
+++ b/app/templates/frameworks/agreement.html
@@ -96,7 +96,7 @@ with items = [
                 <li>Scan the page and save as PDF, JPG or PNG.</li>
             </ol>
             <p>
-                Please don’t send paper copies to the CCS.
+                Please don’t send paper copies to CSS.
             </p>
         </div>
         

--- a/app/templates/frameworks/agreement.html
+++ b/app/templates/frameworks/agreement.html
@@ -24,6 +24,15 @@ with items = [
 {% endblock %}
 
 {% block main_content %}
+  {% if agreement_uploaded %}
+    {% with
+        message = "Your framework agreement has been uploaded. You'll be notified once your framework has been countersigned by Crown Commercial Service.",
+        type = "success"
+    %}
+      {% include "toolkit/notification-banner.html" %}
+    {% endwith %}
+  {% endif %}
+
     <div class='column-two-thirds large-paragraph'>
         {% with
             heading = "Sign your " + framework.name + " framework agreement",
@@ -104,14 +113,16 @@ with items = [
                     {%
                     with
                     question = "Please replace the file you previously uploaded",
-                    name = "agreement"
+                    name = "agreement",
+                    error = upload_error
                     %}
                     {% include "toolkit/forms/upload.html" %}
                     {% endwith %}
                 {% else %}
                     {%
                     with
-                    name = "agreement"
+                    name = "agreement",
+                    error = upload_error
                     %}
                     {% include "toolkit/forms/upload.html" %}
                     {% endwith %}

--- a/app/templates/frameworks/agreement.html
+++ b/app/templates/frameworks/agreement.html
@@ -111,7 +111,7 @@ with items = [
                     {%
                     with
                     question = "Upload your signed framework agreement",
-                    value = "Document uploaded {}".format(last_modified),
+                    value = "Document uploaded {}".format(supplier_framework.agreementReturnedAt),
                     file_type = "PDF",
                     name = "agreement",
                     error = upload_error

--- a/app/templates/frameworks/agreement.html
+++ b/app/templates/frameworks/agreement.html
@@ -75,13 +75,13 @@ with items = [
               <li>Use <strong>Adobe Reader</strong> to open your {{ framework.name }} framework agreement. 
                     You can download it for free from the <a rel="external" href="https://get.adobe.com/uk/reader/">Adobe Acrobat Reader</a> website.</li>
 
-                <li>Go to page 15 and click the signature box under the title ‘Signed duly authorised for and on behalf of the supplier’.</li>
+                <li>Go to page 16 and click the signature box under the title ‘Signed duly authorised for and on behalf of the supplier’.</li>
 
                 <li>Use an existing digital ID or create a new one.</li>
 
                 <li>Enter your name, email and organisation details.</li>
 
-                <li>Enter and confirm your new password. </li>
+                <li>Enter and confirm your new password.</li>
 
                 <li>Enter your password and click ‘Sign’.</li>
 

--- a/app/templates/frameworks/agreement.html
+++ b/app/templates/frameworks/agreement.html
@@ -51,10 +51,9 @@ with items = [
                 before you can sell {{ framework.name }} services.</p>
         </div>
 
-        <div class="padding-bottom framework-section">
+        <div class="padding-bottom framework-agreement-section-first">
             <h3>1. Download your framework agreement</h3>
-            {%
-            with
+            {% with
                 items = [
                     {
                     "file_type": "PDF",
@@ -67,15 +66,15 @@ with items = [
             {% endwith %}
         </div>
         
-        <div class="padding-bottom framework-section">
+        <div class="padding-bottom framework-agreement-section">
             <h3>2. Read your framework agreement</h3>
             <p>If you have a question about your framework agreement, <a href="{{ url_for('.framework_updates', framework_slug=framework.slug) }}">contact CCS</a>.</p>
         </div>
 
-        <div class="padding-bottom framework-section">
+        <div class="padding-bottom framework-agreement-section">
             <h3>3. Sign your framework agreement</h3>
-            <p class='padding-bottom-small'>To digitally sign your framework agreement, you need to:</p>
-            <ol class='number-list indent-list-large loose-list padding-bottom-small'>
+            <p class="lead-in">To digitally sign your framework agreement, you need to:</p>
+            <ol>
               <li>Use <strong>Adobe Reader</strong> to open your {{ framework.name }} framework agreement. 
                     You can download it for free from the <a rel="external" href="https://get.adobe.com/uk/reader/">Adobe Acrobat Reader</a> website.</li>
 
@@ -94,10 +93,10 @@ with items = [
                 <li>Upload and return your signed framework agreement via the Digital Marketplace.</li>
 
             </ol>
-            <p class='padding-bottom-small'>
+            <p class="lead-in">
                 If you can’t digitally sign your framework agreement:
             </p>
-            <ol class='number-list indent-list-large loose-list padding-bottom-small'>
+            <ol>
                 <li>Print and sign page 15.</li>
                 <li>Scan the page and save as PDF, JPG or PNG.</li>
                 <li>Upload and return your signed framework agreement via the Digital&nbsp;Marketplace.</li>
@@ -107,13 +106,14 @@ with items = [
             </p>
         </div>
         
-        <div class="padding-bottom framework-section">
+        <div class="padding-bottom framework-agreement-section">
             <form method="post" enctype="multipart/form-data" action="{{ url_for(".upload_framework_agreement", framework_slug=framework.slug) }}">
                 <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
                 <h3>4. Upload your signed framework agreement</h3>
                 {% if supplier_framework.agreementReturned %}
                     {%
                     with
+                    question = "Upload your signed framework agreement",
                     value = "Document uploaded {}".format(last_modified),
                     file_type = "PDF",
                     name = "agreement",
@@ -124,6 +124,7 @@ with items = [
                 {% else %}
                     {%
                     with
+                    question = "Upload your signed framework agreement",
                     file_type = "PDF",
                     name = "agreement",
                     name = "agreement",

--- a/app/templates/frameworks/agreement.html
+++ b/app/templates/frameworks/agreement.html
@@ -52,7 +52,7 @@ with items = [
         </div>
 
         <div class="padding-bottom framework-agreement-section-first">
-            <h3>1. Download your framework agreement</h3>
+            <h2>1. Download your framework agreement</h2>
             {% with
                 items = [
                     {
@@ -67,12 +67,12 @@ with items = [
         </div>
         
         <div class="padding-bottom framework-agreement-section">
-            <h3>2. Read your framework agreement</h3>
+            <h2>2. Read your framework agreement</h2>
             <p>If you have a question about your framework agreement, <a href="{{ url_for('.framework_updates', framework_slug=framework.slug) }}">contact CCS</a>.</p>
         </div>
 
         <div class="padding-bottom framework-agreement-section">
-            <h3>3. Sign your framework agreement</h3>
+            <h2>3. Sign your framework agreement</h2>
             <p class="lead-in">To digitally sign your framework agreement, you need to:</p>
             <ol>
               <li>Use <strong>Adobe Reader</strong> to open your {{ framework.name }} framework agreement. 
@@ -90,16 +90,13 @@ with items = [
 
                 <li>Save your document to add your digital ID to the signature box.</li>
 
-                <li>Upload and return your signed framework agreement via the Digital Marketplace.</li>
-
             </ol>
             <p class="lead-in">
                 If you can’t digitally sign your framework agreement:
             </p>
             <ol>
-                <li>Print and sign page 15.</li>
+                <li>Print and sign page 16.</li>
                 <li>Scan the page and save as PDF, JPG or PNG.</li>
-                <li>Upload and return your signed framework agreement via the Digital&nbsp;Marketplace.</li>
             </ol>
             <p>
                 Please don’t send paper copies to the CCS.
@@ -109,7 +106,7 @@ with items = [
         <div class="padding-bottom framework-agreement-section">
             <form method="post" enctype="multipart/form-data" action="{{ url_for(".upload_framework_agreement", framework_slug=framework.slug) }}">
                 <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
-                <h3>4. Upload your signed framework agreement</h3>
+                <h2>4. Upload your signed framework agreement</h2>
                 {% if supplier_framework.agreementReturned %}
                     {%
                     with

--- a/app/templates/frameworks/agreement.html
+++ b/app/templates/frameworks/agreement.html
@@ -57,7 +57,7 @@ with items = [
                 <li class='document-list-item'>
                     <a href="{{ url_for('.download_agreement_file', framework_slug=framework.slug, document_name='framework-agreement.pdf') }}" class='document-link-with-icon' download>
                       <span class='document-icon'>PDF<span> document:</span></span>
-                      Download framework agreement (PDF, 216KB)
+                      Download framework agreement
                     </a>
                 </li>
             </ul>

--- a/app/templates/frameworks/agreement.html
+++ b/app/templates/frameworks/agreement.html
@@ -24,12 +24,14 @@ with items = [
 {% endblock %}
 
 {% block main_content %}
-  {% if agreement_uploaded %}
-    {% with
-        message = "Your framework agreement has been uploaded. You'll be notified once your framework has been countersigned by Crown Commercial Service.",
-        type = "success"
+  {% if supplier_framework.agreementReturned %}
+  {% with
+     heading = "Your document has been uploaded",
+     messages = [
+      "You’ll be notified once your framework agreement has been countersigned by the Crown Commercial Service."
+     ]
     %}
-      {% include "toolkit/notification-banner.html" %}
+      {% include "toolkit/temporary-message.html" %}
     {% endwith %}
   {% endif %}
 
@@ -106,13 +108,14 @@ with items = [
         </div>
         
         <div class="padding-bottom framework-section">
-            <form method="post" action="{{ url_for(".upload_framework_agreement", framework_slug=framework.slug) }}">
+            <form method="post" enctype="multipart/form-data" action="{{ url_for(".upload_framework_agreement", framework_slug=framework.slug) }}">
                 <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
                 <h3>4. Upload your signed framework agreement</h3>
                 {% if supplier_framework.agreementReturned %}
                     {%
                     with
-                    question = "Please replace the file you previously uploaded",
+                    value = "Document uploaded {}".format(last_modified),
+                    file_type = "PDF",
                     name = "agreement",
                     error = upload_error
                     %}
@@ -121,6 +124,8 @@ with items = [
                 {% else %}
                     {%
                     with
+                    file_type = "PDF",
+                    name = "agreement",
                     name = "agreement",
                     error = upload_error
                     %}

--- a/app/templates/frameworks/dashboard.html
+++ b/app/templates/frameworks/dashboard.html
@@ -76,7 +76,7 @@
           <div class="grid-row">
             <div class="column-two-thirds">
               <a class="browse-list-item-link" href="{{ url_for('.download_agreement_file', framework_slug=framework.slug, document_name='result-letter.pdf') }}">
-                <span>Download your application result letter</span>
+                <span>Download your application result letter (.pdf)</span>
               </a>
               <p>This letter informs you if your {{ framework.name }} application has been successful.</p>
             </div>

--- a/app/templates/frameworks/dashboard.html
+++ b/app/templates/frameworks/dashboard.html
@@ -75,7 +75,7 @@
         <li class="browse-list-item framework-application-section">
           <div class="grid-row">
             <div class="column-two-thirds">
-              <a class="browse-list-item-link" href="{{ url_for('.download_agreement_file', framework_slug=framework.slug, document_name='result-letter.pdf') }}">
+              <a class="browse-list-item-link" href="{{ url_for('.download_agreement_file', framework_slug=framework.slug, document_name='result-letter.pdf') }}" download>
                 <span>Download your application result letter (.pdf)</span>
               </a>
               <p>This letter informs you if your {{ framework.name }} application has been successful.</p>

--- a/config.py
+++ b/config.py
@@ -25,7 +25,7 @@ class Config(object):
     DM_DATA_API_AUTH_TOKEN = None
     DM_MANDRILL_API_KEY = None
     DM_CLARIFICATION_QUESTION_EMAIL = 'digitalmarketplace@mailinator.com'
-    DM_FRAMEWORK_AGREEMENTS_EMAIL = 'example@example.com'
+    DM_FRAMEWORK_AGREEMENTS_EMAIL = 'enquiries@example.com'
     G7_CLOSING_DATE = '3pm&nbsp;<abbr title="British Summer Time">BST</abbr>, 6 October 2015'
     DOS_CLOSING_DATE = '14 February 2016'
     G7_LIVE_DATE = '23 November 2015'
@@ -116,6 +116,8 @@ class Live(Config):
     """Base config for deployed environments"""
     DEBUG = False
     DM_HTTP_PROTO = 'https'
+
+    DM_FRAMEWORK_AGREEMENTS_EMAIL = 'enquiries@digitalmarketplace.service.gov.uk'
 
 
 class Preview(Live):

--- a/config.py
+++ b/config.py
@@ -25,6 +25,7 @@ class Config(object):
     DM_DATA_API_AUTH_TOKEN = None
     DM_MANDRILL_API_KEY = None
     DM_CLARIFICATION_QUESTION_EMAIL = 'digitalmarketplace@mailinator.com'
+    DM_FRAMEWORK_AGREEMENTS_EMAIL = 'example@example.com'
     G7_CLOSING_DATE = '3pm&nbsp;<abbr title="British Summer Time">BST</abbr>, 6 October 2015'
     DOS_CLOSING_DATE = '14 February 2016'
     G7_LIVE_DATE = '23 November 2015'

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ Flask==0.10.1
 Flask-Login==0.2.11
 Flask-WTF==0.12
 werkzeug==0.10.4
+python-dateutil==2.4.2
 
 git+https://github.com/madzak/python-json-logger.git@v0.1.3#egg=python-json-logger==v0.1.3
 git+https://github.com/alphagov/digitalmarketplace-utils.git@13.1.0#egg=digitalmarketplace-utils==13.1.0

--- a/tests/app/helpers.py
+++ b/tests/app/helpers.py
@@ -183,7 +183,8 @@ class BaseApplicationTest(object):
         }
 
     @staticmethod
-    def supplier_framework(declaration='default', status=None, on_framework=False, agreement_returned=False):
+    def supplier_framework(declaration='default', status=None, on_framework=False,
+                           agreement_returned=False, agreement_returned_at=None):
         if declaration == 'default':
             declaration = FULL_G7_SUBMISSION.copy()
         if status is not None:
@@ -193,6 +194,7 @@ class BaseApplicationTest(object):
                 'declaration': declaration,
                 'onFramework': on_framework,
                 'agreementReturned': agreement_returned,
+                'agreementReturnedAt': agreement_returned_at,
             }
         }
 

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -634,7 +634,7 @@ class TestFrameworkAgreementUpload(BaseApplicationTest):
             )
 
             assert_equal(res.status_code, 302)
-            assert_equal(res.location, '/suppliers/frameworks/g-cloud-7/agreement')
+            assert_equal(res.location, 'http://localhost/suppliers/frameworks/g-cloud-7/agreement')
 
 
 @mock.patch('dmutils.s3.S3')

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -433,9 +433,8 @@ class TestFrameworkAgreement(BaseApplicationTest):
 
             data_api_client.get_framework.return_value = self.framework(status='standstill')
             data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
-                on_framework=True, agreement_returned=True
+                on_framework=True, agreement_returned=True, agreement_returned_at='2015-11-02T15:25:56.000000Z'
             )
-            s3.return_value.bucket.get_key.return_value = mock.Mock(last_modified='Mon, 02 Nov 2015 15:25:56 GMT')
 
             res = self.client.get('/suppliers/frameworks/g-cloud-7/agreement')
             data = res.get_data(as_text=True)

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -562,7 +562,7 @@ class TestFrameworkAgreementUpload(BaseApplicationTest):
 
             assert_equal(res.status_code, 503)
             s3.return_value.save.assert_called_with(
-                'g-cloud-7/agreements/1234/1234-signed-framework-agreement.pdf',
+                'g-cloud-7/agreements/1234/Supplier_Name-1234-signed-framework-agreement.pdf',
                 mock.ANY,
                 acl='private')
             assert not data_api_client.register_framework_agreement_returned.called
@@ -586,7 +586,7 @@ class TestFrameworkAgreementUpload(BaseApplicationTest):
 
             assert_equal(res.status_code, 500)
             s3.return_value.save.assert_called_with(
-                'g-cloud-7/agreements/1234/1234-signed-framework-agreement.pdf',
+                'g-cloud-7/agreements/1234/Supplier_Name-1234-signed-framework-agreement.pdf',
                 mock.ANY,
                 acl='private')
             data_api_client.register_framework_agreement_returned.assert_called_with(
@@ -611,7 +611,7 @@ class TestFrameworkAgreementUpload(BaseApplicationTest):
 
             assert_equal(res.status_code, 503)
             s3.return_value.save.assert_called_with(
-                'g-cloud-7/agreements/1234/1234-signed-framework-agreement.pdf',
+                'g-cloud-7/agreements/1234/Supplier_Name-1234-signed-framework-agreement.pdf',
                 mock.ANY,
                 acl='private')
             data_api_client.register_framework_agreement_returned.assert_called_with(

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -525,24 +525,6 @@ class TestFrameworkAgreementUpload(BaseApplicationTest):
             assert_equal(res.status_code, 400)
             assert_in(u'Document must be less than 5Mb', res.get_data(as_text=True))
 
-    def test_page_returns_400_if_file_is_not_pdf(self, data_api_client, send_email, s3):
-        with self.app.test_client():
-            self.login()
-
-            data_api_client.get_framework.return_value = self.framework(status='standstill')
-            data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
-                on_framework=True)
-
-            res = self.client.post(
-                '/suppliers/frameworks/g-cloud-7/agreement',
-                data={
-                    'agreement': (StringIO(b'doc'), 'test.txt'),
-                }
-            )
-
-            assert_equal(res.status_code, 400)
-            assert_in(u'Document must be a PDF', res.get_data(as_text=True))
-
     def test_api_is_not_updated_and_email_not_sent_if_upload_fails(self, data_api_client, send_email, s3):
         with self.app.test_client():
             self.login()


### PR DESCRIPTION
Allow G-Cloud 7 signed framework agreements to be uploaded by suppliers.

![screenshot-localhost 2015-11-06 10-52-54](https://cloud.githubusercontent.com/assets/14287/10995424/a18689f0-8474-11e5-95bf-e06b415e7124.png)

## Depends on
- [x] Sign off from Ralph
- [x] https://github.com/alphagov/digitalmarketplace-utils/pull/201
- [x] https://github.com/alphagov/digitalmarketplace-supplier-frontend/pull/318
- [x] #322 (because of utils version 12.0.0)