### PR TITLE
Make "Save and continue" button return to summary

### DIFF
--- a/app/main/helpers/services.py
+++ b/app/main/helpers/services.py
@@ -67,10 +67,3 @@ def parse_document_upload_time(data):
     match = re.search("(\d{4}-\d{2}-\d{2}-\d{2}\d{2})\..{2,3}$", data)
     if match:
         return datetime.strptime(match.group(1), "%Y-%m-%d-%H%M")
-
-
-def get_next_section_name(content, current_section_id):
-    if content.get_next_editable_section_id(current_section_id):
-        return content.get_section(
-            content.get_next_editable_section_id(current_section_id)
-        ).name

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -7,8 +7,7 @@ from ...main import main, content_loader
 from ..helpers.services import (
     is_service_modifiable, is_service_associated_with_supplier,
     get_signed_document_url, count_unanswered_questions,
-    get_next_section_name)
-
+)
 from ..helpers.frameworks import get_framework_and_lot, get_declaration_status
 
 from dmutils.apiclient import APIError, HTTPError
@@ -261,8 +260,7 @@ def copy_draft_service(framework_slug, lot_slug, service_id):
                             framework_slug=framework['slug'],
                             lot_slug=draft['lot'],
                             service_id=draft_copy['id'],
-                            section_id=content.get_next_editable_section_id(),
-                            return_to_summary=1))
+                            section_id=content.get_next_editable_section_id()))
 
 
 @main.route('/frameworks/<framework_slug>/submissions/<lot_slug>/<service_id>/complete', methods=['POST'])
@@ -375,7 +373,7 @@ def view_service_submission(framework_slug, lot_slug, service_id):
         framework=framework,
         confirm_remove=request.args.get("confirm_remove", None),
         one_service_limit=[
-            lot['oneServiceLimit'] for lot in framework['lots'] if lot['slug'] == draft['lot']
+            l['oneServiceLimit'] for l in framework['lots'] if l['slug'] == draft['lot']
         ][0],
         service_id=service_id,
         service_data=draft,
@@ -419,10 +417,8 @@ def edit_service_submission(framework_slug, lot_slug, service_id, section_id, qu
         "services/edit_submission_section.html",
         section=section,
         framework=framework,
-        next_section_name=get_next_section_name(content, section.id),
         service_data=draft,
         service_id=service_id,
-        return_to_summary=bool(request.args.get('return_to_summary')),
         **main.config['BASE_TEMPLATE_DATA']
     )
 
@@ -483,29 +479,17 @@ def update_section_submission(framework_slug, lot_slug, service_id, section_id, 
             "services/edit_submission_section.html",
             framework=framework,
             section=section,
-            next_section_name=get_next_section_name(content, section.id),
             service_data=update_data,
             service_id=service_id,
-            return_to_summary=bool(request.args.get('return_to_summary')),
             errors=errors,
             **main.config['BASE_TEMPLATE_DATA']
             )
 
-    return_to_summary = bool(request.args.get('return_to_summary'))
-    next_section = content.get_next_editable_section_id(section_id)
-
-    if next_section and not return_to_summary and request.form.get('continue_to_next_section'):
-        return redirect(url_for(".edit_service_submission",
-                                framework_slug=framework['slug'],
-                                lot_slug=draft['lot'],
-                                service_id=service_id,
-                                section_id=next_section))
-    else:
-        return redirect(url_for(".view_service_submission",
-                                framework_slug=framework['slug'],
-                                lot_slug=draft['lot'],
-                                service_id=service_id,
-                                _anchor=section_id))
+    return redirect(url_for(".view_service_submission",
+                            framework_slug=framework['slug'],
+                            lot_slug=draft['lot'],
+                            service_id=service_id,
+                            _anchor=section_id))
 
 
 @main.route('/frameworks/<framework_slug>/submissions/<lot_slug>/<service_id>/remove/<section_id>/<question_slug>',

--- a/app/templates/services/edit_submission_section.html
+++ b/app/templates/services/edit_submission_section.html
@@ -31,36 +31,14 @@
 
 {% block save_button %}
 
-  {% if next_section_name and not return_to_summary %}
-    {%
-      with
-      label="Save and continue",
-      name = "continue_to_next_section",
-      type="save"
-    %}
-      {% include "toolkit/button.html" %}
-    {% endwith %}
-    <p class="next-page-message">
-      Next: {{ next_section_name }}
-    </p>
-    {%
-      with
-      type = "secondary",
-      label = "Save and return to service overview",
-      name = "return_to_overview"
-    %}
-      {% include "toolkit/button.html" %}
-    {% endwith %}
-  {% else %}
-    {%
-      with
-      label="Save and continue",
-      type="save",
-      name = "return_to_overview"
-    %}
-      {% include "toolkit/button.html" %}
-    {% endwith %}
-  {% endif %}
+  {%
+    with
+    label="Save and continue",
+    type="save",
+    name = "return_to_overview"
+  %}
+    {% include "toolkit/button.html" %}
+  {% endwith %}
 
 {% endblock %}
 {% block return_to_service_link %} {% endblock %}

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -826,55 +826,7 @@ class TestEditDraftService(BaseApplicationTest):
         )
         assert_equal(404, res.status_code)
 
-    def test_update_redirects_to_next_editable_section(self, data_api_client, s3):
-        s3.return_value.bucket_short_name = 'submissions'
-        data_api_client.get_framework.return_value = self.framework(status='open')
-        data_api_client.get_draft_service.return_value = self.empty_draft
-        data_api_client.update_draft_service.return_value = None
-
-        res = self.client.post(
-            '/suppliers/frameworks/g-cloud-7/submissions/scs/1/edit/service-description',
-            data={
-                'continue_to_next_section': 'Save and continue'
-            })
-
-        assert_equal(302, res.status_code)
-        assert_equal('http://localhost/suppliers/frameworks/g-cloud-7/submissions/scs/1/edit/service-type',
-                     res.headers['Location'])
-
-    def test_update_redirects_to_edit_submission_if_no_next_editable_section(self, data_api_client, s3):
-        s3.return_value.bucket_short_name = 'submissions'
-        data_api_client.get_framework.return_value = self.framework(status='open')
-        data_api_client.get_draft_service.return_value = self.empty_draft
-        data_api_client.update_draft_service.return_value = None
-
-        res = self.client.post(
-            '/suppliers/frameworks/g-cloud-7/submissions/scs/1/edit/sfia-rate-card',
-            data={})
-
-        assert_equal(302, res.status_code)
-        assert_equal(
-            'http://localhost/suppliers/frameworks/g-cloud-7/submissions/scs/1#sfia-rate-card',
-            res.headers['Location']
-        )
-
-    def test_update_redirects_to_edit_submission_if_return_to_summary(self, data_api_client, s3):
-        s3.return_value.bucket_short_name = 'submissions'
-        data_api_client.get_framework.return_value = self.framework(status='open')
-        data_api_client.get_draft_service.return_value = self.empty_draft
-        data_api_client.update_draft_service.return_value = None
-
-        res = self.client.post(
-            '/suppliers/frameworks/g-cloud-7/submissions/scs/1/edit/service-description?return_to_summary=1',
-            data={})
-
-        assert_equal(302, res.status_code)
-        assert_equal(
-            'http://localhost/suppliers/frameworks/g-cloud-7/submissions/scs/1#service-description',
-            res.headers['Location']
-        )
-
-    def test_update_redirects_to_edit_submission_if_grey_button_clicked(self, data_api_client, s3):
+    def test_update_redirects_to_summary(self, data_api_client, s3):
         s3.return_value.bucket_short_name = 'submissions'
         data_api_client.get_framework.return_value = self.framework(status='open')
         data_api_client.get_draft_service.return_value = self.empty_draft


### PR DESCRIPTION
Removes the secondary "Save and return to summary" button and makes
all service "Save and continue" buttons return to the summary page
with the current section slug anchor.

Removes `next_section` and `return_to_summary` mentions from service
pages.