### PR TITLE
Make clarification emails non-G7 specific

### DIFF
--- a/app/main/helpers/frameworks.py
+++ b/app/main/helpers/frameworks.py
@@ -252,4 +252,4 @@ def get_status_for_multi_service_lot_and_service_type(
 def has_one_service_limit(lot_slug, framework_lots):
     for lot in framework_lots:
         if lot['slug'] == lot_slug:
-            return lot['one_service_limit']
+            return lot['oneServiceLimit']

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -392,9 +392,10 @@ def framework_updates_email_clarification_question(framework_slug):
         to_address = current_app.config['DM_FOLLOW_UP_EMAIL_TO']
         from_address = current_user.email_address
         email_body = render_template(
-            "emails/g7_follow_up_question.html",
+            "emails/follow_up_question.html",
             supplier_name=current_user.supplier_name,
             user_name=current_user.name,
+            framework_name=framework['name'],
             message=clarification_question
         )
         tags = ["application-question"]
@@ -426,6 +427,7 @@ def framework_updates_email_clarification_question(framework_slug):
         email_body = render_template(
             "emails/clarification_question_submitted.html",
             user_name=current_user.name,
+            framework_name=framework['name'],
             message=clarification_question
         )
         try:

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -151,7 +151,7 @@ def framework_submission_services(framework_slug, lot_slug):
     if framework['status'] == 'pending' and declaration_status != 'complete':
         abort(404)
 
-    if lot['one_service_limit']:
+    if lot['oneServiceLimit']:
         draft = next(iter(drafts + complete_drafts), None)
         if not draft:
             draft = data_api_client.create_new_draft_service(

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -411,9 +411,10 @@ def framework_updates_email_clarification_question(framework_slug):
         )
     except MandrillException as e:
         current_app.logger.error(
-            "Clarification question email failed to send. "
+            "{framework} clarification question email failed to send. "
             "error {error} supplier_id {supplier_id} email_hash {email_hash}",
             extra={'error': six.text_type(e),
+                   'framework': framework['slug'],
                    'supplier_id': current_user.supplier_id,
                    'email_hash': hash_email(current_user.email_address)})
         abort(503, "Clarification question email failed to send")
@@ -442,22 +443,23 @@ def framework_updates_email_clarification_question(framework_slug):
             )
         except MandrillException as e:
             current_app.logger.error(
-                "Clarification question confirmation email failed to send. "
+                "{} clarification question confirmation email failed to send. "
                 "error {error} supplier_id {supplier_id} email_hash {email_hash}",
                 extra={'error': six.text_type(e),
+                       'framework': framework['slug'],
                        'supplier_id': current_user.supplier_id,
                        'email_hash': hash_email(current_user.email_address)})
     else:
         # Do not send confirmation email to the user who submitted the question
         # Zendesk will handle this instead
-        audit_type = AuditTypes.send_g7_application_question
+        audit_type = AuditTypes.send_application_question
 
     data_api_client.create_audit_event(
         audit_type=audit_type,
         user=current_user.email_address,
         object_type="suppliers",
         object_id=current_user.supplier_id,
-        data={"question": clarification_question})
+        data={"question": clarification_question, 'framework': framework['slug']})
 
     flash('message_sent', 'success')
     return framework_updates(framework['slug'])

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -292,7 +292,7 @@ def complete_draft_service(framework_slug, lot_slug, service_id):
         )
     }, 'service_completed')
 
-    if lot['one_service_limit']:
+    if lot['oneServiceLimit']:
         return redirect(url_for(".framework_submission_lots", framework_slug=framework['slug']))
     else:
         return redirect(url_for(".framework_submission_services",
@@ -320,7 +320,7 @@ def delete_draft_service(framework_slug, lot_slug, service_id):
             abort(e.status_code)
 
         flash({'service_name': draft.get('serviceName', draft['lotName'])}, 'service_deleted')
-        if lot['one_service_limit']:
+        if lot['oneServiceLimit']:
             return redirect(url_for(".framework_submission_lots", framework_slug=framework['slug']))
         else:
             return redirect(url_for(".framework_submission_services",

--- a/app/templates/emails/clarification_question_submitted.html
+++ b/app/templates/emails/clarification_question_submitted.html
@@ -6,7 +6,7 @@
 <body>
 Hello {{ user_name }},
 <br /><br />
-Thanks for sending your G-Cloud 7 clarification question. All clarification questions and answers will be published regularly on the Digital Marketplace G-Cloud 7 updates page.
+Thanks for sending your {{ framework_name }} clarification question. All clarification questions and answers will be published regularly on the Digital Marketplace {{ framework_name }} updates page.
 <br /><br />
 You’ll receive an email when new clarification answers are posted. The Crown Commercial Service will not respond to you individually.
 <br /><br />

--- a/app/templates/emails/follow_up_question.html
+++ b/app/templates/emails/follow_up_question.html
@@ -8,7 +8,7 @@ Supplier name: {{ supplier_name }}
 <br />
 User name: {{ user_name }}
 <br /><br />
-G-Cloud 7 question asked:
+{{ framework_name }} question asked:
 <br />
 {{ message }}
 </body>

--- a/app/templates/frameworks/dashboard.html
+++ b/app/templates/frameworks/dashboard.html
@@ -227,7 +227,7 @@
               <li class="guidance-link">
                 <a href="{{ url_for('.framework_updates', framework_slug=framework.slug) }}">
                   <span>
-                    {% if framework.status == 'open' %}
+                    {% if framework.clarificationQuestionsOpen %}
                       Read updates and ask clarification questions
                     {% else %}
                       Read updates and clarification question responses

--- a/app/templates/frameworks/updates.html
+++ b/app/templates/frameworks/updates.html
@@ -29,10 +29,10 @@
   {% with messages = get_flashed_messages(with_categories=true) %}
     {% for category, message in messages %}
       {% if message == 'message_sent' %}
-        {% if 'G7_CLARIFICATIONS_CLOSED' is active_feature %}
-          {% set message = "Your question has been sent. You'll get a reply from the Crown Commercial Service soon." %}
-        {% else %}
+        {% if framework.clarificationQuestionsOpen %}
           {% set message = "Your clarification question has been sent. Answers to all clarification questions will be published on this page." %}
+        {% else %}
+          {% set message = "Your question has been sent. You'll get a reply from the Crown Commercial Service soon." %}
         {% endif %}
       {% endif %}
       {%
@@ -96,45 +96,16 @@
         {% endcall %}
       {% endfor %}
       <p class="hint">
-        {% if 'G7_CLARIFICATIONS_CLOSED' is active_feature %}
-          The deadline for asking clarification questions has now passed. All clarification questions and answers will be published by 5pm <abbr title="British Summer Time">BST</abbr>, 29 September 2015. You'll receive an email when new answers are posted.
-        {% else %}
+        {% if framework.clarificationQuestionsOpen %}
           All clarification questions and answers will be published here regularly. You will receive an email when new answers are posted.
+        {% else %}
+          The deadline for asking clarification questions has now passed. All clarification questions and answers will be published by 5pm <abbr title="British Summer Time">BST</abbr>, 29 September 2015. You'll receive an email when new answers are posted.
         {% endif %}
       </p>
     </div>
   </div>
 
-  {% if 'G7_CLARIFICATIONS_CLOSED' is active_feature %}
-    <form method="post">
-      <div class="grid-row">
-        <div class="column-two-thirds">
-          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
-          {%
-            with
-            large=true,
-            question = "Ask a question about your G-Cloud 7 application",
-            name = clarification_question_name,
-            hint = "If you have any questions about your G-Cloud 7 application, you can ask them here. You'll get a private reply from the Crown Commercial Service. (Maximum 5000 characters per question.)",
-            error = error_message,
-            value = clarification_question_value
-          %}
-          {% include "toolkit/forms/textbox.html" %}
-          {% endwith %}
-          {%
-            with
-            label="Ask question",
-            type="save"
-          %}
-          {% include "toolkit/button.html" %}
-          {% endwith %}
-        
-          <a href="{{ url_for('.framework_dashboard', framework_slug=framework.slug) }}">Return to {{ framework.name }} application</a>
-
-        </div>
-      </div>
-    </form>
-  {% else %}
+  {% if framework.clarificationQuestionsOpen %}
     <form method="post">
       <div class="grid-row">
         <div class="column-two-thirds">
@@ -160,11 +131,40 @@
             %}
               {% include "toolkit/button.html" %}
             {% endwith %}
-      
+
             <a href="{{ url_for('.framework_dashboard', framework_slug=framework.slug) }}">Return to {{ framework.name }} application</a>
 
           </div>
         </div>
       </form>
+  {% else %}
+    <form method="post">
+      <div class="grid-row">
+        <div class="column-two-thirds">
+          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+          {%
+            with
+            large=true,
+            question = "Ask a question about your {} application".format(framework.name),
+            name = clarification_question_name,
+            hint = "If you have any questions about your {} application, you can ask them here. You'll get a private reply from the Crown Commercial Service. (Maximum 5000 characters per question.)".format(framework.name),
+            error = error_message,
+            value = clarification_question_value
+          %}
+          {% include "toolkit/forms/textbox.html" %}
+          {% endwith %}
+          {%
+            with
+            label="Ask question",
+            type="save"
+          %}
+          {% include "toolkit/button.html" %}
+          {% endwith %}
+
+          <a href="{{ url_for('.framework_dashboard', framework_slug=framework.slug) }}">Return to {{ framework.name }} application</a>
+
+        </div>
+      </div>
+    </form>
   {% endif %}
 {% endblock %}

--- a/app/templates/frameworks/updates.html
+++ b/app/templates/frameworks/updates.html
@@ -1,7 +1,7 @@
 {% extends "_base_page.html" %}
 {% import "toolkit/summary-table.html" as summary %}
 
-{% block page_title %}G-Cloud 7 updates – Digital Marketplace{% endblock %}
+{% block page_title %}{{ framework.name }} updates – Digital Marketplace{% endblock %}
 
 {% block breadcrumb %}
   {%
@@ -51,7 +51,7 @@
       errors = [
         {
             "input_name": clarification_question_name,
-            "question": "Ask a G-Cloud 7 clarification question"
+            "question": "Ask a {} clarification question".format(framework.name)
         }
     ],
       lede = "There was a problem with your submitted question"
@@ -64,7 +64,7 @@
     <div class="column-two-thirds">
       {% with
          smaller = true,
-         heading = "G-Cloud 7 updates"
+         heading = "{} updates".format(framework.name)
       %}
         {% include "toolkit/page-heading.html" %}
       {% endwith %}
@@ -113,9 +113,9 @@
             {%
               with
               large=true,
-              question = "Ask a G-Cloud 7 clarification question",
+              question = "Ask a {} clarification question".format(framework.name),
               name = clarification_question_name,
-              hint = "You should ask any questions you have about G-Cloud 7 here. The Crown Commercial Service will not respond to you individually. All answers to clarification questions will be published here regularly. (Maximum 5000 characters per question.)",
+              hint = "You should ask any questions you have about {} here. The Crown Commercial Service will not respond to you individually. All answers to clarification questions will be published here regularly. (Maximum 5000 characters per question.)".format(framework.name),
               error = error_message,
               value = clarification_question_value
             %}

--- a/config.py
+++ b/config.py
@@ -52,8 +52,7 @@ class Config(object):
     CLARIFICATION_EMAIL_NAME = 'Digital Marketplace Admin'
     CLARIFICATION_EMAIL_FROM = 'do-not-reply@digitalmarketplace.service.gov.uk'
     CLARIFICATION_EMAIL_SUBJECT = 'Thanks for your clarification question'
-    G7_FOLLOW_UP_EMAIL_SUBJECT = 'Thanks for your G-Cloud 7 question'
-    DM_G7_FOLLOW_UP_EMAIL_TO = 'digitalmarketplace@mailinator.com'
+    DM_FOLLOW_UP_EMAIL_TO = 'digitalmarketplace@mailinator.com'
 
     CREATE_USER_SUBJECT = 'Create your Digital Marketplace account'
     SECRET_KEY = os.getenv('DM_PASSWORD_SECRET_KEY')
@@ -73,7 +72,6 @@ class Config(object):
     RAISE_ERROR_ON_MISSING_FEATURES = True
 
     FEATURE_FLAGS_EDIT_SERVICE_PAGE = False
-    FEATURE_FLAGS_G7_CLARIFICATIONS_CLOSED = False
 
     # Logging
     DM_LOG_LEVEL = 'DEBUG'
@@ -111,7 +109,6 @@ class Development(Config):
 
     # Dates not formatted like YYYY-(0)M-(0)D will fail
     FEATURE_FLAGS_EDIT_SERVICE_PAGE = enabled_since('2015-06-03')
-    FEATURE_FLAGS_G7_CLARIFICATIONS_CLOSED = enabled_since('2015-09-15')
 
 
 class Live(Config):
@@ -124,15 +121,14 @@ class Live(Config):
 
 class Preview(Live):
     FEATURE_FLAGS_EDIT_SERVICE_PAGE = enabled_since('2015-06-03')
-    FEATURE_FLAGS_G7_CLARIFICATIONS_CLOSED = enabled_since('2015-09-18')
 
 
 class Production(Live):
-    FEATURE_FLAGS_G7_CLARIFICATIONS_CLOSED = enabled_since('2015-09-22')
+    pass
 
 
 class Staging(Production):
-    FEATURE_FLAGS_G7_CLARIFICATIONS_CLOSED = enabled_since('2015-09-18')
+    pass
 
 configs = {
     'development': Development,

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ werkzeug==0.10.4
 python-dateutil==2.4.2
 
 git+https://github.com/madzak/python-json-logger.git@v0.1.3#egg=python-json-logger==v0.1.3
-git+https://github.com/alphagov/digitalmarketplace-utils.git@15.2.0#egg=digitalmarketplace-utils==15.2.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@15.3.0#egg=digitalmarketplace-utils==15.3.0
 
 markdown==2.6.2
 

--- a/tests/app/helpers.py
+++ b/tests/app/helpers.py
@@ -174,12 +174,12 @@ class BaseApplicationTest(object):
     def framework(status='open', name='G-Cloud 7', slug='g-cloud-7', clarification_questions_open=True):
         if slug == 'g-cloud-7':
             lots = [
-                {'id': 1, 'slug': 'iaas', 'name': 'Infrastructure as a Service', 'one_service_limit': False},
-                {'id': 2, 'slug': 'scs', 'name': 'Specialist Cloud Services', 'one_service_limit': False},
+                {'id': 1, 'slug': 'iaas', 'name': 'Infrastructure as a Service', 'oneServiceLimit': False},
+                {'id': 2, 'slug': 'scs', 'name': 'Specialist Cloud Services', 'oneServiceLimit': False},
             ]
         elif slug == 'digital-outcomes-and-specialists':
             lots = [
-                {'id': 1, 'slug': 'digital-specialists', 'name': 'Digital specialists', 'one_service_limit': True},
+                {'id': 1, 'slug': 'digital-specialists', 'name': 'Digital specialists', 'oneServiceLimit': True},
             ]
 
         return {

--- a/tests/app/helpers.py
+++ b/tests/app/helpers.py
@@ -171,7 +171,7 @@ class BaseApplicationTest(object):
         }
 
     @staticmethod
-    def framework(status='open', name='G-Cloud 7', slug='g-cloud-7'):
+    def framework(status='open', name='G-Cloud 7', slug='g-cloud-7', clarification_questions_open=True):
         if slug == 'g-cloud-7':
             lots = [
                 {'id': 1, 'slug': 'iaas', 'name': 'Infrastructure as a Service', 'one_service_limit': False},
@@ -185,6 +185,7 @@ class BaseApplicationTest(object):
         return {
             'frameworks': {
                 'status': status,
+                'clarificationQuestionsOpen': clarification_questions_open,
                 'name': name,
                 'slug': slug,
                 'lots': lots,

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -1255,7 +1255,7 @@ class TestSendClarificationQuestionEmail(BaseApplicationTest):
             user="email@email.com",
             object_type="suppliers",
             object_id=1234,
-            data={"question": clarification_question})
+            data={"question": clarification_question, 'framework': 'g-cloud-7'})
 
     @mock.patch('dmutils.s3.S3')
     @mock.patch('app.main.views.frameworks.data_api_client')
@@ -1270,11 +1270,11 @@ class TestSendClarificationQuestionEmail(BaseApplicationTest):
 
         assert_equal(response.status_code, 200)
         data_api_client.create_audit_event.assert_called_with(
-            audit_type=AuditTypes.send_g7_application_question,
+            audit_type=AuditTypes.send_application_question,
             user="email@email.com",
             object_type="suppliers",
             object_id=1234,
-            data={"question": clarification_question})
+            data={"question": clarification_question, 'framework': 'g-cloud-7'})
 
     @mock.patch('app.main.views.frameworks.data_api_client')
     @mock.patch('app.main.views.frameworks.send_email')


### PR DESCRIPTION
### Make clarification emails non-G7 specific
Removes the `G7_CLARIFICATIONS_CLOSED` feature flag in favour of the
framework data `clarificationQuestionsOpen` flag returned by the API.
This requires a switch in `if ... else ...` order to make conditions
more readable.

Changes to clarification emails sent to zendesk:
* Email subject changed from "Clarification question" to "<framework>
  clarification question"
* Email from address changed from `suppliers@...` to
  `suppliers+<framework-slug>@...`

Changes to application emails:
* Subject will use the current framework name in "<framework>
  application question"
* Tags changed from "g7-application-question" to "application-question"

#### Replace "G-Cloud 7" template strings with current framework name
#### Update clarification email templates with current framework name
#### Add framework slug to clarification email logs and audit events