### PR TITLE
Format confirmation flash message in services

### DIFF
--- a/app/templates/services/service_submission.html
+++ b/app/templates/services/service_submission.html
@@ -115,7 +115,7 @@
           <p class="banner-message">
             Are you sure you want to delete this service?
           </p>
-          <button type="submit" class="button-destructive banner-action">Yes, delete &ldquo;{{ service_data.serviceName or service_data.lotName }}&rdquo;</button>
+          <button type="submit" class="button-destructive banner-action">Yes, delete &lsquo;{{ service_data.serviceName or service_data.lotName | lower }}&rsquo;</button>
         </div>
       </form>
     </div>


### PR DESCRIPTION
Format confirmation flash message in services.  Replace double quotes with single quotes and change text to lowercase to match delete button at end of services pages.

Delete button:

<img width="362" alt="screen shot 2015-12-01 at 17 20 07" src="https://cloud.githubusercontent.com/assets/11633362/11508274/ccfe70c2-984f-11e5-9f23-032979952c8c.png">


Flash Message before:

<img width="1065" alt="screen shot 2015-12-01 at 17 17 30" src="https://cloud.githubusercontent.com/assets/11633362/11508236/81ce6b5c-984f-11e5-8553-bd653f0a0840.png">

Flash Message after:

<img width="1008" alt="screen shot 2015-12-01 at 17 19 01" src="https://cloud.githubusercontent.com/assets/11633362/11508256/abd6b918-984f-11e5-9601-faed55065ee4.png">
