### PR TITLE
Make contextual help make sense

### DIFF
--- a/app/templates/services/_base_edit_section_page.html
+++ b/app/templates/services/_base_edit_section_page.html
@@ -16,6 +16,12 @@
         {% include 'toolkit/page-heading.html' %}
       {% endwith %}
 
+      {% if section.description %}
+        <div class="section-description">
+          {{ section.description|markdown }}
+        </div>
+      {% endif %}
+
     </div>
   </div>
 

--- a/app/templates/services/_base_service_page.html
+++ b/app/templates/services/_base_service_page.html
@@ -60,6 +60,9 @@
         {% if section.editable %}
           {% block edit_link scoped %}{% endblock %}
         {% endif %}
+        {% if section.summary_page_description %}
+          {{ summary.description(section.summary_page_description) }}
+        {% endif %}
         {% call(question) summary.list_table(
           section.questions,
           caption=section.name,

--- a/app/templates/services/service_submission.html
+++ b/app/templates/services/service_submission.html
@@ -76,7 +76,7 @@
     by {{ last_edit.userName }}
   </p>
   {% if framework.status == 'open' %}
-    {% if unanswered_required or unanswered_optional %}
+    {% if not one_service_limit and (unanswered_required or unanswered_optional) %}
       <p class="last-edited">
         {{ submission.multiline_string(
           submission.unanswered_required_text(unanswered_required, unanswered_optional),

--- a/app/templates/services/service_submission.html
+++ b/app/templates/services/service_submission.html
@@ -89,8 +89,6 @@
     {% endif %}
     {% if service_data.status == 'not-submitted' and can_mark_complete and framework.status == 'open' %}
       {% include "partials/complete_service.html" %}
-    {% elif unanswered_required > 0 %}
-      <p class="move-to-complete-hint">When you have added all the required information, you can mark the service as complete.</p>
     {% endif %}
   {% elif framework.status == 'pending' %}
     {% if unanswered_required or unanswered_optional %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ werkzeug==0.10.4
 python-dateutil==2.4.2
 
 git+https://github.com/madzak/python-json-logger.git@v0.1.3#egg=python-json-logger==v0.1.3
-git+https://github.com/alphagov/digitalmarketplace-utils.git@15.3.0#egg=digitalmarketplace-utils==15.3.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@15.4.0#egg=digitalmarketplace-utils==15.4.0
 
 markdown==2.6.2
 


### PR DESCRIPTION
## Don’t show unanswered count for one service lots

## Get rid of required answer hint text
This is replaced by…

## Show section description on summary page

Brings in and depends on:
- [x] alphagov/digitalmarketplace-frameworks#147
- [x] alphagov/digitalmarketplace-frontend-toolkit#196
- [x] alphagov/digitalmarketplace-utils#220

## Add section description to service edit pages
