### PR TITLE
Change uploaded document filenames and set a Content-Disposition header

### DIFF
--- a/app/main/helpers/frameworks.py
+++ b/app/main/helpers/frameworks.py
@@ -93,17 +93,17 @@ def get_supplier_framework_info(data_api_client, framework_slug):
 
 
 def get_declaration_status_from_info(supplier_framework_info):
-    if not (supplier_framework_info or {}).get('declaration'):
+    if not supplier_framework_info or not supplier_framework_info.get('declaration'):
         return 'unstarted'
-    else:
-        return supplier_framework_info['declaration'].get('status', 'unstarted')
+
+    return supplier_framework_info['declaration'].get('status', 'unstarted')
 
 
 def get_supplier_on_framework_from_info(supplier_framework_info):
-    if supplier_framework_info is None:
+    if not supplier_framework_info:
         return False
-    else:
-        return bool(supplier_framework_info.get('onFramework'))
+
+    return bool(supplier_framework_info.get('onFramework'))
 
 
 def question_references(data, get_question):

--- a/app/main/helpers/services.py
+++ b/app/main/helpers/services.py
@@ -11,7 +11,7 @@ except ImportError:
     import urllib.parse as urlparse
 
 
-def get_drafts(apiclient, supplier_id, framework_slug):
+def get_drafts(apiclient, framework_slug):
     try:
         drafts = apiclient.find_draft_services(
             current_user.supplier_id,
@@ -27,8 +27,8 @@ def get_drafts(apiclient, supplier_id, framework_slug):
     return drafts, complete_drafts
 
 
-def get_lot_drafts(apiclient, supplier_id, framework_slug, lot_slug):
-    drafts, complete_drafts = get_drafts(apiclient, supplier_id, framework_slug)
+def get_lot_drafts(apiclient, framework_slug, lot_slug):
+    drafts, complete_drafts = get_drafts(apiclient, framework_slug)
     return (
         [draft for draft in drafts if draft['lot'] == lot_slug],
         [draft for draft in complete_drafts if draft['lot'] == lot_slug]

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -27,13 +27,10 @@ from .users import get_current_suppliers_users
 def dashboard():
     template_data = main.config['BASE_TEMPLATE_DATA']
 
-    try:
-        supplier = data_api_client.get_supplier(
-            current_user.supplier_id
-        )['suppliers']
-        supplier['contact'] = supplier['contactInformation'][0]
-    except APIError as e:
-        abort(e.status_code)
+    supplier = data_api_client.get_supplier(
+        current_user.supplier_id
+    )['suppliers']
+    supplier['contact'] = supplier['contactInformation'][0]
 
     all_frameworks = sorted(
         data_api_client.find_frameworks()['frameworks'],

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ Flask-WTF==0.12
 werkzeug==0.10.4
 python-dateutil==2.4.2
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@16.0.0#egg=digitalmarketplace-utils==16.0.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@16.2.1#egg=digitalmarketplace-utils==16.2.1
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@1.1.0#egg=digitalmarketplace-apiclient==1.1.0
 
 markdown==2.6.2

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -661,9 +661,11 @@ class TestFrameworkAgreementUpload(BaseApplicationTest):
 
             assert_equal(res.status_code, 503)
             s3.return_value.save.assert_called_with(
-                'g-cloud-7/agreements/1234/Legal_Supplier_Name-1234-signed-framework-agreement.pdf',
+                'g-cloud-7/agreements/1234/1234-signed-framework-agreement.pdf',
                 mock.ANY,
-                acl='private')
+                acl='private',
+                download_filename='Supplier_Name-1234-signed-framework-agreement.pdf'
+            )
             assert not data_api_client.register_framework_agreement_returned.called
             assert not send_email.called
 
@@ -685,9 +687,11 @@ class TestFrameworkAgreementUpload(BaseApplicationTest):
 
             assert_equal(res.status_code, 500)
             s3.return_value.save.assert_called_with(
-                'g-cloud-7/agreements/1234/Legal_Supplier_Name-1234-signed-framework-agreement.pdf',
+                'g-cloud-7/agreements/1234/1234-signed-framework-agreement.pdf',
                 mock.ANY,
-                acl='private')
+                acl='private',
+                download_filename='Supplier_Name-1234-signed-framework-agreement.pdf'
+            )
             data_api_client.register_framework_agreement_returned.assert_called_with(
                 1234, 'g-cloud-7', 'email@email.com')
             assert not send_email.called
@@ -710,9 +714,11 @@ class TestFrameworkAgreementUpload(BaseApplicationTest):
 
             assert_equal(res.status_code, 503)
             s3.return_value.save.assert_called_with(
-                'g-cloud-7/agreements/1234/Legal_Supplier_Name-1234-signed-framework-agreement.pdf',
+                'g-cloud-7/agreements/1234/1234-signed-framework-agreement.pdf',
                 mock.ANY,
-                acl='private')
+                acl='private',
+                download_filename='Supplier_Name-1234-signed-framework-agreement.pdf'
+            )
             data_api_client.register_framework_agreement_returned.assert_called_with(
                 1234, 'g-cloud-7', 'email@email.com')
             send_email.assert_called()
@@ -733,8 +739,11 @@ class TestFrameworkAgreementUpload(BaseApplicationTest):
             )
 
             s3.return_value.save.assert_called_with(
-                'g-cloud-7/agreements/1234/Legal_Supplier_Name-1234-signed-framework-agreement.pdf',
-                mock.ANY, acl='private')
+                'g-cloud-7/agreements/1234/1234-signed-framework-agreement.pdf',
+                mock.ANY,
+                acl='private',
+                download_filename='Supplier_Name-1234-signed-framework-agreement.pdf'
+            )
             assert_equal(res.status_code, 302)
             assert_equal(res.location, 'http://localhost/suppliers/frameworks/g-cloud-7/agreement')
 
@@ -754,8 +763,11 @@ class TestFrameworkAgreementUpload(BaseApplicationTest):
             )
 
             s3.return_value.save.assert_called_with(
-                'g-cloud-7/agreements/1234/Legal_Supplier_Name-1234-signed-framework-agreement.jpg',
-                mock.ANY, acl='private')
+                'g-cloud-7/agreements/1234/1234-signed-framework-agreement.jpg',
+                mock.ANY,
+                acl='private',
+                download_filename='Supplier_Name-1234-signed-framework-agreement.jpg'
+            )
             assert_equal(res.status_code, 302)
             assert_equal(res.location, 'http://localhost/suppliers/frameworks/g-cloud-7/agreement')
 


### PR DESCRIPTION
Because including the supplier names in the filenames for
uploaded documents is quite finicky, we've opted to keep only the
`supplier_id` in the filename proper but suggest a different filename
(which includes the supplier_name) when the file is downloaded.
By setting a `Content-Disposition` header on the uploaded file, we:

- force the browser to download it
- suggest a different filename in the 'Save As' dialog

Note that since we use the same dmutils function for both viewing
and downloading files, and since all existing files are tied to the
old naming convention, we have to update the supplier uploading method
separately from the supplier downloading method.
Once existing files have been renamed, we can port the change over to
dmutils.

### As a tangible example.

If the old filename was:
`Supplier_Name-10101-framework-agreement.pdf`

The new filename will be:
`10101-framework-agreement.pdf`

But when you download it, the filename suggested will be:
`Supplier_Name-10101-framework-agreement.pdf`
