### PR TITLE
Tidy up various things

### DIFF
--- a/app/templates/frameworks/agreement.html
+++ b/app/templates/frameworks/agreement.html
@@ -97,7 +97,7 @@ with items = [
                 <li>Scan the page and save as PDF, JPG or PNG.</li>
             </ol>
             <p>
-                Please don’t send paper copies to CSS.
+                Please don’t send paper copies to CCS.
             </p>
         </div>
 

--- a/app/templates/frameworks/agreement.html
+++ b/app/templates/frameworks/agreement.html
@@ -25,16 +25,17 @@ with items = [
 
 {% block main_content %}
   {% if supplier_framework.agreementReturned %}
-  {% with
-     heading = "Your document has been uploaded",
-     messages = [
-      "You’ll be notified once your framework agreement has been countersigned by the Crown Commercial Service."
-     ]
+    {% with
+      heading = "Your document has been uploaded",
+      messages = [
+        "You’ll be notified once your framework agreement has been countersigned by the Crown Commercial Service."
+      ]
     %}
       {% include "toolkit/temporary-message.html" %}
     {% endwith %}
   {% endif %}
 
+  <div class='grid-row'>
     <div class='column-two-thirds large-paragraph'>
         {% with
             heading = "Sign your " + framework.name + " framework agreement",
@@ -47,7 +48,7 @@ with items = [
 
     <div class='column-two-thirds large-paragraph'>
         <div class="padding-bottom-small">
-            <p>Your agreement will need to be signed by both you and the Crown Commercial Service (CCS) 
+            <p>Your agreement will need to be signed by both you and the Crown Commercial Service (CCS)
                 before you can sell {{ framework.name }} services.</p>
         </div>
 
@@ -62,7 +63,7 @@ with items = [
                 </li>
             </ul>
         </div>
-        
+
         <div class="padding-bottom framework-agreement-section">
             <h2>2. Read your framework agreement</h2>
             <p>If you have a question about your framework agreement, <a href="{{ url_for('.framework_updates', framework_slug=framework.slug) }}">contact CCS</a>.</p>
@@ -72,7 +73,7 @@ with items = [
             <h2>3. Sign your framework agreement</h2>
             <p class="lead-in">To digitally sign your framework agreement, you need to:</p>
             <ol>
-              <li>Use <strong>Adobe Reader</strong> to open your {{ framework.name }} framework agreement. 
+              <li>Use <strong>Adobe Reader</strong> to open your {{ framework.name }} framework agreement.
                     You can download it for free from the <a rel="external" href="https://get.adobe.com/uk/reader/">Adobe Acrobat Reader</a> website.</li>
 
                 <li>Go to page 16 and click the signature box under the title ‘Signed duly authorised for and on behalf of the supplier’.</li>
@@ -99,7 +100,7 @@ with items = [
                 Please don’t send paper copies to CSS.
             </p>
         </div>
-        
+
         <div class="padding-bottom framework-agreement-section">
             <form method="post" enctype="multipart/form-data" action="{{ url_for(".upload_framework_agreement", framework_slug=framework.slug) }}">
                 <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
@@ -126,7 +127,7 @@ with items = [
                     {% include "toolkit/forms/upload.html" %}
                     {% endwith %}
                 {% endif %}
-    
+
                 {%
                 with
                 type = "save",
@@ -136,7 +137,8 @@ with items = [
                 {% endwith %}
             </form>
         </div>
-        
+
         <a href="{{url_for('.framework_dashboard', framework_slug=framework.slug)}}">Return to your {{ framework.name }} application</a>
     </div>
+  </div>
 {% endblock %}

--- a/app/templates/frameworks/services.html
+++ b/app/templates/frameworks/services.html
@@ -85,7 +85,7 @@
   {% call(draft) summary.list_table(
     drafts,
     caption="Draft services",
-    empty_message="You haven't added any services yet.",
+    empty_message="You haven’t added any services yet." if framework.status == 'open' else "You didn’t add any services.",
     field_headings=[
         "Service name",
         summary.hidden_field_heading("Progress"),
@@ -113,14 +113,14 @@
   {% endcall %}
 
   {% if framework.status == 'open' %}
-  {{ summary.heading("Complete services") }}
-  {% elif framework.status == 'pending' %}
-  {{ summary.heading("Submitted services") }}
+    {{ summary.heading("Complete services") }}
+  {% elif framework.status == 'pending' or 'standstill' %}
+    {{ summary.heading("Submitted services") }}
   {% endif %}
   {% call(draft) summary.list_table(
     complete_drafts,
     caption="Complete services",
-    empty_message="You haven’t marked any services as complete yet.",
+    empty_message="You haven’t marked any services as complete yet." if framework.status == 'open' else "You didn’t mark any services as complete.",
     field_headings=[
         "Service name",
         summary.hidden_field_heading("Progress"),


### PR DESCRIPTION
## Services page was missing a heading…

…because it wasn’t considering the 'standstill' state.

This commit:
- fixes that
- changes the 'empty' message to be in the correct tense for each state

![image](https://cloud.githubusercontent.com/assets/355079/10999210/afe63090-8492-11e5-8cb7-a8c3766aa6dc.png)

## Fix alignment of columns on agreement page

## Fix typo