### PR TITLE
Add new statuses for services on framework dashboard

### DIFF
--- a/app/assets/scss/_framework-application.scss
+++ b/app/assets/scss/_framework-application.scss
@@ -21,23 +21,23 @@
   //padding-right: 1px;
 }
 
-%framework-application-section,
-.framework-application-section {
+.framework-dashboard {
 
-  border-top: 1px solid $grey-2;
-  padding-top: $gutter * 2/3;
-  margin-bottom: $gutter * 2/3;
+  .browse-list-item {
 
-  p {
-    margin-bottom: 5px;
-  }
+    border-top: 1px solid $grey-2;
+    padding-top: $gutter * 2/3;
+    margin-bottom: $gutter * 2/3;
 
-  h2 {
-    @include bold-24;
-  }
+    h2 {
+      @include bold-24;
+      margin-bottom: 10px;
+    }
 
-  li {
-    margin-top: 5px;
+    li {
+      margin-bottom: 10px;
+    }
+
   }
 
 }

--- a/app/assets/scss/_framework-application.scss
+++ b/app/assets/scss/_framework-application.scss
@@ -5,8 +5,7 @@
 
   @include core-19;
   font-weight: bold;
-  padding-bottom: $gutter * 2/3;
-  padding-top: $gutter * 1/2;
+  padding-bottom: $gutter;
 
   @include media(tablet) {
     padding-top: 0;
@@ -14,144 +13,21 @@
 
 }
 
-.big-number {
-  //@include bold-27;
-  @include inline-block;
-  padding-top: 5px;
-  //padding-right: 1px;
-}
-
 .framework-dashboard {
 
   .browse-list-item {
 
-    border-top: 1px solid $grey-2;
-    padding-top: $gutter * 2/3;
-    margin-bottom: $gutter * 2/3;
-
     h2 {
       @include bold-24;
-      margin-bottom: 10px;
-    }
-
-    li {
-      margin-bottom: 10px;
-    }
-
-  }
-
-}
-
-.framework-application-section-last {
-  @extend %framework-application-section;
-  border-bottom: 1px solid $grey-2;
-  padding-bottom: $gutter * 2/3;
-}
-
-.framework-section-status-neutral {
-  @extend %framework-section-status;
-  color: $secondary-text-colour;
-  font-weight: normal;
-  margin-top: 5px;
-}
-
-.framework-section-status-bad {
-
-  @extend %framework-section-status;
-  color: $mellow-red;
-
-  p {
-    margin-bottom: -5px;
-  }
-
-}
-
-.framework-section-status-good {
-  @extend %framework-section-status;
-}
-
-.framework-section-validation-bar {
-  border-left: 5px solid $mellow-red;
-  padding-left: 15px;
-  margin-bottom: 25px;
-}
-
-
-.submission-status-bad {
-
-  @extend %submission-status;
-  color: $mellow-red;
-
-  @include bold-16;
-
-  @include media(desktop) {
-    @include bold-19;
-  }
-
-}
-
-.submission-service-counts-column {
-
-  float: left;
-  box-sizing: border-box;
-  margin-top: 10px;
-  width: 49%;
-  padding-right: 10px;
-  vertical-align: top;
-  @include core-16;
-
-  @include media(desktop) {
-    margin-top: 0;
-    @include core-19;
-  }
-
-}
-
-.draft-service-count {
-  margin-top: $gutter/3;
-  color: $secondary-text-colour;
-}
-
-%framework-agreement-section,
-.framework-agreement-section {
-  padding: 20px 0 15px 0;
-  border-top: 1px solid #dee0e2;
-
-  .document-list {
-    padding-bottom: 0;
-  }
-
-  .question {
-    margin: 0;
-
-    .question-heading {
-      position: absolute;
-      left: -9999em;
-    }
-  }
-
-  h3 {
-    margin-bottom: 5px;
-  }
-
-  .lead-in {
-    margin-bottom: 10px;
-  }
-
-  ol {
-    list-style: decimal;
-    margin-left: 1.5em;
-    margin-bottom: 10px;
-
-    li {
       margin-bottom: 5px;
     }
-  }
-}
 
-.framework-agreement-section-first {
-  @extend %framework-agreement-section;
-  border-top: none;
+    li {
+      margin-bottom: 10px
+    }
+
+  }
+
 }
 
 /* Temporary styles, to be added to toolkit */

--- a/app/assets/scss/_framework-application.scss
+++ b/app/assets/scss/_framework-application.scss
@@ -17,6 +17,9 @@
 
   .browse-list-item {
 
+    border-top: 1px solid $border-colour;
+    padding-top: $gutter * 2/3;
+
     h2 {
       @include bold-24;
       margin-bottom: 5px;

--- a/app/assets/scss/_framework-application.scss
+++ b/app/assets/scss/_framework-application.scss
@@ -4,11 +4,14 @@
 .framework-application-status {
 
   @include core-19;
-  font-weight: bold;
-  padding-bottom: $gutter;
+  padding-bottom: $gutter * 2/3;
 
   @include media(tablet) {
     padding-top: 0;
+  }
+
+  strong {
+    font-weight: normal;
   }
 
 }
@@ -25,7 +28,7 @@
       margin-bottom: 5px;
     }
 
-    li {
+    .guidance-link {
       margin-bottom: 10px
     }
 

--- a/app/main/helpers/frameworks.py
+++ b/app/main/helpers/frameworks.py
@@ -247,3 +247,9 @@ def get_status_for_multi_service_lot_and_service_type(
             ),
             'type': u'quiet'
         }
+
+
+def has_one_service_limit(lot_slug, framework_lots):
+    for lot in framework_lots:
+        if lot['slug'] == lot_slug:
+            return lot['one_service_limit']

--- a/app/templates/frameworks/dashboard.html
+++ b/app/templates/frameworks/dashboard.html
@@ -23,11 +23,11 @@
 
   {% with messages = get_flashed_messages(with_categories=True) %}
     {% for category, message in messages %}
-          {% if category == 'declaration_complete' %}
-            <div data-analytics="trackPageView"
-              data-url="{{message}}">
-            </div>
-          {% endif %}
+      {% if category == 'declaration_complete' %}
+        <div data-analytics="trackPageView"
+          data-url="{{message}}">
+        </div>
+      {% endif %}
     {% endfor %}
   {% endwith %}
 
@@ -39,8 +39,7 @@
            "Your " + framework.name + " documents" if framework.status == 'live' else
            "Your " + framework.name + " application"
          ),
-         smaller = True,
-         with_breadcrumb = True
+         smaller = True
       %}
         {% include "toolkit/page-heading.html" %}
       {% endwith %}
@@ -92,59 +91,58 @@
 
           {% if framework.status == 'open' %}
             <li class="browse-list-item">
-              {% if not counts.draft %}
-                <div class="framework-section-validation-bar-good">
-              {% endif %}
-                <a class="browse-list-item-link" href="{{ url_for('.framework_submission_lots', framework_slug=framework.slug) }}">
-                  <span>
-                    Add, edit and delete services
-                  </span>
-                </a>
-              {% if not counts.draft %}
-                </div>
-              {% endif %}
+              <a class="browse-list-item-link" href="{{ url_for('.framework_submission_lots', framework_slug=framework.slug) }}">
+                <span>
+                  Add, edit and delete services
+                </span>
+              </a>
               {% if not counts.complete and not counts.draft %}
-                <div class="framework-section-status-neutral">
-                  <p>
+                <div class="browse-list-item-status-quiet">
+                  <p class="browse-list-item-status-title">
                     You need to add and complete services
                   </p>
                 </div>
               {% endif %}
 
               {% if counts.draft and not counts.complete %}
-                <div class="framework-section-status-neutral">
-                  You have
-                  {{ counts.draft }} draft
-                  {{ 'service' if counts.draft == 1 else 'services' }}
-                  that won’t be submitted
+                <div class="browse-list-item-status-quiet">
+                  <p class="browse-list-item-status-title">
+                    You have
+                    {{ counts.draft }} draft
+                    {{ 'service' if counts.draft == 1 else 'services' }}
+                    that won’t be submitted
+                  </p>
                 </div>
               {% endif %}
 
               {% if counts.complete and declaration_status != 'complete' %}
-                <div class="framework-section-status-neutral">
-                  You have {{ counts.complete }} complete
-                  {{ 'service' if counts.complete == 1 else 'services' }}
-                  and {{ counts.draft }} draft
-                  {{ 'service' if counts.draft == 1 else 'services' }}
+                <div class="browse-list-item-status-quiet">
+                  <p class="browse-list-item-status-title">
+                    You have {{ counts.complete }} complete
+                    {{ 'service' if counts.complete == 1 else 'services' }}
+                    and {{ counts.draft }} draft
+                    {{ 'service' if counts.draft == 1 else 'services' }}
+                  </p>
                 </div>
               {% endif %}
 
               {% if counts.complete and declaration_status == 'complete' %}
-                {% if not counts.draft %}
-                  <div class="framework-section-status-good">
-                {% endif %}
-                <p>
-                  <strong><span class="big-number">{{ counts.complete }}</span> complete
-                   {{ 'service' if counts.complete == 1 else 'services' }} will be submitted at the deadline</strong>
-                </p>
-                {% if not counts.draft %}
-                  </div>
-                {% endif %}
-                {% if counts.draft %}
-                  <p class="framework-section-status-neutral">
-                    {{ counts.draft }} draft {{ 'service' if counts.draft == 1 else 'services' }} won’t be submitted
+                <div class="browse-list-item-status-happy">
+                  <p class="browse-list-item-status-title">
+                    <strong>
+                      {{ counts.complete }} complete
+                      {{ 'service' if counts.complete == 1 else 'services' }}
+                      will be submitted at the deadline
+                    </strong>
                   </p>
-                {% endif %}
+                  {% if counts.draft %}
+                    <p class="browse-list-item-status-hint">
+                      {{ counts.draft }} draft
+                      {{ 'service' if counts.draft == 1 else 'services' }}
+                      won’t be submitted
+                    </p>
+                  {% endif %}
+                </div>
               {% endif %}
             </li>
           {% elif framework.status in ['pending', 'standstill'] and application_made %}
@@ -163,109 +161,80 @@
 
           {% if framework.status == 'open' %}
             <li class="browse-list-item">
-              {% if declaration_status != 'complete' and counts.complete %}
-                <div class="framework-section-validation-bar">
-              {% endif %}
-                  <a class="browse-list-item-link" href="{{ url_for('.framework_supplier_declaration', framework_slug=framework.slug, section_id=first_page_of_declaration) }}">
-                    {% if declaration_status == 'unstarted' %}
-                      <span>Make supplier declaration</span>
-                    {% else %}
-                      <span>Edit supplier declaration</span>
-                    {% endif %}
-                  </a>
-                  <p class="browse-list-item-body">
-                    Agree to the terms of the bid, provide supplier information and
-                    confirm&nbsp;eligibility.
+              <a class="browse-list-item-link" href="{{ url_for('.framework_supplier_declaration', framework_slug=framework.slug, section_id=first_page_of_declaration) }}">
+                {% if declaration_status == 'unstarted' %}
+                  <span>Make supplier declaration</span>
+                {% else %}
+                  <span>Edit supplier declaration</span>
+                {% endif %}
+              </a>
+              <p class="browse-list-item-body">
+                Agree to the terms of the bid, provide supplier information and
+                confirm&nbsp;eligibility.
+              </p>
+              {% if declaration_status == 'unstarted' and not counts.complete %}
+                <div class="browse-list-item-status-quiet">
+                  <p class="browse-list-item-status-title">
+                    You need to make the supplier declaration
                   </p>
-                  {% if declaration_status == 'unstarted' and not counts.complete %}
-                    <div class="framework-section-status-neutral">
-                      <p>
-                        You need to make the supplier declaration
-                      </p>
-                    </div>
-                  {% elif declaration_status == 'started' and not counts.complete %}
-                    <div class="framework-section-status-neutral">
-                      <p>
-                        You need to finish making the supplier declaration
-                      </p>
-                    </div>
-                  {% elif declaration_status == 'unstarted' and counts.complete %}
-                    <div class="framework-section-status-bad">
-                      <p>
-                        <strong>No services will be submitted because you haven’t made the
-                        supplier declaration</strong>
-                      </p>
-                    </div>
-                  {% elif declaration_status == 'started' and counts.complete %}
-                    <div class="framework-section-status-bad">
-                      <p>
-                        <strong>No services will be submitted because you haven’t finished making the
-                        supplier declaration</strong>
-                      </p>
-                    </div>
-                  {% elif declaration_status == 'complete' %}
-                    <div class="framework-section-status-good">
-                      <p>
-                        <strong>You’ve made the supplier declaration</strong>
-                      </p>
-                    </div>
-                  {% endif %}
-              {% if declaration_status != 'complete' and counts.complete %}
+                </div>
+              {% elif declaration_status == 'started' and not counts.complete %}
+                <div class="browse-list-item-status-quiet">
+                  <p class="browse-list-item-status-title">
+                    You need to finish making the supplier declaration
+                  </p>
+                </div>
+              {% elif declaration_status == 'unstarted' and counts.complete %}
+                <div class="browse-list-item-status-angry">
+                  <p class="browse-list-item-status-title">
+                    <strong>No services will be submitted because you haven’t made the
+                    supplier declaration</strong>
+                  </p>
+                </div>
+              {% elif declaration_status == 'started' and counts.complete %}
+                <div class="browse-list-item-status-angry">
+                  <p class="browse-list-item-status-title">
+                    <strong>No services will be submitted because you haven’t finished making the
+                    supplier declaration</strong>
+                  </p>
+                </div>
+              {% elif declaration_status == 'complete' %}
+                <div class="browse-list-item-status-happy">
+                  <p class="browse-list-item-status-title">
+                    <strong>You’ve made the supplier declaration</strong>
+                  </p>
                 </div>
               {% endif %}
             </li>
           {% endif %}
 
-          {% if framework.status == 'open' %}
-            <li class="browse-list-item">
-              <h2>
-                Guidance, updates and questions
-              </h2>
-              <ul>
-                <li>
-                  <a href="{{ url_for('.download_supplier_file', framework_slug=framework.slug, filepath='g-cloud-7-supplier-pack.zip') }}"><span>Download guidance and legal documentation (.zip)</span></a>
-                  {% if last_modified.supplier_pack %}
-                    <div class="hint">Last updated <time datetime="{{ last_modified.supplier_pack }}">{{ last_modified.supplier_pack|dateformat }}</time></div>
-                  {% endif %}
-                </li>
-                <li>
-                  <a href="{{ url_for('.framework_updates', framework_slug=framework.slug) }}">
-                    <span>
-                    {% if 'G7_CLARIFICATIONS_CLOSED' is active_feature %}
-                      Read updates and clarification question responses
-                    {% else %}
-                      Read updates and ask clarification questions
-                    {% endif %}
-                    </span>
-                  </a>
-                  {% if last_modified.supplier_updates %}
-                    <div class="hint">Last updated <time datetime="{{ last_modified.supplier_updates }}">{{ last_modified.supplier_updates|dateformat }}</time></div>
-                  {% endif %}
-                </li>
-              </ul>
-            </li>
-          {% else %}
-            <li class="browse-list-item">
-              <a href="{{ url_for('.download_supplier_file', filepath='g-cloud-7-supplier-pack.zip', framework_slug=framework.slug) }}"><span>Download guidance and legal documentation (.zip)</span></a>
-              {% if last_modified.supplier_pack %}
-                <div class="hint">Last updated <time datetime="{{ last_modified.supplier_pack }}">{{ last_modified.supplier_pack|dateformat }}</time></div>
-              {% endif %}
-            </li>
-            <li class="browse-list-item">
-              <a href="{{ url_for('.framework_updates', framework_slug=framework.slug) }}">
-                <span>
-                {% if 'G7_CLARIFICATIONS_CLOSED' is active_feature %}
-                  Read updates and clarification question responses
-                {% else %}
-                  Read updates and ask clarification questions
+          <li class="browse-list-item">
+            <h2>
+              Guidance, updates and questions
+            </h2>
+            <ul>
+              <li>
+                <a href="{{ url_for('.download_supplier_file', filepath='g-cloud-7-supplier-pack.zip', framework_slug=framework.slug) }}"><span>Download guidance and legal documentation (.zip)</span></a>
+                {% if last_modified.supplier_pack %}
+                  <div class="hint">Last updated <time datetime="{{ last_modified.supplier_pack }}">{{ last_modified.supplier_pack|dateformat }}</time></div>
                 {% endif %}
-                </span>
-              </a>
-              {% if last_modified.supplier_updates %}
-                <div class="hint">Last updated <time datetime="{{ last_modified.supplier_updates }}">{{ last_modified.supplier_updates|dateformat }}</time></div>
-              {% endif %}
-            </li>
-          {% endif %}
+              </li>
+              <li>
+                <a href="{{ url_for('.framework_updates', framework_slug=framework.slug) }}">
+                  <span>
+                    {% if framework.status == 'open' %}
+                      Read updates and ask clarification questions
+                    {% else %}
+                      Read updates and clarification question responses
+                    {% endif %}
+                  </span>
+                </a>
+                {% if last_modified.supplier_updates %}
+                  <div class="hint">Last updated <time datetime="{{ last_modified.supplier_updates }}">{{ last_modified.supplier_updates|dateformat }}</time></div>
+                {% endif %}
+              </li>
+            </ul>
+          </li>
         </ul>
       </nav>
     </div>

--- a/app/templates/frameworks/dashboard.html
+++ b/app/templates/frameworks/dashboard.html
@@ -31,41 +31,26 @@
     {% endfor %}
   {% endwith %}
 
+  <div class="grid-row framework-dashboard">
+    <div class="column-two-thirds">
+      {% with
+         heading = (
+           "Apply to " + framework.name if framework.status == 'open' else
+           "Your " + framework.name + " documents" if framework.status == 'live' else
+           "Your " + framework.name + " application"
+         ),
+         smaller = True,
+         with_breadcrumb = True
+      %}
+        {% include "toolkit/page-heading.html" %}
+      {% endwith %}
 
-  {% if framework.status == 'open' %}
-    {% with
-       heading = "Apply to " + framework.name,
-       smaller = True,
-       with_breadcrumb = True
-    %}
-      {% include "toolkit/page-heading.html" %}
-    {% endwith %}
-  {% elif framework.status == 'live' %}
-    {% with
-      heading = "Your " + framework.name + " documents",
-      smaller = True,
-      with_breadcrumb = True
-    %}
-      {% include "toolkit/page-heading.html" %}
-    {% endwith %}
-  {% else %}
-    {% with
-      heading = "Your " + framework.name + " application",
-      smaller = True,
-      with_breadcrumb = True
-    %}
-      {% include "toolkit/page-heading.html" %}
-    {% endwith %}
-  {% endif %}
-  {% if framework.status == 'open' %}
-  <aside role="complementary" class="framework-application-status" aria-label="G-Cloud status">
-    Deadline <strong>{{ deadline|safe }}</strong>
-  </aside>
-  <nav role="navigation">
-  {% elif framework.status == 'pending' %}
-    <div class="summary-item-lede">
-      <div class="grid-row">
-        <div class="column-two-thirds">
+      {% if framework.status == 'open' %}
+        <aside role="complementary" class="framework-application-status" aria-label="G-Cloud status">
+          Deadline <strong>{{ deadline|safe }}</strong>
+        </aside>
+      {% elif framework.status == 'pending' %}
+        <div class="summary-item-lede">
           <h2 class="summary-item-heading">{{ framework.name }} is closed for applications</h2>
           {% if application_made %}
             <p>You made your supplier declaration and submitted {{ counts.complete }} {{ 'service' if counts.complete == 1 else 'services' }} for consideration.</p>
@@ -74,52 +59,39 @@
             <p>You didn't submit an application.</p>
           {% endif %}
         </div>
-      </div>
-    </div>
-  {% elif framework.status == 'standstill' %}
-    <div class="summary-item-lede">
-      <div class="grid-row">
-        <div class="column-two-thirds">
+      {% elif framework.status == 'standstill' %}
+        <div class="summary-item-lede">
           {% if application_made %}
             <p>You made your supplier declaration and submitted {{ counts.complete }} {{ 'service' if counts.complete == 1 else 'services' }}.</p>
           {% else %}
             <p>You didn't submit an application.</p>
           {% endif %}
         </div>
-      </div>
-    </div>
-  {% endif %}
-    <ul class="browse-list">
+      {% endif %}
 
-      {% if framework.status in ['standstill', 'live'] and application_made %}
-        <li class="browse-list-item framework-application-section">
-          <div class="grid-row">
-            <div class="column-two-thirds">
+
+      <nav role="navigation">
+        <ul class="browse-list">
+
+          {% if framework.status in ['standstill', 'live'] and application_made %}
+            <li class="browse-list-item">
               <a class="browse-list-item-link" href="{{ url_for('.download_agreement_file', framework_slug=framework.slug, document_name='result-letter.pdf') }}" download>
                 <span>Download your application result letter (.pdf)</span>
               </a>
               <p>This letter informs you if your {{ framework.name }} application has been successful.</p>
-            </div>
-          </div>
-        </li>
-        {% if supplier_is_on_framework %}
-        <li class="browse-list-item framework-application-section">
-          <div class="grid-row">
-            <div class="column-two-thirds">
-              <a class="browse-list-item-link" href="{{ url_for('.framework_agreement', framework_slug=framework.slug) }}">
-                <span>Sign and return your framework agreement</span>
-              </a>
-              <p>Your agreement will need to be signed by both you and the Crown Commercial Service before you can sell {{framework.name}} services.</p>
-            </div>
-          </div>
-        </li>
-        {% endif %}
-      {% endif %}
+            </li>
+            {% if supplier_is_on_framework %}
+              <li class="browse-list-item">
+                <a class="browse-list-item-link" href="{{ url_for('.framework_agreement', framework_slug=framework.slug) }}">
+                  <span>Sign and return your framework agreement</span>
+                </a>
+                <p>Your agreement will need to be signed by both you and the Crown Commercial Service before you can sell {{framework.name}} services.</p>
+              </li>
+            {% endif %}
+          {% endif %}
 
-      {% if framework.status == 'open' %}
-        <li class="browse-list-item framework-application-section">
-          <div class="grid-row">
-            <div class="column-two-thirds">
+          {% if framework.status == 'open' %}
+            <li class="browse-list-item">
               {% if not counts.draft %}
                 <div class="framework-section-validation-bar-good">
               {% endif %}
@@ -131,8 +103,6 @@
               {% if not counts.draft %}
                 </div>
               {% endif %}
-            </div>
-            <div class="column-two-thirds">
               {% if not counts.complete and not counts.draft %}
                 <div class="framework-section-status-neutral">
                   <p>
@@ -176,16 +146,10 @@
                   </p>
                 {% endif %}
               {% endif %}
-            </div>
-          </div>
-        </li>
-      {% elif framework.status in ['pending', 'standstill'] and application_made %}
-        <li class="browse-list-item framework-application-section">
-          <div class="grid-row">
-            <div class="column-two-thirds">
+            </li>
+          {% elif framework.status in ['pending', 'standstill'] and application_made %}
+            <li class="browse-list-item">
               <a href="{{ url_for('.framework_submission_lots', framework_slug=framework.slug) }}">View services</a>
-            </div>
-            <div class="column-two-thirds">
               <div class="framework-section-status-neutral">
                 <p>{{ counts.complete }} complete
                 {{ 'service' if counts.complete == 1 else 'services' }} {{ 'was' if counts.complete == 1 else 'were' }} submitted</p>
@@ -194,75 +158,69 @@
                   {{ 'service' if counts.draft == 1 else 'services' }} {{ 'was' if counts.draft == 1 else 'were' }} not submitted</p>
                 {% endif %}
               </div>
-            </div>
-          </div>
-        </li>
-      {% endif %}
-
-      {% if framework.status == 'open' %}
-        <li class="browse-list-item framework-application-section">
-          {% if declaration_status != 'complete' and counts.complete %}
-            <div class="framework-section-validation-bar">
+            </li>
           {% endif %}
-          <div class="grid-row">
-            <div class="column-two-thirds">
-              <a class="browse-list-item-link" href="{{ url_for('.framework_supplier_declaration', framework_slug=framework.slug, section_id=first_page_of_declaration) }}">
-                {% if declaration_status == 'unstarted' %}
-                  <span>Make supplier declaration</span>
-                {% else %}
-                  <span>Edit supplier declaration</span>
-                {% endif %}
-              </a>
-              <p class="browse-list-item-body">
-                Agree to the terms of the bid, provide supplier information and
-                confirm&nbsp;eligibility.
-              </p>
-              {% if declaration_status == 'unstarted' and not counts.complete %}
-                <div class="framework-section-status-neutral">
-                  <p>
-                    You need to make the supplier declaration
+
+          {% if framework.status == 'open' %}
+            <li class="browse-list-item">
+              {% if declaration_status != 'complete' and counts.complete %}
+                <div class="framework-section-validation-bar">
+              {% endif %}
+                  <a class="browse-list-item-link" href="{{ url_for('.framework_supplier_declaration', framework_slug=framework.slug, section_id=first_page_of_declaration) }}">
+                    {% if declaration_status == 'unstarted' %}
+                      <span>Make supplier declaration</span>
+                    {% else %}
+                      <span>Edit supplier declaration</span>
+                    {% endif %}
+                  </a>
+                  <p class="browse-list-item-body">
+                    Agree to the terms of the bid, provide supplier information and
+                    confirm&nbsp;eligibility.
                   </p>
-                </div>
-              {% elif declaration_status == 'started' and not counts.complete %}
-                <div class="framework-section-status-neutral">
-                  <p>
-                    You need to finish making the supplier declaration
-                  </p>
-                </div>
-              {% elif declaration_status == 'unstarted' and counts.complete %}
-                <div class="framework-section-status-bad">
-                  <p>
-                    <strong>No services will be submitted because you haven’t made the
-                    supplier declaration</strong>
-                  </p>
-                </div>
-              {% elif declaration_status == 'started' and counts.complete %}
-                <div class="framework-section-status-bad">
-                  <p>
-                    <strong>No services will be submitted because you haven’t finished making the
-                    supplier declaration</strong>
-                  </p>
-                </div>
-              {% elif declaration_status == 'complete' %}
-                <div class="framework-section-status-good">
-                  <p>
-                    <strong>You’ve made the supplier declaration</strong>
-                  </p>
+                  {% if declaration_status == 'unstarted' and not counts.complete %}
+                    <div class="framework-section-status-neutral">
+                      <p>
+                        You need to make the supplier declaration
+                      </p>
+                    </div>
+                  {% elif declaration_status == 'started' and not counts.complete %}
+                    <div class="framework-section-status-neutral">
+                      <p>
+                        You need to finish making the supplier declaration
+                      </p>
+                    </div>
+                  {% elif declaration_status == 'unstarted' and counts.complete %}
+                    <div class="framework-section-status-bad">
+                      <p>
+                        <strong>No services will be submitted because you haven’t made the
+                        supplier declaration</strong>
+                      </p>
+                    </div>
+                  {% elif declaration_status == 'started' and counts.complete %}
+                    <div class="framework-section-status-bad">
+                      <p>
+                        <strong>No services will be submitted because you haven’t finished making the
+                        supplier declaration</strong>
+                      </p>
+                    </div>
+                  {% elif declaration_status == 'complete' %}
+                    <div class="framework-section-status-good">
+                      <p>
+                        <strong>You’ve made the supplier declaration</strong>
+                      </p>
+                    </div>
+                  {% endif %}
+              {% if declaration_status != 'complete' and counts.complete %}
                 </div>
               {% endif %}
-            </div>
-          </div>
-          {% if declaration_status != 'complete' and counts.complete %}
-            </div>
+            </li>
           {% endif %}
-        </li>
-      {% endif %}
 
-      {% if framework.status == 'open' %}
-        <li class="browse-list-item framework-application-section">
-          <div class="grid-row">
-            <div class="column-two-thirds">
-              <h2>About {{ framework.name }}</h2>
+          {% if framework.status == 'open' %}
+            <li class="browse-list-item">
+              <h2>
+                Guidance, updates and questions
+              </h2>
               <ul>
                 <li>
                   <a href="{{ url_for('.download_supplier_file', framework_slug=framework.slug, filepath='g-cloud-7-supplier-pack.zip') }}"><span>Download guidance and legal documentation (.zip)</span></a>
@@ -278,29 +236,22 @@
                     {% else %}
                       Read updates and ask clarification questions
                     {% endif %}
-                    </span></a>
+                    </span>
+                  </a>
                   {% if last_modified.supplier_updates %}
                     <div class="hint">Last updated <time datetime="{{ last_modified.supplier_updates }}">{{ last_modified.supplier_updates|dateformat }}</time></div>
                   {% endif %}
                 </li>
               </ul>
-            </div>
-          </div>
-        </li>
-      {% else %}
-        <li class="browse-list-item framework-application-section">
-          <div class="grid-row">
-            <div class="column-two-thirds">
+            </li>
+          {% else %}
+            <li class="browse-list-item">
               <a href="{{ url_for('.download_supplier_file', filepath='g-cloud-7-supplier-pack.zip', framework_slug=framework.slug) }}"><span>Download guidance and legal documentation (.zip)</span></a>
               {% if last_modified.supplier_pack %}
                 <div class="hint">Last updated <time datetime="{{ last_modified.supplier_pack }}">{{ last_modified.supplier_pack|dateformat }}</time></div>
               {% endif %}
-            </div>
-          </div>
-        </li>
-        <li class="browse-list-item framework-application-section">
-          <div class="grid-row">
-            <div class="column-two-thirds">
+            </li>
+            <li class="browse-list-item">
               <a href="{{ url_for('.framework_updates', framework_slug=framework.slug) }}">
                 <span>
                 {% if 'G7_CLARIFICATIONS_CLOSED' is active_feature %}
@@ -308,16 +259,16 @@
                 {% else %}
                   Read updates and ask clarification questions
                 {% endif %}
-                </span></a>
+                </span>
+              </a>
               {% if last_modified.supplier_updates %}
                 <div class="hint">Last updated <time datetime="{{ last_modified.supplier_updates }}">{{ last_modified.supplier_updates|dateformat }}</time></div>
               {% endif %}
-                </li>
-            </div>
-          </div>
-      </li>
-      {% endif %}
-    </ul>
-  </nav>
+            </li>
+          {% endif %}
+        </ul>
+      </nav>
+    </div>
+  </div>
 
 {% endblock %}

--- a/app/templates/frameworks/dashboard.html
+++ b/app/templates/frameworks/dashboard.html
@@ -142,7 +142,7 @@
             <li class="browse-list-item">
               <a class="browse-list-item-link" href="{{ url_for('.framework_submission_lots', framework_slug=framework.slug) }}">
                 <span>
-                  Add, edit and delete services
+                  Add, edit and complete services
                 </span>
               </a>
               {% if not counts.complete and not counts.draft %}
@@ -156,55 +156,60 @@
               {% if counts.draft and not counts.complete %}
                 <div class="browse-list-item-status-quiet">
                   <p class="browse-list-item-status-title">
-                    You have
-                    {{ counts.draft }} draft
-                    {{ 'service' if counts.draft == 1 else 'services' }}
-                    that won’t be submitted
+                    No services marked as complete
                   </p>
                 </div>
               {% endif %}
 
-              {% if counts.complete and declaration_status != 'complete' %}
-                <div class="browse-list-item-status-quiet">
-                  <p class="browse-list-item-status-title">
-                    {{ counts.complete }} complete
-                    {{ 'service' if counts.complete == 1 else 'services' }}
-                    and {{ counts.draft }} draft
-                    {{ 'service' if counts.draft == 1 else 'services' }}
-                  </p>
-                </div>
-              {% endif %}
-
-              {% if counts.complete and declaration_status == 'complete' %}
-                <div class="browse-list-item-status-happy">
-                  <p class="browse-list-item-status-title">
-                    <strong>
-                      {{ counts.complete }} complete
-                      {{ 'service' if counts.complete == 1 else 'services' }}
-                      will be submitted at the deadline
-                    </strong>
-                  </p>
-                  {% if counts.draft %}
-                    <p class="browse-list-item-status-hint">
-                      {{ counts.draft }} draft
-                      {{ 'service' if counts.draft == 1 else 'services' }}
-                      won’t be submitted
+              {% if counts.complete %}
+                {% if declaration_status == 'complete' %}
+                  <div class="browse-list-item-status-happy">
+                    <p class="browse-list-item-status-title">
+                      You’re submitting
                     </p>
-                  {% endif %}
+                {% else %}
+                  <div class="browse-list-item-status-default">
+                    <p class="browse-list-item-status-title">
+                      You’ve completed
+                    </p>
+                {% endif %}
+                  <ul class="browse-list-item-status-list">
+                    {% for lot in completed_lots %}
+                      {% if lot.one_service_limit %}
+                        <li>{{lot.name}}</li>
+                      {% else %}
+                        <li>
+                          {{ lot.complete_count }} {{ lot.name }}
+                          {{ lot.unit if (1 == lot.complete_count) else lot.unit_plural }}
+                        </li>
+                      {% endif %}
+                    {% endfor %}
+                  </ul>
                 </div>
               {% endif %}
             </li>
           {% elif framework.status in ['pending', 'standstill'] and application_made %}
             <li class="browse-list-item">
-              <a href="{{ url_for('.framework_submission_lots', framework_slug=framework.slug) }}">View services</a>
-              <div class="framework-section-status-neutral">
-                <p>{{ counts.complete }} complete
-                {{ 'service' if counts.complete == 1 else 'services' }} {{ 'was' if counts.complete == 1 else 'were' }} submitted</p>
-                {% if counts.draft > 0 %}
-                  <p>{{ counts.draft }} draft
-                  {{ 'service' if counts.draft == 1 else 'services' }} {{ 'was' if counts.draft == 1 else 'were' }} not submitted</p>
-                {% endif %}
+              <a class="browse-list-item-link" href="{{ url_for('.framework_submission_lots', framework_slug=framework.slug) }}">
+                View services
+              </a>
+              <div class="browse-list-item-status-happy">
+                <p class="browse-list-item-status-title">
+                  You submitted
+                </p>
               </div>
+              <ul class="browse-list-item-status-list">
+                {% for lot in completed_lots %}
+                  {% if lot.one_service_limit %}
+                    <li>{{ lot.name }}</li>
+                  {% else %}
+                    <li>
+                      {{ lot.complete_count }} {{ lot.name }}
+                      {{ lot.unit if (1 == lot.complete_count) else lot.unit_plural }}
+                    </li>
+                  {% endif %}
+                {% endfor %}
+              </ul>
             </li>
           {% endif %}
 
@@ -213,13 +218,13 @@
               Guidance, updates and questions
             </h2>
             <ul>
-              <li>
+              <li class="guidance-link">
                 <a href="{{ url_for('.download_supplier_file', filepath='g-cloud-7-supplier-pack.zip', framework_slug=framework.slug) }}"><span>Download guidance and legal documentation (.zip)</span></a>
                 {% if last_modified.supplier_pack %}
                   <div class="hint">Last updated <time datetime="{{ last_modified.supplier_pack }}">{{ last_modified.supplier_pack|dateformat }}</time></div>
                 {% endif %}
               </li>
-              <li>
+              <li class="guidance-link">
                 <a href="{{ url_for('.framework_updates', framework_slug=framework.slug) }}">
                   <span>
                     {% if framework.status == 'open' %}

--- a/app/templates/frameworks/dashboard.html
+++ b/app/templates/frameworks/dashboard.html
@@ -91,76 +91,6 @@
 
           {% if framework.status == 'open' %}
             <li class="browse-list-item">
-              <a class="browse-list-item-link" href="{{ url_for('.framework_submission_lots', framework_slug=framework.slug) }}">
-                <span>
-                  Add, edit and delete services
-                </span>
-              </a>
-              {% if not counts.complete and not counts.draft %}
-                <div class="browse-list-item-status-quiet">
-                  <p class="browse-list-item-status-title">
-                    You need to add and complete services
-                  </p>
-                </div>
-              {% endif %}
-
-              {% if counts.draft and not counts.complete %}
-                <div class="browse-list-item-status-quiet">
-                  <p class="browse-list-item-status-title">
-                    You have
-                    {{ counts.draft }} draft
-                    {{ 'service' if counts.draft == 1 else 'services' }}
-                    that won’t be submitted
-                  </p>
-                </div>
-              {% endif %}
-
-              {% if counts.complete and declaration_status != 'complete' %}
-                <div class="browse-list-item-status-quiet">
-                  <p class="browse-list-item-status-title">
-                    You have {{ counts.complete }} complete
-                    {{ 'service' if counts.complete == 1 else 'services' }}
-                    and {{ counts.draft }} draft
-                    {{ 'service' if counts.draft == 1 else 'services' }}
-                  </p>
-                </div>
-              {% endif %}
-
-              {% if counts.complete and declaration_status == 'complete' %}
-                <div class="browse-list-item-status-happy">
-                  <p class="browse-list-item-status-title">
-                    <strong>
-                      {{ counts.complete }} complete
-                      {{ 'service' if counts.complete == 1 else 'services' }}
-                      will be submitted at the deadline
-                    </strong>
-                  </p>
-                  {% if counts.draft %}
-                    <p class="browse-list-item-status-hint">
-                      {{ counts.draft }} draft
-                      {{ 'service' if counts.draft == 1 else 'services' }}
-                      won’t be submitted
-                    </p>
-                  {% endif %}
-                </div>
-              {% endif %}
-            </li>
-          {% elif framework.status in ['pending', 'standstill'] and application_made %}
-            <li class="browse-list-item">
-              <a href="{{ url_for('.framework_submission_lots', framework_slug=framework.slug) }}">View services</a>
-              <div class="framework-section-status-neutral">
-                <p>{{ counts.complete }} complete
-                {{ 'service' if counts.complete == 1 else 'services' }} {{ 'was' if counts.complete == 1 else 'were' }} submitted</p>
-                {% if counts.draft > 0 %}
-                  <p>{{ counts.draft }} draft
-                  {{ 'service' if counts.draft == 1 else 'services' }} {{ 'was' if counts.draft == 1 else 'were' }} not submitted</p>
-                {% endif %}
-              </div>
-            </li>
-          {% endif %}
-
-          {% if framework.status == 'open' %}
-            <li class="browse-list-item">
               <a class="browse-list-item-link" href="{{ url_for('.framework_supplier_declaration', framework_slug=framework.slug, section_id=first_page_of_declaration) }}">
                 {% if declaration_status == 'unstarted' %}
                   <span>Make supplier declaration</span>
@@ -205,6 +135,76 @@
                   </p>
                 </div>
               {% endif %}
+            </li>
+          {% endif %}
+
+          {% if framework.status == 'open' %}
+            <li class="browse-list-item">
+              <a class="browse-list-item-link" href="{{ url_for('.framework_submission_lots', framework_slug=framework.slug) }}">
+                <span>
+                  Add, edit and delete services
+                </span>
+              </a>
+              {% if not counts.complete and not counts.draft %}
+                <div class="browse-list-item-status-quiet">
+                  <p class="browse-list-item-status-title">
+                    You need to add and complete services
+                  </p>
+                </div>
+              {% endif %}
+
+              {% if counts.draft and not counts.complete %}
+                <div class="browse-list-item-status-quiet">
+                  <p class="browse-list-item-status-title">
+                    You have
+                    {{ counts.draft }} draft
+                    {{ 'service' if counts.draft == 1 else 'services' }}
+                    that won’t be submitted
+                  </p>
+                </div>
+              {% endif %}
+
+              {% if counts.complete and declaration_status != 'complete' %}
+                <div class="browse-list-item-status-quiet">
+                  <p class="browse-list-item-status-title">
+                    {{ counts.complete }} complete
+                    {{ 'service' if counts.complete == 1 else 'services' }}
+                    and {{ counts.draft }} draft
+                    {{ 'service' if counts.draft == 1 else 'services' }}
+                  </p>
+                </div>
+              {% endif %}
+
+              {% if counts.complete and declaration_status == 'complete' %}
+                <div class="browse-list-item-status-happy">
+                  <p class="browse-list-item-status-title">
+                    <strong>
+                      {{ counts.complete }} complete
+                      {{ 'service' if counts.complete == 1 else 'services' }}
+                      will be submitted at the deadline
+                    </strong>
+                  </p>
+                  {% if counts.draft %}
+                    <p class="browse-list-item-status-hint">
+                      {{ counts.draft }} draft
+                      {{ 'service' if counts.draft == 1 else 'services' }}
+                      won’t be submitted
+                    </p>
+                  {% endif %}
+                </div>
+              {% endif %}
+            </li>
+          {% elif framework.status in ['pending', 'standstill'] and application_made %}
+            <li class="browse-list-item">
+              <a href="{{ url_for('.framework_submission_lots', framework_slug=framework.slug) }}">View services</a>
+              <div class="framework-section-status-neutral">
+                <p>{{ counts.complete }} complete
+                {{ 'service' if counts.complete == 1 else 'services' }} {{ 'was' if counts.complete == 1 else 'were' }} submitted</p>
+                {% if counts.draft > 0 %}
+                  <p>{{ counts.draft }} draft
+                  {{ 'service' if counts.draft == 1 else 'services' }} {{ 'was' if counts.draft == 1 else 'were' }} not submitted</p>
+                {% endif %}
+              </div>
             </li>
           {% endif %}
 

--- a/app/templates/frameworks/services.html
+++ b/app/templates/frameworks/services.html
@@ -89,10 +89,10 @@
     empty_message="You haven’t added any services yet." if framework.status == 'open' else "You didn’t add any services.",
     field_headings=[
         "Service name",
-        summary.hidden_field_heading("Progress"),
-        summary.hidden_field_heading("Make a copy")
+        "Progress",
+        "Make a copy"
     ],
-    field_headings_visible=True
+    field_headings_visible=False
   ) %}
     {% call summary.row() %}
       {{ summary.service_link(draft.serviceName,
@@ -124,10 +124,10 @@
     empty_message="You haven’t marked any services as complete yet." if framework.status == 'open' else "You didn’t mark any services as complete.",
     field_headings=[
         "Service name",
-        summary.hidden_field_heading("Progress"),
-        summary.hidden_field_heading("Make a copy")
+        "Progress",
+        "Make a copy"
     ],
-    field_headings_visible=True
+    field_headings_visible=False
   ) %}
     {% call summary.row() %}
       {{ summary.service_link(draft.serviceName,

--- a/app/templates/frameworks/submission_lots.html
+++ b/app/templates/frameworks/submission_lots.html
@@ -46,7 +46,7 @@
     {%
       with
       message = 'You need to <a href="' + url_for('.framework_supplier_declaration', framework_slug=framework.slug) + '">make the supplier&nbsp;declaration</a> before any services can be submitted',
-      type = 'warning'
+      type = 'destructive'
     %}
       {% include 'toolkit/notification-banner.html' %}
     {% endwith %}

--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "jquery": "1.11.2",
     "hogan": "3.0.2",
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
-    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v13.0.0",
+    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v13.0.1",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.14.1/jinja_govuk_template-0.14.1.tgz",
     "digitalmarketplace-frameworks": "git://github.com/alphagov/digitalmarketplace-frameworks#v0.9.4"
   }

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -34,7 +34,7 @@ class TestFrameworksDashboard(BaseApplicationTest):
 
         for last_updated in last_updateds:
             hint = doc.xpath(
-                '//li[contains(@class, "framework-application-section")]'
+                '//li[contains(@class, "browse-list-item")]'
                 '//span[contains(text(), "{}")]'
                 '/../..'
                 '/div[@class="hint"]'.format(last_updated['text'])

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -136,7 +136,7 @@ class TestFrameworksDashboard(BaseApplicationTest):
             data_api_client.get_framework_interest.return_value = {'frameworks': ['g-cloud-7']}
             data_api_client.find_draft_services.return_value = {
                 "services": [
-                    {'serviceName': 'A service', 'status': 'submitted'}
+                    {'serviceName': 'A service', 'status': 'submitted', 'lot': 'iaas'}
                 ]
             }
             data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(declaration=None)
@@ -177,7 +177,7 @@ class TestFrameworksDashboard(BaseApplicationTest):
             data_api_client.get_framework_interest.return_value = {'frameworks': ['g-cloud-7']}
             data_api_client.find_draft_services.return_value = {
                 "services": [
-                    {'serviceName': 'A service', 'status': 'submitted'}
+                    {'serviceName': 'A service', 'status': 'submitted', 'lot': 'iaas'}
                 ]
             }
             data_api_client.get_supplier_framework_info.return_value = self.supplier_framework()
@@ -348,7 +348,7 @@ class TestFrameworksDashboard(BaseApplicationTest):
             data_api_client.get_framework_interest.return_value = {'frameworks': ['g-cloud-7']}
             data_api_client.find_draft_services.return_value = {
                 "services": [
-                    {'serviceName': 'A service', 'status': 'submitted'}
+                    {'serviceName': 'A service', 'status': 'submitted', 'lot': 'iaas'}
                 ]
             }
             data_api_client.get_supplier_framework_info.return_value = self.supplier_framework()
@@ -367,7 +367,7 @@ class TestFrameworksDashboard(BaseApplicationTest):
             data_api_client.get_framework_interest.return_value = {'frameworks': ['g-cloud-7']}
             data_api_client.find_draft_services.return_value = {
                 "services": [
-                    {'serviceName': 'A service', 'status': 'submitted'}
+                    {'serviceName': 'A service', 'status': 'submitted', 'lot': 'iaas'}
                 ]
             }
             data_api_client.get_supplier_framework_info.return_value = self.supplier_framework()
@@ -405,7 +405,7 @@ class TestFrameworksDashboard(BaseApplicationTest):
             data_api_client.get_framework_interest.return_value = {'frameworks': ['g-cloud-7']}
             data_api_client.find_draft_services.return_value = {
                 "services": [
-                    {'serviceName': 'A service', 'status': 'submitted'}
+                    {'serviceName': 'A service', 'status': 'submitted', 'lot': 'iaas'}
                 ]
             }
             data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
@@ -425,7 +425,7 @@ class TestFrameworksDashboard(BaseApplicationTest):
             data_api_client.get_framework_interest.return_value = {'frameworks': ['g-cloud-7']}
             data_api_client.find_draft_services.return_value = {
                 "services": [
-                    {'serviceName': 'A service', 'status': 'submitted'}
+                    {'serviceName': 'A service', 'status': 'submitted', 'lot': 'iaas'}
                 ]
             }
             data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(


### PR DESCRIPTION
Based on talking this through with @ralph-hawkins.

## This:
- cuts down the number of status we show you by not talking about drafts on this page
- makes the statuses work for lots which have a limit of one service, as well as lots that have a limit of more than one service
- tells you which lots you are submitting to

![image](https://cloud.githubusercontent.com/assets/355079/11425490/3f1011d6-944d-11e5-98c3-9eb6a0558d93.png)

![image](https://cloud.githubusercontent.com/assets/355079/11425473/27119992-944d-11e5-9bb1-20021e01372f.png)

## Also
- Tidy and simplify the dashboard template (to pave the way for the meat of this PR)
- Use new browse list status
- Move declaration above services