### PR TITLE
Fix overlapping text on supplier declaration

### DIFF
--- a/app/assets/scss/_supplier-declaration.scss
+++ b/app/assets/scss/_supplier-declaration.scss
@@ -25,7 +25,27 @@
    }
 
   .question-number {
-    @include bold-19;
+
+    @include core-19;
+    font-weight: bold;
+    display: inline-block;
+    height: 0.5em;
+
+    @include media(mobile) {
+      line-height: 1.25;
+      font-size: 19px;
+    }
+
+    @include media(tablet) {
+      line-height: 1.25;
+      font-size: 19px;
+    }
+
+    @include media(1080px) {
+      display: block;
+      height: 50px;
+    }
+
   }
 
   .validation-wrapper {

--- a/app/assets/scss/_supplier-declaration.scss
+++ b/app/assets/scss/_supplier-declaration.scss
@@ -11,10 +11,10 @@
   .question-heading-with-hint li,
   .hint li {
 
-    margin: 10px 0 10px 10px;
+    margin: 10px 0 10px 20px;
     list-style: disc;
 
-    @include media(tablet) {
+    @include media(1080px) {
       margin-left: 0;
     }
 

--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "jquery": "1.11.2",
     "hogan": "3.0.2",
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
-    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v13.3.0",
+    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v13.3.1",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.14.1/jinja_govuk_template-0.14.1.tgz",
     "digitalmarketplace-frameworks": "git://github.com/alphagov/digitalmarketplace-frameworks#v0.11.3"
   }


### PR DESCRIPTION
Fixes: https://www.pivotaltracker.com/story/show/106191644

Brings in: https://github.com/alphagov/digitalmarketplace-frontend-toolkit/pull/197

Has some custom CSS to deal with the question headings on the declaration being
smaller than standard.

![image](https://cloud.githubusercontent.com/assets/355079/11505777/0a9f8620-9844-11e5-95f6-3fbcb83c9b80.png)

![image](https://cloud.githubusercontent.com/assets/355079/11505787/155525de-9844-11e5-8ce2-1af9670a02d1.png)

![image](https://cloud.githubusercontent.com/assets/355079/11505796/203d32d4-9844-11e5-84d6-d1943ff3e074.png)


