### PR TITLE
[#112422463] Upload and retrieve framework (agreement) documents without supplier names in their filenames

### DIFF
--- a/app/main/helpers/frameworks.py
+++ b/app/main/helpers/frameworks.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from dmutils.documents import get_countersigned_agreement_document_path
+from dmutils.documents import get_agreement_document_path, COUNTERSIGNED_AGREEMENT_FILENAME
 import re
 
 from flask import abort
@@ -262,5 +262,6 @@ def has_one_service_limit(lot_slug, framework_lots):
 
 def countersigned_framework_agreement_exists_in_bucket(framework_slug, bucket):
     agreements_bucket = s3.S3(bucket)
-    countersigned_path = get_countersigned_agreement_document_path(framework_slug, current_user.supplier_id)
+    countersigned_path = get_agreement_document_path(
+        framework_slug, current_user.supplier_id, COUNTERSIGNED_AGREEMENT_FILENAME)
     return agreements_bucket.path_exists(countersigned_path)

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -496,6 +496,7 @@ def framework_agreement(framework_slug):
         "frameworks/agreement.html",
         framework=framework,
         supplier_framework=supplier_framework,
+        agreement_filename=AGREEMENT_FILENAME,
         **template_data
     ), 200
 
@@ -527,6 +528,7 @@ def upload_framework_agreement(framework_slug):
             framework=framework,
             supplier_framework=supplier_framework,
             upload_error=upload_error,
+            agreement_filename=AGREEMENT_FILENAME,
             **template_data
         ), 400
 

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -14,8 +14,9 @@ from dmutils.formats import format_service_price, datetimeformat
 from dmutils import s3
 from dmutils.deprecation import deprecated
 from dmutils.documents import (
+    RESULT_LETTER_FILENAME, AGREEMENT_FILENAME, SIGNED_AGREEMENT_PREFIX, COUNTERSIGNED_AGREEMENT_FILENAME,
     get_agreement_document_path, get_signed_url, get_extension, file_is_less_than_5mb, file_is_empty,
-    get_countersigned_agreement_document_path, sanitise_supplier_name
+    sanitise_supplier_name,
 )
 
 from ... import data_api_client
@@ -532,19 +533,19 @@ def upload_framework_agreement(framework_slug):
     agreements_bucket = s3.S3(current_app.config['DM_AGREEMENTS_BUCKET'])
     extension = get_extension(request.files['agreement'].filename)
 
-    # TODO: get rid of this; rewrite `.get_agreement_document_path()` function in dmutils
-    path = '{0}/agreements/{1}/{1}-signed-framework-agreement{2}'.format(
+    path = get_agreement_document_path(
         framework_slug,
         current_user.supplier_id,
-        extension
+        '{}{}'.format(SIGNED_AGREEMENT_PREFIX, extension)
     )
     agreements_bucket.save(
         path,
         request.files['agreement'],
         acl='private',
-        download_filename='{}-{}-signed-framework-agreement{}'.format(
+        download_filename='{}-{}-{}{}'.format(
             sanitise_supplier_name(current_user.supplier_name),
             current_user.supplier_id,
+            SIGNED_AGREEMENT_PREFIX,
             extension
         )
     )

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -302,14 +302,9 @@ def download_agreement_file(framework_slug, document_name):
     supplier_framework_info = get_supplier_framework_info(data_api_client, framework_slug)
     if supplier_framework_info is None or not supplier_framework_info.get("declaration"):
         abort(404)
-    legal_supplier_name = supplier_framework_info['declaration']['SQ1-1a']
 
     agreements_bucket = s3.S3(current_app.config['DM_AGREEMENTS_BUCKET'])
-    if document_name == 'countersigned-agreement':
-        path = get_countersigned_agreement_document_path(framework_slug, supplier_framework_info['supplierId'])
-    else:
-        path = get_agreement_document_path(
-            framework_slug, current_user.supplier_id, legal_supplier_name, document_name)
+    path = get_agreement_document_path(framework_slug, current_user.supplier_id, document_name)
     url = get_signed_url(agreements_bucket, path, current_app.config['DM_ASSETS_URL'])
     if not url:
         abort(404)

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -79,13 +79,15 @@ def framework_dashboard(framework_slug):
         framework_slug, 'declaration'
     ).get_next_editable_section_id()
 
+    # filenames
     supplier_pack_filename = '{}-supplier-pack.zip'.format(framework_slug)
+    result_letter_filename = RESULT_LETTER_FILENAME
+    countersigned_agreement_filename = None
+    if countersigned_framework_agreement_exists_in_bucket(framework_slug, current_app.config['DM_AGREEMENTS_BUCKET']):
+        countersigned_agreement_filename = COUNTERSIGNED_AGREEMENT_FILENAME
 
-    # a lot of these variables are being set quite differently on the supplier dashboard
     return render_template(
         "frameworks/dashboard.html",
-        agreement_countersigned=countersigned_framework_agreement_exists_in_bucket(
-            framework_slug, current_app.config['DM_AGREEMENTS_BUCKET']),
         application_made=(len(complete_drafts) > 0 and declaration_status == 'complete'),
         completed_lots=[{
             'name': lot['name'],
@@ -113,6 +115,8 @@ def framework_dashboard(framework_slug):
         },
         supplier_is_on_framework=supplier_is_on_framework,
         supplier_pack_filename=supplier_pack_filename,
+        result_letter_filename=result_letter_filename,
+        countersigned_agreement_filename=countersigned_agreement_filename,
         **main.config['BASE_TEMPLATE_DATA']
     ), 200
 

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -515,7 +515,7 @@ def upload_framework_agreement(framework_slug):
     supplier_framework = data_api_client.get_supplier_framework_info(
         current_user.supplier_id, framework_slug
     )['frameworkInterest']
-    if not supplier_framework['onFramework']:
+    if not supplier_framework or not supplier_framework['onFramework']:
         abort(404)
 
     template_data = main.config['BASE_TEMPLATE_DATA']

--- a/app/templates/frameworks/agreement.html
+++ b/app/templates/frameworks/agreement.html
@@ -56,7 +56,7 @@ with items = [
             <h2>1. Download your framework agreement</h2>
             <ul class='document-list'>
                 <li class='document-list-item'>
-                    <a href="{{ url_for('.download_agreement_file', framework_slug=framework.slug, document_name='framework-agreement.pdf') }}" class='document-link-with-icon' download>
+                    <a href="{{ url_for('.download_agreement_file', framework_slug=framework.slug, document_name=agreement_filename) }}" class='document-link-with-icon' download>
                       <span class='document-icon'>PDF<span> document:</span></span>
                       Download framework agreement
                     </a>

--- a/app/templates/frameworks/dashboard.html
+++ b/app/templates/frameworks/dashboard.html
@@ -211,13 +211,13 @@
             </li>
           {% endif %}
 
-          {% if framework.status in ['standstill', 'live'] and agreement_countersigned %}
+          {% if framework.status in ['standstill', 'live'] and countersigned_agreement_filename %}
             <li class="unbulleted-item">
-              <a href="{{ url_for('.download_agreement_file', framework_slug=framework.slug, document_name='countersigned-agreement') }}"><span>Download your countersigned framework agreement (.pdf)</span></a>
+              <a href="{{ url_for('.download_agreement_file', framework_slug=framework.slug, document_name=countersigned_agreement_filename) }}"><span>Download your countersigned framework agreement (.pdf)</span></a>
             </li>
 
             <li class="unbulleted-item">
-              <a href="{{ url_for('.download_agreement_file', framework_slug=framework.slug, document_name='result-letter.pdf') }}">
+              <a href="{{ url_for('.download_agreement_file', framework_slug=framework.slug, document_name=result_letter_filename) }}">
                 <span>Download your application result letter (.pdf)</span>
               </a>
             </li>

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ Flask-WTF==0.12
 werkzeug==0.10.4
 python-dateutil==2.4.2
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@16.2.1#egg=digitalmarketplace-utils==16.2.1
+git+https://github.com/alphagov/digitalmarketplace-utils.git@17.0.0#egg=digitalmarketplace-utils==17.0.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@1.1.0#egg=digitalmarketplace-apiclient==1.1.0
 
 markdown==2.6.2

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -810,7 +810,7 @@ class TestFrameworkAgreementDocumentDownload(BaseApplicationTest):
             assert_equal(res.status_code, 302)
             assert_equal(res.location, 'http://asset-host/path?param=value')
             uploader.get_signed_url.assert_called_with(
-                'g-cloud-7/agreements/1234/Legal_Supplier_Name-1234-example.pdf')
+                'g-cloud-7/agreements/1234/1234-example.pdf')
 
     def test_download_document_with_asset_url(self, S3, data_api_client):
         data_api_client.get_supplier_framework_info.return_value = self.supplier_framework()
@@ -828,7 +828,7 @@ class TestFrameworkAgreementDocumentDownload(BaseApplicationTest):
             assert_equal(res.status_code, 302)
             assert_equal(res.location, 'https://example/path?param=value')
             uploader.get_signed_url.assert_called_with(
-                'g-cloud-7/agreements/1234/Legal_Supplier_Name-1234-example.pdf')
+                'g-cloud-7/agreements/1234/1234-example.pdf')
 
 
 @mock.patch('dmutils.s3.S3')


### PR DESCRIPTION
This pull request: 

- changes the pathnames for getting uploaded documents to look for document names without the suppliers' names
- refactors  the `upload_framework_agreement` route to once again use the `.get_agreement_document_path()` function in dmutils
- swaps filenames hardcoded in templates for filename variables pulled in from dmutils

Once all agreement files have been renamed on our production AWS bucket, we can release this to production.