### PR TITLE
Use the declaration supplier name for agreements

### DIFF
--- a/tests/app/helpers.py
+++ b/tests/app/helpers.py
@@ -39,7 +39,7 @@ FULL_G7_SUBMISSION = {
     "SQ5-2a": "true",
     "SQD2b": "true",
     "SQD2d": "true",
-    "SQ1-1a": "Blah",
+    "SQ1-1a": "Legal Supplier Name",
     "SQ1-1b": "Blah",
     "SQ1-1cii": "Blah",
     "SQ1-1d": "Blah",


### PR DESCRIPTION
The files for the framework agreements need to use the registered
company name from the declaration.