### PR TITLE
Make use of draft service validation errors

### DIFF
--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -358,7 +358,7 @@ def view_service_submission(framework_slug, lot_slug, service_id):
 
     try:
         data = data_api_client.get_draft_service(service_id)
-        draft, last_edit = data['services'], data['auditEvents']
+        draft, last_edit, validation_errors = data['services'], data['auditEvents'], data['validationErrors']
     except HTTPError as e:
         abort(e.status_code)
 
@@ -382,6 +382,7 @@ def view_service_submission(framework_slug, lot_slug, service_id):
         sections=sections,
         unanswered_required=unanswered_required,
         unanswered_optional=unanswered_optional,
+        can_mark_complete=not validation_errors,
         delete_requested=delete_requested,
         declaration_status=get_declaration_status(data_api_client, framework['slug']),
         deadline=current_app.config['G7_CLOSING_DATE'],

--- a/app/templates/services/service_submission.html
+++ b/app/templates/services/service_submission.html
@@ -87,7 +87,7 @@
     {% if service_data.status == 'submitted' and declaration_status == 'complete' %}
       <span class="service-status-published">This service is marked as complete and will be submitted at {{ deadline|safe }}</span>
     {% endif %}
-    {% if service_data.status == 'not-submitted' and unanswered_required == 0 and framework.status == 'open' %}
+    {% if service_data.status == 'not-submitted' and can_mark_complete and framework.status == 'open' %}
       {% include "partials/complete_service.html" %}
     {% elif unanswered_required > 0 %}
       <p class="move-to-complete-hint">When you have added all the required information, you can mark the service as complete.</p>
@@ -137,7 +137,7 @@
         &nbsp;
       </div>
       <div class="column-one-third delete-draft-button">
-        {% if service_data.status == 'not-submitted' and unanswered_required == 0 and framework.status == 'open' %}
+        {% if service_data.status == 'not-submitted' and can_mark_complete and framework.status == 'open' %}
           <div class="space-underneath">
             {% include "partials/complete_service.html" %}
           </div>

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -936,7 +936,8 @@ class TestShowDraftService(BaseApplicationTest):
             'createdAt': "2015-06-29T15:26:07.650368Z",
             'userName': "Supplier User",
 
-        }
+        },
+        'validationErrors': {}
     }
 
     complete_service = copy.deepcopy(draft_service)
@@ -987,6 +988,20 @@ class TestShowDraftService(BaseApplicationTest):
         data_api_client.get_framework.return_value = self.framework(status='other')
         data_api_client.get_draft_service.return_value = self.draft_service
         count_unanswered.return_value = 0, 1
+        res = self.client.get('/suppliers/frameworks/g-cloud-7/submissions/scs/1')
+
+        assert_not_in(u'<input type="submit" class="button-save"  value="Mark as complete" />',
+                      res.get_data(as_text=True))
+
+    @mock.patch('app.main.views.services.count_unanswered_questions')
+    def test_no_move_to_complete_button_if_validation_errors(self, count_unanswered, data_api_client):
+        draft_service = copy.deepcopy(self.draft_service)
+        draft_service['validationErrors'] = {'_errors': "Everything's busted"}
+
+        data_api_client.get_framework.return_value = self.framework(status='open')
+        data_api_client.get_draft_service.return_value = draft_service
+        count_unanswered.return_value = 0, 1
+
         res = self.client.get('/suppliers/frameworks/g-cloud-7/submissions/scs/1')
 
         assert_not_in(u'<input type="submit" class="button-save"  value="Mark as complete" />',
@@ -1046,7 +1061,8 @@ class TestDeleteDraftService(BaseApplicationTest):
         'auditEvents': {
             'createdAt': "2015-06-29T15:26:07.650368Z",
             'userName': "Supplier User",
-        }
+        },
+        'validationErrors': {}
     }
 
     def setup(self):


### PR DESCRIPTION
After https://github.com/alphagov/digitalmarketplace-api/pull/297 validation errors will come back in API responses when getting a single draft service. This change makes use of them to decide whether or not to show the 'mark as complete' button. This is required because not all of the validation rules can be determined just by whether any required fields are unfilled.