### PR TITLE
Show label for contributor email field

### DIFF
--- a/app/templates/auth/submit-email-address.html
+++ b/app/templates/auth/submit-email-address.html
@@ -27,72 +27,61 @@
 
 {% block main_content %}
 
-<div class="single-question-page">
+{% with messages = get_flashed_messages(with_categories=true) %}
+{% if messages %}
+{% for category, message in messages %}
+    {% if category == 'error' %}
+      <div class="banner-destructive-without-action">
+    {% elif category == 'success' %}
+      <div class="banner-success-without-action">
+    {% endif %}
+    {% if message == 'user_invited' %}
+    <p class="banner-message">
+        Contributor invited
+    </p>
+    {% elif message == 'user_not_invited' %}
+    <p class="banner-message">
+        Not Invited
+    </p>
+    {% endif %}
+          </div><div class="/sc"></div>
+{% endfor %}
+{% endif %}
+{% endwith %}
 
-  {% with messages = get_flashed_messages(with_categories=true) %}
-  {% if messages %}
-  {% for category, message in messages %}
-      {% if category == 'error' %}
-        <div class="banner-destructive-without-action">
-      {% elif category == 'success' %}
-        <div class="banner-success-without-action">
-      {% endif %}
-      {% if message == 'user_invited' %}
-      <p class="banner-message">
-          Contributor invited
-      </p>
-      {% elif message == 'user_not_invited' %}
-      <p class="banner-message">
-          Not Invited
-      </p>
-      {% endif %}
-            </div><div class="/sc"></div>
-  {% endfor %}
-  {% endif %}
+  {% with
+    heading = "Invite a contributor",
+    smaller = true
+  %}
+    {% include 'toolkit/page-heading.html' %}
   {% endwith %}
 
-    {% with
-      heading = "Invite a contributor",
-      smaller = true
-    %}
-      {% include 'toolkit/page-heading.html' %}
-    {% endwith %}
+<form autocomplete="off" action="{{ url_for('.send_invite_user') }}" method="POST">
 
-  <form autocomplete="off" action="{{ url_for('.send_invite_user') }}" method="POST">
+    <div class="grid-row">
+        <div class="column-two-thirds">
+            {{ form.hidden_tag() }}
 
-      <div class="grid-row">
-          <div class="column-two-thirds">
-              {{ form.hidden_tag() }}
+            {%
+              with
+                question = "Email address",
+                name = "email_address",
+                hint = "An invite will be sent asking the recipient to register as a contributor.",
+                value = form.email_address.data,
+                error = form.email_address.errors[0]
+            %}
+            {% include "toolkit/forms/textbox.html" %}
+            {% endwith %}
 
-              {% if form.email_address.errors %}
-                  <div class="validation-wrapper">
-              {% endif %}
-                  <div class="question">
-                      {{ form.email_address.label(class="question-heading-with-hint") }}
-                      <p class="hint">
-                          An invite will be sent asking the recipient to register as a contributor.
-                      </p>
-                      {% if form.email_address.errors %}
-                      <p class="validation-message" id="error-email-address-textbox">
-                          {% for error in form.email_address.errors %}{{ error }}{% endfor %}
-                      </p>
-                      {% endif %}
-                      {{ form.email_address(class="text-box", autocomplete="off") }}
-                  </div>
-              {% if form.email_address.errors %}
-                  </div>
-              {% endif %}
-
-              {%
-                with
-                type = "save",
-                label = "Send invite"
-              %}
-                {% include "toolkit/button.html" %}
-              {% endwith %}
-          </div>
-      </div>
-  </form>
-</div>
+            {%
+              with
+              type = "save",
+              label = "Send invite"
+            %}
+              {% include "toolkit/button.html" %}
+            {% endwith %}
+        </div>
+    </div>
+</form>
 
 {% endblock %}


### PR DESCRIPTION
This field was using the `single-question-page`
class. This class currently assumes the page
heading will be a duplicate of the field label so
hides it.

The field was also using a different markup
pattern to other pages with one question (for
example, those in the 'create a new supplier
flow'). The markup for this pattern was missing
some span tags, causing the label to be hidden
normally but shown if validation messages were
present.

This change removes the `single-question-page`
class to ensure the label is shown and swaps the
markup out to use the [toolkit textbox pattern](http://alphagov.github.io/digitalmarketplace-frontend-toolkit/forms/textbox.html)
(which has markup that works both for the field
in its base and invalid states).

The page now looks like this:

![image](https://cloud.githubusercontent.com/assets/87140/11559901/70181d2a-99b4-11e5-8740-a391ae06eb63.png)

![image](https://cloud.githubusercontent.com/assets/87140/11559923/939aa0d8-99b4-11e5-8adc-e190f97984bb.png)