### PR TITLE
Reflect status code in errorhandler name

### DIFF
--- a/app/main/errors.py
+++ b/app/main/errors.py
@@ -38,7 +38,7 @@ def page_not_found(e):
 
 
 @main.app_errorhandler(500)
-def exception(e):
+def internal_server_error(e):
     return _render_error_page(500)
 
 


### PR DESCRIPTION
Our 500-level errorhandler had a generic name instead of the standard 'Internal Server Error'.
Fixed it in the buyer app, so fixing it here as well.