### PR TITLE
Don't show the "Sign and return your framework agreement" link if countersigned framework agreement exists

### DIFF
--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -82,9 +82,9 @@ def framework_dashboard(framework_slug):
     # filenames
     supplier_pack_filename = '{}-supplier-pack.zip'.format(framework_slug)
     result_letter_filename = RESULT_LETTER_FILENAME
-    countersigned_agreement_filename = None
+    countersigned_agreement_file = None
     if countersigned_framework_agreement_exists_in_bucket(framework_slug, current_app.config['DM_AGREEMENTS_BUCKET']):
-        countersigned_agreement_filename = COUNTERSIGNED_AGREEMENT_FILENAME
+        countersigned_agreement_file = COUNTERSIGNED_AGREEMENT_FILENAME
 
     return render_template(
         "frameworks/dashboard.html",
@@ -116,7 +116,7 @@ def framework_dashboard(framework_slug):
         supplier_is_on_framework=supplier_is_on_framework,
         supplier_pack_filename=supplier_pack_filename,
         result_letter_filename=result_letter_filename,
-        countersigned_agreement_filename=countersigned_agreement_filename,
+        countersigned_agreement_file=countersigned_agreement_file,
         **main.config['BASE_TEMPLATE_DATA']
     ), 200
 

--- a/app/templates/frameworks/dashboard.html
+++ b/app/templates/frameworks/dashboard.html
@@ -72,7 +72,7 @@
       <nav role="navigation">
         <ul class="browse-list">
 
-          {% if framework.status in ['standstill', 'live'] and application_made and not agreement_countersigned %}
+          {% if framework.status in ['standstill', 'live'] and application_made and not countersigned_agreement_file %}
             <li class="browse-list-item">
               <a class="browse-list-item-link" href="{{ url_for('.download_agreement_file', framework_slug=framework.slug, document_name='result-letter.pdf') }}" download>
                 <span>Download your application result letter (.pdf)</span>
@@ -211,9 +211,9 @@
             </li>
           {% endif %}
 
-          {% if framework.status in ['standstill', 'live'] and countersigned_agreement_filename %}
+          {% if framework.status in ['standstill', 'live'] and countersigned_agreement_file %}
             <li class="unbulleted-item">
-              <a href="{{ url_for('.download_agreement_file', framework_slug=framework.slug, document_name=countersigned_agreement_filename) }}"><span>Download your countersigned framework agreement (.pdf)</span></a>
+              <a href="{{ url_for('.download_agreement_file', framework_slug=framework.slug, document_name=countersigned_agreement_file) }}"><span>Download your countersigned framework agreement (.pdf)</span></a>
             </li>
 
             <li class="unbulleted-item">

--- a/scripts/run_app.sh
+++ b/scripts/run_app.sh
@@ -17,7 +17,7 @@ export DM_API_AUTH_TOKEN=${DM_API_AUTH_TOKEN:=myToken}
 
 export DM_SUBMISSIONS_BUCKET=${DM_SUBMISSIONS_BUCKET:=digitalmarketplace-documents-dev-dev}
 export DM_COMMUNICATIONS_BUCKET=${DM_COMMUNICATIONS_BUCKET:=digitalmarketplace-documents-dev-dev}
-export DM_AGREEMENTS_BUCKET=${DM_AGREEMENTS_BUCKET:=digitalmarketplace-agreements-dev-dev}
+export DM_AGREEMENTS_BUCKET=${DM_AGREEMENTS_BUCKET:=digitalmarketplace-documents-dev-dev}
 export DM_DOCUMENTS_BUCKET=${DM_DOCUMENTS_BUCKET:=digitalmarketplace-documents-dev-dev}
 export DM_ASSETS_URL=${DM_ASSETS_URL:=https://${DM_SUBMISSIONS_BUCKET}.s3-eu-west-1.amazonaws.com}
 


### PR DESCRIPTION
### Fix if condition to display links properly
Even after judiciously refactoring the /frameworks/dashboard page, it
turned out that there was a stray `if` condition checking for a
template variable that was no longer being passed in.

This meant that, after uploading a signed framework agreement and
receiving a countersigned one back, that it would still be possible
to upload a *new* signed framework agreement -- anarchy, basically.

This bugfix removes that possibility.