### PR TITLE
Fix `return to summary` link while editing services

### DIFF
--- a/app/templates/services/_base_edit_section_page.html
+++ b/app/templates/services/_base_edit_section_page.html
@@ -52,7 +52,7 @@
           {% block save_button %}{% endblock %}
 
           {% block return_to_service_link %}
-          <a href="{% block return_to_service %}{% endblock %}">Return to service summary</a>
+            <a href="{% block return_to_service %}{% endblock %}">Return to service summary</a>
           {% endblock %}
 
       </div>

--- a/app/templates/services/edit_section.html
+++ b/app/templates/services/edit_section.html
@@ -35,4 +35,4 @@
   {% endwith %}
 {% endblock %}
 
-{% block return_to_service_link %}{{ url_for(".edit_service", service_id=service_id) }}{% endblock %}
+{% block return_to_service %}{{ url_for(".edit_service", service_id=service_id) }}{% endblock %}

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -294,6 +294,15 @@ class TestEditService(BaseApplicationTest):
         with self.app.test_client():
             self.login()
 
+    def test_return_to_service_summary_link_present(self, data_api_client):
+        data_api_client.get_service.return_value = self.empty_service
+        res = self.client.get('/suppliers/services/1/edit/description')
+        assert_equal(res.status_code, 200)
+        assert_in(
+            self.strip_all_whitespace('<a href="/suppliers/services/1">Return to service summary</a>'),
+            self.strip_all_whitespace(res.get_data(as_text=True))
+        )
+
     def test_questions_for_this_service_section_can_be_changed(self, data_api_client):
         data_api_client.get_service.return_value = self.empty_service
         res = self.client.post(


### PR DESCRIPTION
At some point, our `return to service summary` links stopped displaying
properly.  Got them back and added a test.

[>> Story on Pivotal](https://www.pivotaltracker.com/story/show/107279234)

***

### Whoops

![screen shot 2015-11-17 at 15 33 06](https://cloud.githubusercontent.com/assets/2454380/11215942/8f674c08-8d40-11e5-81c4-03c38415ed75.png)

### Fixed

![screen shot 2015-11-17 at 15 32 46](https://cloud.githubusercontent.com/assets/2454380/11215944/92af8d26-8d40-11e5-8cca-2801b70f58dc.png)
