### PR TITLE
Update framework agreements page for standstill.

### DIFF
--- a/app/assets/scss/_lists.scss
+++ b/app/assets/scss/_lists.scss
@@ -71,3 +71,46 @@ ol {
   list-style-type: none;
   margin-bottom: 10px;
 }
+
+%framework-agreement-section,
+.framework-agreement-section {
+  padding: 20px 0 15px 0;
+  border-top: 1px solid #dee0e2;
+
+  .document-list {
+    padding-bottom: 0;
+  }
+
+  .question {
+    margin: 0;
+
+    .question-heading {
+      position: absolute;
+      left: -9999em;
+      margin-bottom: 10px
+    }
+  }
+
+  h3 {
+    margin-bottom: 5px;
+  }
+
+  .lead-in {
+    margin-bottom: 10px;
+  }
+
+  ol {
+    list-style: decimal;
+    margin-left: 1.5em;
+    margin-bottom: 10px;
+
+    li {
+      margin-bottom: 5px;
+    }
+  }
+}
+
+.framework-agreement-section-first {
+  @extend %framework-agreement-section;
+  border-top: none;
+}

--- a/app/templates/frameworks/agreement.html
+++ b/app/templates/frameworks/agreement.html
@@ -76,7 +76,7 @@ with items = [
               <li>Use <strong>Adobe Reader</strong> to open your {{ framework.name }} framework agreement.
                     You can download it for free from the <a rel="external" href="https://get.adobe.com/uk/reader/">Adobe Acrobat Reader</a> website.</li>
 
-                <li>Go to page 16 and click the signature box under the title ‘Signed duly authorised for and on behalf of the supplier’.</li>
+                <li>Go to page 5 and click the first signature box.</li>
 
                 <li>Use an existing digital ID or create a new one.</li>
 
@@ -95,7 +95,7 @@ with items = [
                 If you can’t digitally sign your framework agreement:
             </p>
             <ol>
-                <li>Print and sign page 16.</li>
+                <li>Print and sign page 5.</li>
                 
                 <li>Scan the page and save as PDF, JPG or PNG.</li>
                 

--- a/app/templates/suppliers/_frameworks_standstill.html
+++ b/app/templates/suppliers/_frameworks_standstill.html
@@ -17,7 +17,7 @@
           <p>
             {{ framework.name }}
           </p>
-          {% if framework.onFramework %}
+          {% if framework.onFramework and framework.dates.framework_live_date %}
             <p class='second-line'>
               Live from {{ framework.dates.framework_live_date|safe }}
             </p>


### PR DESCRIPTION
This pull request makes several small changes requested by @cathrooney on [the DOS - update content for signing framework agreement story on Pivotal](https://www.pivotaltracker.com/story/show/112422239).

#### Changes to the framework agreement page

| Existing text                                                                                                         | New text                                        |
|-----------------------------------------------------------------------------------------------------------------------|-------------------------------------------------|
| Go to page 16 and click the signature box under the title ‘Signed duly authorised for and on behalf of the supplier’. | Go to page 5 and click the first signature box. |
| Print and sign page 16.                                                                                               | Print and sign page 5.                          |

- Also re-added some CSS to the framework agreements page.

#### Changes to the supplier dashboard

- If there is no `framework_live_date` for a framework in standstill, it no longer says "Live from" 

***

## Screenshots 

### Framework agreements page (w/o CSS)
![screen shot 2016-02-17 at 16 36 37](https://cloud.githubusercontent.com/assets/2454380/13141770/f63bbf98-d630-11e5-88d3-39211b08dd5f.png)

### Framework agreements page (with CSS)
![screen shot 2016-02-17 at 16 35 49](https://cloud.githubusercontent.com/assets/2454380/13141772/f8d2ecf4-d630-11e5-8061-0772a23fba17.png)

-

### Supplier dashboard ("Live from")
![screen shot 2016-02-17 at 16 34 08](https://cloud.githubusercontent.com/assets/2454380/13141763/e8033cc6-d630-11e5-907b-527663e5e417.png)

### Supplier dashboard (no longer says "Live from")
![screen shot 2016-02-17 at 16 34 44](https://cloud.githubusercontent.com/assets/2454380/13141767/edbef2d6-d630-11e5-889c-ce149a8bbcfd.png)