### PR TITLE
Update titles

### DIFF
--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -582,8 +582,9 @@ def _update_service_status(service, error_message=None):
 
     template_data = main.config['BASE_TEMPLATE_DATA']
     status_code = 400 if error_message else 200
+    framework = data_api_client.get_framework(service['frameworkSlug'])['frameworks']
 
-    content = content_loader.get_manifest('g-cloud-6', 'edit_service').filter(service)
+    content = content_loader.get_manifest(framework['slug'], 'edit_service').filter(service)
 
     question = {
         'question': 'Choose service status',
@@ -607,6 +608,7 @@ def _update_service_status(service, error_message=None):
         "services/service.html",
         service_id=service.get('id'),
         service_data=service,
+        framework=framework,
         sections=content.summary(service),
         error=error_message,
         **dict(question, **template_data)), status_code

--- a/app/templates/services/_base_service_page.html
+++ b/app/templates/services/_base_service_page.html
@@ -1,6 +1,6 @@
 {% extends "_base_page.html" %}
 
-{% block page_title %}{{ service_data.serviceName or service_data.lotName }} – Digital Marketplace{% endblock %}
+{% block page_title %}{{ framework.name }} {{ service_data.lotName }} – Digital Marketplace{% endblock %}
 
 {% block main_content %}
   <div class="grid-row">

--- a/app/templates/services/_base_service_page.html
+++ b/app/templates/services/_base_service_page.html
@@ -1,6 +1,6 @@
 {% extends "_base_page.html" %}
 
-{% block page_title %}{{ framework.name }} {{ service_data.lotName }} – Digital Marketplace{% endblock %}
+{% block page_title %}{{ service_data.serviceName or service_data.lotName }} – Digital Marketplace{% endblock %}
 
 {% block main_content %}
   <div class="grid-row">

--- a/app/templates/services/service_submission.html
+++ b/app/templates/services/service_submission.html
@@ -1,5 +1,7 @@
 {% extends "services/_base_service_page.html" %}
 
+{% block page_title %}{{ service_data.lotName }} submission summary – Digital Marketplace{% endblock %}
+
 {% import "macros/submission.html" as submission %}
 
 {% block breadcrumb %}

--- a/app/templates/suppliers/dashboard.html
+++ b/app/templates/suppliers/dashboard.html
@@ -1,5 +1,5 @@
 {% extends "_base_page.html" %}
-{% block page_title %}{{ current_user.supplier_name }} – Digital Marketplace{% endblock %}
+{% block page_title %}Supplier dashboard – Digital Marketplace{% endblock %}
 
 {% block breadcrumb %}
   {%

--- a/app/templates/suppliers/dashboard.html
+++ b/app/templates/suppliers/dashboard.html
@@ -1,5 +1,5 @@
 {% extends "_base_page.html" %}
-{% block page_title %}Supplier dashboard – Digital Marketplace{% endblock %}
+{% block page_title %}Your account – Digital Marketplace{% endblock %}
 
 {% block breadcrumb %}
   {%

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -141,7 +141,14 @@ class TestSupplierUpdateService(BaseApplicationTest):
                 'status': service_status,
                 'id': '123',
                 'frameworkName': 'G-Cloud 6',
+                'frameworkSlug': 'g-cloud-6',
                 'supplierId': 1234 if service_belongs_to_user else 1235
+            }
+        }
+        data_api_client.get_framework.return_value = {
+            'frameworks': {
+                'name': 'G-Cloud 6',
+                'slug': 'g-cloud-6',
             }
         }
 


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/109883600

## Pass framework into edit_service templates
The framework is required by the framework but it hasn't been passed in. This was raised while trying to change the page titles.

## Change page titles to remove supplier specifics

While a framework is open for submissions we are not allowed to see what specific suppliers are doing. This change removes supplier identifiable information from titles as these are sent to google and therefore are very easy for us to see.