### PR TITLE
[#107186966] Return countersigned framework agreements to suppliers

### DIFF
--- a/app/assets/scss/_lists.scss
+++ b/app/assets/scss/_lists.scss
@@ -62,3 +62,8 @@ ol {
     }
   }
 }
+
+.unbulleted-item {
+  list-style-type: none;
+  margin-bottom: 10px;
+}

--- a/app/main/helpers/frameworks.py
+++ b/app/main/helpers/frameworks.py
@@ -1,9 +1,11 @@
 # -*- coding: utf-8 -*-
+from dmutils.documents import get_countersigned_agreement_document_path
 import re
 
 from flask import abort
 from flask_login import current_user
 from dmapiclient import APIError
+from dmutils import s3
 
 
 def get_framework(client, framework_slug, open_only=True):
@@ -256,3 +258,9 @@ def has_one_service_limit(lot_slug, framework_lots):
     for lot in framework_lots:
         if lot['slug'] == lot_slug:
             return lot['oneServiceLimit']
+
+
+def countersigned_framework_agreement_exists_in_bucket(framework_slug, bucket):
+    agreements_bucket = s3.S3(bucket)
+    countersigned_path = get_countersigned_agreement_document_path(framework_slug, current_user.supplier_id)
+    return agreements_bucket.path_exists(countersigned_path)

--- a/app/templates/frameworks/dashboard.html
+++ b/app/templates/frameworks/dashboard.html
@@ -216,35 +216,32 @@
           {% endif %}
 
           {% if framework.status in ['standstill', 'live'] and agreement_countersigned %}
-            <li class="browse-list-item">
-              <ul>
-                <li class="guidance-link">
-                  <a href="{{ url_for('.download_agreement_file', framework_slug=framework.slug, document_name='countersigned-agreement') }}"><span>Download your countersigned framework agreement (.pdf)</span></a>
-                </li>
-                
-                <li class="guidance-link">
-                  <a href="{{ url_for('.download_agreement_file', framework_slug=framework.slug, document_name='result-letter.pdf') }}">
-                    <span>Download your application result letter (.pdf)</span>
-                  </a>
-                </li>
-              
-                <li class="guidance-link">
-                  <a href="{{ url_for('.download_supplier_file', filepath=supplier_pack_filename, framework_slug=framework.slug) }}"><span>Download guidance and legal documentation (.zip)</span></a>
-                  {% if last_modified.supplier_pack %}
-                  <div class="hint">Last updated <time datetime="{{ last_modified.supplier_pack }}">{{ last_modified.supplier_pack|dateformat }}</time></div>
-                  {% endif %}
-                </li>
-                  
-                <li class="guidance-link">
-                  <a href="{{ url_for('.framework_updates', framework_slug=framework.slug) }}">
-                        <span>Read updates and clarification question responses</span>
-                  </a>
-                  {% if last_modified.supplier_updates %}
-                  <div class="hint">Last updated <time datetime="{{ last_modified.supplier_updates }}">{{ last_modified.supplier_updates|dateformat }}</time></div>
-                  {% endif %}
-                </li>
-              </ul>
+            <li class="unbulleted-item">
+              <a href="{{ url_for('.download_agreement_file', framework_slug=framework.slug, document_name='countersigned-agreement') }}"><span>Download your countersigned framework agreement (.pdf)</span></a>
             </li>
+
+            <li class="unbulleted-item">
+              <a href="{{ url_for('.download_agreement_file', framework_slug=framework.slug, document_name='result-letter.pdf') }}">
+                <span>Download your application result letter (.pdf)</span>
+              </a>
+            </li>
+
+            <li class="unbulleted-item">
+              <a href="{{ url_for('.download_supplier_file', filepath=supplier_pack_filename, framework_slug=framework.slug) }}"><span>Download guidance and legal documentation (.zip)</span></a>
+              {% if last_modified.supplier_pack %}
+              <div class="hint">Last updated <time datetime="{{ last_modified.supplier_pack }}">{{ last_modified.supplier_pack|dateformat }}</time></div>
+              {% endif %}
+            </li>
+
+            <li class="unbulleted-item">
+              <a href="{{ url_for('.framework_updates', framework_slug=framework.slug) }}">
+                    <span>Read updates and clarification question responses</span>
+              </a>
+              {% if last_modified.supplier_updates %}
+              <div class="hint">Last updated <time datetime="{{ last_modified.supplier_updates }}">{{ last_modified.supplier_updates|dateformat }}</time></div>
+              {% endif %}
+            </li>
+
           {% else %}
 
           <li class="browse-list-item">

--- a/app/templates/frameworks/dashboard.html
+++ b/app/templates/frameworks/dashboard.html
@@ -72,7 +72,7 @@
       <nav role="navigation">
         <ul class="browse-list">
 
-          {% if framework.status in ['standstill', 'live'] and application_made %}
+          {% if framework.status in ['standstill', 'live'] and application_made and not agreement_countersigned %}
             <li class="browse-list-item">
               <a class="browse-list-item-link" href="{{ url_for('.download_agreement_file', framework_slug=framework.slug, document_name='result-letter.pdf') }}" download>
                 <span>Download your application result letter (.pdf)</span>
@@ -211,6 +211,21 @@
                     </li>
                   {% endif %}
                 {% endfor %}
+              </ul>
+            </li>
+          {% endif %}
+
+          {% if framework.status in ['standstill', 'live'] and agreement_countersigned %}
+            <li class="browse-list-item">
+              <ul>
+                <li class="guidance-link">
+                  <a href="{{ url_for('.download_agreement_file', framework_slug=framework.slug, document_name='countersigned-agreement') }}"><span>Download your countersigned framework agreement (.pdf)</span></a>
+                </li>
+                <li class="guidance-link">
+                  <a href="{{ url_for('.download_agreement_file', framework_slug=framework.slug, document_name='result-letter.pdf') }}">
+                    <span>Download your application result letter (.pdf)</span>
+                  </a>
+                </li>
               </ul>
             </li>
           {% endif %}

--- a/app/templates/frameworks/dashboard.html
+++ b/app/templates/frameworks/dashboard.html
@@ -221,14 +221,31 @@
                 <li class="guidance-link">
                   <a href="{{ url_for('.download_agreement_file', framework_slug=framework.slug, document_name='countersigned-agreement') }}"><span>Download your countersigned framework agreement (.pdf)</span></a>
                 </li>
+                
                 <li class="guidance-link">
                   <a href="{{ url_for('.download_agreement_file', framework_slug=framework.slug, document_name='result-letter.pdf') }}">
                     <span>Download your application result letter (.pdf)</span>
                   </a>
                 </li>
+              
+                <li class="guidance-link">
+                  <a href="{{ url_for('.download_supplier_file', filepath=supplier_pack_filename, framework_slug=framework.slug) }}"><span>Download guidance and legal documentation (.zip)</span></a>
+                  {% if last_modified.supplier_pack %}
+                  <div class="hint">Last updated <time datetime="{{ last_modified.supplier_pack }}">{{ last_modified.supplier_pack|dateformat }}</time></div>
+                  {% endif %}
+                </li>
+                  
+                <li class="guidance-link">
+                  <a href="{{ url_for('.framework_updates', framework_slug=framework.slug) }}">
+                        <span>Read updates and clarification question responses</span>
+                  </a>
+                  {% if last_modified.supplier_updates %}
+                  <div class="hint">Last updated <time datetime="{{ last_modified.supplier_updates }}">{{ last_modified.supplier_updates|dateformat }}</time></div>
+                  {% endif %}
+                </li>
               </ul>
             </li>
-          {% endif %}
+          {% else %}
 
           <li class="browse-list-item">
             <h2>
@@ -257,6 +274,7 @@
               </li>
             </ul>
           </li>
+          {% endif %}
         </ul>
       </nav>
     </div>

--- a/app/templates/frameworks/updates.html
+++ b/app/templates/frameworks/updates.html
@@ -120,66 +120,68 @@
     </div>
   </div>
 
-  {% if framework.clarificationQuestionsOpen %}
-    <form method="post">
-      <div class="grid-row">
-        <div class="column-two-thirds">
-          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+  {% if not agreement_countersigned %}
+    {% if framework.clarificationQuestionsOpen %}
+      <form method="post">
+        <div class="grid-row">
+          <div class="column-two-thirds">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+              {%
+                with
+                large=true,
+                question = "Ask a clarification question",
+                name = clarification_question_name,
+                hint = "You should ask any questions you have about {} here. The Crown Commercial Service will not respond to you individually. (Maximum 5000 characters per question.)".format(framework.name),
+                error = error_message,
+                value = clarification_question_value
+              %}
+                {% include "toolkit/forms/textbox.html" %}
+              {% endwith %}
+              <p>
+                The deadline for clarification questions is {{ dates.clarifications_close_date|safe }}. All responses will be published by {{ dates.clarifications_publish_date|safe }}.
+              </p>
+              {%
+                with
+                label="Ask question",
+                type="save"
+              %}
+                {% include "toolkit/button.html" %}
+              {% endwith %}
+  
+              <a href="{{ url_for('.framework_dashboard', framework_slug=framework.slug) }}">Return to {{ framework.name }} application</a>
+  
+            </div>
+          </div>
+        </form>
+    {% else %}
+      <form method="post">
+        <div class="grid-row">
+          <div class="column-two-thirds">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
             {%
               with
               large=true,
-              question = "Ask a clarification question",
+              question = "Ask a question about your {} application".format(framework.name),
               name = clarification_question_name,
-              hint = "You should ask any questions you have about {} here. The Crown Commercial Service will not respond to you individually. (Maximum 5000 characters per question.)".format(framework.name),
+              hint = "If you have any questions about your {} application, you can ask them here. You'll get a private reply from the Crown Commercial Service. (Maximum 5000 characters per question.)".format(framework.name),
               error = error_message,
               value = clarification_question_value
             %}
-              {% include "toolkit/forms/textbox.html" %}
+            {% include "toolkit/forms/textbox.html" %}
             {% endwith %}
-            <p>
-              The deadline for clarification questions is {{ dates.clarifications_close_date|safe }}. All responses will be published by {{ dates.clarifications_publish_date|safe }}.
-            </p>
             {%
               with
               label="Ask question",
               type="save"
             %}
-              {% include "toolkit/button.html" %}
+            {% include "toolkit/button.html" %}
             {% endwith %}
-
+  
             <a href="{{ url_for('.framework_dashboard', framework_slug=framework.slug) }}">Return to {{ framework.name }} application</a>
-
+  
           </div>
         </div>
       </form>
-  {% else %}
-    <form method="post">
-      <div class="grid-row">
-        <div class="column-two-thirds">
-          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
-          {%
-            with
-            large=true,
-            question = "Ask a question about your {} application".format(framework.name),
-            name = clarification_question_name,
-            hint = "If you have any questions about your {} application, you can ask them here. You'll get a private reply from the Crown Commercial Service. (Maximum 5000 characters per question.)".format(framework.name),
-            error = error_message,
-            value = clarification_question_value
-          %}
-          {% include "toolkit/forms/textbox.html" %}
-          {% endwith %}
-          {%
-            with
-            label="Ask question",
-            type="save"
-          %}
-          {% include "toolkit/button.html" %}
-          {% endwith %}
-
-          <a href="{{ url_for('.framework_dashboard', framework_slug=framework.slug) }}">Return to {{ framework.name }} application</a>
-
-        </div>
-      </div>
-    </form>
+    {% endif %}
   {% endif %}
 {% endblock %}


### PR DESCRIPTION
See: https://www.pivotaltracker.com/story/show/107186966

The first batch of countersigned framework agreements from CCS have now been uploaded to S3.

This story allows suppliers to access their countersigned agreement from their framework dashboard page if it has been uploaded.  The page checks for the existence of a countersigned agreement for the supplier in S3, and displays a link to it if it finds one.

This is how the page will look once the countersigned agreement has been uploaded (OK'd by @ralph-hawkins ):
![screen shot 2016-01-13 at 11 18 24](https://cloud.githubusercontent.com/assets/6525554/12292865/da416b90-b9e7-11e5-8f88-2d46bacb7906.png)

Once they have their countersigned agreement then suppliers should no longer be able to contact CCS from the question box:
![screen shot 2016-01-13 at 11 18 44](https://cloud.githubusercontent.com/assets/6525554/12292899/017be212-b9e8-11e5-8a6f-f7d623377c92.png)
