### PR TITLE
Load custom timestamps on communications

### DIFF
--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -73,7 +73,7 @@ def framework_dashboard(framework_slug):
     if declaration_status == 'unstarted' and framework['status'] == 'live':
         abort(404)
 
-    key_list = s3.S3(current_app.config['DM_COMMUNICATIONS_BUCKET']).list(framework_slug)
+    key_list = s3.S3(current_app.config['DM_COMMUNICATIONS_BUCKET']).list(framework_slug, load_timestamps=True)
     key_list.reverse()
 
     try:
@@ -343,7 +343,7 @@ def framework_updates(framework_slug, error_message=None, default_textbox_value=
                                    'supplier_id': current_user.supplier_id})
 
     communications_bucket = s3.S3(current_app.config['DM_COMMUNICATIONS_BUCKET'])
-    file_list = communications_bucket.list('{}/communications/updates/'.format(framework_slug))
+    file_list = communications_bucket.list('{}/communications/updates/'.format(framework_slug), load_timestamps=True)
     files = {
         'communications': [],
         'clarifications': [],

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ werkzeug==0.10.4
 python-dateutil==2.4.2
 
 git+https://github.com/madzak/python-json-logger.git@v0.1.3#egg=python-json-logger==v0.1.3
-git+https://github.com/alphagov/digitalmarketplace-utils.git@15.8.1#egg=digitalmarketplace-utils==15.8.1
+git+https://github.com/alphagov/digitalmarketplace-utils.git@15.9.1#egg=digitalmarketplace-utils==15.9.1
 
 markdown==2.6.2
 


### PR DESCRIPTION
The communications that have been copied over from the G7 bucket have
had timestamps set in a custom metadata field. This change loads those
metadata fields if available.