### PR TITLE
Bump utils to 15.6.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ werkzeug==0.10.4
 python-dateutil==2.4.2
 
 git+https://github.com/madzak/python-json-logger.git@v0.1.3#egg=python-json-logger==v0.1.3
-git+https://github.com/alphagov/digitalmarketplace-utils.git@15.6.0#egg=digitalmarketplace-utils==15.6.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@15.6.1#egg=digitalmarketplace-utils==15.6.1
 
 markdown==2.6.2
 


### PR DESCRIPTION
Brings in
- [#221](https://github.com/alphagov/digitalmarketplace-utils/pull/221)
  which fixes rendering for questions with assurances

None are breaking changes, so there shouldn't be anything else to do.