### PR TITLE
Make section descriptions look the same

### DIFF
--- a/app/assets/scss/_supplier-declaration.scss
+++ b/app/assets/scss/_supplier-declaration.scss
@@ -58,12 +58,14 @@
 
   }
 
-  .section-description {
+}
 
-    p {
-      margin-bottom: $gutter/2;
-    }
+.section-description {
 
+  @include copy-19;
+
+  p {
+    margin-bottom: $gutter/2;
   }
 
 }


### PR DESCRIPTION
In both the declaration and the 'service essentials' sections. In other words, don’t have it scoped to the declaration.

Also sets the type size explicitly for safety.