### PR TITLE
Upgrade dmutils to 13.0.0

### DIFF
--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -243,7 +243,8 @@ def download_supplier_file(framework_slug, filepath):
 @login_required
 def download_agreement_file(framework_slug, document_name):
     agreements_bucket = s3.S3(current_app.config['DM_AGREEMENTS_BUCKET'])
-    path = get_agreement_document_path(framework_slug, current_user.supplier_id, document_name)
+    path = get_agreement_document_path(
+        framework_slug, current_user.supplier_id, current_user.supplier_name, document_name)
     url = get_signed_url(agreements_bucket, path, current_app.config['DM_ASSETS_URL'])
     if not url:
         abort(404)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ Flask-WTF==0.12
 werkzeug==0.10.4
 
 git+https://github.com/madzak/python-json-logger.git@v0.1.3#egg=python-json-logger==v0.1.3
-git+https://github.com/alphagov/digitalmarketplace-utils.git@12.0.0#egg=digitalmarketplace-utils==12.0.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@13.0.0#egg=digitalmarketplace-utils==13.0.0
 
 markdown==2.6.2
 

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -460,7 +460,8 @@ class TestFrameworkAgreementDocumentDownload(BaseApplicationTest):
 
             assert_equal(res.status_code, 302)
             assert_equal(res.location, 'http://url/path?param=value')
-            uploader.get_signed_url.assert_called_with('g-cloud-7/agreements/1234/1234-example.pdf')
+            uploader.get_signed_url.assert_called_with(
+                'g-cloud-7/agreements/1234/Supplier_Name-1234-example.pdf')
 
     def test_download_document_with_asset_url(self, S3):
         uploader = mock.Mock()
@@ -475,7 +476,8 @@ class TestFrameworkAgreementDocumentDownload(BaseApplicationTest):
 
             assert_equal(res.status_code, 302)
             assert_equal(res.location, 'https://example/path?param=value')
-            uploader.get_signed_url.assert_called_with('g-cloud-7/agreements/1234/1234-example.pdf')
+            uploader.get_signed_url.assert_called_with(
+                'g-cloud-7/agreements/1234/Supplier_Name-1234-example.pdf')
 
 
 @mock.patch('dmutils.s3.S3')


### PR DESCRIPTION
This brings in changes to how the agreement document path is generated. The function now expects the supplier name as well.