### PR TITLE
Fix breadcrumbs on lots with a limit of one service

### DIFF
--- a/app/templates/services/service_submission.html
+++ b/app/templates/services/service_submission.html
@@ -24,7 +24,7 @@
       {
         "link": url_for(".framework_submission_services", framework_slug=framework.slug, lot_slug=service_data.lot),
         "label": service_data.lotName
-      }
+      } if not one_service_limit else {}
     ]
   %}
     {% include "toolkit/breadcrumb.html" %}


### PR DESCRIPTION
If a lot has a limit of one service it doesn’t make sense to link to the lot from the service page—it just links to the current page, which we don’t do anywhere else.

This commit adds a condition to hide the link.

Fixes [109072944](https://www.pivotaltracker.com/story/show/109072944).