### PR TITLE
Fix declaration validation

### DIFF
--- a/app/main/helpers/validation.py
+++ b/app/main/helpers/validation.py
@@ -66,9 +66,8 @@ class DeclarationValidator(object):
         return reduce(add, (section.get_question_ids() for section in self.content))
 
     def fields_with_values(self):
-        # empty list types will not be included so only string types need to be considered
         return set(key for key, value in self.answers.items()
-                   if not isinstance(value, six.string_types) or len(value) > 0)
+                   if value is not None and (not isinstance(value, six.string_types) or len(value) > 0))
 
     def errors(self):
         errors_map = {}
@@ -209,8 +208,8 @@ class DOSValidator(DeclarationValidator):
                 req_fields.add('appropriateTradeRegistersNumber')
 
             req_fields.add('licenceOrMemberRequired')
-            # If 'none of the above' to licenceOrMemberRequired
-            if self.answers.get('licenceOrMemberRequired') is True:
+            # If not 'none of the above' to licenceOrMemberRequired
+            if self.answers.get('licenceOrMemberRequired') in ['licensed', 'a member of a relevant organisation']:
                 req_fields.add('licenceOrMemberRequiredDetails')
 
         return req_fields

--- a/tests/app/main/helpers/validation/test_dos_declaration.py
+++ b/tests/app/main/helpers/validation/test_dos_declaration.py
@@ -25,7 +25,7 @@ FULL_DOS_SUBMISSION = {
     "fullAccountability": True,
     "skillsAndCapabilityAssessment": True,
     "subcontracting": "yourself without the use of third parties (subcontractors)",
-    "licenceOrMemberRequired": "licensed",
+    "licenceOrMemberRequired": "none of the above",
     "mitigatingFactors2": "",
     "accuratelyDescribed": True,
     "tradingStatus": "other (please specify)",
@@ -214,12 +214,12 @@ def test_licence_or_member_details_error_depends_on_licence_or_member(content, s
     assert validator.errors() == {}
 
     submission['establishedInTheUK'] = False
-    submission['licenceOrMemberRequired'] = False
+    submission['licenceOrMemberRequired'] = 'none of the above'
     validator = DOSValidator(content, submission)
     assert validator.errors() == {}
 
     submission['establishedInTheUK'] = False
-    submission['licenceOrMemberRequired'] = True
+    submission['licenceOrMemberRequired'] = 'licensed'
     validator = DOSValidator(content, submission)
     assert validator.errors() == {"licenceOrMemberRequiredDetails": "answer_required"}
 


### PR DESCRIPTION
Two things fixed here:
  * Validation was treating `None` values as though they were valid answers for required strings
  * Conditional validation for Q72 (`licenceOrMemberRequiredDetails`) had the wrong condition on it

Fixes these three bugs:
https://www.pivotaltracker.com/story/show/109608322
https://www.pivotaltracker.com/story/show/109608580
https://www.pivotaltracker.com/story/show/109608626
