### PR TITLE
Add lot counts to submitted lots page

### DIFF
--- a/app/main/helpers/frameworks.py
+++ b/app/main/helpers/frameworks.py
@@ -251,3 +251,9 @@ def get_frameworks_by_status(frameworks, status, extra_condition=False):
         if framework['status'] == status and
         (framework.get(extra_condition) if extra_condition else True)
     ]
+
+
+def count_drafts_by_lot(drafts, lot):
+    return len([
+        draft for draft in drafts if draft['lot'] == lot
+    ])

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -22,7 +22,7 @@ from ..helpers.frameworks import get_error_messages_for_page, get_first_question
     get_error_messages, get_declaration_status, get_last_modified_from_first_matching_file, \
     register_interest_in_framework, get_supplier_framework_info, \
     get_supplier_on_framework_from_info, get_declaration_status_from_info, \
-    get_framework, get_framework_and_lot
+    get_framework, get_framework_and_lot, count_drafts_by_lot
 from ..helpers.services import (
     get_draft_document_url, get_service_attributes, get_drafts, get_lot_drafts,
     count_unanswered_questions
@@ -102,6 +102,19 @@ def framework_submission_lots(framework_slug):
             'link': url_for('.framework_submission_services', framework_slug=framework_slug, lot_slug=lot['value']),
             'title': lot['label'],
             'body': lot['description'],
+            'statuses': [
+                {
+                    'message': '{} complete services'.format(
+                        count_drafts_by_lot(complete_drafts, lot['value'])
+                    ),
+                    'important': True
+                } if count_drafts_by_lot(complete_drafts, lot['value']) else {},
+                {
+                    'message': '{} draft services'.format(
+                        count_drafts_by_lot(drafts, lot['value'])
+                    )
+                } if count_drafts_by_lot(drafts, lot['value']) else {}
+            ]
         } for lot in lot_question['options']],
         **main.config['BASE_TEMPLATE_DATA']
     ), 200

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import itertools
 from datetime import datetime
 
@@ -104,14 +105,18 @@ def framework_submission_lots(framework_slug):
             'body': lot['description'],
             'statuses': [
                 {
-                    'message': '{} complete services'.format(
-                        count_drafts_by_lot(complete_drafts, lot['value'])
+                    'message': '{} complete service{} {} submitted'.format(
+                        count_drafts_by_lot(complete_drafts, lot['value']),
+                        '' if 1 == count_drafts_by_lot(complete_drafts, lot['value']) else 's',
+                        'was' if 1 == count_drafts_by_lot(complete_drafts, lot['value']) else 'were'
                     ),
                     'important': True
                 } if count_drafts_by_lot(complete_drafts, lot['value']) else {},
                 {
-                    'message': '{} draft services'.format(
-                        count_drafts_by_lot(drafts, lot['value'])
+                    'message': u'{} draft service{} {} submitted'.format(
+                        count_drafts_by_lot(drafts, lot['value']),
+                        '' if 1 == count_drafts_by_lot(drafts, lot['value']) else 's',
+                        u'wasn’t' if 1 == count_drafts_by_lot(drafts, lot['value']) else u'weren’t',
                     )
                 } if count_drafts_by_lot(drafts, lot['value']) else {}
             ]

--- a/app/templates/frameworks/dashboard.html
+++ b/app/templates/frameworks/dashboard.html
@@ -167,12 +167,12 @@
             </div>
             <div class="column-two-thirds">
               <div class="framework-section-status-neutral">
+                <p>{{ counts.complete }} complete
+                {{ 'service' if counts.complete == 1 else 'services' }} {{ 'was' if counts.complete == 1 else 'were' }} submitted</p>
                 {% if counts.draft > 0 %}
                   <p>{{ counts.draft }} draft
                   {{ 'service' if counts.draft == 1 else 'services' }} {{ 'was' if counts.draft == 1 else 'were' }} not submitted</p>
                 {% endif %}
-                <p>{{ counts.complete }} complete
-                {{ 'service' if counts.complete == 1 else 'services' }} {{ 'was' if counts.complete == 1 else 'were' }} submitted</p>
               </div>
             </div>
           </div>

--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "jquery": "1.11.2",
     "hogan": "3.0.2",
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
-    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v11.4.3",
+    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v11.5.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.14.1/jinja_govuk_template-0.14.1.tgz",
     "digitalmarketplace-frameworks": "git://github.com/alphagov/digitalmarketplace-frameworks#38fbfa0"
   }

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -1230,10 +1230,14 @@ class TestG7ServicesList(BaseApplicationTest):
             ]
         }
 
-        res = self.client.get('/suppliers/frameworks/g-cloud-7/submissions/scs')
+        submissions = self.client.get('/suppliers/frameworks/g-cloud-7/submissions')
+        lot_page = self.client.get('/suppliers/frameworks/g-cloud-7/submissions/scs')
 
-        assert_true(u'Service can be moved to complete' not in res.get_data(as_text=True))
-        assert_in(u'4 unanswered questions', res.get_data(as_text=True))
+        assert_true(u'Service can be moved to complete' not in lot_page.get_data(as_text=True))
+        assert_in(u'4 unanswered questions', lot_page.get_data(as_text=True))
+
+        assert_in(u'1 draft service', submissions.get_data(as_text=True))
+        assert_true(u'complete service' not in submissions.get_data(as_text=True))
 
     def test_drafts_list_can_be_completed(self, count_unanswered, data_api_client):
         with self.app.test_client():
@@ -1266,7 +1270,11 @@ class TestG7ServicesList(BaseApplicationTest):
             ]
         }
 
-        res = self.client.get('/suppliers/frameworks/g-cloud-7/submissions/scs')
+        submissions = self.client.get('/suppliers/frameworks/g-cloud-7/submissions')
+        lot_page = self.client.get('/suppliers/frameworks/g-cloud-7/submissions/scs')
 
-        assert_true(u'Service can be moved to complete' not in res.get_data(as_text=True))
-        assert_in(u'1 optional question unanswered', res.get_data(as_text=True))
+        assert_true(u'Service can be moved to complete' not in lot_page.get_data(as_text=True))
+        assert_in(u'1 optional question unanswered', lot_page.get_data(as_text=True))
+
+        assert_in(u'1 complete service', submissions.get_data(as_text=True))
+        assert_true(u'draft service' not in submissions.get_data(as_text=True))

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -1236,7 +1236,7 @@ class TestG7ServicesList(BaseApplicationTest):
         assert_true(u'Service can be moved to complete' not in lot_page.get_data(as_text=True))
         assert_in(u'4 unanswered questions', lot_page.get_data(as_text=True))
 
-        assert_in(u'1 draft service', submissions.get_data(as_text=True))
+        assert_in(u'1 draft service wasn’t submitted', submissions.get_data(as_text=True))
         assert_true(u'complete service' not in submissions.get_data(as_text=True))
 
     def test_drafts_list_can_be_completed(self, count_unanswered, data_api_client):
@@ -1276,5 +1276,5 @@ class TestG7ServicesList(BaseApplicationTest):
         assert_true(u'Service can be moved to complete' not in lot_page.get_data(as_text=True))
         assert_in(u'1 optional question unanswered', lot_page.get_data(as_text=True))
 
-        assert_in(u'1 complete service', submissions.get_data(as_text=True))
+        assert_in(u'1 complete service was submitted', submissions.get_data(as_text=True))
         assert_true(u'draft service' not in submissions.get_data(as_text=True))


### PR DESCRIPTION
This implements: https://github.com/alphagov/digitalmarketplace-frontend-toolkit/pull/178

For each lot, it tells the user how many draft and complete services they have submitted.

Right now it’s fairly specific to the G-Cloud 7 sitation (without actually having `g-cloud-7` anywhere). We’ll need to handle some different states when DOS comes along.

--

![image](https://cloud.githubusercontent.com/assets/355079/11037237/b03ba854-86f4-11e5-9429-d8e1dc162954.png)

