### PR TITLE
Show status of application by lot

### DIFF
--- a/app/main/helpers/frameworks.py
+++ b/app/main/helpers/frameworks.py
@@ -139,8 +139,8 @@ def get_statuses_for_lot(
     if not drafts_count and not complete_drafts_count:
         return []
 
-    framework_is_open = 'open' == framework_status
-    declaration_complete = 'complete' == declaration_status
+    framework_is_open = ('open' == framework_status)
+    declaration_complete = ('complete' == declaration_status)
 
     if has_one_service_limit:
         return [get_status_for_one_service_lot(
@@ -205,7 +205,7 @@ def get_status_for_multi_service_lot_and_service_type(
     count, services_status, framework_is_open, declaration_complete, unit, unit_plural
 ):
 
-    singular = 1 == count
+    singular = (1 == count)
     description_of_services = u'{} {} {}'.format(
         count, services_status, unit if singular else unit_plural
     )

--- a/app/main/helpers/frameworks.py
+++ b/app/main/helpers/frameworks.py
@@ -126,138 +126,124 @@ def count_drafts_by_lot(drafts, lot):
 
 
 def get_statuses_for_lot(
-    has_one_service_limit, drafts_count, complete_drafts_count, declaration_status, framework_status, lot_name
+    has_one_service_limit,
+    drafts_count,
+    complete_drafts_count,
+    declaration_status,
+    framework_status,
+    lot_name,
+    unit,
+    unit_plural
 ):
+
+    if not drafts_count and not complete_drafts_count:
+        return []
 
     framework_is_open = 'open' == framework_status
     declaration_complete = 'complete' == declaration_status
 
-    if not drafts_count and not complete_drafts_count:
-        if framework_is_open:
-            return [{
-                'title': u'You haven’t applied to provide {}'.format(lot_name),
-                'type': u'quiet'
-            }]
-        else:
-            return [{
-                'title': u'You didn’t apply to provide {}'.format(lot_name),
-                'type': u'quiet'
-            }]
-
     if has_one_service_limit:
-        one_service_lot_status = get_status_for_one_service_lot(
-            drafts_count, complete_drafts_count, declaration_complete, framework_is_open, lot_name
-        )
-        if one_service_lot_status:
-            return [one_service_lot_status]
+        return [get_status_for_one_service_lot(
+            drafts_count, complete_drafts_count, declaration_complete, framework_is_open, lot_name, unit, unit_plural
+        )]
 
     if not complete_drafts_count:
-        return [
-            get_status_for_multi_service_lot_and_service_type(
-                drafts_count, 'draft', framework_is_open, declaration_complete
-            ) or None
-        ]
+        return [get_status_for_multi_service_lot_and_service_type(
+            drafts_count, 'draft', framework_is_open, declaration_complete, unit, unit_plural
+        )] if framework_is_open else [{
+            'title': 'No {} were marked as complete'.format(unit_plural),
+            'type': 'quiet'
+        }]
 
     if not drafts_count:
-        return [
-            get_status_for_multi_service_lot_and_service_type(
-                complete_drafts_count, 'complete', framework_is_open, declaration_complete
-            )
-        ]
+        return [get_status_for_multi_service_lot_and_service_type(
+            complete_drafts_count, 'complete', framework_is_open, declaration_complete, unit, unit_plural
+        )]
 
     return [
         get_status_for_multi_service_lot_and_service_type(
-            complete_drafts_count, 'complete', framework_is_open, declaration_complete
+            complete_drafts_count, 'complete', framework_is_open, declaration_complete, unit, unit_plural
         ),
         get_status_for_multi_service_lot_and_service_type(
-            drafts_count, 'draft', framework_is_open, declaration_complete
+            drafts_count, 'draft', framework_is_open, declaration_complete, unit, unit_plural
         )
-    ]
+    ] if framework_is_open else [get_status_for_multi_service_lot_and_service_type(
+        complete_drafts_count, 'complete', framework_is_open, declaration_complete, unit, unit_plural
+    )]
 
 
 def get_status_for_one_service_lot(
-    drafts_count, complete_drafts_count, declaration_complete, framework_is_open, lot_name
+    drafts_count, complete_drafts_count, declaration_complete, framework_is_open, lot_name, unit, unit_plural
 ):
 
     if drafts_count:
-        if framework_is_open:
-            return {
-                'title': u'You’ve started your application',
-                'type': u'quiet'
-            }
-        else:
-            return {
-                'title': u'You started your application',
-                'type': u'quiet'
-            }
+        return {
+            'title': u'Started but not complete' if framework_is_open else u'Not completed',
+            'type': u'quiet'
+        }
+
     if complete_drafts_count:
         if framework_is_open:
-            if declaration_complete:
-                return {
-                    'title': u'You’re submitting this service',
-                    'hint': u'You can edit it until the deadline',
-                    'type': u'happy'
-                }
-            else:
-                return {
-                    'title': u'You’ve completed this service',
-                    'hint': u'You can edit it until the deadline'
-                }
+            return {
+                'title': u'This will be submitted',
+                'hint': u'You can edit it until the deadline',
+                'type': u'happy'
+            } if declaration_complete else {
+                'title': u'Marked as complete',
+                'hint': u'You can edit it until the deadline'
+            }
         else:
-            if declaration_complete:
-                return {
-                    'title': u'You submitted this service',
-                    'type': u'happy'
-                }
-            else:
-                return {
-                    'title': u'You marked this service as complete'
-                }
+            return {
+                'title': u'Submitted',
+                'type': u'happy'
+            } if declaration_complete else {
+                'title': u'Marked as complete'
+            }
 
 
-def get_status_for_multi_service_lot_and_service_type(count, services_status, framework_is_open, declaration_complete):
+def get_status_for_multi_service_lot_and_service_type(
+    count, services_status, framework_is_open, declaration_complete, unit, unit_plural
+):
 
     singular = 1 == count
-    description_of_services = u'{} {} service{}'.format(
-        count, services_status, u'' if singular else u's'
+    description_of_services = u'{} {} {}'.format(
+        count, services_status, unit if singular else unit_plural
     )
 
+    if services_status == 'draft':
+        return {
+            'title': description_of_services,
+            'hint': u'Answer all the questions and mark as complete',
+            'type': u'quiet'
+        } if framework_is_open else {
+            'title': u'{} {} submitted'.format(
+                description_of_services, u'wasn’t' if singular else u'weren’t'
+            ),
+            'type': u'quiet'
+        }
+
     if framework_is_open:
-        if services_status == 'complete':
-            return {
-                'title': u'{}{}'.format(
-                    description_of_services, u' will be submitted' if declaration_complete else u''
-                ),
-                'hint': u'You can edit {} until the deadline'.format(u'it' if singular else u'them'),
-                'type': u'happy' if declaration_complete else None
-            }
-        else:
-            return {
-                'title': u'{}{}'.format(
-                    description_of_services, u' won’t be submitted' if declaration_complete else ''
-                ),
-                'type': u'quiet'
-            }
+        return {
+            'title': u'{} {} will be submitted'.format(
+                count, unit if singular else unit_plural
+            ),
+            'hint': u'You can edit {} until the deadline'.format(u'it' if singular else u'them'),
+            'type': u'happy'
+        } if declaration_complete else {
+            'title': u'{} {} marked as complete'.format(
+                count, unit if singular else unit_plural
+            ),
+            'hint': u'You can edit {} until the deadline'.format(u'it' if singular else u'them')
+        }
     else:
-        if services_status == 'complete':
-            if declaration_complete:
-                return {
-                    'title': u'{} {} submitted'.format(
-                        description_of_services, u'was' if singular else u'were'
-                    ),
-                    'type': u'happy' if declaration_complete else None
-                }
-            else:
-                return {
-                    'title': u'{} {} submitted'.format(
-                        description_of_services, u'wasn’t' if singular else u'weren’t'
-                    ),
-                    'type': u'quiet'
-                }
-        else:
-            return {
-                'title': u'{} {} submitted'.format(
-                    description_of_services, u'wasn’t' if singular else u'weren’t'
-                ),
-                'type': u'quiet'
-            }
+        return {
+            'title': u'{} {} submitted'.format(
+                description_of_services, u'was' if singular else u'were'
+            ),
+            'type': u'happy'
+        } if declaration_complete else {
+            'title': u'{} {} submitted'.format(
+                description_of_services, u'wasn’t' if singular else u'weren’t'
+            ),
+            'type': u'quiet'
+        }

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -126,7 +126,10 @@ def framework_submission_lots(framework_slug):
                 count_drafts_by_lot(complete_drafts, lot['value']),
                 declaration_status,
                 framework['status'],
-                lot['label']
+                lot['label'],
+                'lab' if framework['slug'] == 'digital-outcomes-and-specialists' else 'service',
+                'labs' if framework['slug'] == 'digital-outcomes-and-specialists' else 'service'
+                # TODO: ^ make this dynamic, eg, lab, service, unit
             )
         } for lot in lot_question['options']],
         **main.config['BASE_TEMPLATE_DATA']

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -26,7 +26,7 @@ from ..helpers import hash_email
 from ..helpers.frameworks import get_declaration_status, \
     get_last_modified_from_first_matching_file, register_interest_in_framework, \
     get_supplier_on_framework_from_info, get_declaration_status_from_info, \
-    get_supplier_framework_info, get_framework, get_framework_and_lot, count_drafts_by_lot
+    get_supplier_framework_info, get_framework, get_framework_and_lot, count_drafts_by_lot, get_statuses_for_lot
 from ..helpers.validation import get_validator
 from ..helpers.services import (
     get_draft_document_url, get_drafts, get_lot_drafts,
@@ -106,33 +106,28 @@ def framework_submission_lots(framework_slug):
 
     lot_question = content_loader.get_question(framework_slug, 'services', 'lot')
 
+    def has_one_service_limit(lot_slug):
+        for lot in framework['lots']:
+            if lot['slug'] == lot_slug:
+                return lot['one_service_limit']
+
     return render_template(
         "frameworks/submission_lots.html",
         complete_drafts=list(reversed(complete_drafts)),
         drafts=list(reversed(drafts)),
-        declaration_status=declaration_status,
         framework=framework,
         lots=[{
             'link': url_for('.framework_submission_services', framework_slug=framework_slug, lot_slug=lot['value']),
             'title': lot['label'],
             'body': lot['description'],
-            'statuses': [
-                {
-                    'title': '{} complete service{} {} submitted'.format(
-                        count_drafts_by_lot(complete_drafts, lot['value']),
-                        '' if 1 == count_drafts_by_lot(complete_drafts, lot['value']) else 's',
-                        'was' if 1 == count_drafts_by_lot(complete_drafts, lot['value']) else 'were'
-                    )
-                } if count_drafts_by_lot(complete_drafts, lot['value']) else {},
-                {
-                    'title': u'{} draft service{} {} submitted'.format(
-                        count_drafts_by_lot(drafts, lot['value']),
-                        '' if 1 == count_drafts_by_lot(drafts, lot['value']) else 's',
-                        u'wasn’t' if 1 == count_drafts_by_lot(drafts, lot['value']) else u'weren’t',
-                    ),
-                    'type': 'quiet'
-                } if count_drafts_by_lot(drafts, lot['value']) else {}
-            ]
+            'statuses': get_statuses_for_lot(
+                has_one_service_limit(lot['value']),
+                count_drafts_by_lot(drafts, lot['value']),
+                count_drafts_by_lot(complete_drafts, lot['value']),
+                declaration_status,
+                framework['status'],
+                lot['label']
+            )
         } for lot in lot_question['options']],
         **main.config['BASE_TEMPLATE_DATA']
     ), 200

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -115,6 +115,7 @@ def framework_submission_lots(framework_slug):
         "frameworks/submission_lots.html",
         complete_drafts=list(reversed(complete_drafts)),
         drafts=list(reversed(drafts)),
+        declaration_status=declaration_status,
         framework=framework,
         lots=[{
             'link': url_for('.framework_submission_services', framework_slug=framework_slug, lot_slug=lot['value']),
@@ -130,7 +131,7 @@ def framework_submission_lots(framework_slug):
                 'lab' if framework['slug'] == 'digital-outcomes-and-specialists' else 'service',
                 'labs' if framework['slug'] == 'digital-outcomes-and-specialists' else 'service'
                 # TODO: ^ make this dynamic, eg, lab, service, unit
-            )
+            ),
         } for lot in lot_question['options']],
         **main.config['BASE_TEMPLATE_DATA']
     ), 200

--- a/app/templates/frameworks/submission_lots.html
+++ b/app/templates/frameworks/submission_lots.html
@@ -42,6 +42,15 @@
     {% endfor %}
   {% endwith %}
 
+  {% if complete_drafts and declaration_status != 'complete' and framework.status == 'open' %}
+    {%
+      with
+      message = 'You need to <a href="' + url_for('.framework_supplier_declaration', framework_slug=framework.slug) + '">make the supplier&nbsp;declaration</a> before any services can be submitted',
+      type = 'warning'
+    %}
+      {% include 'toolkit/notification-banner.html' %}
+    {% endwith %}
+  {% endif %}
 
   <div class="grid-row">
     <div class="column-two-thirds">

--- a/tests/app/main/helpers/test_frameworks.py
+++ b/tests/app/main/helpers/test_frameworks.py
@@ -1,0 +1,324 @@
+# -*- coding: utf-8 -*-
+import pytest
+from nose.tools import assert_equal
+from app.main.helpers.frameworks import get_statuses_for_lot
+
+
+def get_lot_status_examples():
+    # limit, drafts, complete, declaration, framework
+    cases = [
+        # Lots with limit of one service
+        (
+            [True, 0, 0, None, 'open'],
+            [{
+                'title': u'You haven’t applied to provide digital shoutcomes',
+                'type': u'quiet'
+            }]
+        ),
+        (
+            [True, 1, 0, None, 'open'],
+            [{
+                'title': u'You’ve started your application',
+                'type': u'quiet'
+            }]
+        ),
+        (
+            [True, 0, 1, None, 'open'],
+            [{
+                'title': u'You’ve completed this service',
+                'hint': u'You can edit it until the deadline'
+            }]
+        ),
+        (
+            [True, 0, 1, 'complete', 'open'],
+            [{
+                'title': u'You’re submitting this service',
+                'hint': u'You can edit it until the deadline',
+                'type': u'happy'
+            }]
+        ),
+
+        # Lots with limit of one, framework in standstill
+        (
+            [True, 0, 0, None, 'standstill'],
+            [{
+                'title': u'You didn’t apply to provide digital shoutcomes',
+                'type': u'quiet'
+            }]
+        ),
+        (
+            [True, 1, 0, None, 'standstill'],
+            [{
+                'title': u'You started your application',
+                'type': u'quiet'
+            }]
+        ),
+        (
+            [True, 0, 1, None, 'standstill'],
+            [{
+                'title': 'You marked this service as complete'
+            }]
+        ),
+        (
+            [True, 0, 1, 'complete', 'standstill'],
+            [{
+                'title': u'You submitted this service',
+                'type': u'happy'
+            }]
+        ),
+
+        # Multi-service lots, no declaration, framework open
+        (
+            [False, 0, 0, None, 'open'],
+            [{
+                'title': u'You haven’t applied to provide digital shoutcomes',
+                'type': u'quiet'
+            }]
+        ),
+        (
+            [False, 1, 0, None, 'open'],
+            [{
+                'title': u'1 draft service',
+                'type': u'quiet'
+            }]
+        ),
+        (
+            [False, 0, 1, None, 'open'],
+            [{
+                'title': u'1 complete service',
+                'hint': u'You can edit it until the deadline',
+                'type': None
+            }]
+        ),
+        (
+            [False, 1, 1, None, 'open'],
+            [
+                {
+                    'title': u'1 complete service',
+                    'hint': u'You can edit it until the deadline',
+                    'type': None
+                },
+                {
+                    'title': u'1 draft service',
+                    'type': u'quiet'
+                }
+            ]
+        ),
+        (
+            [False, 3, 3, None, 'open'],
+            [
+                {
+                    'title': u'3 complete services',
+                    'hint': u'You can edit them until the deadline',
+                    'type': None
+                },
+                {
+                    'title': u'3 draft services',
+                    'type': u'quiet'
+                }
+            ]
+        ),
+
+        # Multi-service lots, declaration_complete, framework open
+        (
+            [False, 0, 0, 'complete', 'open'],
+            [{
+                'title': u'You haven’t applied to provide digital shoutcomes',
+                'type': u'quiet'
+            }]
+        ),
+        (
+            [False, 1, 0, 'complete', 'open'],
+            [{
+                'title': u'1 draft service won’t be submitted',
+                'type': u'quiet'
+            }]
+        ),
+        (
+            [False, 0, 1, 'complete', 'open'],
+            [{
+                'title': u'1 complete service will be submitted',
+                'hint': u'You can edit it until the deadline',
+                'type': u'happy'
+            }]
+        ),
+        (
+            [False, 1, 1, 'complete', 'open'],
+            [
+                {
+                    'title': u'1 complete service will be submitted',
+                    'hint': u'You can edit it until the deadline',
+                    'type': u'happy'
+                },
+                {
+                    'title': u'1 draft service won’t be submitted',
+                    'type': u'quiet'
+                }
+            ]
+        ),
+        (
+            [False, 3, 3, 'complete', 'open'],
+            [
+                {
+                    'title': u'3 complete services will be submitted',
+                    'hint': u'You can edit them until the deadline',
+                    'type': u'happy'
+                },
+                {
+                    'title': u'3 draft services won’t be submitted',
+                    'type': u'quiet'
+                }
+            ]
+        ),
+        (
+            [False, 3, 1, 'complete', 'open'],
+            [
+                {
+                    'title': u'1 complete service will be submitted',
+                    'hint': u'You can edit it until the deadline',
+                    'type': u'happy'
+                },
+                {
+                    'title': u'3 draft services won’t be submitted',
+                    'type': u'quiet'
+                }
+            ]
+        ),
+        (
+            [False, 1, 3, 'complete', 'open'],
+            [
+                {
+                    'title': u'3 complete services will be submitted',
+                    'hint': u'You can edit them until the deadline',
+                    'type': u'happy'
+                },
+                {
+                    'title': u'1 draft service won’t be submitted',
+                    'type': u'quiet'
+                }
+            ]
+        ),
+
+        # Multi-service lots, no declaration, framework closed
+        (
+            [False, 0, 0, None, 'standstill'],
+            [{
+                'title': u'You didn’t apply to provide digital shoutcomes',
+                'type': u'quiet'
+            }]
+        ),
+        (
+            [False, 1, 0, None, 'standstill'],
+            [{
+                'title': u'1 draft service wasn’t submitted',
+                'type': u'quiet'
+            }]
+        ),
+        (
+            [False, 0, 1, None, 'standstill'],
+            [{
+                'title': u'1 complete service wasn’t submitted',
+                'type': u'quiet'
+            }]
+        ),
+        (
+            [False, 1, 1, None, 'standstill'],
+            [
+                {
+                    'title': u'1 complete service wasn’t submitted',
+                    'type': u'quiet'
+                },
+                {
+                    'title': u'1 draft service wasn’t submitted',
+                    'type': u'quiet'
+                }
+            ]
+        ),
+        (
+            [False, 3, 3, None, 'standstill'],
+            [
+                {
+                    'title': u'3 complete services weren’t submitted',
+                    'type': u'quiet'
+                },
+                {
+                    'title': u'3 draft services weren’t submitted',
+                    'type': u'quiet'
+                }
+            ]
+        ),
+
+        # Multi-service lots, declaration complete, framework closed
+        (
+            [False, 0, 0, 'complete', 'standstill'],
+            [{
+                'title': u'You didn’t apply to provide digital shoutcomes',
+                'type': u'quiet'
+            }]
+        ),
+        (
+            [False, 1, 0, 'complete', 'standstill'],
+            [{
+                'title': u'1 draft service wasn’t submitted',
+                'type': u'quiet'
+            }]
+        ),
+        (
+            [False, 0, 1, 'complete', 'standstill'],
+            [{
+                'title': u'1 complete service was submitted',
+                'type': u'happy'
+            }]
+        ),
+        (
+            [False, 1, 1, 'complete', 'standstill'],
+            [
+                {
+                    'title': u'1 complete service was submitted',
+                    'type': u'happy'
+                },
+                {
+                    'title': u'1 draft service wasn’t submitted',
+                    'type': u'quiet'
+                }
+            ]
+        ),
+        (
+            [False, 3, 3, 'complete', 'standstill'],
+            [
+                {
+                    'title': u'3 complete services were submitted',
+                    'type': u'happy'
+                },
+                {
+                    'title': u'3 draft services weren’t submitted',
+                    'type': u'quiet'
+                }
+            ]
+        )
+    ]
+
+    def get_example():
+        for parameters, result in cases:
+            yield (parameters, result)
+
+    return get_example()
+
+
+@pytest.mark.parametrize(("parameters", "expected_result"), get_lot_status_examples())
+def test_get_status_for_lot(parameters, expected_result):
+
+    # This print statement makes it easier to debug failing tests
+    for index, label in enumerate([
+        'has_one_service_limit...',
+        'drafts_count............',
+        'complete_drafts_count...',
+        'declaration_status......',
+        'framework_status........'
+    ]):
+        print(label, parameters[index])
+
+    assert_equal(
+        expected_result,
+        get_statuses_for_lot(*parameters, lot_name='digital shoutcomes')
+    )

--- a/tests/app/main/helpers/test_frameworks.py
+++ b/tests/app/main/helpers/test_frameworks.py
@@ -260,7 +260,16 @@ def get_lot_status_examples():
                     'type': u'happy'
                 }
             ]
-        )
+        ),
+
+        # Test that declaration started is treated the same way as no declaration
+        (
+            [True, 0, 1, 'started', 'open'],
+            [{
+                'title': u'Marked as complete',
+                'hint': u'You can edit it until the deadline'
+            }]
+        ),
     ]
 
     def get_example():

--- a/tests/app/main/helpers/test_frameworks.py
+++ b/tests/app/main/helpers/test_frameworks.py
@@ -10,29 +10,26 @@ def get_lot_status_examples():
         # Lots with limit of one service
         (
             [True, 0, 0, None, 'open'],
-            [{
-                'title': u'You haven’t applied to provide digital shoutcomes',
-                'type': u'quiet'
-            }]
+            []
         ),
         (
             [True, 1, 0, None, 'open'],
             [{
-                'title': u'You’ve started your application',
+                'title': u'Started but not complete',
                 'type': u'quiet'
             }]
         ),
         (
             [True, 0, 1, None, 'open'],
             [{
-                'title': u'You’ve completed this service',
+                'title': u'Marked as complete',
                 'hint': u'You can edit it until the deadline'
             }]
         ),
         (
             [True, 0, 1, 'complete', 'open'],
             [{
-                'title': u'You’re submitting this service',
+                'title': u'This will be submitted',
                 'hint': u'You can edit it until the deadline',
                 'type': u'happy'
             }]
@@ -41,28 +38,25 @@ def get_lot_status_examples():
         # Lots with limit of one, framework in standstill
         (
             [True, 0, 0, None, 'standstill'],
-            [{
-                'title': u'You didn’t apply to provide digital shoutcomes',
-                'type': u'quiet'
-            }]
+            []
         ),
         (
             [True, 1, 0, None, 'standstill'],
             [{
-                'title': u'You started your application',
+                'title': u'Not completed',
                 'type': u'quiet'
             }]
         ),
         (
             [True, 0, 1, None, 'standstill'],
             [{
-                'title': 'You marked this service as complete'
+                'title': 'Marked as complete'
             }]
         ),
         (
             [True, 0, 1, 'complete', 'standstill'],
             [{
-                'title': u'You submitted this service',
+                'title': u'Submitted',
                 'type': u'happy'
             }]
         ),
@@ -70,36 +64,33 @@ def get_lot_status_examples():
         # Multi-service lots, no declaration, framework open
         (
             [False, 0, 0, None, 'open'],
-            [{
-                'title': u'You haven’t applied to provide digital shoutcomes',
-                'type': u'quiet'
-            }]
+            []
         ),
         (
             [False, 1, 0, None, 'open'],
             [{
-                'title': u'1 draft service',
+                'title': u'1 draft lab',
+                'hint': u'Answer all the questions and mark as complete',
                 'type': u'quiet'
             }]
         ),
         (
             [False, 0, 1, None, 'open'],
             [{
-                'title': u'1 complete service',
-                'hint': u'You can edit it until the deadline',
-                'type': None
+                'title': u'1 lab marked as complete',
+                'hint': u'You can edit it until the deadline'
             }]
         ),
         (
             [False, 1, 1, None, 'open'],
             [
                 {
-                    'title': u'1 complete service',
-                    'hint': u'You can edit it until the deadline',
-                    'type': None
+                    'title': u'1 lab marked as complete',
+                    'hint': u'You can edit it until the deadline'
                 },
                 {
-                    'title': u'1 draft service',
+                    'title': u'1 draft lab',
+                    'hint': u'Answer all the questions and mark as complete',
                     'type': u'quiet'
                 }
             ]
@@ -108,12 +99,12 @@ def get_lot_status_examples():
             [False, 3, 3, None, 'open'],
             [
                 {
-                    'title': u'3 complete services',
-                    'hint': u'You can edit them until the deadline',
-                    'type': None
+                    'title': u'3 labs marked as complete',
+                    'hint': u'You can edit them until the deadline'
                 },
                 {
-                    'title': u'3 draft services',
+                    'title': u'3 draft labs',
+                    'hint': u'Answer all the questions and mark as complete',
                     'type': u'quiet'
                 }
             ]
@@ -122,22 +113,20 @@ def get_lot_status_examples():
         # Multi-service lots, declaration_complete, framework open
         (
             [False, 0, 0, 'complete', 'open'],
-            [{
-                'title': u'You haven’t applied to provide digital shoutcomes',
-                'type': u'quiet'
-            }]
+            []
         ),
         (
             [False, 1, 0, 'complete', 'open'],
             [{
-                'title': u'1 draft service won’t be submitted',
+                'title': u'1 draft lab',
+                'hint': u'Answer all the questions and mark as complete',
                 'type': u'quiet'
             }]
         ),
         (
             [False, 0, 1, 'complete', 'open'],
             [{
-                'title': u'1 complete service will be submitted',
+                'title': u'1 lab will be submitted',
                 'hint': u'You can edit it until the deadline',
                 'type': u'happy'
             }]
@@ -146,12 +135,13 @@ def get_lot_status_examples():
             [False, 1, 1, 'complete', 'open'],
             [
                 {
-                    'title': u'1 complete service will be submitted',
+                    'title': u'1 lab will be submitted',
                     'hint': u'You can edit it until the deadline',
                     'type': u'happy'
                 },
                 {
-                    'title': u'1 draft service won’t be submitted',
+                    'title': u'1 draft lab',
+                    'hint': u'Answer all the questions and mark as complete',
                     'type': u'quiet'
                 }
             ]
@@ -160,12 +150,13 @@ def get_lot_status_examples():
             [False, 3, 3, 'complete', 'open'],
             [
                 {
-                    'title': u'3 complete services will be submitted',
+                    'title': u'3 labs will be submitted',
                     'hint': u'You can edit them until the deadline',
                     'type': u'happy'
                 },
                 {
-                    'title': u'3 draft services won’t be submitted',
+                    'title': u'3 draft labs',
+                    'hint': u'Answer all the questions and mark as complete',
                     'type': u'quiet'
                 }
             ]
@@ -174,12 +165,13 @@ def get_lot_status_examples():
             [False, 3, 1, 'complete', 'open'],
             [
                 {
-                    'title': u'1 complete service will be submitted',
+                    'title': u'1 lab will be submitted',
                     'hint': u'You can edit it until the deadline',
                     'type': u'happy'
                 },
                 {
-                    'title': u'3 draft services won’t be submitted',
+                    'title': u'3 draft labs',
+                    'hint': u'Answer all the questions and mark as complete',
                     'type': u'quiet'
                 }
             ]
@@ -188,12 +180,13 @@ def get_lot_status_examples():
             [False, 1, 3, 'complete', 'open'],
             [
                 {
-                    'title': u'3 complete services will be submitted',
+                    'title': u'3 labs will be submitted',
                     'hint': u'You can edit them until the deadline',
                     'type': u'happy'
                 },
                 {
-                    'title': u'1 draft service won’t be submitted',
+                    'title': u'1 draft lab',
+                    'hint': u'Answer all the questions and mark as complete',
                     'type': u'quiet'
                 }
             ]
@@ -202,97 +195,69 @@ def get_lot_status_examples():
         # Multi-service lots, no declaration, framework closed
         (
             [False, 0, 0, None, 'standstill'],
-            [{
-                'title': u'You didn’t apply to provide digital shoutcomes',
-                'type': u'quiet'
-            }]
+            []
         ),
         (
             [False, 1, 0, None, 'standstill'],
             [{
-                'title': u'1 draft service wasn’t submitted',
+                'title': u'No labs were marked as complete',
                 'type': u'quiet'
             }]
         ),
         (
             [False, 0, 1, None, 'standstill'],
             [{
-                'title': u'1 complete service wasn’t submitted',
+                'title': u'1 complete lab wasn’t submitted',
                 'type': u'quiet'
             }]
         ),
         (
             [False, 1, 1, None, 'standstill'],
-            [
-                {
-                    'title': u'1 complete service wasn’t submitted',
-                    'type': u'quiet'
-                },
-                {
-                    'title': u'1 draft service wasn’t submitted',
-                    'type': u'quiet'
-                }
-            ]
+            [{
+                'title': u'1 complete lab wasn’t submitted',
+                'type': u'quiet'
+            }]
         ),
         (
             [False, 3, 3, None, 'standstill'],
-            [
-                {
-                    'title': u'3 complete services weren’t submitted',
-                    'type': u'quiet'
-                },
-                {
-                    'title': u'3 draft services weren’t submitted',
-                    'type': u'quiet'
-                }
-            ]
+            [{
+                'title': u'3 complete labs weren’t submitted',
+                'type': u'quiet'
+            }]
         ),
 
         # Multi-service lots, declaration complete, framework closed
         (
             [False, 0, 0, 'complete', 'standstill'],
-            [{
-                'title': u'You didn’t apply to provide digital shoutcomes',
-                'type': u'quiet'
-            }]
+            []
         ),
         (
             [False, 1, 0, 'complete', 'standstill'],
             [{
-                'title': u'1 draft service wasn’t submitted',
+                'title': u'No labs were marked as complete',
                 'type': u'quiet'
             }]
         ),
         (
             [False, 0, 1, 'complete', 'standstill'],
             [{
-                'title': u'1 complete service was submitted',
+                'title': u'1 complete lab was submitted',
                 'type': u'happy'
             }]
         ),
         (
             [False, 1, 1, 'complete', 'standstill'],
-            [
-                {
-                    'title': u'1 complete service was submitted',
-                    'type': u'happy'
-                },
-                {
-                    'title': u'1 draft service wasn’t submitted',
-                    'type': u'quiet'
-                }
-            ]
+            [{
+                'title': u'1 complete lab was submitted',
+                'type': u'happy'
+            }]
         ),
         (
             [False, 3, 3, 'complete', 'standstill'],
             [
                 {
-                    'title': u'3 complete services were submitted',
+                    'title': u'3 complete labs were submitted',
                     'type': u'happy'
-                },
-                {
-                    'title': u'3 draft services weren’t submitted',
-                    'type': u'quiet'
                 }
             ]
         )
@@ -320,5 +285,10 @@ def test_get_status_for_lot(parameters, expected_result):
 
     assert_equal(
         expected_result,
-        get_statuses_for_lot(*parameters, lot_name='digital shoutcomes')
+        get_statuses_for_lot(
+            *parameters,
+            lot_name='user research studios',
+            unit='lab',
+            unit_plural='labs'
+        )
     )

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -1399,6 +1399,7 @@ class TestG7ServicesList(BaseApplicationTest):
 
         assert_true(u'Service can be moved to complete' not in lot_page.get_data(as_text=True))
         assert_in(u'1 optional question unanswered', lot_page.get_data(as_text=True))
+        assert_in(u'make the supplier&nbsp;declaration', lot_page.get_data(as_text=True))
 
         assert_in(u'1 service marked as complete', submissions.get_data(as_text=True))
         assert_true(u'draft service' not in submissions.get_data(as_text=True))

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -1360,7 +1360,8 @@ class TestG7ServicesList(BaseApplicationTest):
         assert_true(u'Service can be moved to complete' not in lot_page.get_data(as_text=True))
         assert_in(u'4 unanswered questions', lot_page.get_data(as_text=True))
 
-        assert_in(u'1 draft service wasn’t submitted', submissions.get_data(as_text=True))
+        assert_in(u'1 draft service', submissions.get_data(as_text=True))
+        assert_not_in(u'1 draft service wasn’t submitted', submissions.get_data(as_text=True))
         assert_true(u'complete service' not in submissions.get_data(as_text=True))
 
     def test_drafts_list_can_be_completed(self, count_unanswered, data_api_client):
@@ -1400,5 +1401,49 @@ class TestG7ServicesList(BaseApplicationTest):
         assert_true(u'Service can be moved to complete' not in lot_page.get_data(as_text=True))
         assert_in(u'1 optional question unanswered', lot_page.get_data(as_text=True))
 
-        assert_in(u'1 complete service was submitted', submissions.get_data(as_text=True))
+        assert_in(u'1 complete service', submissions.get_data(as_text=True))
         assert_true(u'draft service' not in submissions.get_data(as_text=True))
+
+    def test_drafts_list_completed_with_declaration_status(self, count_unanswered, data_api_client):
+        with self.app.test_client():
+            self.login()
+
+        data_api_client.get_framework.return_value = self.framework(status='open')
+        data_api_client.get_supplier_declaration.return_value = {
+            'declaration': {
+                'status': 'complete'
+            }
+        }
+        data_api_client.find_draft_services.return_value = {
+            'services': [
+                {'serviceName': 'draft', 'lot': 'scs', 'status': 'submitted'},
+            ]
+        }
+
+        submissions = self.client.get('/suppliers/frameworks/g-cloud-7/submissions')
+
+        assert_in(u'1 complete service', submissions.get_data(as_text=True))
+        assert_not_in(u'1 complete service was submitted', submissions.get_data(as_text=True))
+        assert_in(u'browse-list-item-status-happy', submissions.get_data(as_text=True))
+
+    def test_drafts_list_services_were_submitted(self, count_unanswered, data_api_client):
+        with self.app.test_client():
+            self.login()
+
+        data_api_client.get_framework.return_value = self.framework(status='standstill')
+        data_api_client.get_supplier_declaration.return_value = {
+            'declaration': {
+                'status': 'complete'
+            }
+        }
+        data_api_client.find_draft_services.return_value = {
+            'services': [
+                {'serviceName': 'draft', 'lot': 'scs', 'status': 'not-submitted'},
+                {'serviceName': 'draft', 'lot': 'scs', 'status': 'submitted'},
+            ]
+        }
+
+        submissions = self.client.get('/suppliers/frameworks/g-cloud-7/submissions')
+
+        assert_in(u'1 draft service wasn’t submitted', submissions.get_data(as_text=True))
+        assert_in(u'1 complete service was submitted', submissions.get_data(as_text=True))

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -1361,7 +1361,6 @@ class TestG7ServicesList(BaseApplicationTest):
         assert_in(u'4 unanswered questions', lot_page.get_data(as_text=True))
 
         assert_in(u'1 draft service', submissions.get_data(as_text=True))
-        assert_not_in(u'1 draft service wasn’t submitted', submissions.get_data(as_text=True))
         assert_true(u'complete service' not in submissions.get_data(as_text=True))
 
     def test_drafts_list_can_be_completed(self, count_unanswered, data_api_client):
@@ -1401,7 +1400,7 @@ class TestG7ServicesList(BaseApplicationTest):
         assert_true(u'Service can be moved to complete' not in lot_page.get_data(as_text=True))
         assert_in(u'1 optional question unanswered', lot_page.get_data(as_text=True))
 
-        assert_in(u'1 complete service', submissions.get_data(as_text=True))
+        assert_in(u'1 service marked as complete', submissions.get_data(as_text=True))
         assert_true(u'draft service' not in submissions.get_data(as_text=True))
 
     def test_drafts_list_completed_with_declaration_status(self, count_unanswered, data_api_client):
@@ -1422,7 +1421,7 @@ class TestG7ServicesList(BaseApplicationTest):
 
         submissions = self.client.get('/suppliers/frameworks/g-cloud-7/submissions')
 
-        assert_in(u'1 complete service', submissions.get_data(as_text=True))
+        assert_in(u'1 service will be submitted', submissions.get_data(as_text=True))
         assert_not_in(u'1 complete service was submitted', submissions.get_data(as_text=True))
         assert_in(u'browse-list-item-status-happy', submissions.get_data(as_text=True))
 
@@ -1445,5 +1444,4 @@ class TestG7ServicesList(BaseApplicationTest):
 
         submissions = self.client.get('/suppliers/frameworks/g-cloud-7/submissions')
 
-        assert_in(u'1 draft service wasn’t submitted', submissions.get_data(as_text=True))
         assert_in(u'1 complete service was submitted', submissions.get_data(as_text=True))


### PR DESCRIPTION
Shows the status of a suppliers application to a framework on the page which lists the lots.

--

![image](https://cloud.githubusercontent.com/assets/355079/11399823/a5d3b426-9381-11e5-8a14-af5dacc24aec.png)

--

_Notes for reviewing:_
- _You won’t be able to follow the logic in the code—I’d be more interested to know if you think there are any obvious test cases I’ve missed_

--

This should work for existing G7 applications, future DOS applications and any other framework that fits our current model.

The exact messaging depends on:
- whether the lot has a limit of one service
- status of framework
- number of draft and complete services
- status of supplier declaration
- name of the lot

…which makes it quite complicated.

This commit adds a couple of tests to the existing tests for this endpoint. It then adds a _lot_ of explicit tests for the helper functions that generate the status messages. This is the only way I could think to do this, because the code itself is not elegant.

The wording itself has been reviewed by Sarah, Sue and Ralph, and Sue has done some guerilla testing of it.