### PR TITLE
Fix bug with display of current services

### DIFF
--- a/app/templates/suppliers/_frameworks_live.html
+++ b/app/templates/suppliers/_frameworks_live.html
@@ -1,7 +1,7 @@
 {% import "toolkit/summary-table.html" as summary %}
 
 {{ summary.heading("Current services") }}
-{% if supplier.service_counts %}
+{% if frameworks.live %}
   {{ summary.top_link('View', url_for('.list_services')) }}
 {% endif %}
 {% call(framework) summary.list_table(

--- a/tests/app/main/test_suppliers.py
+++ b/tests/app/main/test_suppliers.py
@@ -112,6 +112,11 @@ class TestSuppliersDashboard(BaseApplicationTest):
     def test_shows_edit_buttons(self, get_current_suppliers_users, data_api_client):
         data_api_client.get_supplier.side_effect = get_supplier
         data_api_client.find_frameworks.return_value = find_frameworks_return_value
+        data_api_client.get_supplier_frameworks.return_value = {
+            'frameworkInterest': [
+                {'frameworkSlug': 'g-cloud-6', 'services_count': 99}
+            ]
+        }
         get_current_suppliers_users.side_effect = get_user
         with self.app.test_client():
             self.login()


### PR DESCRIPTION
There is an edge case where:
- a supplier has services
- a supplier is not 'on' a framework

In this case the link to view services should not be shown.

In actuality, the link was being shown.

This is because the logic was checking for different things when deciding to
- show the list of current frameworks and service counts
- showing the view link

This commit changes the code to check for the same thing (`frameworks.live`) for both purposes.