### PR TITLE
Don't send welcome email to deactivated users

### DIFF
--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -49,7 +49,7 @@ def framework_dashboard(framework_slug):
         try:
             email_body = render_template('emails/dos_application_started.html')
             send_email(
-                [user['emailAddress'] for user in supplier_users['users']],
+                [user['emailAddress'] for user in supplier_users['users'] if user['active']],
                 email_body,
                 current_app.config['DM_MANDRILL_API_KEY'],
                 'You have started your {} application'.format(framework['name']),

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -125,7 +125,9 @@ class TestFrameworksDashboard(BaseApplicationTest):
             data_api_client.get_framework.return_value = self.framework(status='open')
             data_api_client.get_supplier_framework_info.return_value = self.supplier_framework()
             data_api_client.find_users.return_value = {'users': [
-                {'emailAddress': 'email1'}, {'emailAddress': 'email2'}
+                {'emailAddress': 'email1', 'active': True},
+                {'emailAddress': 'email2', 'active': True},
+                {'emailAddress': 'email3', 'active': False}
             ]}
             res = self.client.post("/suppliers/frameworks/digital-outcomes-and-specialists")
 


### PR DESCRIPTION
Is a user was removed from the contributors list they should not
receive the application started email.