### PR TITLE
Remove G-Cloud 7 deadline and declaration link

### DIFF
--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -385,7 +385,7 @@ def view_service_submission(framework_slug, lot_slug, service_id):
         can_mark_complete=not validation_errors,
         delete_requested=delete_requested,
         declaration_status=get_declaration_status(data_api_client, framework['slug']),
-        deadline=current_app.config['G7_CLOSING_DATE'],
+        deadline=current_app.config['DOS_CLOSING_DATE'],
         **main.config['BASE_TEMPLATE_DATA']), 200
 
 

--- a/app/templates/partials/service_warning.html
+++ b/app/templates/partials/service_warning.html
@@ -1,7 +1,7 @@
 {% if true %}
   {%
     with
-    message = 'This service will not be submitted at the deadline because the <a href="' + url_for('.framework_supplier_declaration', section_id='g_cloud_7_essentials') + '">supplier&nbsp;declaration</a> hasn’t been made.',
+    message = 'This service will not be submitted at the deadline because the <a href="' + url_for('.framework_supplier_declaration', framework_slug=framework.slug) + '">supplier&nbsp;declaration</a> hasn’t been made.',
     type = 'warning'
   %}
     {% include 'toolkit/notification-banner.html' %}

--- a/app/templates/services/service_submission.html
+++ b/app/templates/services/service_submission.html
@@ -33,7 +33,7 @@
     <div class="wrapper">
       {%
         with
-        message = 'You need to <a href="' + url_for('.framework_supplier_declaration', framework_slug=framework.slug, section_id='g_cloud_7_essentials') + '">make the supplier&nbsp;declaration</a> before ' + service_data.get('serviceName', service_data['lotName'])|lower + ' can be submitted',
+        message = 'You need to <a href="' + url_for('.framework_supplier_declaration', framework_slug=framework.slug) + '">make the supplier&nbsp;declaration</a> before ' + service_data.get('serviceName', service_data['lotName'])|lower + ' can be submitted',
         type = 'warning'
       %}
         {% include 'toolkit/notification-banner.html' %}

--- a/config.py
+++ b/config.py
@@ -26,8 +26,7 @@ class Config(object):
     DM_MANDRILL_API_KEY = None
     DM_CLARIFICATION_QUESTION_EMAIL = 'digitalmarketplace@mailinator.com'
     DM_FRAMEWORK_AGREEMENTS_EMAIL = 'enquiries@example.com'
-    G7_CLOSING_DATE = '3pm&nbsp;<abbr title="British Summer Time">BST</abbr>, 6 October 2015'
-    DOS_CLOSING_DATE = '19 January 2016'
+    DOS_CLOSING_DATE = '3pm, 19 January 2016'
     G7_LIVE_DATE = '23 November 2015'
 
     DM_AGREEMENTS_BUCKET = None


### PR DESCRIPTION
This pull request makes a few small changes where I noticed problems while clicking through the app.

1. Services that were marked as complete before the framework declaration was finished would direct users to the G7 declaration.
2. Otherwise, once the (DOS) declaration was completed, the old G7 deadline would be displayed.
3. Added time of day into the `DOS_CLOSING_DATE`

##### `DOS_CLOSING_DATE`
![screen shot 2015-11-30 at 13 26 07](https://cloud.githubusercontent.com/assets/2454380/11472653/f4a450fa-9765-11e5-992d-83c6089fd1c2.png)


### Notes

Should we move the DOS closing date into `digitalmarketplace-frameworks`?

There's still [one reference to `g_cloud_7_essentials` still in `_event.js`](https://github.com/alphagov/digitalmarketplace-supplier-frontend/blob/808f074085346aaf70baa74491cc7f3d1210f428/app/assets/javascripts/analytics/_events.js#L5)?  Do we change it or get rid of it?  I don't know what it is.