### PR TITLE
[#109538382] Clarifications "from" should be framework-specific

### DIFF
--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -414,7 +414,7 @@ def framework_updates_email_clarification_question(framework_slug):
             current_app.config['DM_MANDRILL_API_KEY'],
             subject,
             from_address,
-            "G-Cloud 7 Supplier",
+            "{} Supplier".format(framework['name']),
             tags
         )
     except MandrillException as e:

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -1197,7 +1197,7 @@ class TestSendClarificationQuestionEmail(BaseApplicationTest):
                 "MANDRILL",
                 "Test Framework clarification question",
                 "suppliers+g-cloud-7@digitalmarketplace.service.gov.uk",
-                "G-Cloud 7 Supplier",
+                "Test Framework Supplier",
                 ["clarification-question"]
             )
         if succeeds:
@@ -1225,7 +1225,7 @@ class TestSendClarificationQuestionEmail(BaseApplicationTest):
                 "MANDRILL",
                 "Test Framework application question",
                 "email@email.com",
-                "G-Cloud 7 Supplier",
+                "Test Framework Supplier",
                 ["application-question"]
             )
 


### PR DESCRIPTION
See: https://www.pivotaltracker.com/story/show/109538382

Previously all clarification questions were being sent "from" `G-Cloud 7 Supplier`.
Instead the framework in the "from" should match the framework that the question is about.