### PR TITLE
Bump toolkit version to 13.0.2

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "jquery": "1.11.2",
     "hogan": "3.0.2",
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
-    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v13.0.1",
+    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v13.0.2",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.14.1/jinja_govuk_template-0.14.1.tgz",
     "digitalmarketplace-frameworks": "git://github.com/alphagov/digitalmarketplace-frameworks#v0.9.4"
   }


### PR DESCRIPTION
[☞  v13.0.2](https://github.com/alphagov/digitalmarketplace-frontend-toolkit/releases/tag/v13.0.2)

Includes:
- https://github.com/alphagov/digitalmarketplace-frontend-toolkit/pull/190