### PR TITLE
Remove markdown package and filter definition.

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,6 +1,6 @@
 import re
 
-from flask import Flask, request, redirect, session, Markup, abort
+from flask import Flask, request, redirect, session, abort
 from flask_login import LoginManager
 from flask_wtf.csrf import CsrfProtect
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,8 +6,6 @@ werkzeug==0.10.4
 git+https://github.com/madzak/python-json-logger.git@v0.1.3#egg=python-json-logger==v0.1.3
 git+https://github.com/alphagov/digitalmarketplace-utils.git@11.4.0#egg=digitalmarketplace-utils==11.4.0
 
-markdown==2.6.2
-
 # Required for SNI to work in requests
 pyOpenSSL==0.14
 ndg-httpsclient==0.3.3


### PR DESCRIPTION
As part of [an earlier pull request](https://github.com/alphagov/digitalmarketplace-utils/pull/192), a markdown filter was added to flask apps that import dmutils.

Means we can still use the `markdown` filter in our jinja2 templates, but we shouldn't be duplicating it in the `create_app` function.

*Might* have forgotten to do this earlier.