### PR TITLE
Linkifying URLs in summary tables

### DIFF
--- a/app/templates/suppliers/_information.html
+++ b/app/templates/suppliers/_information.html
@@ -24,7 +24,7 @@
   {% endcall %}
   {% call summary.row() %}
     {{ summary.field_name('Website') }}
-    {{ summary.text(supplier.contact.website) }}
+    {{ summary.external_link(supplier.contact.website, supplier.contact.website)}}
   {% endcall %}
   {% call summary.row() %}
     {{ summary.field_name('Address') }}

--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "jquery": "1.11.2",
     "hogan": "3.0.2",
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
-    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v13.3.4",
+    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v13.4.1",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.14.1/jinja_govuk_template-0.14.1.tgz",
     "digitalmarketplace-frameworks": "git://github.com/alphagov/digitalmarketplace-frameworks#v0.12.2"
   }


### PR DESCRIPTION
Requires the merging of [PR 192](https://github.com/alphagov/digitalmarketplace-frontend-toolkit/pull/192) on frontend toolkit.

If there's a URL, people should be able to click on it.