### PR TITLE
Only copy the frameworks folder to app/content

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -237,7 +237,7 @@ gulp.task(
   'copy:frameworks',
   copyFactory(
     "frameworks YAML into app folder",
-    sspContentRoot, 'app/content'
+    sspContentRoot + '/frameworks', 'app/content/frameworks'
   )
 );
 


### PR DESCRIPTION
When copying the digitalmarketplace-frameworks contents from bower
components to app/content the build process used to copy all repo
files. Since we've added more non-content related files to the
repo (tests, scripts, etc.) that aren't used by the apps there's
no reason to add them to the app release package and they could be
causing issues in the future (eg being picked up by pep8 and pytest).