### PR TITLE
Update content.

### DIFF
--- a/app/templates/macros/assurance.html
+++ b/app/templates/macros/assurance.html
@@ -30,14 +30,6 @@
       {'label': 'independent testing of implementation',
        'value': 'Independent testing of implementation'}
     ],
-    '2answers-type2': [
-      {'label': 'service provider assertion',
-       'value': 'Service provider assertion'},
-      {'label': 'independent validation of assertion',
-       'value': 'Independent validation of assertion'},
-      {'label': 'independent testing of implementation',
-       'value': 'Independent testing of implementation'}
-    ],
     '3answers-type3': [
       {'label': 'service provider assertion',
        'value': 'Service provider assertion'},

--- a/app/templates/macros/toolkit_forms.html
+++ b/app/templates/macros/toolkit_forms.html
@@ -19,7 +19,7 @@
     name=question_content.id,
     value=service_data[question_content.id],
     large=True,
-    max_length_in_words=question_content["maxLengthInWords"],
+    max_length_in_words=question_content.max_length_in_words,
     error=errors.get(question_content.id)['message']
   %}
     {% include "toolkit/forms/textbox.html" %}

--- a/bower.json
+++ b/bower.json
@@ -7,6 +7,6 @@
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
     "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v11.4.3",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.14.1/jinja_govuk_template-0.14.1.tgz",
-    "digitalmarketplace-frameworks": "git://github.com/alphagov/digitalmarketplace-frameworks#38fbfa0"
+    "digitalmarketplace-frameworks": "git://github.com/alphagov/digitalmarketplace-frameworks#895b2a6"
   }
 }

--- a/tests/app/helpers.py
+++ b/tests/app/helpers.py
@@ -39,7 +39,7 @@ FULL_G7_SUBMISSION = {
     "SQ5-2a": "true",
     "SQD2b": "true",
     "SQD2d": "true",
-    "SQ1-1a": "Blah",
+    "SQ1-1a": "Legal Supplier Name",
     "SQ1-1b": "Blah",
     "SQ1-1cii": "Blah",
     "SQ1-1d": "Blah",


### PR DESCRIPTION
Update [digitalmarketplace-frameworks](https://github.com/alphagov/digitalmarketplace-frameworks) content, and update the supplier app so it's consistent with the new changes.

Specifically:

- Change `maxLengthInWords` to `max_length_in_words` in the form field macro
- Remove the `2answers-type2` macro which has been removed from the content


Doesn't really depend on: 
- [ ] https://github.com/alphagov/digitalmarketplace-frameworks/pull/113