### PR TITLE
Enable suppliers removing their services

### DIFF
--- a/config.py
+++ b/config.py
@@ -95,7 +95,7 @@ class Test(Config):
     SHARED_EMAIL_KEY = "KEY"
     DM_CLARIFICATION_QUESTION_EMAIL = 'digitalmarketplace@mailinator.com'
 
-    FEATURE_FLAGS_EDIT_SECTIONS = enabled_since('2016-01-20')
+    FEATURE_FLAGS_EDIT_SECTIONS = enabled_since('2015-06-03')
 
 
 class Development(Config):
@@ -103,7 +103,7 @@ class Development(Config):
     SESSION_COOKIE_SECURE = False
 
     # Dates not formatted like YYYY-(0)M-(0)D will fail
-    FEATURE_FLAGS_EDIT_SECTIONS = enabled_since('2016-01-25')
+    FEATURE_FLAGS_EDIT_SECTIONS = enabled_since('2015-06-03')
 
 
 class Live(Config):
@@ -124,7 +124,7 @@ class Production(Live):
 
 class Staging(Production):
     pass
-    FEATURE_FLAGS_EDIT_SECTIONS = enabled_since('2016-01-25')
+    FEATURE_FLAGS_EDIT_SECTIONS = enabled_since('2015-06-03')
 
 configs = {
     'development': Development,

--- a/config.py
+++ b/config.py
@@ -65,7 +65,7 @@ class Config(object):
     # Feature Flags
     RAISE_ERROR_ON_MISSING_FEATURES = True
 
-    FEATURE_FLAGS_EDIT_SERVICE_PAGE = False
+    FEATURE_FLAGS_EDIT_SERVICE_PAGE = enabled_since('2016-02-02')
     FEATURE_FLAGS_EDIT_SECTIONS = False
 
     # Logging
@@ -95,7 +95,6 @@ class Test(Config):
     SHARED_EMAIL_KEY = "KEY"
     DM_CLARIFICATION_QUESTION_EMAIL = 'digitalmarketplace@mailinator.com'
 
-    FEATURE_FLAGS_EDIT_SERVICE_PAGE = enabled_since('2015-06-03')
     FEATURE_FLAGS_EDIT_SECTIONS = enabled_since('2016-01-20')
 
 
@@ -104,7 +103,6 @@ class Development(Config):
     SESSION_COOKIE_SECURE = False
 
     # Dates not formatted like YYYY-(0)M-(0)D will fail
-    FEATURE_FLAGS_EDIT_SERVICE_PAGE = enabled_since('2015-06-03')
     FEATURE_FLAGS_EDIT_SECTIONS = enabled_since('2016-01-25')
 
 
@@ -117,7 +115,7 @@ class Live(Config):
 
 
 class Preview(Live):
-    FEATURE_FLAGS_EDIT_SERVICE_PAGE = enabled_since('2015-06-03')
+    pass
 
 
 class Production(Live):
@@ -125,7 +123,7 @@ class Production(Live):
 
 
 class Staging(Production):
-    FEATURE_FLAGS_EDIT_SERVICE_PAGE = enabled_since('2015-06-03')
+    pass
     FEATURE_FLAGS_EDIT_SECTIONS = enabled_since('2016-01-25')
 
 configs = {


### PR DESCRIPTION
@cathrooney asked for the feature (suppliers' ability to remove their own services) to go live, so here it goes.