### PR TITLE
Make `framework uploaded` email text match the story

### DIFF
--- a/app/templates/emails/framework_agreement_uploaded.html
+++ b/app/templates/emails/framework_agreement_uploaded.html
@@ -4,17 +4,14 @@
     <meta charset="UTF-8">
 </head>
 <body>
-<h2>{{ framework_name }} framework agreement uploaded</h2>
-<br />
-<p>
-  {{ supplier_name }} has uploaded their signed framework agreement.
-  You can download it from the admin console.
-</p>
 
-Supplier name: {{ supplier_name }}
-<br />
-User name: {{ user_name }}
-<br />
-Supplier ID: {{ supplier_id }}
+Supplier name: {{ supplier_name }} <br />
+
+Supplier ID: {{ supplier_id }} <br />
+
+User name: {{ user_name }} <br />
+
+{{ framework_name }} framework agreement
+
 </body>
 </html>


### PR DESCRIPTION
 The format needs to be exactly as in the story so that Zendesk filters will work properly.