### PR TITLE
Redirect when logged in

### DIFF
--- a/app/main/views/login.py
+++ b/app/main/views/login.py
@@ -253,10 +253,12 @@ def create_user(encoded_token):
         # valid supplier account exists
         if user.role == 'supplier' and not is_registered_to_another_supplier and not is_inactive_or_locked:
             # valid supplier account exists and is logged in
-            if not current_user.is_anonymous() and current_user.email_address == user.email_address:
+            if not current_user.is_authenticated():
+                return redirect(url_for('.render_login'))
+            else:
+                if current_user.email_address != user.email_address:
+                    flash('You are trying to create a user while logged in as a different user', 'error')
                 return redirect(url_for('.dashboard'))
-
-            return redirect(url_for('.render_login'))
 
         return render_template(
             "auth/update-user.html",

--- a/app/main/views/login.py
+++ b/app/main/views/login.py
@@ -23,6 +23,8 @@ SEVEN_DAYS_IN_SECONDS = 604800
 
 @main.route('/login', methods=["GET"])
 def render_login():
+    if current_user.is_authenticated():
+        return redirect(url_for('.dashboard'))
     next_url = request.args.get('next')
     template_data = main.config['BASE_TEMPLATE_DATA']
     return render_template(

--- a/app/main/views/login.py
+++ b/app/main/views/login.py
@@ -23,9 +23,11 @@ SEVEN_DAYS_IN_SECONDS = 604800
 
 @main.route('/login', methods=["GET"])
 def render_login():
-    if current_user.is_authenticated():
-        return redirect(url_for('.dashboard'))
     next_url = request.args.get('next')
+    if current_user.is_authenticated():
+        if next_url and next_url.startswith('/suppliers'):
+            return redirect(next_url)
+        return redirect(url_for('.dashboard'))
     template_data = main.config['BASE_TEMPLATE_DATA']
     return render_template(
         "auth/login.html",

--- a/app/templates/suppliers/dashboard.html
+++ b/app/templates/suppliers/dashboard.html
@@ -16,6 +16,18 @@
 
 {% block main_content %}
 
+  {% with messages = get_flashed_messages(with_categories=True) %}
+    {% for category, message in messages %}
+      {%
+        with
+        message = message,
+        type = "destructive" if category == 'error' else "success"
+      %}
+        {% include "toolkit/notification-banner.html" %}
+      {% endwith %}
+    {% endfor %}
+  {% endwith %}
+
   <div class="grid-row">
     <div class="column-two-thirds">
       {% with

--- a/tests/app/main/test_login.py
+++ b/tests/app/main/test_login.py
@@ -54,6 +54,15 @@ class TestLogin(BaseApplicationTest):
         assert_equal(res.location, 'http://localhost/suppliers')
         assert_in('Secure;', res.headers['Set-Cookie'])
 
+    def test_should_redirect_to_dashboard_if_already_logged_in(self):
+        self.client.post("/suppliers/login", data={
+            'email_address': 'valid@email.com',
+            'password': '1234567890'
+        })
+        res = self.client.get("/suppliers/login")
+        assert_equal(res.status_code, 302)
+        assert_equal(res.location, 'http://localhost/suppliers')
+
     def test_should_strip_whitespace_surrounding_login_email_address_field(self):
         self.client.post("/suppliers/login", data={
             'email_address': '  valid@email.com  ',

--- a/tests/app/main/test_login.py
+++ b/tests/app/main/test_login.py
@@ -55,10 +55,7 @@ class TestLogin(BaseApplicationTest):
         assert_in('Secure;', res.headers['Set-Cookie'])
 
     def test_should_redirect_to_dashboard_if_already_logged_in(self):
-        self.client.post("/suppliers/login", data={
-            'email_address': 'valid@email.com',
-            'password': '1234567890'
-        })
+        self.login()
         res = self.client.get("/suppliers/login")
         assert_equal(res.status_code, 302)
         assert_equal(res.location, 'http://localhost/suppliers')
@@ -991,7 +988,6 @@ class TestInviteUser(BaseApplicationTest):
     @mock.patch('app.main.views.login.data_api_client')
     def test_should_redirect_to_login_page_if_logged_in_user_is_not_invited_user(self, data_api_client):
         with self.app.app_context():
-
             self.login()
             data_api_client.get_user.return_value = self.user(
                 999,
@@ -1003,13 +999,14 @@ class TestInviteUser(BaseApplicationTest):
 
             token = self._generate_token()
             res = self.client.get(
-                '/suppliers/create-user/{}'.format(token),
-                follow_redirects=True
+                '/suppliers/create-user/{}'.format(token)
             )
-            assert_equal(res.status_code, 200)
-            assert_in(
-                "Log in to the Digital Marketplace",
-                res.get_data(as_text=True)
+            assert res.status_code == 302
+            assert res.location == 'http://localhost/suppliers'
+
+        with self.client.session_transaction() as session:
+            assert session['_flashes'][0] == (
+                'error', 'You are trying to create a user while logged in as a different user'
             )
 
     @mock.patch('app.main.views.login.data_api_client')
@@ -1019,7 +1016,7 @@ class TestInviteUser(BaseApplicationTest):
             self.login()
             data_api_client.get_user.return_value = self.user(
                 123,
-                'test@email.com',
+                'email@email.com',
                 1234,
                 'Supplier Name',
                 'Users name'
@@ -1027,14 +1024,10 @@ class TestInviteUser(BaseApplicationTest):
 
             token = self._generate_token()
             res = self.client.get(
-                '/suppliers/create-user/{}'.format(token),
-                follow_redirects=True
+                '/suppliers/create-user/{}'.format(token)
             )
-            assert_equal(res.status_code, 200)
-            assert_in(
-                "Log in to the Digital Marketplace",
-                res.get_data(as_text=True)
-            )
+            assert_equal(res.status_code, 302)
+            assert_in(res.location, 'http://localhost/suppliers')
 
     @mock.patch('app.main.views.login.data_api_client')
     def test_should_create_user_if_user_does_not_exist(self, data_api_client):

--- a/tests/app/main/test_login.py
+++ b/tests/app/main/test_login.py
@@ -60,6 +60,18 @@ class TestLogin(BaseApplicationTest):
         assert_equal(res.status_code, 302)
         assert_equal(res.location, 'http://localhost/suppliers')
 
+    def test_should_redirect_to_next_url_if_supplier_app(self):
+        self.login()
+        res = self.client.get("/suppliers/login?next=/suppliers/foo-bar")
+        assert_equal(res.status_code, 302)
+        assert_equal(res.location, 'http://localhost/suppliers/foo-bar')
+
+    def test_should_redirect_to_dashboard_if_next_url_not_supplier_app(self):
+        self.login()
+        res = self.client.get("/suppliers/login?next=/foo-bar")
+        assert_equal(res.status_code, 302)
+        assert_equal(res.location, 'http://localhost/suppliers')
+
     def test_should_strip_whitespace_surrounding_login_email_address_field(self):
         self.client.post("/suppliers/login", data={
             'email_address': '  valid@email.com  ',

--- a/tests/app/main/test_suppliers.py
+++ b/tests/app/main/test_suppliers.py
@@ -109,6 +109,25 @@ class TestSuppliersDashboard(BaseApplicationTest):
 
     @mock.patch("app.main.views.suppliers.data_api_client")
     @mock.patch("app.main.views.suppliers.get_current_suppliers_users")
+    def test_shows_flashed_messages(self, get_current_suppliers_users, data_api_client):
+        with self.client.session_transaction() as session:
+            session['_flashes'] = [('error', 'This is an error')]
+
+        data_api_client.get_framework.return_value = self.framework('open')
+        data_api_client.get_supplier.side_effect = get_supplier
+        data_api_client.find_audit_events.return_value = {
+            "auditEvents": []
+        }
+        get_current_suppliers_users.side_effect = get_user
+        with self.app.test_client():
+            self.login()
+
+            res = self.client.get("/suppliers")
+
+            assert "This is an error" in res.get_data(as_text=True)
+
+    @mock.patch("app.main.views.suppliers.data_api_client")
+    @mock.patch("app.main.views.suppliers.get_current_suppliers_users")
     def test_shows_edit_buttons(self, get_current_suppliers_users, data_api_client):
         data_api_client.get_supplier.side_effect = get_supplier
         data_api_client.find_frameworks.return_value = find_frameworks_return_value


### PR DESCRIPTION
## Redirect logged in users on /login

If a logged in user navigates to the login page they should be
redirected to the supplier dashboard.

## Change redirect flow for create-users
This commit changes the redirect flow for the `/suppliers/create-user` route. Before this change if a logged in user clicked the create user link for a different email address they would be redirected to the `/suppliers/login` route rather than the supplier dashboard. Since changing the `/suppliers/login` route to redirect logged in users to the supplier dashboard this different flow just adds in another redirect step.

With this change we redirect the user to the same place (the supplier dashboard) but show them an error message telling them what has gone wrong.

The tests associated with this flow have been updated to not follow redirects and we instead verify the location header and cookies are set. The reason for this is that the supplier dashboard has a lot of dependencies which detract from the meaning of the create user tests.