### PR TITLE
Don’t jump down page after incorrect submission

### DIFF
--- a/app/templates/services/_base_edit_section_page.html
+++ b/app/templates/services/_base_edit_section_page.html
@@ -25,7 +25,7 @@
     {% endwith %}
   {% endif %}
 
-  <form method="post" enctype="multipart/form-data">
+  <form method="post" enctype="multipart/form-data" action="{{ request.path }}">
 
     <div class="grid-row">
       <div class="column-two-thirds">


### PR DESCRIPTION
Sue found an excellent bug: https://www.pivotaltracker.com/story/show/109279212

1. Click answer required on a section with multiple questions
2. Answer less than all the questions on the page
3. Click on save and continue

**Expected**: you are back at the top of the page and see the validation masthead

**Actual**: you are jumped down the page to the question for which you clicked 'answer required'

This is because the form always posts to it’s own URL. And if this url has a `#fragment` at the end of it, then this is the URL that gets posted to. Since you stay on the same page if there are any errors then the page you stay on also has the fragment, which matches the ID of the question, which is where you get jumped to.

This commit changes the HTMl to always post to the page’s own URL _without_ the fragment.