### PR TITLE
Jump links

### DIFF
--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -500,10 +500,15 @@ def update_section_submission(framework_slug, lot_slug, service_id, section_id, 
                                 service_id=service_id,
                                 section_id=next_section))
     else:
-        return redirect(url_for(".view_service_submission",
-                                framework_slug=framework['slug'],
-                                lot_slug=draft['lot'],
-                                service_id=service_id))
+        return redirect("{}#{}".format(
+            url_for(
+                ".view_service_submission",
+                framework_slug=framework['slug'],
+                lot_slug=draft['lot'],
+                service_id=service_id
+            ),
+            section_id
+        ))
 
 
 def _update_service_status(service, error_message=None):

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -500,15 +500,11 @@ def update_section_submission(framework_slug, lot_slug, service_id, section_id, 
                                 service_id=service_id,
                                 section_id=next_section))
     else:
-        return redirect("{}#{}".format(
-            url_for(
-                ".view_service_submission",
-                framework_slug=framework['slug'],
-                lot_slug=draft['lot'],
-                service_id=service_id
-            ),
-            section_id
-        ))
+        return redirect(url_for(".view_service_submission",
+                                framework_slug=framework['slug'],
+                                lot_slug=draft['lot'],
+                                service_id=service_id,
+                                _anchor=section_id))
 
 
 def _update_service_status(service, error_message=None):

--- a/app/templates/services/_base_service_page.html
+++ b/app/templates/services/_base_service_page.html
@@ -39,7 +39,7 @@
             {% if question.answer_required %}
               {% call summary.field() %}
                 {% if framework and framework.status == 'open' %}
-                    <a href="{{ url_for(".edit_service_submission", framework_slug=framework.slug, lot_slug=service_data.lot, service_id=service_id, section_id=section.id) }}">Answer required</a>
+                    <a href="{{ url_for(".edit_service_submission", framework_slug=framework.slug, lot_slug=service_data.lot, service_id=service_id, section_id=section.id) }}#{{ question.id }}">Answer required</a>
                 {% else %}
                   Not answered
                 {% endif %}

--- a/app/templates/services/_base_service_page.html
+++ b/app/templates/services/_base_service_page.html
@@ -39,7 +39,7 @@
             {% if question.answer_required %}
               {% call summary.field() %}
                 {% if framework and framework.status == 'open' %}
-                    <a href="{{ url_for(".edit_service_submission", framework_slug=framework.slug, lot_slug=service_data.lot, service_id=service_id, section_id=section.id) }}#{{ question.id }}">Answer required</a>
+                    <a href="{{ url_for(".edit_service_submission", framework_slug=framework.slug, lot_slug=service_data.lot, service_id=service_id, section_id=section.id, _anchor=question.id) }}">Answer required</a>
                 {% else %}
                   Not answered
                 {% endif %}

--- a/app/templates/services/_base_service_page.html
+++ b/app/templates/services/_base_service_page.html
@@ -17,7 +17,7 @@
     <div class="column-one-whole">
       {% import "toolkit/summary-table.html" as summary %}
       {% for section in sections %}
-        {{ summary.heading(section.name) }}
+        {{ summary.heading(section.name, id=section.slug) }}
         {% if section.editable %}
           {% block edit_link scoped %}{% endblock %}
         {% endif %}

--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "jquery": "1.11.2",
     "hogan": "3.0.2",
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
-    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v13.0.3",
+    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v13.1.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.14.1/jinja_govuk_template-0.14.1.tgz",
     "digitalmarketplace-frameworks": "git://github.com/alphagov/digitalmarketplace-frameworks#v0.9.4"
   }

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -831,7 +831,10 @@ class TestEditDraftService(BaseApplicationTest):
             data={})
 
         assert_equal(302, res.status_code)
-        assert_equal('http://localhost/suppliers/frameworks/g-cloud-7/submissions/scs/1', res.headers['Location'])
+        assert_equal(
+            'http://localhost/suppliers/frameworks/g-cloud-7/submissions/scs/1#sfia-rate-card',
+            res.headers['Location']
+        )
 
     def test_update_redirects_to_edit_submission_if_return_to_summary(self, data_api_client, s3):
         s3.return_value.bucket_short_name = 'submissions'
@@ -844,7 +847,10 @@ class TestEditDraftService(BaseApplicationTest):
             data={})
 
         assert_equal(302, res.status_code)
-        assert_equal('http://localhost/suppliers/frameworks/g-cloud-7/submissions/scs/1', res.headers['Location'])
+        assert_equal(
+            'http://localhost/suppliers/frameworks/g-cloud-7/submissions/scs/1#service-description',
+            res.headers['Location']
+        )
 
     def test_update_redirects_to_edit_submission_if_grey_button_clicked(self, data_api_client, s3):
         s3.return_value.bucket_short_name = 'submissions'
@@ -857,7 +863,10 @@ class TestEditDraftService(BaseApplicationTest):
             data={})
 
         assert_equal(302, res.status_code)
-        assert_equal('http://localhost/suppliers/frameworks/g-cloud-7/submissions/scs/1', res.headers['Location'])
+        assert_equal(
+            'http://localhost/suppliers/frameworks/g-cloud-7/submissions/scs/1#service-description',
+            res.headers['Location']
+        )
 
     def test_update_with_answer_required_error(self, data_api_client, s3):
         s3.return_value.bucket_short_name = 'submissions'


### PR DESCRIPTION
## Make 'Answer required' jump to the exact question

This worked in previous SSPs. It got lost somewhere along the way.

## Jump to summary section after answering a question

It is jarring to be taken back to the top of a long page after answering a question, and having to scroll all the way down to find where the answer is played back (and potentially where the next section of questions you want to answer are).

This commit adds an anchor to jump between these pages more seamlessly.