### PR TITLE
[#111771966] Change layout of submitted services

### DIFF
--- a/app/assets/scss/_lists.scss
+++ b/app/assets/scss/_lists.scss
@@ -27,6 +27,9 @@ ol {
 .list-bullet,
 .list-number {
   margin-top: 5px;
+}
+
+.list-number {
   margin-bottom: 20px;
 }
 
@@ -44,6 +47,7 @@ ol {
 
   ul {
     padding-bottom: 0;
+    margin-bottom: 20px;
 
     @include media(tablet) {
       padding-bottom: $gutter-half;

--- a/app/templates/frameworks/dashboard.html
+++ b/app/templates/frameworks/dashboard.html
@@ -192,15 +192,8 @@
             </li>
           {% elif framework.status in ['pending', 'standstill'] and application_made %}
             <li class="browse-list-item">
-              <a class="browse-list-item-link" href="{{ url_for('.framework_submission_lots', framework_slug=framework.slug) }}">
-                View services
-              </a>
-              <div class="browse-list-item-status-happy">
-                <p class="browse-list-item-status-title">
-                  You submitted
-                </p>
-              </div>
-              <ul class="browse-list-item-status-list">
+              <h2>You submitted:</h2>
+              <ul class="list-bullet">
                 {% for lot in completed_lots %}
                   {% if lot.one_service_limit %}
                     <li>{{ lot.name }}</li>
@@ -212,6 +205,9 @@
                   {% endif %}
                 {% endfor %}
               </ul>
+              <a href="{{ url_for('.framework_submission_lots', framework_slug=framework.slug) }}">
+                View submitted services
+              </a>
             </li>
           {% endif %}
 

--- a/app/templates/suppliers/create_new_supplier.html
+++ b/app/templates/suppliers/create_new_supplier.html
@@ -43,8 +43,8 @@
             contact details
           </li>
         </ul>
-        <a href='{{ url_for(".duns_number") }}' class="button-save" role="button">Start</a>
       </div>
+      <a href='{{ url_for(".duns_number") }}' class="button-save" role="button">Start</a>
     </div>
   </div>
 </div>


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/111771966

When a framework is in the pending / standstill state the list of lots that have been submitted to should be displayed differently.

## Before
![screen shot 2016-02-01 at 17 10 40](https://cloud.githubusercontent.com/assets/14287/12724652/c287a64e-c906-11e5-9dff-f308bd7cc3ff.png)

## After
![screen shot 2016-02-02 at 17 23 36](https://cloud.githubusercontent.com/assets/14287/12757875/cdb0d678-c9d1-11e5-96af-8bb4f8b1b648.png)

