### PR TITLE
Breadcrumb bugfix

### DIFF
--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -8,7 +8,7 @@ from ..helpers.services import (
     is_service_modifiable, is_service_associated_with_supplier,
     get_signed_document_url, count_unanswered_questions,
 )
-from ..helpers.frameworks import get_framework_and_lot, get_declaration_status
+from ..helpers.frameworks import get_framework_and_lot, get_declaration_status, has_one_service_limit
 
 from dmutils.apiclient import APIError, HTTPError
 from dmutils import s3
@@ -372,9 +372,7 @@ def view_service_submission(framework_slug, lot_slug, service_id):
         "services/service_submission.html",
         framework=framework,
         confirm_remove=request.args.get("confirm_remove", None),
-        one_service_limit=[
-            l['oneServiceLimit'] for l in framework['lots'] if l['slug'] == draft['lot']
-        ][0],
+        one_service_limit=has_one_service_limit(lot_slug, framework['lots']),
         service_id=service_id,
         service_data=draft,
         last_edit=last_edit,
@@ -419,9 +417,7 @@ def edit_service_submission(framework_slug, lot_slug, service_id, section_id, qu
         framework=framework,
         service_data=draft,
         service_id=service_id,
-        one_service_limit=[
-            l['oneServiceLimit'] for l in framework['lots'] if l['slug'] == draft['lot']
-            ][0],
+        one_service_limit=has_one_service_limit(lot_slug, framework['lots']),
         **main.config['BASE_TEMPLATE_DATA']
     )
 
@@ -486,9 +482,7 @@ def update_section_submission(framework_slug, lot_slug, service_id, section_id, 
             section=section,
             service_data=update_data,
             service_id=service_id,
-            one_service_limit=[
-                l['oneServiceLimit'] for l in framework['lots'] if l['slug'] == draft['lot']
-                ][0],
+            one_service_limit=has_one_service_limit(lot_slug, framework['lots']),
             errors=errors,
             **main.config['BASE_TEMPLATE_DATA']
             )

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -419,6 +419,9 @@ def edit_service_submission(framework_slug, lot_slug, service_id, section_id, qu
         framework=framework,
         service_data=draft,
         service_id=service_id,
+        one_service_limit=[
+            l['oneServiceLimit'] for l in framework['lots'] if l['slug'] == draft['lot']
+            ][0],
         **main.config['BASE_TEMPLATE_DATA']
     )
 
@@ -473,14 +476,19 @@ def update_section_submission(framework_slug, lot_slug, service_id, section_id, 
             errors = section.get_error_messages(e.message, draft['lot'])
 
     if errors:
-        if not update_data.get('serviceName', None):
-            update_data['serviceName'] = draft.get('serviceName', '')
+        keys_required_for_template = ['serviceName', 'lot', 'lotName']
+        for k in keys_required_for_template:
+            if k in draft and k not in update_data:
+                update_data[k] = draft[k]
         return render_template(
             "services/edit_submission_section.html",
             framework=framework,
             section=section,
             service_data=update_data,
             service_id=service_id,
+            one_service_limit=[
+                l['oneServiceLimit'] for l in framework['lots'] if l['slug'] == draft['lot']
+                ][0],
             errors=errors,
             **main.config['BASE_TEMPLATE_DATA']
             )

--- a/app/templates/services/edit_submission_section.html
+++ b/app/templates/services/edit_submission_section.html
@@ -20,9 +20,13 @@
         "label": "Services"
       },
       {
+        "link": url_for(".framework_submission_services", framework_slug=framework.slug, lot_slug=service_data.lot),
+        "label": service_data.lotName
+      },
+      {
         "link": url_for(".view_service_submission", framework_slug=framework.slug, lot_slug=service_data.lot, service_id=service_id),
         "label": service_data.get('serviceName', service_data['lotName'])
-      }
+      } if not one_service_limit else {}
     ]
   %}
     {% include "toolkit/breadcrumb.html" %}


### PR DESCRIPTION
See: https://www.pivotaltracker.com/story/show/108242580
And: https://www.pivotaltracker.com/story/show/109717458
(They are the same bug)

As well as fixing breadcrumbs after a validation failure - as described in the bugs - this also adds a breadcrumb that was missing for multi-lot services.

Before:
![screen shot 2015-12-11 at 12 47 51](https://cloud.githubusercontent.com/assets/6525554/11744775/3f58330c-a00b-11e5-973e-53f12be41153.png)

After:
![screen shot 2015-12-11 at 12 48 18](https://cloud.githubusercontent.com/assets/6525554/11744785/49fd3866-a00b-11e5-8a4b-bac651ac7e4d.png)
