### PR TITLE
Add question references to validation messages

### DIFF
--- a/app/main/helpers/frameworks.py
+++ b/app/main/helpers/frameworks.py
@@ -105,6 +105,8 @@ def get_supplier_on_framework_from_info(supplier_framework_info):
 
 
 def question_references(data, get_question):
+    if not data:
+        return data
     return re.sub(
         r"\[\[([^\]]+)\]\]",  # anything that looks like [[nameOfQuestion]]
         lambda question_id: str(get_question(question_id.group(1))['number']),

--- a/app/templates/macros/toolkit_forms.html
+++ b/app/templates/macros/toolkit_forms.html
@@ -5,7 +5,7 @@
     hint=(question_content.hint or '')|question_references(get_question)|markdown,
     name=question_content.id,
     value=service_data[question_content.id],
-    error=errors.get(question_content.id)['message']
+    error=errors.get(question_content.id)['message']|question_references(get_question)
   %}
     {% include "toolkit/forms/textbox.html" %}
   {% endwith %}
@@ -20,7 +20,7 @@
     value=service_data[question_content.id],
     large=True,
     max_length_in_words=question_content.max_length_in_words,
-    error=errors.get(question_content.id)['message']
+    error=errors.get(question_content.id)['message']|question_references(get_question)
   %}
     {% include "toolkit/forms/textbox.html" %}
   {% endwith %}
@@ -35,7 +35,7 @@
     hint=(question_content.hint or '')|question_references(get_question)|markdown,
     values=service_data[question_content.id],
     id=question_content.id,
-    error=errors.get(question_content.id)['message']
+    error=errors.get(question_content.id)['message']|question_references(get_question)
   %}
     {% include "toolkit/forms/list-entry.html" %}
   {% endwith %}
@@ -51,7 +51,7 @@
     id=question_content.id,
     options=question_content.options,
     type='checkbox',
-    error=errors.get(question_content.id)['message'],
+    error=errors.get(question_content.id)['message']|question_references(get_question),
     question_number=question_number
   %}
     {% include "toolkit/forms/selection-buttons.html" %}
@@ -69,7 +69,7 @@
     id=question_content.id,
     options=question_content.options,
     type='radio',
-    error=errors.get(question_content.id)['message'],
+    error=errors.get(question_content.id)['message']|question_references(get_question),
     question_number=question_number
   %}
     {% include "toolkit/forms/selection-buttons.html" %}
@@ -85,7 +85,7 @@
     value=service_data[question_content.id],
     id=question_content.id,
     type='boolean',
-    error=errors.get(question_content.id)['message'],
+    error=errors.get(question_content.id)['message']|question_references(get_question),
     question_number=question_number
   %}
     {% include "toolkit/forms/selection-buttons.html" %}
@@ -101,7 +101,7 @@
     value="Document uploaded {}".format(
       service_data[question_content.id]|parse_document_upload_time|datetimeformat
     ) if service_data[question_content.id] else service_data[question_content.id],
-    error=errors.get(question_content.id)['message'],
+    error=errors.get(question_content.id)['message']|question_references(get_question),
     question_number=question_number
   %}
     {% include "toolkit/forms/upload.html" %}
@@ -122,7 +122,7 @@
     hours_for_price=service_data.get(question_content.fields.hours_for_price),
     hint=(question_content.hint or '')|markdown,
     id=question_content.id,
-    error=errors.get(question_content.id)['message'],
+    error=errors.get(question_content.id)['message']|question_references(get_question),
     question_number=question_number
   %}
     {% include "toolkit/forms/pricing.html" %}
@@ -139,7 +139,7 @@
     hint=(question_content.hint or '')|question_references(get_question)|markdown,
     name=question_content.id,
     value=service_data[question_content.id],
-    error=errors.get(question_content.id)['message'],
+    error=errors.get(question_content.id)['message']|question_references(get_question),
     question_number=question_number
   %}
     {% include "toolkit/forms/textbox.html" %}


### PR DESCRIPTION
This is so that, for conditional questions, we can say something like “you need
to answer this question because question 99”.

Depends on:
- [x] https://github.com/alphagov/digitalmarketplace-frameworks/pull/171