### PR TITLE
Refactored framework validation to make it modular

### DIFF
--- a/app/main/__init__.py
+++ b/app/main/__init__.py
@@ -17,5 +17,5 @@ def add_cache_control(response):
     return response
 
 
-from . import errors
 from .views import services, suppliers, login, frameworks, users
+from . import errors

--- a/app/main/helpers/frameworks.py
+++ b/app/main/helpers/frameworks.py
@@ -1,20 +1,8 @@
+import re
+
 from flask import abort
 from flask_login import current_user
 from dmutils.apiclient import APIError
-import re
-from operator import add
-from functools import reduce
-import six
-from werkzeug.datastructures import ImmutableOrderedMultiDict
-
-
-EMAIL_REGEX = r'^[^@^\s]+@[^@^\.^\s]+(\.[^@^\.^\s]+)+$'
-TEXT_FIELD_CHARACTER_LIMIT = 5000
-OPTIONAL_FIELDS = set([
-    "SQ1-1p-i", "SQ1-1p-ii", "SQ1-1p-iii", "SQ1-1p-iv",
-    "SQ1-1q-i", "SQ1-1q-ii", "SQ1-1q-iii", "SQ1-1q-iv", "SQ1-1cii", "SQ1-1i-ii",
-    "SQ1-1j-i", "SQ1-1j-ii", "SQ4-1c", "SQ3-1k", "SQ1-1i-i"
-])
 
 
 def get_framework(client, framework_slug, open_only=True):
@@ -61,129 +49,6 @@ def get_last_modified_from_first_matching_file(key_list, path_starts_with):
     :return: the timestamp of the first matching file key or None
     """
     return next((key for key in key_list if key.get('path').startswith(path_starts_with)), {}).get('last_modified')
-
-
-def get_required_fields(all_fields, answers):
-    required_fields = set(all_fields)
-    #  Remove optional fields
-    required_fields -= OPTIONAL_FIELDS
-
-    #  If you answered other to question 19 (trading status)
-    if answers.get('SQ1-1ci') == 'other (please specify)':
-        required_fields.add('SQ1-1cii')
-
-    #  If you answered yes to question 27 (non-UK business registered in EU)
-    if answers.get('SQ1-1i-i', False):
-        required_fields.add('SQ1-1i-ii')
-
-    #  If you answered 'licensed' or 'a member of a relevant organisation' in question 29
-    answer_29 = answers.get('SQ1-1j-i', [])
-    if len(answer_29) > 0 and \
-            ('licensed' in answer_29 or 'a member of a relevant organisation' in answer_29):
-            required_fields.add('SQ1-1j-ii')
-
-    # If you answered yes to either question 53 or 54 (tax returns)
-    if answers.get('SQ4-1a', False) or answers.get('SQ4-1b', False):
-        required_fields.add('SQ4-1c')
-
-    # If you answered Yes to questions 39 - 51 (discretionary exclusion)
-    dependent_fields = [
-        'SQ2-2a', 'SQ3-1a', 'SQ3-1b', 'SQ3-1c', 'SQ3-1d', 'SQ3-1e', 'SQ3-1f', 'SQ3-1g',
-        'SQ3-1h-i', 'SQ3-1h-ii', 'SQ3-1i-i', 'SQ3-1i-ii', 'SQ3-1j'
-    ]
-    if any(answers.get(field) for field in dependent_fields):
-        required_fields.add('SQ3-1k')
-
-    # If you answered No to question 26 (established in the UK)
-    if 'SQ5-2a' in answers and not answers['SQ5-2a']:
-        required_fields.add('SQ1-1i-i')
-        required_fields.add('SQ1-1j-i')
-
-    return required_fields
-
-
-def get_all_fields(content):
-    return reduce(add, (section.get_question_ids() for section in content))
-
-
-def get_fields_with_values(answers):
-    return set(key for key, value in answers.items()
-               # empty list types will not be included so only string types need to be considered
-               if not isinstance(value, six.string_types) or len(value) > 0)
-
-
-def get_answer_required_errors(content, answers):
-    required_fields = get_required_fields(content, answers)
-    fields_with_values = get_fields_with_values(answers)
-    errors_map = {}
-
-    for field in required_fields - fields_with_values:
-        errors_map[field] = 'answer_required'
-
-    return errors_map
-
-
-def get_character_limit_errors(content, answers):
-    errors_map = {}
-    for question_id in get_all_fields(content):
-        if content.get_question(question_id).get('type') in ['text', 'textbox_large']:
-            if len(answers.get(question_id, "")) > TEXT_FIELD_CHARACTER_LIMIT:
-                errors_map[question_id] = "under_character_limit"
-
-    return errors_map
-
-
-def get_formatting_errors(answers):
-    errors_map = {}
-    if not re.match(EMAIL_REGEX, answers.get('SQ1-1o', '')):
-        errors_map['SQ1-1o'] = 'invalid_format'
-    if not re.match(EMAIL_REGEX, answers.get('SQ1-2b', '')):
-        errors_map['SQ1-2b'] = 'invalid_format'
-    return errors_map
-
-
-def get_error_message(content, question_id, message_key):
-    for validation in content.get_question(question_id).get('validations', []):
-        if validation['name'] == message_key:
-            return validation['message']
-    default_messages = {
-        'answer_required': 'Answer required'
-    }
-    return default_messages.get(
-        message_key, 'There was a problem with the answer to this question')
-
-
-def get_all_errors(content, answers):
-    all_fields = set(get_all_fields(content))
-    errors_map = {}
-
-    errors_map.update(get_character_limit_errors(content, answers))
-    errors_map.update(get_formatting_errors(answers))
-    errors_map.update(get_answer_required_errors(all_fields, answers))
-
-    return errors_map
-
-
-def get_error_messages(content, answers):
-    raw_errors_map = get_all_errors(content, answers)
-    errors_map = list()
-    for question_number, question_id in enumerate(get_all_fields(content)):
-        if question_id in raw_errors_map:
-            validation_message = get_error_message(content, question_id, raw_errors_map[question_id])
-            errors_map.append((question_id, {
-                'input_name': question_id,
-                'question': "Question {}".format(question_number + 1),
-                'message': validation_message,
-            }))
-
-    return errors_map
-
-
-def get_error_messages_for_page(content, answers, section):
-    all_errors = get_error_messages(content, answers)
-    page_ids = section.get_question_ids()
-    page_errors = ImmutableOrderedMultiDict(filter(lambda err: err[0] in page_ids, all_errors))
-    return page_errors
 
 
 def get_first_question_index(content, section):

--- a/app/main/helpers/validation.py
+++ b/app/main/helpers/validation.py
@@ -1,0 +1,169 @@
+from functools import reduce
+from operator import add
+import re
+import six
+from werkzeug.datastructures import ImmutableOrderedMultiDict
+
+EMAIL_REGEX = r'^[^@^\s]+@[^@^\.^\s]+(\.[^@^\.^\s]+)+$'
+
+
+def get_validator(framework, content, answers):
+    """
+    Retrieves a validator by slug contained in the framework dictionary.
+    """
+    if framework is None:
+        raise ValueError("a framework dictionary must be provided")
+    if framework is not None:
+        validator_cls = VALIDATORS.get(framework['slug'])
+        return validator_cls(content, answers)
+
+
+class DeclarationValidator(object):
+    email_validation_fields = []
+    character_limit = None
+    optional_fields = set([])
+
+    def __init__(self, content, answers):
+        self.content = content
+        self.answers = answers
+
+    def get_error_messages_for_page(self, section):
+        all_errors = self.get_error_messages()
+        page_ids = section.get_question_ids()
+        page_errors = ImmutableOrderedMultiDict(filter(lambda err: err[0] in page_ids, all_errors))
+        return page_errors
+
+    def get_error_messages(self):
+        raw_errors_map = self.errors()
+        errors_map = list()
+        for question_number, question_id in enumerate(self.all_fields()):
+            if question_id in raw_errors_map:
+                validation_message = self.get_error_message(question_id, raw_errors_map[question_id])
+                errors_map.append((question_id, {
+                    'input_name': question_id,
+                    'question': "Question {}".format(question_number + 1),
+                    'message': validation_message,
+                }))
+
+        return errors_map
+
+    def get_error_message(self, question_id, message_key):
+        for validation in self.content.get_question(question_id).get('validations', []):
+            if validation['name'] == message_key:
+                return validation['message']
+        default_messages = {
+            'answer_required': 'Answer required'
+        }
+        return default_messages.get(
+            message_key, 'There was a problem with the answer to this question')
+
+    def errors(self):
+        raise NotImplementedError("only a subclass should be used")
+
+    def all_fields(self):
+        return reduce(add, (section.get_question_ids() for section in self.content))
+
+    def fields_with_values(self):
+        # empty list types will not be included so only string types need to be considered
+        return set(key for key, value in self.answers.items()
+                   if not isinstance(value, six.string_types) or len(value) > 0)
+
+    def errors(self):
+        errors_map = {}
+        errors_map.update(self.character_limit_errors())
+        errors_map.update(self.formatting_errors(self.answers))
+        errors_map.update(self.answer_required_errors())
+        return errors_map
+
+    def answer_required_errors(self):
+        req_fields = self.get_required_fields()
+        filled_fields = self.fields_with_values()
+        errors_map = {}
+
+        for field in req_fields - filled_fields:
+            errors_map[field] = 'answer_required'
+
+        return errors_map
+
+    def character_limit_errors(self):
+        errors_map = {}
+        for question_id in self.all_fields():
+            if self.content.get_question(question_id).get('type') in ['text', 'textbox_large']:
+                answer_length = len(self.answers.get(question_id, ""))
+                if self.character_limit is not None and answer_length > self.character_limit:
+                    errors_map[question_id] = "under_character_limit"
+
+        return errors_map
+
+    def formatting_errors(self, answers):
+        errors_map = {}
+        if self.email_validation_fields is not None and len(self.email_validation_fields) > 0:
+            for field in self.email_validation_fields:
+                if not re.match(EMAIL_REGEX, self.answers.get(field, '')):
+                    errors_map[field] = 'invalid_format'
+        return errors_map
+
+    def get_required_fields(self):
+        try:
+            req_fields = self.required_fields
+        except AttributeError:
+            req_fields = set(self.all_fields())
+
+        #  Remove optional fields
+        if self.optional_fields is not None:
+            req_fields -= set(self.optional_fields)
+
+        return req_fields
+
+
+class G7Validator(DeclarationValidator):
+    """
+    Validator for G-Cloud 7.
+    """
+    optional_fields = set([
+        "SQ1-1p-i", "SQ1-1p-ii", "SQ1-1p-iii", "SQ1-1p-iv",
+        "SQ1-1q-i", "SQ1-1q-ii", "SQ1-1q-iii", "SQ1-1q-iv", "SQ1-1cii", "SQ1-1i-ii",
+        "SQ1-1j-i", "SQ1-1j-ii", "SQ4-1c", "SQ3-1k", "SQ1-1i-i"
+    ])
+    email_validation_fields = set(['SQ1-1o', 'SQ1-2b'])
+    character_limit = 5000
+
+    def get_required_fields(self):
+        req_fields = super(G7Validator, self).get_required_fields()
+
+        #  If you answered other to question 19 (trading status)
+        if self.answers.get('SQ1-1ci') == 'other (please specify)':
+            req_fields.add('SQ1-1cii')
+
+        #  If you answered yes to question 27 (non-UK business registered in EU)
+        if self.answers.get('SQ1-1i-i', False):
+            req_fields.add('SQ1-1i-ii')
+
+        #  If you answered 'licensed' or 'a member of a relevant organisation' in question 29
+        answer_29 = self.answers.get('SQ1-1j-i', [])
+        if len(answer_29) > 0 and \
+                ('licensed' in answer_29 or 'a member of a relevant organisation' in answer_29):
+                req_fields.add('SQ1-1j-ii')
+
+        # If you answered yes to either question 53 or 54 (tax returns)
+        if self.answers.get('SQ4-1a', False) or self.answers.get('SQ4-1b', False):
+            req_fields.add('SQ4-1c')
+
+        # If you answered Yes to questions 39 - 51 (discretionary exclusion)
+        dependent_fields = [
+            'SQ2-2a', 'SQ3-1a', 'SQ3-1b', 'SQ3-1c', 'SQ3-1d', 'SQ3-1e', 'SQ3-1f', 'SQ3-1g',
+            'SQ3-1h-i', 'SQ3-1h-ii', 'SQ3-1i-i', 'SQ3-1i-ii', 'SQ3-1j'
+        ]
+        if any(self.answers.get(field) for field in dependent_fields):
+            req_fields.add('SQ3-1k')
+
+        # If you answered No to question 26 (established in the UK)
+        if 'SQ5-2a' in self.answers and not self.answers['SQ5-2a']:
+            req_fields.add('SQ1-1i-i')
+            req_fields.add('SQ1-1j-i')
+
+        return req_fields
+
+VALIDATORS = {
+    "g-cloud-7": G7Validator
+}

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -19,11 +19,11 @@ from dmutils.documents import get_agreement_document_path, get_signed_url, file_
 from ... import data_api_client
 from ...main import main, content_loader
 from ..helpers import hash_email
-from ..helpers.frameworks import get_error_messages_for_page, get_first_question_index, \
-    get_error_messages, get_declaration_status, get_last_modified_from_first_matching_file, \
-    register_interest_in_framework, get_supplier_framework_info, \
+from ..helpers.frameworks import get_declaration_status, \
+    get_last_modified_from_first_matching_file, register_interest_in_framework, \
     get_supplier_on_framework_from_info, get_declaration_status_from_info, \
-    get_framework, get_framework_and_lot, count_drafts_by_lot
+    get_supplier_framework_info, get_framework, get_framework_and_lot, count_drafts_by_lot
+from ..helpers.validation import get_validator
 from ..helpers.services import (
     get_draft_document_url, get_service_attributes, get_drafts, get_lot_drafts,
     count_unanswered_questions
@@ -201,12 +201,15 @@ def framework_supplier_declaration(framework_slug, section_id=None):
 
     if request.method == 'POST':
         answers = content.get_all_data(request.form)
-        errors = get_error_messages_for_page(content, answers, section)
+
+        validator = get_validator(framework, content, answers)
+        errors = validator.get_error_messages_for_page(section)
+
         if len(errors) > 0:
             status_code = 400
         else:
             latest_answers.update(answers)
-            if get_error_messages(content, latest_answers):
+            if validator.get_error_messages():
                 latest_answers.update({"status": "started"})
             else:
                 latest_answers.update({"status": "complete"})

--- a/tests/app/main/helpers/test_frameworks.py
+++ b/tests/app/main/helpers/test_frameworks.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from nose.tools import assert_equal
 
-from app.main.helpers.frameworks import get_all_errors
+from app.main.helpers.validation import G7Validator, get_validator
 from app.main import content_loader
 
 
@@ -86,36 +86,42 @@ def test_error_if_required_field_is_missing():
     content = content_loader.get_builder('g-cloud-7', 'declaration')
     submission = FULL_G7_SUBMISSION.copy()
     del submission['SQ3-1i-i']
+    validator = G7Validator(content, submission)
 
-    assert_equal(get_all_errors(content, submission), {'SQ3-1i-i': 'answer_required'})
+    assert_equal(validator.errors(), {'SQ3-1i-i': 'answer_required'})
 
 
 def test_error_if_required_text_field_is_empty():
     content = content_loader.get_builder('g-cloud-7', 'declaration')
     submission = FULL_G7_SUBMISSION.copy()
     submission['SQ1-2b'] = ""
+    validator = G7Validator(content, submission)
 
-    assert_equal(get_all_errors(content, submission), {'SQ1-2b': 'answer_required'})
+    assert_equal(validator.errors(), {'SQ1-2b': 'answer_required'})
 
 
 def test_no_error_if_optional_field_is_missing():
     content = content_loader.get_builder('g-cloud-7', 'declaration')
     submission = FULL_G7_SUBMISSION.copy()
     del submission['SQ1-1p-i']
+    validator = G7Validator(content, submission)
 
-    assert_equal(get_all_errors(content, submission), {})
+    assert_equal(validator.errors(), {})
 
 
 def test_trading_status_details_error_depends_on_trading_status():
     content = content_loader.get_builder('g-cloud-7', 'declaration')
     submission = FULL_G7_SUBMISSION.copy()
     del submission['SQ1-1cii']
+    validator = G7Validator(content, submission)
 
     submission['SQ1-1ci'] = "something"
-    assert_equal(get_all_errors(content, submission), {})
+    validator = G7Validator(content, submission)
+    assert_equal(validator.errors(), {})
 
     submission['SQ1-1ci'] = "other (please specify)"
-    assert_equal(get_all_errors(content, submission), {'SQ1-1cii': 'answer_required'})
+    validator = G7Validator(content, submission)
+    assert_equal(validator.errors(), {'SQ1-1cii': 'answer_required'})
 
 
 def test_trade_registers_details_error_depends_on_trade_registers():
@@ -124,10 +130,12 @@ def test_trade_registers_details_error_depends_on_trade_registers():
     del submission['SQ1-1i-ii']
 
     submission['SQ1-1i-i'] = False
-    assert_equal(get_all_errors(content, submission), {})
+    validator = G7Validator(content, submission)
+    assert_equal(validator.errors(), {})
 
     submission['SQ1-1i-i'] = True
-    assert_equal(get_all_errors(content, submission), {'SQ1-1i-ii': 'answer_required'})
+    validator = G7Validator(content, submission)
+    assert_equal(validator.errors(), {'SQ1-1i-ii': 'answer_required'})
 
 
 def test_licenced_details_error_depends_on_licenced():
@@ -136,10 +144,12 @@ def test_licenced_details_error_depends_on_licenced():
     del submission['SQ1-1j-ii']
 
     del submission['SQ1-1j-i']
-    assert_equal(get_all_errors(content, submission), {})
+    validator = G7Validator(content, submission)
+    assert_equal(validator.errors(), {})
 
     submission['SQ1-1j-i'] = ["licensed"]
-    assert_equal(get_all_errors(content, submission), {'SQ1-1j-ii': 'answer_required'})
+    validator = G7Validator(content, submission)
+    assert_equal(validator.errors(), {'SQ1-1j-ii': 'answer_required'})
 
 
 def test_no_error_if_no_tax_issues_and_no_details():
@@ -150,7 +160,8 @@ def test_no_error_if_no_tax_issues_and_no_details():
     submission['SQ4-1b'] = False
     del submission['SQ4-1c']
 
-    assert_equal(get_all_errors(content, submission), {})
+    validator = G7Validator(content, submission)
+    assert_equal(validator.errors(), {})
 
 
 def test_error_if_tax_issues_and_no_details():
@@ -161,11 +172,13 @@ def test_error_if_tax_issues_and_no_details():
 
     submission['SQ4-1a'] = True
     submission['SQ4-1b'] = False
-    assert_equal(get_all_errors(content, submission), {'SQ4-1c': 'answer_required'})
+    validator = G7Validator(content, submission)
+    assert_equal(validator.errors(), {'SQ4-1c': 'answer_required'})
 
     submission['SQ4-1a'] = False
     submission['SQ4-1b'] = True
-    assert_equal(get_all_errors(content, submission), {'SQ4-1c': 'answer_required'})
+    validator = G7Validator(content, submission)
+    assert_equal(validator.errors(), {'SQ4-1c': 'answer_required'})
 
 
 def test_error_if_mitigation_factors_not_provided_when_required():
@@ -184,7 +197,8 @@ def test_error_if_mitigation_factors_not_provided_when_required():
             submission[other] = False
         submission[field] = True
 
-        assert_equal(get_all_errors(content, submission), {'SQ3-1k': 'answer_required'})
+        validator = G7Validator(content, submission)
+        assert_equal(validator.errors(), {'SQ3-1k': 'answer_required'})
 
 
 def test_mitigation_factors_not_required():
@@ -199,7 +213,8 @@ def test_mitigation_factors_not_required():
     ]
     for field in dependent_fields:
         submission[field] = False
-    assert_equal(get_all_errors(content, submission), {})
+    validator = G7Validator(content, submission)
+    assert_equal(validator.errors(), {})
 
 
 def test_fields_only_relevant_to_non_uk():
@@ -209,7 +224,8 @@ def test_fields_only_relevant_to_non_uk():
     submission['SQ5-2a'] = False
     del submission['SQ1-1i-i']
 
-    assert_equal(get_all_errors(content, submission), {'SQ1-1i-i': 'answer_required'})
+    validator = G7Validator(content, submission)
+    assert_equal(validator.errors(), {'SQ1-1i-i': 'answer_required'})
 
 
 def test_invalid_email_addresses_cause_errors():
@@ -218,7 +234,9 @@ def test_invalid_email_addresses_cause_errors():
 
     submission['SQ1-1o'] = '@invalid.com'
     submission['SQ1-2b'] = 'some.user.missed.their.at.com'
-    assert_equal(get_all_errors(content, submission),
+
+    validator = G7Validator(content, submission)
+    assert_equal(validator.errors(),
                  {'SQ1-1o': 'invalid_format',
                   'SQ1-2b': 'invalid_format'}
                  )
@@ -238,7 +256,14 @@ def test_character_limit_errors():
 
     for field, limit in cases:
         submission[field] = "a" * (limit + 1)
-        assert_equal(get_all_errors(content, submission), {field: 'under_character_limit'})
+        validator = G7Validator(content, submission)
+        assert_equal(validator.errors(), {field: 'under_character_limit'})
 
         submission[field] = "a" * limit
-        assert_equal(get_all_errors(content, submission), {})
+        validator = G7Validator(content, submission)
+        assert_equal(validator.errors(), {})
+
+
+def test_get_validator():
+    validator = get_validator({"slug": "g-cloud-7"}, None, None)
+    assert_equal(type(validator), G7Validator)

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -801,7 +801,7 @@ class TestSupplierDeclaration(BaseApplicationTest):
 
             assert_equal(res.status_code, 400)
 
-    @mock.patch('app.main.views.frameworks.get_error_messages_for_page')
+    @mock.patch('app.main.helpers.validation.G7Validator.get_error_messages_for_page')
     def test_post_with_validation_errors(self, get_error_messages_for_page, data_api_client):
         """Test that answers are not saved if there are errors
 


### PR DESCRIPTION
Previously framework validation rules were specifically for G-Cloud 7. To support DOS, we need to have the ability to have multiple validators. This lays the groundwork for this by separating out G7 framework rules into one class.