### PR TITLE
Fixing agreement uploads

### DIFF
--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -15,7 +15,7 @@ from dmutils.email import send_email, MandrillException
 from dmutils.formats import format_service_price, datetimeformat
 from dmutils import s3
 from dmutils.deprecation import deprecated
-from dmutils.documents import get_agreement_document_path, get_signed_url, file_is_less_than_5mb
+from dmutils.documents import get_agreement_document_path, get_signed_url, file_is_less_than_5mb, get_extension
 
 from ... import data_api_client
 from ...main import main, content_loader
@@ -508,8 +508,10 @@ def upload_framework_agreement(framework_slug):
 
     agreements_bucket = s3.S3(current_app.config['DM_AGREEMENTS_BUCKET'])
     legal_supplier_name = supplier_framework['declaration']['SQ1-1a']
+    extension = get_extension(request.files['agreement'].filename)
     path = get_agreement_document_path(
-        framework_slug, current_user.supplier_id, legal_supplier_name, 'signed-framework-agreement.pdf')
+        framework_slug, current_user.supplier_id, legal_supplier_name,
+        'signed-framework-agreement{}'.format(extension))
     agreements_bucket.save(path, request.files['agreement'], acl='private')
 
     data_api_client.register_framework_agreement_returned(

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -15,7 +15,10 @@ from dmutils.email import send_email, MandrillException
 from dmutils.formats import format_service_price, datetimeformat
 from dmutils import s3
 from dmutils.deprecation import deprecated
-from dmutils.documents import get_agreement_document_path, get_signed_url, file_is_less_than_5mb, get_extension
+from dmutils.documents import (
+    get_agreement_document_path, get_signed_url, get_extension,
+    file_is_less_than_5mb, file_is_empty
+)
 
 from ... import data_api_client
 from ...main import main, content_loader
@@ -496,6 +499,8 @@ def upload_framework_agreement(framework_slug):
     upload_error = None
     if not file_is_less_than_5mb(request.files['agreement']):
         upload_error = "Document must be less than 5Mb"
+    elif file_is_empty(request.files['agreement']):
+        upload_error = "Document must not be empty"
 
     if upload_error is not None:
         return render_template(

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ werkzeug==0.10.4
 python-dateutil==2.4.2
 
 git+https://github.com/madzak/python-json-logger.git@v0.1.3#egg=python-json-logger==v0.1.3
-git+https://github.com/alphagov/digitalmarketplace-utils.git@13.1.0#egg=digitalmarketplace-utils==13.1.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@13.4.0#egg=digitalmarketplace-utils==13.4.0
 
 markdown==2.6.2
 

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -575,6 +575,26 @@ class TestFrameworkAgreementUpload(BaseApplicationTest):
             assert_equal(res.status_code, 400)
             assert_in(u'Document must be less than 5Mb', res.get_data(as_text=True))
 
+    @mock.patch('app.main.views.frameworks.file_is_empty')
+    def test_page_returns_400_if_file_is_too_large(self, file_is_empty, data_api_client, send_email, s3):
+        with self.app.test_client():
+            self.login()
+
+            data_api_client.get_framework.return_value = self.framework(status='standstill')
+            data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
+                on_framework=True)
+            file_is_empty.return_value = True
+
+            res = self.client.post(
+                '/suppliers/frameworks/g-cloud-7/agreement',
+                data={
+                    'agreement': (StringIO(b'doc'), 'test.pdf'),
+                }
+            )
+
+            assert_equal(res.status_code, 400)
+            assert_in(u'Document must not be empty', res.get_data(as_text=True))
+
     def test_api_is_not_updated_and_email_not_sent_if_upload_fails(self, data_api_client, send_email, s3):
         with self.app.test_client():
             self.login()

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -664,6 +664,30 @@ class TestFrameworkAgreementUpload(BaseApplicationTest):
                 }
             )
 
+            s3.return_value.save.assert_called_with(
+                'g-cloud-7/agreements/1234/Legal_Supplier_Name-1234-signed-framework-agreement.pdf',
+                mock.ANY, acl='private')
+            assert_equal(res.status_code, 302)
+            assert_equal(res.location, 'http://localhost/suppliers/frameworks/g-cloud-7/agreement')
+
+    def test_upload_jpeg_agreement_document(self, data_api_client, send_email, s3):
+        with self.app.test_client():
+            self.login()
+
+            data_api_client.get_framework.return_value = self.framework(status='standstill')
+            data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
+                on_framework=True)
+
+            res = self.client.post(
+                '/suppliers/frameworks/g-cloud-7/agreement',
+                data={
+                    'agreement': (StringIO(b'doc'), 'test.jpg'),
+                }
+            )
+
+            s3.return_value.save.assert_called_with(
+                'g-cloud-7/agreements/1234/Legal_Supplier_Name-1234-signed-framework-agreement.jpg',
+                mock.ANY, acl='private')
             assert_equal(res.status_code, 302)
             assert_equal(res.location, 'http://localhost/suppliers/frameworks/g-cloud-7/agreement')
 

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -707,13 +707,13 @@ class TestEditDraftService(BaseApplicationTest):
         assert_equal(res.status_code, 302)
         data_api_client.update_draft_service.assert_called_once_with(
             '1', {
-                'serviceDefinitionDocumentURL': 'http://localhost/suppliers/submission/documents/g-slug/1234/1-service-definition-document-2015-01-02-0304.pdf'  # noqa
+                'serviceDefinitionDocumentURL': 'http://localhost/suppliers/submission/documents/g-slug/documents/1234/1-service-definition-document-2015-01-02-0304.pdf'  # noqa
             }, 'email@email.com',
             page_questions=['serviceDefinitionDocumentURL']
         )
 
         s3.return_value.save.assert_called_once_with(
-            'g-slug/1234/1-service-definition-document-2015-01-02-0304.pdf',
+            'g-slug/documents/1234/1-service-definition-document-2015-01-02-0304.pdf',
             mock.ANY, acl='private'
         )
 


### PR DESCRIPTION
## Set extension name on signed agreement upload
Set the file extension correctly when uploading signed framework agreements.

## Verify that signed agreements are not empty
We have been getting some zero byte files uploaded as signed agreement documents.

## Depends on
- [x] https://github.com/alphagov/digitalmarketplace-utils/pull/207