### PR TITLE
Fix deadline markup escaping bug

### DIFF
--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -2,7 +2,7 @@
 
 from itertools import chain
 
-from flask import render_template, request, redirect, url_for, abort, session
+from flask import render_template, request, redirect, url_for, abort, session, Markup
 from flask_login import login_required, current_user, current_app
 import six
 
@@ -55,6 +55,7 @@ def dashboard():
             pass
         framework.update({
             'dates': dates,
+            'deadline': Markup("Deadline: {}".format(dates.get('framework_close_date', ''))),
             'registered_interest': (framework['slug'] in supplier_frameworks),
             'made_application': (
                 framework.get('declaration') and

--- a/app/templates/suppliers/_frameworks_open.html
+++ b/app/templates/suppliers/_frameworks_open.html
@@ -8,7 +8,7 @@
             "title":
             "Continue your {} application".format(framework.name),
             "link": url_for(".framework_dashboard", framework_slug=framework.slug),
-            "body": "Deadline: {}".format(framework.dates.framework_close_date|safe)
+            "body": framework.deadline,
           }]
         %}
           {% include "toolkit/browse-list.html" %}


### PR DESCRIPTION
Marking a string as safe does not work when building a string with .format.