### PR TITLE
Send application started welcome email to supplier users

### DIFF
--- a/app/templates/emails/dos_application_started.html
+++ b/app/templates/emails/dos_application_started.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head lang="en">
+   <meta charset="UTF-8">
+</head>
+<body>
+    Dear supplier,
+    <br /><br />
+    You, or one of your colleagues, has started an application for the Digital Outcomes and Specialists framework. All contributors on your Digital Marketplace account will now receive email updates.
+    <br /><br />
+    You need to confirm that you’re eligible to offer services under Digital Outcomes and Specialists as part of the application. You don’t need to describe your services now. You’ll be asked to provide more details when you respond to a buyer’s specific brief.
+    <br /><br />
+    The Digital Marketplace blog explains:
+    <ul>
+      <li>
+        why we’re not asking for more details from suppliers at this stage: <a href="https://digitalmarketplace.blog.gov.uk/2015/11/20/themes-from-supplier-responses-to-draft-documents/">https://digitalmarketplace.blog.gov.uk/2015/11/20/themes-from-supplier-responses-to-draft-documents/</a>
+      </li>
+      <li>
+        whether your services are suitable for Digital Outcomes and Specialists: <a href="https://digitalmarketplace.blog.gov.uk/2015/11/12/digital-outcomes-and-specialists-suitable-suppliers-and-services/">https://digitalmarketplace.blog.gov.uk/2015/11/12/digital-outcomes-and-specialists-suitable-suppliers-and-services/</a>
+      </li>
+      <li>
+        the important dates for applications: <a href="https://digitalmarketplace.blog.gov.uk/2015/12/07/digital-outcomes-and-specialists-is-open-for-applications/">https://digitalmarketplace.blog.gov.uk/2015/12/07/digital-outcomes-and-specialists-is-open-for-applications/</a>
+      </li>
+    </ul>
+    Read the suppliers’ guide to find out how to apply to Digital Outcomes and Specialists:  <a href="https://www.gov.uk/guidance/digital-outcomes-and-specialists-suppliers-guide">https://www.gov.uk/guidance/digital-outcomes-and-specialists-suppliers-guide</a>
+    <br /><br />
+    If you have any clarification questions, they must be submitted through your Digital Marketplace account before 5pm GMT, 6 January 2016: <a href="https://www.digitalmarketplace.service.gov.uk/suppliers/frameworks/digital-outcomes-and-specialists/updates">https://www.digitalmarketplace.service.gov.uk/suppliers/frameworks/digital-outcomes-and-specialists/updates</a>
+    <br /><br />
+    Thanks,
+    <br />
+    The Digital Marketplace team
+</body>
+</html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ werkzeug==0.10.4
 python-dateutil==2.4.2
 
 git+https://github.com/madzak/python-json-logger.git@v0.1.3#egg=python-json-logger==v0.1.3
-git+https://github.com/alphagov/digitalmarketplace-utils.git@15.7.1#egg=digitalmarketplace-utils==15.7.1
+git+https://github.com/alphagov/digitalmarketplace-utils.git@15.8.0#egg=digitalmarketplace-utils==15.8.0
 
 markdown==2.6.2
 

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -117,6 +117,29 @@ class TestFrameworksDashboard(BaseApplicationTest):
                 "email@email.com"
             )
 
+    @mock.patch('app.main.frameworks.send_email')
+    def test_email_sent_when_interest_registered_in_framework(self, send_email, data_api_client, s3):
+        with self.app.test_client():
+            self.login()
+
+            data_api_client.get_framework.return_value = self.framework(status='open')
+            data_api_client.get_supplier_framework_info.return_value = self.supplier_framework()
+            data_api_client.find_users.return_value = {'users': [
+                {'emailAddress': 'email1'}, {'emailAddress': 'email2'}
+            ]}
+            res = self.client.post("/suppliers/frameworks/digital-outcomes-and-specialists")
+
+            assert_equal(res.status_code, 200)
+            send_email.assert_called_once_with(
+                ['email1', 'email2'],
+                mock.ANY,
+                'MANDRILL',
+                'You have started your G-Cloud 7 application',
+                'do-not-reply@digitalmarketplace.service.gov.uk',
+                'Digital Marketplace Admin',
+                ['digital-outcomes-and-specialists-application-started']
+            )
+
     def test_interest_not_registered_in_framework_on_get(self, data_api_client, s3):
         with self.app.test_client():
             self.login()


### PR DESCRIPTION
[#107188306](https://www.pivotaltracker.com/story/show/107188306)

Sends a welcome email to all supplier users. Email is sent using
the updated `dmutils.email.send_email`: each recipient will get
a separate message with only one 'to' address.

The request will proceed without returning an error if send_email call
raises an exception, since if framework interest is registered a page
refresh would show the dashboard anyway.