### PR TITLE
Add environment variables for agreements and documents buckets

### DIFF
--- a/scripts/run_app.sh
+++ b/scripts/run_app.sh
@@ -13,7 +13,8 @@ export DM_API_AUTH_TOKEN=${DM_API_AUTH_TOKEN:=myToken}
 
 export DM_SUBMISSIONS_BUCKET=${DM_SUBMISSIONS_BUCKET:=digitalmarketplace-documents-dev-dev}
 export DM_COMMUNICATIONS_BUCKET=${DM_COMMUNICATIONS_BUCKET:=digitalmarketplace-documents-dev-dev}
-export DM_AGREEMENTS_BUCKET=${DM_AGREEMENTS_BUCKET:=digitalmarketplace-documents-dev-dev}
+export DM_AGREEMENTS_BUCKET=${DM_AGREEMENTS_BUCKET:=digitalmarketplace-agreements-dev-dev}
+export DM_DOCUMENTS_BUCKET=${DM_DOCUMENTS_BUCKET:=digitalmarketplace-documents-dev-dev}
 export DM_ASSETS_URL=${DM_ASSETS_URL:=https://${DM_SUBMISSIONS_BUCKET}.s3-eu-west-1.amazonaws.com}
 
 export DM_MANDRILL_API_KEY=${DM_MANDRILL_API_KEY:=not_a_real_key}


### PR DESCRIPTION
The supplier app uses them but they were absent until now.