### PR TITLE
[#107569658] Framework dashboard for 'live' framework

### DIFF
--- a/app/main/helpers/frameworks.py
+++ b/app/main/helpers/frameworks.py
@@ -7,7 +7,7 @@ from dmutils.apiclient import APIError
 
 def get_framework(client, framework_slug, open_only=True):
     framework = client.get_framework(framework_slug)['frameworks']
-    allowed_statuses = ['open'] if open_only else ['open', 'pending', 'standstill']
+    allowed_statuses = ['open'] if open_only else ['open', 'pending', 'standstill', 'live']
     if framework['status'] not in allowed_statuses:
         abort(404)
 

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -21,13 +21,15 @@ from dmutils.documents import upload_service_documents
 @main.route('/services')
 @login_required
 def list_services():
-    suppliers_services = data_api_client.find_services(
-        supplier_id=current_user.supplier_id
+    suppliers_services = sorted(
+        data_api_client.find_services(supplier_id=current_user.supplier_id)["services"],
+        key=lambda service: service['frameworkSlug'],
+        reverse=True
     )
 
     return render_template(
         "services/list_services.html",
-        services=suppliers_services["services"],
+        services=suppliers_services,
         updated_service_id=request.args.get('updated_service_id'),
         updated_service_name=request.args.get('updated_service_name'),
         updated_service_status=request.args.get('updated_service_status'),

--- a/app/templates/frameworks/dashboard.html
+++ b/app/templates/frameworks/dashboard.html
@@ -28,6 +28,14 @@
     %}
       {% include "toolkit/page-heading.html" %}
     {% endwith %}
+  {% elif framework.status == 'live' %}
+    {% with
+      heading = "Your " + framework.name + " documents",
+      smaller = True,
+      with_breadcrumb = True
+    %}
+      {% include "toolkit/page-heading.html" %}
+    {% endwith %}
   {% else %}
     {% with
       heading = "Your " + framework.name + " application",
@@ -71,7 +79,7 @@
   {% endif %}
     <ul class="browse-list">
 
-      {% if framework.status == 'standstill' and application_made %}
+      {% if framework.status in ['standstill', 'live'] and application_made %}
         <li class="browse-list-item framework-application-section">
           <div class="grid-row">
             <div class="column-two-thirds">

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -48,21 +48,66 @@ class TestFrameworksDashboard(BaseApplicationTest):
             else:
                 assert_equal(len(hint), 0)
 
-    def test_shows(self, data_api_client, s3):
+    def test_shows_for_pending(self, data_api_client, s3):
         with self.app.test_client():
-            data_api_client.get_framework.return_value = self.framework(status='open')
             self.login()
 
         data_api_client.get_framework.return_value = self.framework(status='pending')
+        data_api_client.get_supplier_framework_info.return_value = self.supplier_framework()
         res = self.client.get("/suppliers/frameworks/g-cloud-7")
 
         assert_equal(res.status_code, 200)
+
+    def test_title_for_pending(self, data_api_client, s3):
+        with self.app.test_client():
+            self.login()
+
+        data_api_client.get_framework.return_value = self.framework(status='pending')
+        data_api_client.get_supplier_framework_info.return_value = self.supplier_framework()
+        res = self.client.get("/suppliers/frameworks/g-cloud-7")
+
+        doc = html.fromstring(res.get_data(as_text=True))
+        assert_equal(
+            len(doc.xpath('//h1[contains(text(), "Your G-Cloud 7 application")]')), 1)
+
+    def test_shows_for_live_if_declaration_exists(self, data_api_client, s3):
+        with self.app.test_client():
+            self.login()
+
+        data_api_client.get_framework.return_value = self.framework(status='live')
+        data_api_client.get_supplier_framework_info.return_value = self.supplier_framework()
+        res = self.client.get("/suppliers/frameworks/g-cloud-7")
+
+        assert_equal(res.status_code, 200)
+
+    def test_title_for_live(self, data_api_client, s3):
+        with self.app.test_client():
+            self.login()
+
+        data_api_client.get_framework.return_value = self.framework(status='live')
+        data_api_client.get_supplier_framework_info.return_value = self.supplier_framework()
+        res = self.client.get("/suppliers/frameworks/g-cloud-7")
+
+        doc = html.fromstring(res.get_data(as_text=True))
+        assert_equal(
+            len(doc.xpath('//h1[contains(text(), "Your G-Cloud 7 documents")]')), 1)
+
+    def test_does_not_show_for_live_if_no_declaration(self, data_api_client, s3):
+        with self.app.test_client():
+            self.login()
+
+        data_api_client.get_framework.return_value = self.framework(status='live')
+        data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(declaration=None)
+        res = self.client.get("/suppliers/frameworks/g-cloud-7")
+
+        assert_equal(res.status_code, 404)
 
     def test_interest_registered_in_framework_on_post(self, data_api_client, s3):
         with self.app.test_client():
             self.login()
 
             data_api_client.get_framework.return_value = self.framework(status='open')
+            data_api_client.get_supplier_framework_info.return_value = self.supplier_framework()
             res = self.client.post("/suppliers/frameworks/digital-outcomes-and-specialists")
 
             assert_equal(res.status_code, 200)
@@ -77,6 +122,7 @@ class TestFrameworksDashboard(BaseApplicationTest):
             self.login()
 
             data_api_client.get_framework.return_value = self.framework(status='pending')
+            data_api_client.get_supplier_framework_info.return_value = self.supplier_framework()
             res = self.client.get("/suppliers/frameworks/digital-outcomes-and-specialists")
 
             assert_equal(res.status_code, 200)
@@ -110,6 +156,7 @@ class TestFrameworksDashboard(BaseApplicationTest):
                     {'serviceName': 'A service', 'status': 'not-submitted'}
                 ]
             }
+            data_api_client.get_supplier_framework_info.return_value = self.supplier_framework()
 
             res = self.client.get("/suppliers/frameworks/g-cloud-7")
 
@@ -213,6 +260,7 @@ class TestFrameworksDashboard(BaseApplicationTest):
             self.login()
 
             data_api_client.get_framework.return_value = self.framework(status='open')
+            data_api_client.get_supplier_framework_info.return_value = self.supplier_framework()
             res = self.client.get("/suppliers/frameworks/g-cloud-7")
             doc = html.fromstring(res.get_data(as_text=True))
             last_updateds = [
@@ -248,6 +296,7 @@ class TestFrameworksDashboard(BaseApplicationTest):
             self.login()
 
             data_api_client.get_framework.return_value = self.framework(status='open')
+            data_api_client.get_supplier_framework_info.return_value = self.supplier_framework()
             res = self.client.get("/suppliers/frameworks/g-cloud-7")
             doc = html.fromstring(res.get_data(as_text=True))
             last_updateds = [
@@ -272,6 +321,7 @@ class TestFrameworksDashboard(BaseApplicationTest):
             self.login()
 
             data_api_client.get_framework.return_value = self.framework(status='open')
+            data_api_client.get_supplier_framework_info.return_value = self.supplier_framework()
             res = self.client.get("/suppliers/frameworks/g-cloud-7")
             doc = html.fromstring(res.get_data(as_text=True))
             last_updateds = [

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -47,7 +47,8 @@ class TestListServices(BaseApplicationTest):
                     'id': '123',
                     'lot': 'saas',
                     'lotName': 'Software as a Service',
-                    'frameworkName': 'G-Cloud 1'
+                    'frameworkName': 'G-Cloud 1',
+                    'frameworkSlug': 'g-cloud-1'
                 }]
             }
 
@@ -86,7 +87,8 @@ class TestListServices(BaseApplicationTest):
                 'services': [{
                     'serviceName': 'Service name 123',
                     'status': 'published',
-                    'id': '123'
+                    'id': '123',
+                    'frameworkSlug': 'g-cloud-1'
                 }]
             }
 
@@ -106,7 +108,8 @@ class TestListServicesLogin(BaseApplicationTest):
             data_api_client.find_services.return_value = {'services': [{
                 'serviceName': 'Service name 123',
                 'status': 'published',
-                'id': '123'
+                'id': '123',
+                'frameworkSlug': 'g-cloud-1'
             }]}
 
             res = self.client.get('/suppliers/services')


### PR DESCRIPTION
See: https://www.pivotaltracker.com/story/show/107569658

For the supplier dashboard when the framework goes live:
 - Framework dashboard is still visible, and does not have a "View services" link or a "You made your declaration..." summary sentence.
 - The title is "Your <framework> documents".
 - The updates and framework agreement pages both still work the same as when framework is in 'standstill'

Framework dashboard for successful G-Cloud 7 supplier after the framework is live:
![screen shot 2015-11-11 at 11 08 51](https://cloud.githubusercontent.com/assets/6525554/11092931/f5a91648-887e-11e5-902f-497bde4e459a.png)

This PR also fixes this bug with the services ordering: https://www.pivotaltracker.com/story/show/107912404

Before
======
![screen shot 2015-11-11 at 14 09 05](https://cloud.githubusercontent.com/assets/6525554/11092917/d9d3537a-887e-11e5-905e-9be5a637775a.png)


After
=====
![screen shot 2015-11-11 at 14 08 41](https://cloud.githubusercontent.com/assets/6525554/11092920/dfc16330-887e-11e5-8507-e20822dcb252.png)