### PR TITLE
Basic DOS service flow

### DIFF
--- a/app/main/helpers/frameworks.py
+++ b/app/main/helpers/frameworks.py
@@ -216,11 +216,6 @@ def get_supplier_on_framework_from_info(supplier_framework_info):
         return bool(supplier_framework_info.get('onFramework'))
 
 
-def g_cloud_7_is_open_or_404(data_api_client):
-    if data_api_client.get_framework_status('g-cloud-7').get('status', None) != 'open':
-        abort(404)
-
-
 def question_references(data, get_question):
     return re.sub(
         r"\[\[([^\]]+)\]\]",  # anything that looks like [[nameOfQuestion]]

--- a/app/main/helpers/frameworks.py
+++ b/app/main/helpers/frameworks.py
@@ -19,7 +19,7 @@ OPTIONAL_FIELDS = set([
 
 def get_framework(client, framework_slug, open_only=True):
     framework = client.get_framework(framework_slug)['frameworks']
-    allowed_statuses = ['open'] if open_only else ['open', 'pending']
+    allowed_statuses = ['open'] if open_only else ['open', 'pending', 'standstill']
     if framework['status'] not in allowed_statuses:
         abort(404)
 

--- a/app/main/helpers/frameworks.py
+++ b/app/main/helpers/frameworks.py
@@ -17,6 +17,20 @@ OPTIONAL_FIELDS = set([
 ])
 
 
+def get_framework(client, framework_slug, open_only=True):
+    framework = client.get_framework(framework_slug)['frameworks']
+    allowed_statuses = ['open'] if open_only else ['open', 'pending']
+    if framework['status'] not in allowed_statuses:
+        abort(404)
+
+    return framework
+
+
+def get_framework_and_lot(client, framework_slug, lot_slug, open_only=True):
+    framework = get_framework(client, framework_slug, open_only)
+    return framework, get_framework_lot(framework, lot_slug)
+
+
 def frameworks_by_slug(client):
     framework_list = client.find_frameworks().get("frameworks")
     frameworks = {}
@@ -26,10 +40,10 @@ def frameworks_by_slug(client):
 
 
 def get_framework_lot(framework, lot_slug):
-    return next(
-        (lot for lot in framework['lots'] if lot['slug'] == lot_slug),
-        None
-    )
+    try:
+        return next(lot for lot in framework['lots'] if lot['slug'] == lot_slug)
+    except StopIteration:
+        abort(404)
 
 
 def register_interest_in_framework(client, framework_slug):

--- a/app/main/helpers/frameworks.py
+++ b/app/main/helpers/frameworks.py
@@ -25,6 +25,13 @@ def frameworks_by_slug(client):
     return frameworks
 
 
+def get_framework_lot(framework, lot_slug):
+    return next(
+        (lot for lot in framework['lots'] if lot['slug'] == lot_slug),
+        None
+    )
+
+
 def register_interest_in_framework(client, framework_slug):
     client.register_framework_interest(current_user.supplier_id, framework_slug, current_user.email_address)
 

--- a/app/main/helpers/services.py
+++ b/app/main/helpers/services.py
@@ -22,9 +22,6 @@ def get_drafts(apiclient, supplier_id, framework_slug):
     except APIError as e:
         abort(e.status_code)
 
-    # Hide drafts without service name
-    drafts = [draft for draft in drafts if draft.get('serviceName')]
-
     complete_drafts = [draft for draft in drafts if draft['status'] == 'submitted']
     drafts = [draft for draft in drafts if draft['status'] == 'not-submitted']
 

--- a/app/main/helpers/services.py
+++ b/app/main/helpers/services.py
@@ -31,6 +31,14 @@ def get_drafts(apiclient, supplier_id, framework_slug):
     return drafts, complete_drafts
 
 
+def get_lot_drafts(apiclient, supplier_id, framework_slug, lot_slug):
+    drafts, complete_drafts = get_drafts(apiclient, supplier_id, framework_slug)
+    return (
+        [draft for draft in drafts if draft['lot'] == lot_slug],
+        [draft for draft in complete_drafts if draft['lot'] == lot_slug]
+    )
+
+
 def count_unanswered_questions(service_attributes):
     unanswered_required, unanswered_optional = (0, 0)
     for section in service_attributes:

--- a/app/main/helpers/services.py
+++ b/app/main/helpers/services.py
@@ -16,7 +16,7 @@ def get_drafts(apiclient, supplier_id, framework_slug):
     try:
         drafts = apiclient.find_draft_services(
             current_user.supplier_id,
-            framework='g-cloud-7'
+            framework=framework_slug
         )['services']
 
     except APIError as e:

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -120,7 +120,7 @@ def framework_submission_services(framework_slug, lot_slug):
         draft = next(iter(drafts + complete_drafts), None)
         if not draft:
             draft = data_api_client.create_new_draft_service(
-                framework_slug, current_user.supplier_id, current_user.email_address, lot_slug
+                framework_slug, lot_slug, current_user.supplier_id, {}, current_user.email_address,
             )['services']
 
         return redirect(
@@ -145,6 +145,7 @@ def framework_submission_services(framework_slug, lot_slug):
         drafts=list(reversed(drafts)),
         declaration_status=declaration_status,
         framework=framework,
+        lot=lot,
         **main.config['BASE_TEMPLATE_DATA']
     ), 200
 

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -19,10 +19,10 @@ from ...main import main, content_loader
 from ..helpers import hash_email
 from ..helpers.frameworks import get_error_messages_for_page, get_first_question_index, \
     get_error_messages, get_declaration_status, get_last_modified_from_first_matching_file, \
-    register_interest_in_framework, get_supplier_framework_info, \
+    register_interest_in_framework, get_framework_lot, get_supplier_framework_info, \
     get_supplier_on_framework_from_info, get_declaration_status_from_info
 from ..helpers.services import (
-    get_draft_document_url, get_service_attributes, get_drafts,
+    get_draft_document_url, get_service_attributes, get_drafts, get_lot_drafts,
     count_unanswered_questions
 )
 
@@ -79,19 +79,65 @@ def framework_dashboard(framework_slug):
     ), 200
 
 
-@main.route('/frameworks/<framework_slug>/services', methods=['GET'])
+@main.route('/frameworks/<framework_slug>/submissions', methods=['GET'])
 @login_required
-@flask_featureflags.is_active_feature('GCLOUD7_OPEN')
-def framework_services(framework_slug):
-    template_data = main.config['BASE_TEMPLATE_DATA']
-    # TODO add a test for 404 if framework doesn't exist
+def framework_submission_lots(framework_slug):
     framework = data_api_client.get_framework(framework_slug)['frameworks']
+
+    if framework['status'] not in ['open', 'pending']:
+        abort(404)
 
     drafts, complete_drafts = get_drafts(data_api_client, current_user.supplier_id, framework_slug)
     declaration_status = get_declaration_status(data_api_client, framework_slug)
     application_made = len(complete_drafts) > 0 and declaration_status == 'complete'
     if framework['status'] == 'pending' and not application_made:
         abort(404)
+
+    lot_question = content_loader.get_question(framework_slug, 'services', 'lot')
+
+    return render_template(
+        "frameworks/submission_lots.html",
+        complete_drafts=list(reversed(complete_drafts)),
+        drafts=list(reversed(drafts)),
+        declaration_status=declaration_status,
+        framework=framework,
+        lots=[{
+            'link': url_for('.framework_submission_services', framework_slug=framework_slug, lot_slug=lot['value']),
+            'title': lot['label'],
+            'body': lot['description'],
+        } for lot in lot_question['options']],
+        **main.config['BASE_TEMPLATE_DATA']
+    ), 200
+
+
+@main.route('/frameworks/<framework_slug>/submissions/<lot_slug>', methods=['GET'])
+@login_required
+def framework_submission_services(framework_slug, lot_slug):
+    framework = data_api_client.get_framework(framework_slug)['frameworks']
+
+    if framework['status'] not in ['open', 'pending']:
+        abort(404)
+
+    lot = get_framework_lot(framework, lot_slug)
+    if lot is None:
+        abort(404)
+
+    drafts, complete_drafts = get_lot_drafts(data_api_client, current_user.supplier_id, framework_slug, lot_slug)
+    declaration_status = get_declaration_status(data_api_client, framework_slug)
+    if framework['status'] == 'pending' and declaration_status != 'complete':
+        abort(404)
+
+    if lot['one_service_limit']:
+        draft = next(iter(drafts + complete_drafts), None)
+        if not draft:
+            draft = data_api_client.create_new_draft_service(
+                framework_slug, current_user.supplier_id, current_user.email_address, lot_slug
+            )['services']
+
+        return redirect(
+            url_for('.view_service_submission',
+                    framework_slug=framework_slug, lot_slug=lot_slug, service_id=draft['id'])
+        )
 
     for draft in itertools.chain(drafts, complete_drafts):
         draft['priceString'] = format_service_price(draft)
@@ -110,7 +156,7 @@ def framework_services(framework_slug):
         drafts=list(reversed(drafts)),
         declaration_status=declaration_status,
         framework=framework,
-        **template_data
+        **main.config['BASE_TEMPLATE_DATA']
     ), 200
 
 

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -19,8 +19,9 @@ from ...main import main, content_loader
 from ..helpers import hash_email
 from ..helpers.frameworks import get_error_messages_for_page, get_first_question_index, \
     get_error_messages, get_declaration_status, get_last_modified_from_first_matching_file, \
-    register_interest_in_framework, get_framework_lot, get_supplier_framework_info, \
-    get_supplier_on_framework_from_info, get_declaration_status_from_info
+    register_interest_in_framework, get_supplier_framework_info, \
+    get_supplier_on_framework_from_info, get_declaration_status_from_info, \
+    get_framework, get_framework_and_lot
 from ..helpers.services import (
     get_draft_document_url, get_service_attributes, get_drafts, get_lot_drafts,
     count_unanswered_questions
@@ -32,10 +33,8 @@ CLARIFICATION_QUESTION_NAME = 'clarification_question'
 
 @main.route('/frameworks/<framework_slug>', methods=['GET', 'POST'])
 @login_required
-@flask_featureflags.is_active_feature('GCLOUD7_OPEN')
 def framework_dashboard(framework_slug):
-    template_data = main.config['BASE_TEMPLATE_DATA']
-    framework = data_api_client.get_framework(framework_slug)['frameworks']
+    framework = get_framework(data_api_client, framework_slug, open_only=False)
 
     if request.method == 'POST':
         try:
@@ -75,17 +74,14 @@ def framework_dashboard(framework_slug):
             'supplier_pack': get_last_modified_from_first_matching_file(key_list, 'g-cloud-7-supplier-pack.zip'),
             'supplier_updates': get_last_modified_from_first_matching_file(key_list, 'g-cloud-7-updates/')
         },
-        **template_data
+        **main.config['BASE_TEMPLATE_DATA']
     ), 200
 
 
 @main.route('/frameworks/<framework_slug>/submissions', methods=['GET'])
 @login_required
 def framework_submission_lots(framework_slug):
-    framework = data_api_client.get_framework(framework_slug)['frameworks']
-
-    if framework['status'] not in ['open', 'pending']:
-        abort(404)
+    framework = get_framework(data_api_client, framework_slug, open_only=False)
 
     drafts, complete_drafts = get_drafts(data_api_client, current_user.supplier_id, framework_slug)
     declaration_status = get_declaration_status(data_api_client, framework_slug)
@@ -113,14 +109,7 @@ def framework_submission_lots(framework_slug):
 @main.route('/frameworks/<framework_slug>/submissions/<lot_slug>', methods=['GET'])
 @login_required
 def framework_submission_services(framework_slug, lot_slug):
-    framework = data_api_client.get_framework(framework_slug)['frameworks']
-
-    if framework['status'] not in ['open', 'pending']:
-        abort(404)
-
-    lot = get_framework_lot(framework, lot_slug)
-    if lot is None:
-        abort(404)
+    framework, lot = get_framework_and_lot(data_api_client, framework_slug, lot_slug, open_only=False)
 
     drafts, complete_drafts = get_lot_drafts(data_api_client, current_user.supplier_id, framework_slug, lot_slug)
     declaration_status = get_declaration_status(data_api_client, framework_slug)
@@ -163,14 +152,9 @@ def framework_submission_services(framework_slug, lot_slug):
 @main.route('/frameworks/<framework_slug>/declaration', methods=['GET'])
 @main.route('/frameworks/<framework_slug>/declaration/<string:section_id>', methods=['GET', 'POST'])
 @login_required
-@flask_featureflags.is_active_feature('GCLOUD7_OPEN')
 def framework_supplier_declaration(framework_slug, section_id=None):
-    # TODO add a test for 404 if framework doesn't exist
-    framework = data_api_client.get_framework(framework_slug)['frameworks']
-    if framework['status'] != 'open':
-        abort(404)
+    framework = get_framework(data_api_client, framework_slug, open_only=True)
 
-    template_data = main.config['BASE_TEMPLATE_DATA']
     content = content_loader.get_builder(framework_slug, 'declaration')
     status_code = 200
 
@@ -239,13 +223,12 @@ def framework_supplier_declaration(framework_slug, section_id=None):
         is_last_page=is_last_page,
         get_question=content.get_question,
         errors=errors,
-        **template_data
+        **main.config['BASE_TEMPLATE_DATA']
     ), status_code
 
 
 @main.route('/frameworks/<framework_slug>/files/<path:filepath>', methods=['GET'])
 @login_required
-@flask_featureflags.is_active_feature('GCLOUD7_OPEN')
 def download_supplier_file(framework_slug, filepath):
     uploader = s3.S3(current_app.config['DM_G7_DRAFT_DOCUMENTS_BUCKET'])
     url = get_draft_document_url(uploader, filepath)
@@ -285,15 +268,12 @@ def g7_download_zip_redirect_pdf(framework_slug, filepath):
 
 @main.route('/frameworks/<framework_slug>/updates', methods=['GET'])
 @login_required
-@flask_featureflags.is_active_feature('GCLOUD7_OPEN')
 def framework_updates(framework_slug, error_message=None, default_textbox_value=None):
-    framework = data_api_client.get_framework(framework_slug)['frameworks']
+    framework = get_framework(data_api_client, framework_slug, open_only=False)
 
     current_app.logger.info("g7updates.viewed: user_id {user_id} supplier_id {supplier_id}",
                             extra={'user_id': current_user.id,
                                    'supplier_id': current_user.supplier_id})
-
-    template_data = main.config['BASE_TEMPLATE_DATA']
 
     file_list = s3.S3(current_app.config['DM_G7_DRAFT_DOCUMENTS_BUCKET']).list('g-cloud-7-updates/')
 
@@ -323,15 +303,15 @@ def framework_updates(framework_slug, error_message=None, default_textbox_value=
         clarification_question_value=default_textbox_value,
         error_message=error_message,
         sections=sections,
-        **template_data
+        **main.config['BASE_TEMPLATE_DATA']
     ), 200 if not error_message else 400
 
 
 @main.route('/frameworks/<framework_slug>/updates', methods=['POST'])
 @login_required
-@flask_featureflags.is_active_feature('GCLOUD7_OPEN')
 def framework_updates_email_clarification_question(framework_slug):
-    framework = data_api_client.get_framework(framework_slug)['frameworks']
+    framework = get_framework(data_api_client, framework_slug, open_only=False)
+
     # Stripped input should not empty
     clarification_question = request.form.get(CLARIFICATION_QUESTION_NAME, '').strip()
 

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -10,7 +10,7 @@ from ..helpers.services import (
     get_draft_document_url, count_unanswered_questions,
     get_next_section_name
 )
-from ..helpers.frameworks import get_declaration_status, g_cloud_7_is_open_or_404
+from ..helpers.frameworks import get_declaration_status
 
 from dmutils.apiclient import APIError, HTTPError
 from dmutils.formats import format_service_price

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -318,8 +318,9 @@ def complete_draft_service(framework_slug, lot_slug, service_id):
 
     flash({'service_name': draft.get('serviceName')}, 'service_completed')
 
-    return redirect(url_for(".framework_services",
+    return redirect(url_for(".framework_submission_services",
                     framework_slug=framework['slug'],
+                    lot_slug=lot_slug,
                     service_completed=service_id,
                     lot=draft['lot'].lower()))
 
@@ -345,8 +346,8 @@ def delete_draft_service(framework_slug, lot_slug, service_id):
         except APIError as e:
             abort(e.status_code)
 
-        flash({'service_name': draft.get('serviceName')}, 'service_deleted')
-        return redirect(url_for(".framework_services", framework_slug=framework['slug']))
+        flash({'service_name': draft.get('serviceName', draft['lotName'])}, 'service_deleted')
+        return redirect(url_for(".framework_submission_lots", framework_slug=framework['slug']))
     else:
         return redirect(url_for(".view_service_submission",
                                 framework_slug=framework['slug'],

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -258,6 +258,7 @@ def create_new_draft_service(framework_slug):
         url_for(
             ".edit_service_submission",
             framework_slug=framework['slug'],
+            lot_slug=draft_service['lot'],
             service_id=draft_service.get('id'),
             section_id=content.get_next_editable_section_id(),
             return_to_summary=1
@@ -265,10 +266,10 @@ def create_new_draft_service(framework_slug):
     )
 
 
-@main.route('/frameworks/<framework_slug>/submissions/<service_id>/copy', methods=['POST'])
+@main.route('/frameworks/<framework_slug>/submissions/<lot_slug>/<service_id>/copy', methods=['POST'])
 @login_required
 @flask_featureflags.is_active_feature('GCLOUD7_OPEN')
-def copy_draft_service(framework_slug, service_id):
+def copy_draft_service(framework_slug, lot_slug, service_id):
     framework = data_api_client.get_framework(framework_slug)['frameworks']
     if framework['status'] != 'open':
         abort(404)
@@ -288,15 +289,16 @@ def copy_draft_service(framework_slug, service_id):
 
     return redirect(url_for(".edit_service_submission",
                             framework_slug=framework['slug'],
+                            lot_slug=draft['lot'],
                             service_id=draft_copy['id'],
                             section_id='service_name',
                             return_to_summary=1))
 
 
-@main.route('/frameworks/<framework_slug>/submissions/<service_id>/complete', methods=['POST'])
+@main.route('/frameworks/<framework_slug>/submissions/<lot_slug>/<service_id>/complete', methods=['POST'])
 @login_required
 @flask_featureflags.is_active_feature('GCLOUD7_OPEN')
-def complete_draft_service(framework_slug, service_id):
+def complete_draft_service(framework_slug, lot_slug, service_id):
     framework = data_api_client.get_framework(framework_slug)['frameworks']
     if framework['status'] != 'open':
         abort(404)
@@ -322,10 +324,10 @@ def complete_draft_service(framework_slug, service_id):
                     lot=draft['lot'].lower()))
 
 
-@main.route('/frameworks/<framework_slug>/submissions/<service_id>/delete', methods=['POST'])
+@main.route('/frameworks/<framework_slug>/submissions/<lot_slug>/<service_id>/delete', methods=['POST'])
 @login_required
 @flask_featureflags.is_active_feature('GCLOUD7_OPEN')
-def delete_draft_service(framework_slug, service_id):
+def delete_draft_service(framework_slug, lot_slug, service_id):
     framework = data_api_client.get_framework(framework_slug)['frameworks']
     if framework['status'] != 'open':
         abort(404)
@@ -348,6 +350,7 @@ def delete_draft_service(framework_slug, service_id):
     else:
         return redirect(url_for(".view_service_submission",
                                 framework_slug=framework['slug'],
+                                lot_slug=draft['lot'],
                                 service_id=service_id,
                                 delete_requested=True)
                         )
@@ -369,10 +372,10 @@ def service_submission_document(framework_slug, supplier_id, document_name):
     return redirect(s3_url)
 
 
-@main.route('/frameworks/<framework_slug>/submissions/<service_id>', methods=['GET'])
+@main.route('/frameworks/<framework_slug>/submissions/<lot_slug>/<service_id>', methods=['GET'])
 @login_required
 @flask_featureflags.is_active_feature('GCLOUD7_OPEN')
-def view_service_submission(framework_slug, service_id):
+def view_service_submission(framework_slug, lot_slug, service_id):
     framework = data_api_client.get_framework(framework_slug)['frameworks']
     try:
         data = data_api_client.get_draft_service(service_id)
@@ -406,10 +409,10 @@ def view_service_submission(framework_slug, service_id):
         **main.config['BASE_TEMPLATE_DATA']), 200
 
 
-@main.route('/frameworks/<framework_slug>/submissions/<service_id>/edit/<section_id>', methods=['GET'])
+@main.route('/frameworks/<framework_slug>/submissions/<lot_slug>/<service_id>/edit/<section_id>', methods=['GET'])
 @login_required
 @flask_featureflags.is_active_feature('GCLOUD7_OPEN')
-def edit_service_submission(framework_slug, service_id, section_id):
+def edit_service_submission(framework_slug, lot_slug, service_id, section_id):
     framework = data_api_client.get_framework(framework_slug)['frameworks']
     if framework['status'] != 'open':
         abort(404)
@@ -440,10 +443,10 @@ def edit_service_submission(framework_slug, service_id, section_id):
     )
 
 
-@main.route('/frameworks/<framework_slug>/submissions/<service_id>/edit/<section_id>', methods=['POST'])
+@main.route('/frameworks/<framework_slug>/submissions/<lot_slug>/<service_id>/edit/<section_id>', methods=['POST'])
 @login_required
 @flask_featureflags.is_active_feature('GCLOUD7_OPEN')
-def update_section_submission(framework_slug, service_id, section_id):
+def update_section_submission(framework_slug, lot_slug, service_id, section_id):
     framework = data_api_client.get_framework(framework_slug)['frameworks']
     if framework['status'] != 'open':
         abort(404)
@@ -507,11 +510,13 @@ def update_section_submission(framework_slug, service_id, section_id):
     if next_section and not return_to_summary and request.form.get('continue_to_next_section'):
         return redirect(url_for(".edit_service_submission",
                                 framework_slug=framework['slug'],
+                                lot_slug=draft['lot'],
                                 service_id=service_id,
                                 section_id=next_section))
     else:
         return redirect(url_for(".view_service_submission",
                                 framework_slug=framework['slug'],
+                                lot_slug=draft['lot'],
                                 service_id=service_id))
 
 

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -244,6 +244,10 @@ def copy_draft_service(framework_slug, lot_slug, service_id):
     if not is_service_associated_with_supplier(draft):
         abort(404)
 
+    content = content_loader.get_builder(framework_slug, 'edit_submission').filter(
+        {'lot': lot['slug']}
+    )
+
     try:
         draft_copy = data_api_client.copy_draft_service(
             service_id,
@@ -257,7 +261,7 @@ def copy_draft_service(framework_slug, lot_slug, service_id):
                             framework_slug=framework['slug'],
                             lot_slug=draft['lot'],
                             service_id=draft_copy['id'],
-                            section_id='service_name',
+                            section_id=content.get_next_editable_section_id(),
                             return_to_summary=1))
 
 

--- a/app/templates/frameworks/dashboard.html
+++ b/app/templates/frameworks/dashboard.html
@@ -103,7 +103,7 @@
               {% if not counts.draft %}
                 <div class="framework-section-validation-bar-good">
               {% endif %}
-                <a class="browse-list-item-link" href="{{ url_for('.framework_services', framework_slug=framework.slug) }}">
+                <a class="browse-list-item-link" href="{{ url_for('.framework_submission_lots', framework_slug=framework.slug) }}">
                   <span>
                     Add, edit and delete services
                   </span>
@@ -163,7 +163,7 @@
         <li class="browse-list-item framework-application-section">
           <div class="grid-row">
             <div class="column-two-thirds">
-              <a href="{{ url_for('.framework_services', framework_slug=framework.slug) }}">View services</a>
+              <a href="{{ url_for('.framework_submission_lots', framework_slug=framework.slug) }}">View services</a>
             </div>
             <div class="column-two-thirds">
               <div class="framework-section-status-neutral">

--- a/app/templates/frameworks/services.html
+++ b/app/templates/frameworks/services.html
@@ -18,6 +18,10 @@
       {
         "link": url_for(".framework_dashboard", framework_slug=framework.slug),
         "label": "Apply to " + framework.name,
+      },
+      {
+        "link": url_for(".framework_submission_lots", framework_slug=framework.slug),
+        "label": "Services",
       }
     ]
   %}

--- a/app/templates/frameworks/services.html
+++ b/app/templates/frameworks/services.html
@@ -98,17 +98,18 @@
     {% call summary.row() %}
       {{ summary.service_link(draft.serviceName,
                               url_for(".view_service_submission", framework_slug=framework.slug, lot_slug=draft.lot, service_id=draft.id)) }}
-      
+
       {% if framework.status == 'open' %}
       {{ summary.text(submission.multiline_string(
         submission.can_be_completed_text(draft.unanswered_required, framework.status),
         submission.unanswered_required_text(draft.unanswered_required, draft.unanswered_optional),
         submission.unanswered_optional_text(draft.unanswered_required, draft.unanswered_optional)
       )) }}
-      {% endif %}
-      {% if framework.status == 'open' %}
         {{ summary.button(text="Make a copy",
                            action=url_for('.copy_draft_service', framework_slug=framework.slug, lot_slug=draft.lot, service_id=draft.id)) }}
+      {% else %}
+        {{ summary.text() }}
+        {{ summary.text() }}
       {% endif %}
     {% endcall %}
   {% endcall %}
@@ -138,6 +139,8 @@
       {% if framework.status == 'open' %}
         {{ summary.button(text="Make a copy",
                            action=url_for('.copy_draft_service', framework_slug=framework.slug, lot_slug=draft.lot, service_id=draft.id)) }}
+      {% else %}
+        {{ summary.text() }}
       {% endif %}
     {% endcall %}
   {% endcall %}

--- a/app/templates/frameworks/services.html
+++ b/app/templates/frameworks/services.html
@@ -94,7 +94,7 @@
   ) %}
     {% call summary.row() %}
       {{ summary.service_link(draft.serviceName,
-                              url_for(".view_service_submission", framework_slug=framework.slug, service_id=draft.id)) }}
+                              url_for(".view_service_submission", framework_slug=framework.slug, lot_slug=draft.lot, service_id=draft.id)) }}
       {{ summary.text(draft.lot) }}
       
       {% if framework.status == 'open' %}
@@ -106,7 +106,7 @@
       {% endif %}
       {% if framework.status == 'open' %}
         {{ summary.button(text="Make a copy",
-                           action=url_for('.copy_draft_service', framework_slug=framework.slug, service_id=draft.id)) }}
+                           action=url_for('.copy_draft_service', framework_slug=framework.slug, lot_slug=draft.lot, service_id=draft.id)) }}
       {% endif %}
     {% endcall %}
   {% endcall %}
@@ -130,14 +130,14 @@
   ) %}
     {% call summary.row() %}
       {{ summary.service_link(draft.serviceName,
-                              url_for(".view_service_submission", framework_slug=framework.slug, service_id=draft.id)) }}
+                              url_for(".view_service_submission", framework_slug=framework.slug, lot_slug=draft.lot, service_id=draft.id)) }}
       {{ summary.text(draft.lot) }}
       {{ summary.text(
         submission.unanswered_optional_text(draft.unanswered_required, draft.unanswered_optional)
       ) }}
       {% if framework.status == 'open' %}
         {{ summary.button(text="Make a copy",
-                           action=url_for('.copy_draft_service', framework_slug=framework.slug, service_id=draft.id)) }}
+                           action=url_for('.copy_draft_service', framework_slug=framework.slug, lot_slug=draft.lot, service_id=draft.id)) }}
       {% endif %}
     {% endcall %}
   {% endcall %}

--- a/app/templates/frameworks/services.html
+++ b/app/templates/frameworks/services.html
@@ -56,7 +56,7 @@
   {% endif %}
 
   {% with
-     heading = framework.name + " services",
+     heading = lot.name + " services",
      smaller = True,
      with_breadcrumb = True
   %}

--- a/app/templates/frameworks/services.html
+++ b/app/templates/frameworks/services.html
@@ -80,7 +80,7 @@
 
   {{ summary.heading("Draft services") }}
   {% if framework.status == 'open' %}
-    {{ summary.top_link("Add a service", url_for(".start_new_draft_service", framework_slug=framework.slug)) }}
+    {{ summary.top_link("Add a service", url_for(".start_new_draft_service", framework_slug=framework.slug, lot_slug=lot.slug)) }}
   {% elif framework.status == 'pending' %}
     <p class="hint">These services were not submitted</p>
   {% endif %}
@@ -90,7 +90,6 @@
     empty_message="You haven't added any services yet.",
     field_headings=[
         "Service name",
-        "Lot",
         summary.hidden_field_heading("Progress"),
         summary.hidden_field_heading("Make a copy")
     ],
@@ -99,7 +98,6 @@
     {% call summary.row() %}
       {{ summary.service_link(draft.serviceName,
                               url_for(".view_service_submission", framework_slug=framework.slug, lot_slug=draft.lot, service_id=draft.id)) }}
-      {{ summary.text(draft.lot) }}
       
       {% if framework.status == 'open' %}
       {{ summary.text(submission.multiline_string(
@@ -126,7 +124,6 @@
     empty_message="You haven’t marked any services as complete yet.",
     field_headings=[
         "Service name",
-        "Lot",
         summary.hidden_field_heading("Progress"),
         summary.hidden_field_heading("Make a copy")
     ],
@@ -135,7 +132,6 @@
     {% call summary.row() %}
       {{ summary.service_link(draft.serviceName,
                               url_for(".view_service_submission", framework_slug=framework.slug, lot_slug=draft.lot, service_id=draft.id)) }}
-      {{ summary.text(draft.lot) }}
       {{ summary.text(
         submission.unanswered_optional_text(draft.unanswered_required, draft.unanswered_optional)
       ) }}

--- a/app/templates/frameworks/services.html
+++ b/app/templates/frameworks/services.html
@@ -37,8 +37,6 @@
         <p class="banner-message">
           {% if category == 'service_deleted' %}
             <strong>{{message.service_name}}</strong> was deleted
-          {% elif category == 'service_copied' %}
-            <strong>{{message.service_name}}</strong> was copied
           {% elif category == 'service_completed' %}
             <strong>{{message.service_name}}</strong> was marked as complete
           {% endif %}

--- a/app/templates/frameworks/submission_lots.html
+++ b/app/templates/frameworks/submission_lots.html
@@ -1,0 +1,51 @@
+{% extends "_base_page.html" %}
+{% import "toolkit/summary-table.html" as summary %}
+{% import "macros/submission.html" as submission %}
+
+{% block page_title %}Apply to {{ framework.name }} – Digital Marketplace{% endblock %}
+
+{% block breadcrumb %}
+  {%
+    with items = [
+      {
+        "link": "/",
+        "label": "Digital Marketplace",
+      },
+      {
+        "link": url_for(".dashboard"),
+        "label": "Your account",
+      },
+      {
+        "link": url_for(".framework_dashboard", framework_slug=framework.slug),
+        "label": "Apply to " + framework.name,
+      }
+    ]
+  %}
+    {% include "toolkit/breadcrumb.html" %}
+  {% endwith %}
+{% endblock %}
+
+{% block main_content %}
+
+  <div class="grid-row">
+    <div class="column-two-thirds">
+      {% with
+        heading = "Your " + framework.name + " services"
+      %}
+        {% include 'toolkit/page-heading.html' %}
+      {% endwith %}
+    </div>
+  </div>
+
+  <div class="grid-row">
+    <div class="column-two-thirds">
+      {% with items = lots %}
+        {% include "toolkit/browse-list.html" %}
+      {% endwith %}
+
+    <a href="{{ url_for('.framework_dashboard', framework_slug=framework.slug) }}">Return to {{ framework.name }} application</a>
+
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/templates/frameworks/submission_lots.html
+++ b/app/templates/frameworks/submission_lots.html
@@ -27,6 +27,21 @@
 
 {% block main_content %}
 
+  {% with messages = get_flashed_messages(with_categories=True) %}
+    {% for category, message in messages %}
+      <div class="banner-success-without-action">
+        <p class="banner-message">
+          {% if category == 'service_deleted' %}
+            <strong>{{message.service_name}}</strong> was deleted
+          {% elif category == 'service_completed' %}
+            <strong>{{message.service_name}}</strong> was marked as complete
+          {% endif %}
+        </p>
+      </div>
+    {% endfor %}
+  {% endwith %}
+
+
   <div class="grid-row">
     <div class="column-two-thirds">
       {% with

--- a/app/templates/partials/complete_service.html
+++ b/app/templates/partials/complete_service.html
@@ -1,4 +1,4 @@
-<form action="{{ url_for('.complete_draft_service', framework_slug=framework.slug, service_id=service_id) }}" method="POST">
+<form action="{{ url_for('.complete_draft_service', framework_slug=framework.slug, lot_slug=service_data.lot, service_id=service_id) }}" method="POST">
   <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
   {% with type = "save", label = "Mark as complete" %}
     {% include "toolkit/button.html" %}

--- a/app/templates/services/_base_service_page.html
+++ b/app/templates/services/_base_service_page.html
@@ -1,13 +1,13 @@
 {% extends "_base_page.html" %}
 
-{% block page_title %}{{service_data['serviceName'] or 'New service'}} – Digital Marketplace{% endblock %}
+{% block page_title %}{{ service_data.serviceName or service_data.lotName }} – Digital Marketplace{% endblock %}
 
 {% block main_content %}
   <div class="grid-row">
     {% block before_heading %}{% endblock %}
     <div class="column-two-thirds">
       {% with
-        heading = service_data['serviceName'] or 'New service',
+        heading = service_data.get('serviceName', service_data['lotName']),
         smaller = true
       %}
         {% include "toolkit/page-heading.html" %}

--- a/app/templates/services/_base_service_page.html
+++ b/app/templates/services/_base_service_page.html
@@ -35,7 +35,7 @@
               {{ summary.field_name(question.label) }}
               {% call summary.field() %}
                 {% if framework and framework.status == 'open' %}
-                  <a href="{{ url_for(".edit_service_submission", framework_slug=framework.slug, service_id=service_id, section_id=section.id) }}">Answer required</a>
+                  <a href="{{ url_for(".edit_service_submission", framework_slug=framework.slug, lot_slug=service_data.lot, service_id=service_id, section_id=section.id) }}">Answer required</a>
                 {% else %}
                   Not answered
                 {% endif %}

--- a/app/templates/services/edit_submission_section.html
+++ b/app/templates/services/edit_submission_section.html
@@ -16,7 +16,7 @@
         "label": "Apply to " + framework.name
       },
       {
-        "link": url_for(".framework_services", framework_slug=framework.slug),
+        "link": url_for(".framework_submission_lots", framework_slug=framework.slug),
         "label": "Services"
       },
       {

--- a/app/templates/services/edit_submission_section.html
+++ b/app/templates/services/edit_submission_section.html
@@ -20,7 +20,7 @@
         "label": "Services"
       },
       {
-        "link": url_for(".view_service_submission", framework_slug=framework.slug, service_id=service_id),
+        "link": url_for(".view_service_submission", framework_slug=framework.slug, lot_slug=service_data.lot, service_id=service_id),
         "label": service_data['serviceName']
       }
     ]

--- a/app/templates/services/edit_submission_section.html
+++ b/app/templates/services/edit_submission_section.html
@@ -21,7 +21,7 @@
       },
       {
         "link": url_for(".view_service_submission", framework_slug=framework.slug, lot_slug=service_data.lot, service_id=service_id),
-        "label": service_data['serviceName']
+        "label": service_data.get('serviceName', service_data['lotName'])
       }
     ]
   %}

--- a/app/templates/services/service_submission.html
+++ b/app/templates/services/service_submission.html
@@ -20,6 +20,10 @@
       {
         "link": url_for(".framework_services", framework_slug=framework.slug),
         "label": "Services"
+      },
+      {
+        "link": url_for(".framework_submission_services", framework_slug=framework.slug, lot_slug=service_data.lot),
+        "label": service_data.lotName
       }
     ]
   %}
@@ -104,7 +108,7 @@
 {% block before_heading %}
   {% if delete_requested %}
     <div class="column-one-whole">
-      <form action="{{ url_for('.delete_draft_service', framework_slug=framework.slug, service_id=service_id ) }}" method="POST">
+      <form action="{{ url_for('.delete_draft_service', framework_slug=framework.slug, lot_slug=service_data.lot, service_id=service_id ) }}" method="POST">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
         <input type="hidden" name="delete_confirmed" value="true" />
         <div class="banner-destructive-with-action">
@@ -121,7 +125,7 @@
 
 {% block edit_link %}
   {% if framework.status == 'open' %}
-    {{ summary.top_link("Edit", url_for(".edit_service_submission", framework_slug=framework.slug, service_id=service_id, section_id=section.id)) }}
+    {{ summary.top_link("Edit", url_for(".edit_service_submission", framework_slug=framework.slug, lot_slug=service_data.lot, service_id=service_id, section_id=section.id)) }}
   {% endif %}
 {% endblock %}
 
@@ -139,7 +143,7 @@
           </div>
         {% endif %}
         {% if framework.status == 'open' %}
-        <form action="{{ url_for('.delete_draft_service', framework_slug=framework.slug, service_id=service_id ) }}" method="POST">
+        <form action="{{ url_for('.delete_draft_service', framework_slug=framework.slug, lot_slug=service_data.lot, service_id=service_id ) }}" method="POST">
           <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
           {% with type = "destructive", label = "Delete this service" %}
             {% include "toolkit/button.html" %}

--- a/app/templates/services/service_submission.html
+++ b/app/templates/services/service_submission.html
@@ -115,7 +115,7 @@
           <p class="banner-message">
             Are you sure you want to delete this service?
           </p>
-          <button type="submit" class="button-destructive banner-action">Yes, delete &ldquo;{{ service_data['serviceName'] }}&rdquo;</button>
+          <button type="submit" class="button-destructive banner-action">Yes, delete &ldquo;{{ service_data.serviceName or service_data.lotName }}&rdquo;</button>
         </div>
       </form>
     </div>

--- a/app/templates/services/service_submission.html
+++ b/app/templates/services/service_submission.html
@@ -18,7 +18,7 @@
         "label": "Apply to " + framework.name
       },
       {
-        "link": url_for(".framework_services", framework_slug=framework.slug),
+        "link": url_for(".framework_submission_lots", framework_slug=framework.slug),
         "label": "Services"
       },
       {

--- a/bower.json
+++ b/bower.json
@@ -7,6 +7,6 @@
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
     "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v11.3.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.14.1/jinja_govuk_template-0.14.1.tgz",
-    "digitalmarketplace-frameworks": "git://github.com/alphagov/digitalmarketplace-frameworks#fdbbb64cbc042b185ee276b703b1a8e4074f4f4b"
+    "digitalmarketplace-frameworks": "git://github.com/alphagov/digitalmarketplace-frameworks#38fbfa0"
   }
 }

--- a/config.py
+++ b/config.py
@@ -67,7 +67,6 @@ class Config(object):
     RAISE_ERROR_ON_MISSING_FEATURES = True
 
     FEATURE_FLAGS_EDIT_SERVICE_PAGE = False
-    FEATURE_FLAGS_GCLOUD7_OPEN = False
     FEATURE_FLAGS_G7_CLARIFICATIONS_CLOSED = False
 
     # Logging
@@ -98,7 +97,6 @@ class Test(Config):
     DM_CLARIFICATION_QUESTION_EMAIL = 'digitalmarketplace@mailinator.com'
 
     FEATURE_FLAGS_EDIT_SERVICE_PAGE = enabled_since('2015-06-03')
-    FEATURE_FLAGS_GCLOUD7_OPEN = enabled_since('2015-06-18')
 
 
 class Development(Config):
@@ -107,7 +105,6 @@ class Development(Config):
 
     # Dates not formatted like YYYY-(0)M-(0)D will fail
     FEATURE_FLAGS_EDIT_SERVICE_PAGE = enabled_since('2015-06-03')
-    FEATURE_FLAGS_GCLOUD7_OPEN = enabled_since('2015-06-18')
     FEATURE_FLAGS_G7_CLARIFICATIONS_CLOSED = enabled_since('2015-09-15')
 
 
@@ -119,17 +116,14 @@ class Live(Config):
 
 class Preview(Live):
     FEATURE_FLAGS_EDIT_SERVICE_PAGE = enabled_since('2015-06-03')
-    FEATURE_FLAGS_GCLOUD7_OPEN = enabled_since('2015-06-18')
     FEATURE_FLAGS_G7_CLARIFICATIONS_CLOSED = enabled_since('2015-09-18')
 
 
 class Production(Live):
-    FEATURE_FLAGS_GCLOUD7_OPEN = enabled_since('2015-09-01')
     FEATURE_FLAGS_G7_CLARIFICATIONS_CLOSED = enabled_since('2015-09-22')
 
 
 class Staging(Production):
-    FEATURE_FLAGS_GCLOUD7_OPEN = enabled_since('2015-08-26')
     FEATURE_FLAGS_G7_CLARIFICATIONS_CLOSED = enabled_since('2015-09-18')
 
 configs = {

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ Flask-WTF==0.12
 werkzeug==0.10.4
 
 git+https://github.com/madzak/python-json-logger.git@v0.1.3#egg=python-json-logger==v0.1.3
-git+https://github.com/alphagov/digitalmarketplace-utils.git@11.4.0#egg=digitalmarketplace-utils==11.4.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@12.0.0#egg=digitalmarketplace-utils==12.0.0
 
 markdown==2.6.2
 

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -1,5 +1,5 @@
 -r requirements.txt
-nose==1.3.6
+pytest==2.8.2
 pep8==1.5.7
 requests-mock==0.6.0
 mock==1.0.1
@@ -7,3 +7,4 @@ lxml==3.4.4
 cssselect==0.9.1
 freezegun==0.3.4
 watchdog==0.8.3
+nose==1.3.7

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -32,7 +32,7 @@ display_result $? 2 "Code style check"
 npm run --silent frontend-build:production
 display_result $? 1 "Build of front end static assets"
 
-nosetests -v -s --with-doctest
+py.test $@
 display_result $? 3 "Python Unit tests"
 
 npm test

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,3 +4,6 @@ max-line-length = 120
 
 [nosetests]
 nocapture = true
+
+[pytest]
+norecursedirs = node_modules app/content bower_components

--- a/tests/app/helpers.py
+++ b/tests/app/helpers.py
@@ -174,7 +174,11 @@ class BaseApplicationTest(object):
             'frameworks': {
                 'status': status,
                 'name': name,
-                'slug': slug
+                'slug': slug,
+                'lots': [
+                    {'id': 1, 'slug': 'iaas', 'name': 'Infrastructure as a Service', 'one_service_limit': False},
+                    {'id': 2, 'slug': 'scs', 'name': 'Specialist Cloud Services', 'one_service_limit': False},
+                ]
             }
         }
 

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -976,7 +976,7 @@ class TestG7ServicesList(BaseApplicationTest):
         data_api_client.get_framework.return_value = self.framework(status='pending')
         data_api_client.find_draft_services.return_value = {'services': []}
         count_unanswered.return_value = 0
-        response = self.client.get('/suppliers/frameworks/g-cloud-7/services')
+        response = self.client.get('/suppliers/frameworks/g-cloud-7/submissions/iaas')
         assert_equal(response.status_code, 404)
 
     def test_404_when_g7_pending_and_no_declaration(self, count_unanswered, data_api_client):
@@ -986,7 +986,7 @@ class TestG7ServicesList(BaseApplicationTest):
         data_api_client.get_supplier_declaration.return_value = {
             "declaration": {"status": "started"}
         }
-        response = self.client.get('/suppliers/frameworks/g-cloud-7/services')
+        response = self.client.get('/suppliers/frameworks/g-cloud-7/submissions/iaas')
         assert_equal(response.status_code, 404)
 
     def test_no_404_when_g7_open_and_no_complete_services(self, count_unanswered, data_api_client):
@@ -995,7 +995,7 @@ class TestG7ServicesList(BaseApplicationTest):
         data_api_client.get_framework.return_value = self.framework(status='open')
         data_api_client.find_draft_services.return_value = {'services': []}
         count_unanswered.return_value = 0
-        response = self.client.get('/suppliers/frameworks/g-cloud-7/services')
+        response = self.client.get('/suppliers/frameworks/g-cloud-7/submissions/iaas')
         assert_equal(response.status_code, 200)
 
     def test_no_404_when_g7_open_and_no_declaration(self, count_unanswered, data_api_client):
@@ -1006,7 +1006,7 @@ class TestG7ServicesList(BaseApplicationTest):
         data_api_client.get_supplier_declaration.return_value = {
             "declaration": {"status": "started"}
         }
-        response = self.client.get('/suppliers/frameworks/g-cloud-7/services')
+        response = self.client.get('/suppliers/frameworks/g-cloud-7/submissions/iaas')
         assert_equal(response.status_code, 200)
 
     def test_shows_g7_message_if_pending_and_application_made(self, count_unanswered, data_api_client):
@@ -1016,12 +1016,12 @@ class TestG7ServicesList(BaseApplicationTest):
         data_api_client.get_supplier_declaration.return_value = {'declaration': FULL_G7_SUBMISSION}  # noqa
         data_api_client.find_draft_services.return_value = {
             'services': [
-                {'serviceName': 'draft', 'lot': 'SCS', 'status': 'submitted'},
+                {'serviceName': 'draft', 'lot': 'scs', 'status': 'submitted'},
             ]
         }
         count_unanswered.return_value = 0, 1
 
-        response = self.client.get('/suppliers/frameworks/g-cloud-7/services')
+        response = self.client.get('/suppliers/frameworks/g-cloud-7/submissions/scs')
         doc = html.fromstring(response.get_data(as_text=True))
 
         assert_equal(response.status_code, 200)
@@ -1040,11 +1040,11 @@ class TestG7ServicesList(BaseApplicationTest):
         data_api_client.get_framework.return_value = self.framework(status='open')
         data_api_client.find_draft_services.return_value = {
             'services': [
-                {'serviceName': 'draft', 'lot': 'SCS', 'status': 'not-submitted'},
+                {'serviceName': 'draft', 'lot': 'scs', 'status': 'not-submitted'},
             ]
         }
 
-        res = self.client.get('/suppliers/frameworks/g-cloud-7/services')
+        res = self.client.get('/suppliers/frameworks/g-cloud-7/submissions/scs')
 
         assert_true(u'Service can be moved to complete' not in res.get_data(as_text=True))
         assert_in(u'4 unanswered questions', res.get_data(as_text=True))
@@ -1058,11 +1058,11 @@ class TestG7ServicesList(BaseApplicationTest):
         data_api_client.get_framework.return_value = self.framework(status='open')
         data_api_client.find_draft_services.return_value = {
             'services': [
-                {'serviceName': 'draft', 'lot': 'SCS', 'status': 'not-submitted'},
+                {'serviceName': 'draft', 'lot': 'scs', 'status': 'not-submitted'},
             ]
         }
 
-        res = self.client.get('/suppliers/frameworks/g-cloud-7/services')
+        res = self.client.get('/suppliers/frameworks/g-cloud-7/submissions/scs')
 
         assert_in(u'Service can be marked as complete', res.get_data(as_text=True))
         assert_in(u'1 optional question unanswered', res.get_data(as_text=True))
@@ -1076,11 +1076,11 @@ class TestG7ServicesList(BaseApplicationTest):
         data_api_client.get_framework.return_value = self.framework(status='open')
         data_api_client.find_draft_services.return_value = {
             'services': [
-                {'serviceName': 'draft', 'lot': 'SCS', 'status': 'submitted'},
+                {'serviceName': 'draft', 'lot': 'scs', 'status': 'submitted'},
             ]
         }
 
-        res = self.client.get('/suppliers/frameworks/g-cloud-7/services')
+        res = self.client.get('/suppliers/frameworks/g-cloud-7/submissions/scs')
 
         assert_true(u'Service can be moved to complete' not in res.get_data(as_text=True))
         assert_in(u'1 optional question unanswered', res.get_data(as_text=True))

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -1073,6 +1073,7 @@ class TestG7ServicesList(BaseApplicationTest):
 
         count_unanswered.return_value = 0, 1
 
+        data_api_client.get_framework.return_value = self.framework(status='open')
         data_api_client.find_draft_services.return_value = {
             'services': [
                 {'serviceName': 'draft', 'lot': 'SCS', 'status': 'submitted'},

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -50,14 +50,16 @@ class TestFrameworksDashboard(BaseApplicationTest):
             data_api_client.get_framework.return_value = self.framework(status='open')
             self.login()
 
-            res = self.client.get("/suppliers/frameworks/g-cloud-7")
+        data_api_client.get_framework.return_value = self.framework(status='pending')
+        res = self.client.get("/suppliers/frameworks/g-cloud-7")
 
-            assert_equal(res.status_code, 200)
+        assert_equal(res.status_code, 200)
 
     def test_interest_registered_in_framework_on_post(self, data_api_client, s3):
         with self.app.test_client():
             self.login()
 
+            data_api_client.get_framework.return_value = self.framework(status='open')
             res = self.client.post("/suppliers/frameworks/digital-outcomes-and-specialists")
 
             assert_equal(res.status_code, 200)
@@ -71,6 +73,7 @@ class TestFrameworksDashboard(BaseApplicationTest):
         with self.app.test_client():
             self.login()
 
+            data_api_client.get_framework.return_value = self.framework(status='pending')
             res = self.client.get("/suppliers/frameworks/digital-outcomes-and-specialists")
 
             assert_equal(res.status_code, 200)
@@ -189,6 +192,7 @@ class TestFrameworksDashboard(BaseApplicationTest):
         with self.app.test_client():
             self.login()
 
+            data_api_client.get_framework.return_value = self.framework(status='open')
             res = self.client.get("/suppliers/frameworks/g-cloud-7")
             doc = html.fromstring(res.get_data(as_text=True))
             last_updateds = [
@@ -223,6 +227,7 @@ class TestFrameworksDashboard(BaseApplicationTest):
         with self.app.test_client():
             self.login()
 
+            data_api_client.get_framework.return_value = self.framework(status='open')
             res = self.client.get("/suppliers/frameworks/g-cloud-7")
             doc = html.fromstring(res.get_data(as_text=True))
             last_updateds = [
@@ -246,6 +251,7 @@ class TestFrameworksDashboard(BaseApplicationTest):
         with self.app.test_client():
             self.login()
 
+            data_api_client.get_framework.return_value = self.framework(status='open')
             res = self.client.get("/suppliers/frameworks/g-cloud-7")
             doc = html.fromstring(res.get_data(as_text=True))
             last_updateds = [
@@ -890,6 +896,7 @@ class TestSendClarificationQuestionEmail(BaseApplicationTest):
     @mock.patch('app.main.views.frameworks.data_api_client')
     @mock.patch('app.main.views.frameworks.send_email')
     def test_should_call_send_email_with_correct_params(self, send_email, data_api_client, s3):
+        data_api_client.get_framework.return_value = self.framework('open')
 
         clarification_question = 'This is a clarification question.'
         response = self._send_email(clarification_question)
@@ -906,6 +913,7 @@ class TestSendClarificationQuestionEmail(BaseApplicationTest):
     @mock.patch('app.main.views.frameworks.data_api_client')
     @mock.patch('app.main.views.frameworks.send_email')
     def test_should_call_send_g7_email_with_correct_params(self, send_email, data_api_client, s3):
+        data_api_client.get_framework.return_value = self.framework('open')
         self.app.config['FEATURE_FLAGS_G7_CLARIFICATIONS_CLOSED'] = 1
         clarification_question = 'This is a G7 question.'
         response = self._send_email(clarification_question)
@@ -922,6 +930,7 @@ class TestSendClarificationQuestionEmail(BaseApplicationTest):
     @mock.patch('app.main.views.frameworks.data_api_client')
     @mock.patch('app.main.views.frameworks.send_email')
     def test_should_create_audit_event(self, send_email, data_api_client, s3):
+        data_api_client.get_framework.return_value = self.framework('open')
         clarification_question = 'This is a clarification question'
         response = self._send_email(clarification_question)
 
@@ -939,6 +948,7 @@ class TestSendClarificationQuestionEmail(BaseApplicationTest):
     @mock.patch('app.main.views.frameworks.data_api_client')
     @mock.patch('app.main.views.frameworks.send_email')
     def test_should_create_g7_question_audit_event(self, send_email, data_api_client, s3):
+        data_api_client.get_framework.return_value = self.framework('open')
         self.app.config['FEATURE_FLAGS_G7_CLARIFICATIONS_CLOSED'] = 1
         clarification_question = 'This is a G7 question'
         response = self._send_email(clarification_question)

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -281,7 +281,8 @@ class TestEditService(BaseApplicationTest):
             'frameworkName': 'G-Cloud 6',
             'supplierId': 1234,
             'supplierName': 'We supply any',
-            'lot': 'SCS',
+            'lot': 'scs',
+            'lotName': "Specialist Cloud Services",
         }
     }
 
@@ -314,7 +315,7 @@ class TestEditService(BaseApplicationTest):
         res = self.client.post(
             '/suppliers/services/1/edit/service_attributes',
             data={
-                'lot': 'SCS',
+                'lot': 'scs',
             })
         assert_equal(res.status_code, 404)
 
@@ -454,7 +455,7 @@ class TestCreateDraftService(BaseApplicationTest):
             assert_equal(res.status_code, 302)
 
     def test_post_create_draft_service_with_lot_selected_succeeds(self, request, data_api_client):
-        request.form.get.return_value = "SCS"
+        request.form.get.return_value = "scs"
         self._test_post_create_draft_service(if_error_expected=False, data_api_client=data_api_client)
 
     def test_post_create_draft_service_without_lot_selected_fails(self, request, data_api_client):
@@ -485,7 +486,7 @@ class TestCopyDraft(BaseApplicationTest):
             'id': 1,
             'supplierId': 1234,
             'supplierName': "supplierName",
-            'lot': "SCS",
+            'lot': "scs",
             'status': "not-submitted",
             'frameworkName': "frameworkName",
             'links': {},
@@ -496,20 +497,20 @@ class TestCopyDraft(BaseApplicationTest):
         data_api_client.get_framework.return_value = self.framework(status='open')
         data_api_client.get_draft_service.return_value = {'services': self.draft}
 
-        res = self.client.post('/suppliers/frameworks/g-cloud-7/submissions/1/copy')
+        res = self.client.post('/suppliers/frameworks/g-cloud-7/submissions/scs/1/copy')
         assert_equal(res.status_code, 302)
 
     def test_copy_draft_checks_supplier_id(self, data_api_client):
         self.draft['supplierId'] = 2
         data_api_client.get_draft_service.return_value = {'services': self.draft}
 
-        res = self.client.post('/suppliers/frameworks/g-cloud-7/submissions/1/copy')
+        res = self.client.post('/suppliers/frameworks/g-cloud-7/submissions/scs/1/copy')
         assert_equal(res.status_code, 404)
 
     def test_cannot_copy_draft_if_not_open(self, data_api_client):
         data_api_client.get_framework.return_value = self.framework(status='other')
 
-        res = self.client.post('/suppliers/frameworks/g-cloud-7/submissions/1/copy')
+        res = self.client.post('/suppliers/frameworks/g-cloud-7/submissions/scs/1/copy')
         assert_equal(res.status_code, 404)
 
 
@@ -526,7 +527,7 @@ class TestCompleteDraft(BaseApplicationTest):
             'id': 1,
             'supplierId': 1234,
             'supplierName': "supplierName",
-            'lot': "SCS",
+            'lot': "scs",
             'status': "not-submitted",
             'frameworkName': "frameworkName",
             'links': {},
@@ -537,7 +538,7 @@ class TestCompleteDraft(BaseApplicationTest):
         data_api_client.get_framework.return_value = self.framework(status='open')
         data_api_client.get_draft_service.return_value = {'services': self.draft}
 
-        res = self.client.post('/suppliers/frameworks/g-cloud-7/submissions/1/complete')
+        res = self.client.post('/suppliers/frameworks/g-cloud-7/submissions/scs/1/complete')
         assert_equal(res.status_code, 302)
         assert_true('lot=scs' in res.location)
         assert_true('service_completed=1' in res.location)
@@ -547,13 +548,13 @@ class TestCompleteDraft(BaseApplicationTest):
         self.draft['supplierId'] = 2
         data_api_client.get_draft_service.return_value = {'services': self.draft}
 
-        res = self.client.post('/suppliers/frameworks/g-cloud-7/submissions/1/complete')
+        res = self.client.post('/suppliers/frameworks/g-cloud-7/submissions/scs/1/complete')
         assert_equal(res.status_code, 404)
 
     def test_cannot_complete_draft_if_not_open(self, data_api_client):
         data_api_client.get_framework.return_value = self.framework(status='other')
 
-        res = self.client.post('/suppliers/frameworks/g-cloud-7/submissions/1/complete')
+        res = self.client.post('/suppliers/frameworks/g-cloud-7/submissions/scs/1/complete')
         assert_equal(res.status_code, 404)
 
 
@@ -566,7 +567,7 @@ class TestEditDraftService(BaseApplicationTest):
             'id': 1,
             'supplierId': 1234,
             'supplierName': "supplierName",
-            'lot': "SCS",
+            'lot': "scs",
             'status': "not-submitted",
             'frameworkSlug': 'g-slug',
             'frameworkName': "frameworkName",
@@ -584,7 +585,7 @@ class TestEditDraftService(BaseApplicationTest):
         data_api_client.get_framework.return_value = self.framework(status='open')
         data_api_client.get_draft_service.return_value = self.empty_draft
         res = self.client.post(
-            '/suppliers/frameworks/g-cloud-7/submissions/1/edit/service_description',
+            '/suppliers/frameworks/g-cloud-7/submissions/scs/1/edit/service_description',
             data={
                 'serviceSummary': 'This is the service',
             })
@@ -604,7 +605,7 @@ class TestEditDraftService(BaseApplicationTest):
         data_api_client.get_draft_service.return_value = {'services': draft}
 
         res = self.client.post(
-            '/suppliers/frameworks/g-cloud-7/submissions/1/edit/service_description',
+            '/suppliers/frameworks/g-cloud-7/submissions/scs/1/edit/service_description',
             data={
                 'serviceSummary': u"summary",
             })
@@ -618,7 +619,7 @@ class TestEditDraftService(BaseApplicationTest):
         data_api_client.get_framework.return_value = self.framework(status='open')
         data_api_client.get_draft_service.return_value = self.empty_draft
         res = self.client.post(
-            '/suppliers/frameworks/g-cloud-7/submissions/1/edit/service_description',
+            '/suppliers/frameworks/g-cloud-7/submissions/scs/1/edit/service_description',
             data={
                 'serviceSummary': 'This is the service',
             })
@@ -629,14 +630,14 @@ class TestEditDraftService(BaseApplicationTest):
     def test_editing_readonly_section_is_not_allowed(self, data_api_client, s3):
         data_api_client.get_draft_service.return_value = self.empty_draft
 
-        res = self.client.get('/suppliers/frameworks/g-cloud-7/submissions/1/edit/service_attributes')
+        res = self.client.get('/suppliers/frameworks/g-cloud-7/submissions/scs/1/edit/service_attributes')
         assert_equal(res.status_code, 404)
 
         data_api_client.get_draft_service.return_value = self.empty_draft
         res = self.client.post(
-            '/suppliers/frameworks/g-cloud-7/submissions/1/edit/service_attributes',
+            '/suppliers/frameworks/g-cloud-7/submissions/scs/1/edit/service_attributes',
             data={
-                'lot': 'SCS',
+                'lot': 'scs',
             })
         assert_equal(res.status_code, 404)
 
@@ -644,7 +645,7 @@ class TestEditDraftService(BaseApplicationTest):
         data_api_client.get_framework.return_value = self.framework(status='other')
         data_api_client.get_draft_service.return_value = self.empty_draft
         res = self.client.post(
-            '/suppliers/frameworks/g-cloud-7/submissions/1/edit/service_description',
+            '/suppliers/frameworks/g-cloud-7/submissions/scs/1/edit/service_description',
             data={
                 'serviceSummary': 'This is the service',
             })
@@ -654,7 +655,7 @@ class TestEditDraftService(BaseApplicationTest):
         data_api_client.get_framework.return_value = self.framework(status='open')
         data_api_client.get_draft_service.return_value = self.empty_draft
         res = self.client.post(
-            '/suppliers/frameworks/g-cloud-7/submissions/1/edit/service_description',
+            '/suppliers/frameworks/g-cloud-7/submissions/scs/1/edit/service_description',
             data={
                 'serviceFeatures': '',
             })
@@ -671,7 +672,7 @@ class TestEditDraftService(BaseApplicationTest):
         data_api_client.get_framework.return_value = self.framework(status='open')
         data_api_client.get_draft_service.return_value = draft
         response = self.client.get(
-            '/suppliers/frameworks/g-cloud-7/submissions/1/edit/service_definition'
+            '/suppliers/frameworks/g-cloud-7/submissions/scs/1/edit/service_definition'
         )
         document = html.fromstring(response.get_data(as_text=True))
 
@@ -682,7 +683,7 @@ class TestEditDraftService(BaseApplicationTest):
         data_api_client.get_framework.return_value = self.framework(status='open')
         data_api_client.get_draft_service.return_value = self.empty_draft
         response = self.client.get(
-            '/suppliers/frameworks/g-cloud-7/submissions/1/edit/service_definition'
+            '/suppliers/frameworks/g-cloud-7/submissions/scs/1/edit/service_definition'
         )
         document = html.fromstring(response.get_data(as_text=True))
 
@@ -694,7 +695,7 @@ class TestEditDraftService(BaseApplicationTest):
         data_api_client.get_draft_service.return_value = self.empty_draft
         with freeze_time('2015-01-02 03:04:05'):
             res = self.client.post(
-                '/suppliers/frameworks/g-cloud-7/submissions/1/edit/service_definition',
+                '/suppliers/frameworks/g-cloud-7/submissions/scs/1/edit/service_definition',
                 data={
                     'serviceDefinitionDocumentURL': (StringIO(b'doc'), 'document.pdf'),
                 }
@@ -717,7 +718,7 @@ class TestEditDraftService(BaseApplicationTest):
         data_api_client.get_framework.return_value = self.framework(status='open')
         data_api_client.get_draft_service.return_value = self.empty_draft
         res = self.client.post(
-            '/suppliers/frameworks/g-cloud-7/submissions/1/edit/service_definition',
+            '/suppliers/frameworks/g-cloud-7/submissions/scs/1/edit/service_definition',
             data={
                 'serviceDefinitionDocumentURL': (StringIO(b''), 'document.pdf'),
                 'unknownDocumentURL': (StringIO(b'doc'), 'document.pdf'),
@@ -736,7 +737,7 @@ class TestEditDraftService(BaseApplicationTest):
         data_api_client.get_framework.return_value = self.framework(status='open')
         data_api_client.get_draft_service.return_value = self.empty_draft
         res = self.client.post(
-            '/suppliers/frameworks/g-cloud-7/submissions/1/edit/service_definition',
+            '/suppliers/frameworks/g-cloud-7/submissions/scs/1/edit/service_definition',
             data={
                 'serviceDefinitionDocumentURL': 'http://example.com/document.pdf',
             })
@@ -751,7 +752,7 @@ class TestEditDraftService(BaseApplicationTest):
         data_api_client.get_framework.return_value = self.framework(status='open')
         data_api_client.get_draft_service.return_value = self.empty_draft
         res = self.client.post(
-            '/suppliers/frameworks/g-cloud-7/submissions/1/edit/pricing',
+            '/suppliers/frameworks/g-cloud-7/submissions/scs/1/edit/pricing',
             data={
                 'priceString': ["10.10", "11.10", "Person", "Second"],
             })
@@ -770,14 +771,14 @@ class TestEditDraftService(BaseApplicationTest):
 
     def test_edit_non_existent_draft_service_returns_404(self, data_api_client, s3):
         data_api_client.get_draft_service.side_effect = HTTPError(mock.Mock(status_code=404))
-        res = self.client.get('/suppliers/frameworks/g-cloud-7/submissions/1/edit/service_description')
+        res = self.client.get('/suppliers/frameworks/g-cloud-7/submissions/scs/1/edit/service_description')
 
         assert_equal(res.status_code, 404)
 
     def test_edit_non_existent_draft_section_returns_404(self, data_api_client, s3):
         data_api_client.get_draft_service.return_value = self.empty_draft
         res = self.client.get(
-            '/suppliers/frameworks/g-cloud-7/submissions/1/edit/invalid_section'
+            '/suppliers/frameworks/g-cloud-7/submissions/scs/1/edit/invalid_section'
         )
         assert_equal(404, res.status_code)
 
@@ -787,13 +788,13 @@ class TestEditDraftService(BaseApplicationTest):
         data_api_client.update_draft_service.return_value = None
 
         res = self.client.post(
-            '/suppliers/frameworks/g-cloud-7/submissions/1/edit/service_description',
+            '/suppliers/frameworks/g-cloud-7/submissions/scs/1/edit/service_description',
             data={
                 'continue_to_next_section': 'Save and continue'
             })
 
         assert_equal(302, res.status_code)
-        assert_equal('http://localhost/suppliers/frameworks/g-cloud-7/submissions/1/edit/service_type',
+        assert_equal('http://localhost/suppliers/frameworks/g-cloud-7/submissions/scs/1/edit/service_type',
                      res.headers['Location'])
 
     def test_update_redirects_to_edit_submission_if_no_next_editable_section(self, data_api_client, s3):
@@ -802,12 +803,11 @@ class TestEditDraftService(BaseApplicationTest):
         data_api_client.update_draft_service.return_value = None
 
         res = self.client.post(
-            '/suppliers/frameworks/g-cloud-7/submissions/1/edit/sfia_rate_card',
+            '/suppliers/frameworks/g-cloud-7/submissions/scs/1/edit/sfia_rate_card',
             data={})
 
         assert_equal(302, res.status_code)
-        assert_equal('http://localhost/suppliers/frameworks/g-cloud-7/submissions/1',
-                     res.headers['Location'])
+        assert_equal('http://localhost/suppliers/frameworks/g-cloud-7/submissions/scs/1', res.headers['Location'])
 
     def test_update_redirects_to_edit_submission_if_return_to_summary(self, data_api_client, s3):
         data_api_client.get_framework.return_value = self.framework(status='open')
@@ -815,12 +815,11 @@ class TestEditDraftService(BaseApplicationTest):
         data_api_client.update_draft_service.return_value = None
 
         res = self.client.post(
-            '/suppliers/frameworks/g-cloud-7/submissions/1/edit/service_description?return_to_summary=1',
+            '/suppliers/frameworks/g-cloud-7/submissions/scs/1/edit/service_description?return_to_summary=1',
             data={})
 
         assert_equal(302, res.status_code)
-        assert_equal('http://localhost/suppliers/frameworks/g-cloud-7/submissions/1',
-                     res.headers['Location'])
+        assert_equal('http://localhost/suppliers/frameworks/g-cloud-7/submissions/scs/1', res.headers['Location'])
 
     def test_update_redirects_to_edit_submission_if_grey_button_clicked(self, data_api_client, s3):
         data_api_client.get_framework.return_value = self.framework(status='open')
@@ -828,12 +827,11 @@ class TestEditDraftService(BaseApplicationTest):
         data_api_client.update_draft_service.return_value = None
 
         res = self.client.post(
-            '/suppliers/frameworks/g-cloud-7/submissions/1/edit/service_description',
+            '/suppliers/frameworks/g-cloud-7/submissions/scs/1/edit/service_description',
             data={})
 
         assert_equal(302, res.status_code)
-        assert_equal('http://localhost/suppliers/frameworks/g-cloud-7/submissions/1',
-                     res.headers['Location'])
+        assert_equal('http://localhost/suppliers/frameworks/g-cloud-7/submissions/scs/1', res.headers['Location'])
 
     def test_update_with_answer_required_error(self, data_api_client, s3):
         data_api_client.get_framework.return_value = self.framework(status='open')
@@ -842,7 +840,7 @@ class TestEditDraftService(BaseApplicationTest):
             mock.Mock(status_code=400),
             {'serviceSummary': 'answer_required'})
         res = self.client.post(
-            '/suppliers/frameworks/g-cloud-7/submissions/1/edit/service_description',
+            '/suppliers/frameworks/g-cloud-7/submissions/scs/1/edit/service_description',
             data={})
 
         assert_equal(res.status_code, 200)
@@ -858,7 +856,7 @@ class TestEditDraftService(BaseApplicationTest):
             mock.Mock(status_code=400),
             {'serviceSummary': 'under_50_words'})
         res = self.client.post(
-            '/suppliers/frameworks/g-cloud-7/submissions/1/edit/service_description',
+            '/suppliers/frameworks/g-cloud-7/submissions/scs/1/edit/service_description',
             data={})
 
         assert_equal(res.status_code, 200)
@@ -883,7 +881,7 @@ class TestEditDraftService(BaseApplicationTest):
                 mock.Mock(status_code=400),
                 {field: error})
             res = self.client.post(
-                '/suppliers/frameworks/g-cloud-7/submissions/1/edit/pricing',
+                '/suppliers/frameworks/g-cloud-7/submissions/scs/1/edit/pricing',
                 data={})
 
             assert_equal(res.status_code, 200)
@@ -893,14 +891,14 @@ class TestEditDraftService(BaseApplicationTest):
 
     def test_update_non_existent_draft_service_returns_404(self, data_api_client, s3):
         data_api_client.get_draft_service.side_effect = HTTPError(mock.Mock(status_code=404))
-        res = self.client.post('/suppliers/frameworks/g-cloud-7/submissions/1/edit/service_description')
+        res = self.client.post('/suppliers/frameworks/g-cloud-7/submissions/scs/1/edit/service_description')
 
         assert_equal(res.status_code, 404)
 
     def test_update_non_existent_draft_section_returns_404(self, data_api_client, s3):
         data_api_client.get_draft_service.return_value = self.empty_draft
         res = self.client.post(
-            '/suppliers/frameworks/g-cloud-7/submissions/1/edit/invalid_section'
+            '/suppliers/frameworks/g-cloud-7/submissions/scs/1/edit/invalid_section'
         )
         assert_equal(404, res.status_code)
 
@@ -913,7 +911,7 @@ class TestShowDraftService(BaseApplicationTest):
             'id': 1,
             'supplierId': 1234,
             'supplierName': "supplierName",
-            'lot': "SCS",
+            'lot': "scs",
             'status': "not-submitted",
             'frameworkName': "frameworkName",
             'priceMin': '12.50',
@@ -942,7 +940,7 @@ class TestShowDraftService(BaseApplicationTest):
     def test_service_price_is_correctly_formatted(self, data_api_client):
         data_api_client.get_framework.return_value = self.framework('open')
         data_api_client.get_draft_service.return_value = self.draft_service
-        res = self.client.get('/suppliers/frameworks/g-cloud-7/submissions/1')
+        res = self.client.get('/suppliers/frameworks/g-cloud-7/submissions/scs/1')
         document = html.fromstring(res.get_data(as_text=True))
 
         assert_equal(res.status_code, 200)
@@ -957,7 +955,7 @@ class TestShowDraftService(BaseApplicationTest):
         data_api_client.get_framework.return_value = self.framework(status='open')
         data_api_client.get_draft_service.return_value = self.draft_service
         count_unanswered.return_value = 1, 2
-        res = self.client.get('/suppliers/frameworks/g-cloud-7/submissions/1')
+        res = self.client.get('/suppliers/frameworks/g-cloud-7/submissions/scs/1')
 
         assert_true(u'3 unanswered questions' in res.get_data(as_text=True),
                     "'3 unanswered questions' not found in html")
@@ -967,7 +965,7 @@ class TestShowDraftService(BaseApplicationTest):
         data_api_client.get_framework.return_value = self.framework(status='open')
         data_api_client.get_draft_service.return_value = self.draft_service
         count_unanswered.return_value = 0, 1
-        res = self.client.get('/suppliers/frameworks/g-cloud-7/submissions/1')
+        res = self.client.get('/suppliers/frameworks/g-cloud-7/submissions/scs/1')
 
         assert_in(u'1 optional question unanswered', res.get_data(as_text=True))
         assert_in(u'<input type="submit" class="button-save"  value="Mark as complete" />',
@@ -978,7 +976,7 @@ class TestShowDraftService(BaseApplicationTest):
         data_api_client.get_framework.return_value = self.framework(status='other')
         data_api_client.get_draft_service.return_value = self.draft_service
         count_unanswered.return_value = 0, 1
-        res = self.client.get('/suppliers/frameworks/g-cloud-7/submissions/1')
+        res = self.client.get('/suppliers/frameworks/g-cloud-7/submissions/scs/1')
 
         assert_not_in(u'<input type="submit" class="button-save"  value="Mark as complete" />',
                       res.get_data(as_text=True))
@@ -988,7 +986,7 @@ class TestShowDraftService(BaseApplicationTest):
         data_api_client.get_framework.return_value = self.framework(status='pending')
         data_api_client.get_draft_service.return_value = self.draft_service
         count_unanswered.return_value = 3, 1
-        res = self.client.get('/suppliers/frameworks/g-cloud-7/submissions/1')
+        res = self.client.get('/suppliers/frameworks/g-cloud-7/submissions/scs/1')
 
         doc = html.fromstring(res.get_data(as_text=True))
         message = doc.xpath('//aside[@class="temporary-message"]')
@@ -1004,7 +1002,7 @@ class TestShowDraftService(BaseApplicationTest):
         data_api_client.get_framework.return_value = self.framework(status='pending')
         data_api_client.get_draft_service.return_value = self.complete_service
         count_unanswered.return_value = 0, 1
-        res = self.client.get('/suppliers/frameworks/g-cloud-7/submissions/2')
+        res = self.client.get('/suppliers/frameworks/g-cloud-7/submissions/scs/2')
 
         doc = html.fromstring(res.get_data(as_text=True))
         message = doc.xpath('//aside[@class="temporary-message"]')
@@ -1024,7 +1022,8 @@ class TestDeleteDraftService(BaseApplicationTest):
             'id': 1,
             'supplierId': 1234,
             'supplierName': "supplierName",
-            'lot': "SCS",
+            'lot': "scs",
+            'lotName': "Specialist Cloud Services",
             'status': "not-submitted",
             'frameworkSlug': 'g-slug',
             'frameworkName': "frameworkName",
@@ -1048,14 +1047,11 @@ class TestDeleteDraftService(BaseApplicationTest):
         data_api_client.get_framework.return_value = self.framework(status='open')
         data_api_client.get_draft_service.return_value = self.draft_to_delete
         res = self.client.post(
-            '/suppliers/frameworks/g-cloud-7/submissions/1/delete',
+            '/suppliers/frameworks/g-cloud-7/submissions/scs/1/delete',
             data={})
         assert_equal(res.status_code, 302)
-        assert_equal(
-            res.location,
-            'http://localhost/suppliers/frameworks/g-cloud-7/submissions/1?delete_requested=True'
-        )
-        res2 = self.client.get('/suppliers/frameworks/g-cloud-7/submissions/1?delete_requested=True')
+        assert_in('/frameworks/g-cloud-7/submissions/scs/1?delete_requested=True', res.location)
+        res2 = self.client.get('/suppliers/frameworks/g-cloud-7/submissions/scs/1?delete_requested=True')
         assert_in(
             b"Are you sure you want to delete this service?", res2.get_data()
         )
@@ -1064,7 +1060,7 @@ class TestDeleteDraftService(BaseApplicationTest):
         data_api_client.get_framework.return_value = self.framework(status='other')
         data_api_client.get_draft_service.return_value = self.draft_to_delete
         res = self.client.post(
-            '/suppliers/frameworks/g-cloud-7/submissions/1/delete',
+            '/suppliers/frameworks/g-cloud-7/submissions/scs/1/delete',
             data={})
         assert_equal(res.status_code, 404)
 
@@ -1072,7 +1068,7 @@ class TestDeleteDraftService(BaseApplicationTest):
         data_api_client.get_framework.return_value = self.framework(status='open')
         data_api_client.get_draft_service.return_value = self.draft_to_delete
         res = self.client.post(
-            '/suppliers/frameworks/g-cloud-7/submissions/1/delete',
+            '/suppliers/frameworks/g-cloud-7/submissions/scs/1/delete',
             data={'delete_confirmed': 'true'})
 
         data_api_client.delete_draft_service.assert_called_with('1', 'email@email.com')
@@ -1087,7 +1083,7 @@ class TestDeleteDraftService(BaseApplicationTest):
         other_draft['services']['supplierId'] = 12345
         data_api_client.get_draft_service.return_value = other_draft
         res = self.client.post(
-            '/suppliers/frameworks/g-cloud-7/submissions/1/delete',
+            '/suppliers/frameworks/g-cloud-7/submissions/scs/1/delete',
             data={'delete_confirmed': 'true'})
 
         assert_equal(res.status_code, 404)

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -542,7 +542,7 @@ class TestCompleteDraft(BaseApplicationTest):
         assert_equal(res.status_code, 302)
         assert_true('lot=scs' in res.location)
         assert_true('service_completed=1' in res.location)
-        assert_true('/suppliers/frameworks/g-cloud-7/services' in res.location)
+        assert_in('/suppliers/frameworks/g-cloud-7/submissions', res.location)
 
     def test_complete_draft_checks_supplier_id(self, data_api_client):
         self.draft['supplierId'] = 2
@@ -1073,10 +1073,7 @@ class TestDeleteDraftService(BaseApplicationTest):
 
         data_api_client.delete_draft_service.assert_called_with('1', 'email@email.com')
         assert_equal(res.status_code, 302)
-        assert_equal(
-            res.location,
-            'http://localhost/suppliers/frameworks/g-cloud-7/services'
-        )
+        assert_equal(res.location, 'http://localhost/suppliers/frameworks/g-cloud-7/submissions')
 
     def test_cannot_delete_other_suppliers_draft(self, data_api_client):
         other_draft = copy.deepcopy(self.draft_to_delete)

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -1073,7 +1073,7 @@ class TestDeleteDraftService(BaseApplicationTest):
 
         data_api_client.delete_draft_service.assert_called_with('1', 'email@email.com')
         assert_equal(res.status_code, 302)
-        assert_equal(res.location, 'http://localhost/suppliers/frameworks/g-cloud-7/submissions')
+        assert_equal(res.location, 'http://localhost/suppliers/frameworks/g-cloud-7/submissions/scs')
 
     def test_cannot_delete_other_suppliers_draft(self, data_api_client):
         other_draft = copy.deepcopy(self.draft_to_delete)

--- a/tests/app/main/test_suppliers.py
+++ b/tests/app/main/test_suppliers.py
@@ -255,7 +255,7 @@ class TestSuppliersDashboard(BaseApplicationTest):
     @mock.patch("app.main.views.suppliers.data_api_client")
     @mock.patch("app.main.views.suppliers.get_current_suppliers_users")
     def test_shows_register_for_dos_button(self, get_current_suppliers_users, data_api_client):
-        data_api_client.get_framework_status.return_value = {'status': 'open'}
+        data_api_client.get_framework.return_value = self.framework(status='other')
         data_api_client.get_supplier.side_effect = get_supplier
         data_api_client.find_frameworks.return_value = {
             "frameworks": [
@@ -279,7 +279,7 @@ class TestSuppliersDashboard(BaseApplicationTest):
     @mock.patch("app.main.views.suppliers.data_api_client")
     @mock.patch("app.main.views.suppliers.get_current_suppliers_users")
     def test_shows_continue_with_dos_link(self, get_current_suppliers_users, data_api_client):
-        data_api_client.get_framework_status.return_value = {'status': 'open'}
+        data_api_client.get_framework.return_value = self.framework(status='other')
         data_api_client.get_supplier.side_effect = get_supplier
         data_api_client.get_framework_interest.return_value = {'frameworks': ['digital-outcomes-and-specialists']}
         data_api_client.find_frameworks.return_value = {


### PR DESCRIPTION
Requires:
- [x] https://github.com/alphagov/digitalmarketplace-api/pull/281
- [x] https://github.com/alphagov/digitalmarketplace-frameworks/pull/110

### Add service submission page with a list of framework lots
Splits framework services into two pages: list of lots and individual
lot pages with lot services.

Both pages are only displayed if framework status is either open or
pending. For pending frameworks page is only displayed to suppliers
who have submitted an application. Feature flag check is removed.

Lot pages check the 'one service limit' flag and:

* Display the list of lot services for lots with multiple services.
  This is similar to the previous submission services page, except
  the services are filtered by lot.

* For one service lots: creates the service for given lot and supplier
  if it doesn't exist and redirects to the service page right away.

Note: creating an empty draft for one-service lots is an action taken
as a result of a GET request (which are not covered by the CSRF
protection), but this is the only approach we have given the current
design of the lots page.

### Rewrite draft create page to use the first manifest section
Since draft lot is set as part of the URL the first service submission
page can be different for each lot.

The draft creation endpoint will look up the first editable section for
the given lot and use the submitted form data to create the draft service,
similar to how draft updates work at the moment: data is sent to the API
with a list of page questions to validate required answers, any API errors
returned are displayed on the form page, otherwise the draft is created
and user is redirected to the new draft page.

`create_new_draft_service` calls are updated with the breaking changes
in dmutils 12.0.0.

### Add lot slug to service submission URLs
Moves all draft-related endpoints to new URLs that include lot slugs
and updates the tests with lowercase lots, lot names and new URLs.

On redirects and in template links lot_slug is taken from service
data, so while it's not validated right now in most endpoints, if
the initial lot slug doesn't match the service the redirect or link
click will route to the correct lot URL.

#### Remove remaining uses of get_framework_status
`get_framework_status` was replaced with `get_framework` in most
calls, the only remaining instances were in unused helper function
and test mocks that were patching the wrong method.

With this change `get_framework_status` is no longer used by the
supplier frontend and both dmutils.apiclient method and the API
endpoint could be removed.

#### Replace GCLOUD7_OPEN with framework status checks
Adds `get_framework` helper to get framework data from the API and
check that status is 'open' if called with `open_only=True` or
either 'open' or 'pending' if `open_only=False`.

Also adds lot_slug checks by looking up the lot slug in framework
lots.

If framework is in a different state or lot doesn't exist returns
404.

Document redirect URLs are currently not covered by framework checks.

#### Don't filter services without serviceName
With removal of the lot selection form draft creation starts with
the first editable section, which should be serviceName for g-cloud
and listed services, so there's no need to filter drafts without a
service name.

#### Use lot name fallback for services without serviceName
One-per-lot services don't have a serviceName field, so we use
lot name instead.