### PR TITLE
Remove status link from list of current services

### DIFF
--- a/app/templates/services/list_services.html
+++ b/app/templates/services/list_services.html
@@ -57,34 +57,25 @@
   ) %}
     {% call summary.row() %}
 
-      {% if 'EDIT_SERVICE_PAGE' is active_feature %}
-        {{ summary.service_link(
-            item.serviceName,
-            url_for('.edit_service', service_id=item.id)
-        ) }}
-      {% else %}
-        {{ summary.field_name(item.serviceName, wide=True) }}
-      {% endif %}
+      {{ summary.service_link(
+          item.serviceName,
+          url_for('.edit_service', service_id=item.id) if 'EDIT_SERVICE_PAGE' is active_feature
+          else '/g-cloud/services/{}'.format(item.id)
+      ) }}
 
       {{ summary.text(item.frameworkName) }}
 
       {{ summary.text(item.lotName or item.lot) }}
 
-      {% if item.status == "published" %}
-        {{ summary.edit_link("View service", '/g-cloud/services/' + item.id) }}
-      {% elif item.status == "disabled" %}
-        {% call summary.field(action=True) %}
-          <span class="service-status-{{ item.status }}">
+      {% call summary.field(action=True) %}
+          {% if item.status == "published" %}
+            Live
+          {% elif item.status == "enabled" %}
+            Unavailable
+          {% elif item.status == "disabled" %}
             Removed
-          </span>
-        {% endcall %}
-      {% elif item.status == "enabled" %}
-        {% call summary.field(action=True) %}
-          <span class="service-status-{{ item.status }}">
-            Private
-          </span>
-        {% endcall %}
-      {% endif %}
+          {% endif %}
+      {% endcall %}
 
     {% endcall %}
   {% endcall %}

--- a/app/templates/services/list_services.html
+++ b/app/templates/services/list_services.html
@@ -68,13 +68,11 @@
       {{ summary.text(item.lotName or item.lot) }}
 
       {% call summary.field(action=True) %}
-          {% if item.status == "published" %}
-            Live
-          {% elif item.status == "enabled" %}
-            Unavailable
-          {% elif item.status == "disabled" %}
-            Removed
-          {% endif %}
+        {% if item.status == "published" %}
+          Live
+        {% else %}
+          Removed
+        {% endif %}
       {% endcall %}
 
     {% endcall %}


### PR DESCRIPTION
Before | After
--- | ---
![image](https://cloud.githubusercontent.com/assets/355079/12113893/cf6497ce-b39d-11e5-9359-f7313dd00d64.png) | ![image](https://cloud.githubusercontent.com/assets/355079/12113885/be4d57d2-b39d-11e5-984d-664c819500ce.png)

Having two links in the table was confusing.

This commit has one link, which goes to:
- the live service on the buyer app if the 'edit service' feature flag is off (
  because otherwise we’d be sending you to a pointless page)
- the page where you can turn your service off if the 'edit service' feature
  flag is on

It also removes the pretty colours from the statuses, and changes ‘private’ to
‘unavailable’ to match the admin app. We think there’s still value in
differentiating between services that have been removed by an admin and services
that a supplier has removed themselves.

***

https://www.pivotaltracker.com/story/show/110085882