### PR TITLE
Bump toolkit to 12.0.0

### DIFF
--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -115,19 +115,19 @@ def framework_submission_lots(framework_slug):
             'body': lot['description'],
             'statuses': [
                 {
-                    'message': '{} complete service{} {} submitted'.format(
+                    'title': '{} complete service{} {} submitted'.format(
                         count_drafts_by_lot(complete_drafts, lot['value']),
                         '' if 1 == count_drafts_by_lot(complete_drafts, lot['value']) else 's',
                         'was' if 1 == count_drafts_by_lot(complete_drafts, lot['value']) else 'were'
-                    ),
-                    'important': True
+                    )
                 } if count_drafts_by_lot(complete_drafts, lot['value']) else {},
                 {
-                    'message': u'{} draft service{} {} submitted'.format(
+                    'title': u'{} draft service{} {} submitted'.format(
                         count_drafts_by_lot(drafts, lot['value']),
                         '' if 1 == count_drafts_by_lot(drafts, lot['value']) else 's',
                         u'wasn’t' if 1 == count_drafts_by_lot(drafts, lot['value']) else u'weren’t',
-                    )
+                    ),
+                    'type': 'quiet'
                 } if count_drafts_by_lot(drafts, lot['value']) else {}
             ]
         } for lot in lot_question['options']],

--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "jquery": "1.11.2",
     "hogan": "3.0.2",
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
-    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v11.5.0",
+    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v12.0.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.14.1/jinja_govuk_template-0.14.1.tgz",
     "digitalmarketplace-frameworks": "git://github.com/alphagov/digitalmarketplace-frameworks#v0.3.0"
   }


### PR DESCRIPTION
Depends on:
- [x] https://github.com/alphagov/digitalmarketplace-frontend-toolkit/pull/179

This commit accommodates the breaking change made in version 12.0.0 of the toolkit. It does not make any functional changes.