### PR TITLE
Add agreement bucket to `run_app.sh`

### DIFF
--- a/scripts/run_app.sh
+++ b/scripts/run_app.sh
@@ -13,6 +13,7 @@ export DM_API_AUTH_TOKEN=${DM_API_AUTH_TOKEN:=myToken}
 
 export DM_SUBMISSIONS_BUCKET=${DM_SUBMISSIONS_BUCKET:=digitalmarketplace-documents-dev-dev}
 export DM_COMMUNICATIONS_BUCKET=${DM_COMMUNICATIONS_BUCKET:=digitalmarketplace-documents-dev-dev}
+export DM_AGREEMENTS_BUCKET=${DM_AGREEMENTS_BUCKET:=digitalmarketplace-documents-dev-dev}
 export DM_ASSETS_URL=${DM_ASSETS_URL:=https://${DM_SUBMISSIONS_BUCKET}.s3-eu-west-1.amazonaws.com}
 
 export DM_MANDRILL_API_KEY=${DM_MANDRILL_API_KEY:=not_a_real_key}


### PR DESCRIPTION
Running the app without `DM_AGREEMENTS_BUCKET` set causes the app to fail in various places (such as [the frameworks dashboard](https://github.com/alphagov/digitalmarketplace-supplier-frontend/blob/master/app/main/views/frameworks.py#L91)).
Setting the variable resolves the issue.