### PR TITLE
[#111771084] Only show edit links if framework is open & fix banner message

### DIFF
--- a/app/templates/services/_base_service_page.html
+++ b/app/templates/services/_base_service_page.html
@@ -93,7 +93,7 @@
             {% else %}
               {{ summary[question.type](question.value, question.assurance) }}
             {% endif %}
-            {% if section.edit_questions %}
+            {% if section.edit_questions and framework.status == 'open' %}
               {% if not question.is_empty %}
                 {{ summary.remove_link('Remove', url_for(".remove_subsection", framework_slug=framework.slug, lot_slug=service_data.lot, service_id=service_id, section_id=section.id, question_slug=question.slug)) }}
               {% else %}

--- a/app/templates/services/service_submission.html
+++ b/app/templates/services/service_submission.html
@@ -51,7 +51,7 @@
             This service was submitted
           </h2>
           <p class="temporary-message-message">
-            If your application is successful, it will be available on the Digital Marketplace when G-Cloud 7 goes live.
+            If your application is successful, it will be available on the Digital Marketplace when {{ framework.name }} goes live.
           </p>
         {% else %}
           <h2 class="temporary-message-heading" id="temporary-message-heading">


### PR DESCRIPTION
Fixes this bug: https://www.pivotaltracker.com/story/show/111771084

Before:
![screen shot 2016-01-15 at 17 07 37](https://cloud.githubusercontent.com/assets/6525554/12359569/f2f24de8-bbaa-11e5-9508-eeaee205e3d7.png)

After:
![screen shot 2016-01-15 at 17 08 01](https://cloud.githubusercontent.com/assets/6525554/12359570/f72bee28-bbaa-11e5-8b6e-42ff2a683a93.png)


And now also fixes this bug: https://www.pivotaltracker.com/story/show/111770766
Before:
![screen shot 2016-01-15 at 17 19 49](https://cloud.githubusercontent.com/assets/6525554/12359827/41c27370-bbac-11e5-8ac3-372bf04c9aab.png)

After:
![screen shot 2016-01-15 at 17 18 15](https://cloud.githubusercontent.com/assets/6525554/12359781/04e818ec-bbac-11e5-9e18-b46f0fb47bed.png)