### PR TITLE
Pass framework name to email template

### DIFF
--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -481,7 +481,7 @@ def upload_framework_agreement(framework_slug):
     try:
         email_body = render_template(
             'emails/framework_agreement_uploaded.html',
-            framework=framework,
+            framework_name=framework.get('name', 'Unknown framework'),
             supplier_name=current_user.supplier_name,
             supplier_id=current_user.supplier_id,
             user_name=current_user.name

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -481,7 +481,7 @@ def upload_framework_agreement(framework_slug):
     try:
         email_body = render_template(
             'emails/framework_agreement_uploaded.html',
-            framework_name=framework.get('name', 'Unknown framework'),
+            framework_name=framework['name'],
             supplier_name=current_user.supplier_name,
             supplier_id=current_user.supplier_id,
             user_name=current_user.name

--- a/app/templates/frameworks/dashboard.html
+++ b/app/templates/frameworks/dashboard.html
@@ -167,8 +167,10 @@
             </div>
             <div class="column-two-thirds">
               <div class="framework-section-status-neutral">
-                <p>{{ counts.draft }} draft
-                {{ 'service' if counts.draft == 1 else 'services' }} {{ 'was' if counts.draft == 1 else 'were' }} not submitted</p>
+                {% if counts.draft > 0 %}
+                  <p>{{ counts.draft }} draft
+                  {{ 'service' if counts.draft == 1 else 'services' }} {{ 'was' if counts.draft == 1 else 'were' }} not submitted</p>
+                {% endif %}
                 <p>{{ counts.complete }} complete
                 {{ 'service' if counts.complete == 1 else 'services' }} {{ 'was' if counts.complete == 1 else 'were' }} submitted</p>
               </div>


### PR DESCRIPTION
The template was previously getting a framework rather than the framework name.

This also removes confusing messaging  "0 draft services were not submitted" for suppliers who did not leave any services in draft.