### PR TITLE
Consolidate framework dates in the content repo

### DIFF
--- a/app/main/__init__.py
+++ b/app/main/__init__.py
@@ -5,10 +5,13 @@ main = Blueprint('main', __name__)
 
 content_loader = ContentLoader('app/content')
 content_loader.load_manifest('g-cloud-6', 'services', 'edit_service')
+content_loader.load_messages('g-cloud-6', ['dates'])
 content_loader.load_manifest('g-cloud-7', 'services', 'edit_submission')
 content_loader.load_manifest('g-cloud-7', 'declaration', 'declaration')
+content_loader.load_messages('g-cloud-7', ['dates'])
 content_loader.load_manifest('digital-outcomes-and-specialists', 'declaration', 'declaration')
 content_loader.load_manifest('digital-outcomes-and-specialists', 'services', 'edit_submission')
+content_loader.load_messages('digital-outcomes-and-specialists', ['dates'])
 
 
 @main.after_request

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -88,8 +88,8 @@ def framework_dashboard(framework_slug):
             # TODO: ^ make this dynamic, eg, lab, service, unit
         } for lot in lot_question['options'] if count_drafts_by_lot(complete_drafts, lot['value'])],
         declaration_status=declaration_status,
+        dates=content_loader.get_message(framework_slug, 'dates'),
         first_page_of_declaration=first_page,
-        deadline=current_app.config['DOS_CLOSING_DATE'],
         framework=framework,
         application_made=(len(complete_drafts) > 0 and declaration_status == 'complete'),
         supplier_is_on_framework=supplier_is_on_framework,
@@ -348,6 +348,7 @@ def framework_updates(framework_slug, error_message=None, default_textbox_value=
         clarification_question_value=default_textbox_value,
         error_message=error_message,
         files=files,
+        dates=content_loader.get_message(framework_slug, 'dates'),
         **main.config['BASE_TEMPLATE_DATA']
     ), 200 if not error_message else 400
 

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -384,7 +384,7 @@ def view_service_submission(framework_slug, lot_slug, service_id):
         can_mark_complete=not validation_errors,
         delete_requested=delete_requested,
         declaration_status=get_declaration_status(data_api_client, framework['slug']),
-        deadline=current_app.config['DOS_CLOSING_DATE'],
+        dates=content_loader.get_message(framework_slug, 'dates'),
         **main.config['BASE_TEMPLATE_DATA']), 200
 
 

--- a/app/templates/frameworks/dashboard.html
+++ b/app/templates/frameworks/dashboard.html
@@ -46,14 +46,14 @@
 
       {% if framework.status == 'open' %}
         <aside role="complementary" class="framework-application-status" aria-label="{{ framework.name }} status">
-          Deadline: <strong>{{ deadline|safe }}</strong>
+          Deadline: <strong>{{ dates.framework_close_date|safe }}</strong>
         </aside>
       {% elif framework.status == 'pending' %}
         <div class="summary-item-lede">
           <h2 class="summary-item-heading">{{ framework.name }} is closed for applications</h2>
           {% if application_made %}
             <p>You made your supplier declaration and submitted {{ counts.complete }} {{ 'service' if counts.complete == 1 else 'services' }} for consideration.</p>
-            <p>A letter informing you whether your application was successful or not will be posted on your {{ framework.name }} updates page by Monday, 9 November 2015.</p>
+            <p>A letter informing you whether your application was successful or not will be posted on your {{ framework.name }} updates page by {{ dates.intention_to_award_date|safe }}.</p>
           {% else %}
             <p>You didn't submit an application.</p>
           {% endif %}

--- a/app/templates/frameworks/updates.html
+++ b/app/templates/frameworks/updates.html
@@ -112,7 +112,9 @@
         {% if framework.clarificationQuestionsOpen %}
           All clarification questions and answers will be published here regularly. You’ll receive an email when new answers are available.
         {% else %}
-          The deadline for asking clarification questions has now passed. All clarification questions and answers will be published by 5pm <abbr title="British Summer Time">BST</abbr>, 29 September 2015. You'll receive an email when new answers are posted.
+          The deadline for asking clarification questions has now passed.
+          All clarification questions and answers will be published by {{ dates.clarifications_publish_date|safe }}.
+          You'll receive an email when new answers are posted.
         {% endif %}
       </p>
     </div>
@@ -135,7 +137,7 @@
               {% include "toolkit/forms/textbox.html" %}
             {% endwith %}
             <p>
-              The deadline for clarification questions is 5pm <abbr title="British Summer Time">BST</abbr>, 22 September 2015. All responses will be published by 5pm <abbr title="British Summer Time">BST</abbr>, 29 September 2015.
+              The deadline for clarification questions is {{ dates.clarifications_close_date|safe }}. All responses will be published by {{ dates.clarifications_publish_date|safe }}.
             </p>
             {%
               with

--- a/app/templates/services/service_submission.html
+++ b/app/templates/services/service_submission.html
@@ -83,7 +83,7 @@
       </p>
     {% endif %}
     {% if service_data.status == 'submitted' and declaration_status == 'complete' %}
-      <span class="service-status-published">This service is marked as complete and will be submitted at {{ deadline|safe }}</span>
+      <span class="service-status-published">This service is marked as complete and will be submitted at {{ dates.framework_close_date|safe }}</span>
     {% endif %}
     {% if service_data.status == 'not-submitted' and can_mark_complete and framework.status == 'open' %}
       {% include "partials/complete_service.html" %}

--- a/app/templates/suppliers/_frameworks_open.html
+++ b/app/templates/suppliers/_frameworks_open.html
@@ -8,7 +8,7 @@
             "title":
             "Continue your {} application".format(framework.name),
             "link": url_for(".framework_dashboard", framework_slug=framework.slug),
-            "body": "Deadline: {}".format(framework.dates.deadline)
+            "body": "Deadline: {}".format(framework.dates.framework_close_date|safe)
           }]
         %}
           {% include "toolkit/browse-list.html" %}
@@ -20,7 +20,7 @@
                 Apply to {{ framework.name }} 
               </h2>
               <p>
-                Deadline: {{ framework.dates.deadline }}
+                Deadline: {{ framework.dates.framework_close_date|safe }}
               </p>
               {%
               with

--- a/app/templates/suppliers/_frameworks_standstill.html
+++ b/app/templates/suppliers/_frameworks_standstill.html
@@ -19,7 +19,7 @@
           </p>
           {% if framework.onFramework %}
             <p class='second-line'>
-              Live from {{ framework.dates.go_live }}
+              Live from {{ framework.dates.framework_live_date|safe }}
             </p>
           {% endif %}
         {% endcall %}

--- a/bower.json
+++ b/bower.json
@@ -7,6 +7,6 @@
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
     "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v13.3.4",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.14.1/jinja_govuk_template-0.14.1.tgz",
-    "digitalmarketplace-frameworks": "git://github.com/alphagov/digitalmarketplace-frameworks#v0.11.3"
+    "digitalmarketplace-frameworks": "git://github.com/alphagov/digitalmarketplace-frameworks#v0.12.2"
   }
 }

--- a/config.py
+++ b/config.py
@@ -26,8 +26,6 @@ class Config(object):
     DM_MANDRILL_API_KEY = None
     DM_CLARIFICATION_QUESTION_EMAIL = 'digitalmarketplace@mailinator.com'
     DM_FRAMEWORK_AGREEMENTS_EMAIL = 'enquiries@example.com'
-    DOS_CLOSING_DATE = '3pm, 19 January 2016'
-    G7_LIVE_DATE = '23 November 2015'
 
     DM_AGREEMENTS_BUCKET = None
     DM_COMMUNICATIONS_BUCKET = None

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ werkzeug==0.10.4
 python-dateutil==2.4.2
 
 git+https://github.com/madzak/python-json-logger.git@v0.1.3#egg=python-json-logger==v0.1.3
-git+https://github.com/alphagov/digitalmarketplace-utils.git@15.4.0#egg=digitalmarketplace-utils==15.4.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@15.6.0#egg=digitalmarketplace-utils==15.6.0
 
 markdown==2.6.2
 

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -191,7 +191,7 @@ class TestFrameworksDashboard(BaseApplicationTest):
                       heading[0].xpath('text()')[0])
             assert_in(u"You made your supplier declaration and submitted 1 service for consideration.",
                       heading[0].xpath('../p[1]/text()')[0])
-            assert_in(u"A letter informing you whether your application was successful or not will be posted on your G-Cloud 7 updates page by Monday, 9 November 2015.",  # noqa
+            assert_in(u"A letter informing you whether your application was successful or not will be posted on your G-Cloud 7 updates page by 9 November 2015.",  # noqa
                       heading[0].xpath('../p[2]/text()')[0])  # noqa
 
     def test_declaration_status_when_complete(self, data_api_client, s3):
@@ -1012,6 +1012,34 @@ class TestFrameworkUpdatesPage(BaseApplicationTest):
                     self.strip_all_whitespace(empty_message)
                     in self.strip_all_whitespace(response.get_data(as_text=True))
                 )
+
+    def test_dates_for_open_framework_closed_for_questions(self, s3, data_api_client):
+        data_api_client.get_framework.return_value = self.framework('open', clarification_questions_open=False)
+
+        with self.app.test_client():
+            self.login()
+
+            response = self.client.get('/suppliers/frameworks/g-cloud-7/updates')
+            data = response.get_data(as_text=True)
+
+            assert response.status_code == 200
+            assert "All clarification questions and answers will be published by " \
+                   "5pm <abbr title=\"British Summer Time\">BST</abbr>, 29 September 2015" in data
+            assert "The deadline for clarification questions is 5pm, 22 September 2015" not in data
+
+    def test_dates_for_open_framework_open_for_questions(self, s3, data_api_client):
+        data_api_client.get_framework.return_value = self.framework('open', clarification_questions_open=True)
+
+        with self.app.test_client():
+            self.login()
+
+            response = self.client.get('/suppliers/frameworks/g-cloud-7/updates')
+            data = response.get_data(as_text=True)
+
+            assert response.status_code == 200
+            assert "All clarification questions and answers will be published by 5pm, 29 September 2015" not in data
+            assert "The deadline for clarification questions is " \
+                   "5pm <abbr title=\"British Summer Time\">BST</abbr>, 22 September 2015" in data
 
     def test_the_tables_should_be_displayed_correctly(self, s3, data_api_client):
         data_api_client.get_framework.return_value = self.framework('open')


### PR DESCRIPTION
Dates consistently change between frameworks. This moves all dates into
the digitalmarketplace-frameworks repo as messages. Ultimately it would
be good if these were stored in the API against a framework. However,
until we have a clear understanding of what dates are required, what
they mean, and how we want to manage them consolidating them in one
place is a good first step.