### PR TITLE
Submit brief clarification questions

### DIFF
--- a/app/main/__init__.py
+++ b/app/main/__init__.py
@@ -21,5 +21,5 @@ def add_cache_control(response):
     return response
 
 
-from .views import services, suppliers, login, frameworks, users
+from .views import services, suppliers, login, frameworks, users, briefs
 from . import errors

--- a/app/main/helpers/briefs.py
+++ b/app/main/helpers/briefs.py
@@ -1,0 +1,72 @@
+import six
+
+from flask import abort, current_app, render_template
+from flask_login import current_user
+
+from dmutils.email import send_email, hash_email, MandrillException
+
+
+def get_brief(data_api_client, brief_id, live_only=True):
+    brief = data_api_client.get_brief(brief_id)['briefs']
+    if live_only and brief['status'] != 'live':
+        abort(404)
+
+    return brief
+
+
+def check_supplier_is_eligible_for_brief(brief, supplier_id):
+    # TODO connect this with the API endpoint once it exists
+    # Should abort or render an error page if the check fails
+    pass
+
+
+def send_brief_clarification_question(brief, clarification_question):
+    # Email the question to brief owners
+    email_body = render_template(
+        "emails/brief_clarification_question.html",
+        brief_name=brief['title'],
+        message=clarification_question
+    )
+    try:
+        send_email(
+            to_email_addresses=get_brief_user_emails(brief),
+            email_body=email_body,
+            api_key=current_app.config['DM_MANDRILL_API_KEY'],
+            subject="{} clarification question".format(brief['title']),
+            from_email=current_app.config['CLARIFICATION_EMAIL_FROM'],
+            from_name="{} Supplier".format(brief['frameworkName']),
+            tags=["brief-clarification-question"]
+        )
+    except MandrillException as e:
+        current_app.logger.error(
+            "Brief question email failed to send. error={error} supplier_id={supplier_id} brief_id={brief_id}",
+            extra={'error': six.text_type(e), 'supplier_id': current_user.supplier_id, 'brief_id': brief['id']}
+        )
+
+        abort(503, "Clarification question email failed to send")
+
+    # Send the supplier a copy of the question
+    supplier_email_body = render_template(
+        "emails/brief_clarification_question_confirmation.html",
+        brief_name=brief['title'],
+        message=clarification_question
+    )
+    try:
+        send_email(
+            to_email_addresses=[current_user.email_address],
+            email_body=supplier_email_body,
+            api_key=current_app.config['DM_MANDRILL_API_KEY'],
+            subject="Your {} clarification question".format(brief['title']),
+            from_email=current_app.config['CLARIFICATION_EMAIL_FROM'],
+            from_name=current_app.config['CLARIFICATION_EMAIL_NAME'],
+            tags=["brief-clarification-question-confirmation"]
+        )
+    except MandrillException as e:
+        current_app.logger.error(
+            "Brief question supplier email failed to send. error={error} supplier_id={supplier_id} brief_id={brief_id}",
+            extra={'error': six.text_type(e), 'supplier_id': current_user.supplier_id, 'brief_id': brief['id']}
+        )
+
+
+def get_brief_user_emails(brief):
+    return [user['emailAddress'] for user in brief['users'] if user['active']]

--- a/app/main/helpers/briefs.py
+++ b/app/main/helpers/briefs.py
@@ -14,7 +14,7 @@ def get_brief(data_api_client, brief_id, live_only=True):
     return brief
 
 
-def check_supplier_is_eligible_for_brief(brief, supplier_id):
+def ensure_supplier_is_eligible_for_brief(brief, supplier_id):
     # TODO connect this with the API endpoint once it exists
     # Should abort or render an error page if the check fails
     pass

--- a/app/main/views/briefs.py
+++ b/app/main/views/briefs.py
@@ -1,0 +1,41 @@
+from flask import render_template, request, redirect, flash
+from flask_login import current_user
+
+from ..helpers import login_required
+from ..helpers.briefs import (
+    get_brief,
+    check_supplier_is_eligible_for_brief,
+    send_brief_clarification_question,
+)
+from ...main import main
+from ... import data_api_client
+
+
+@main.route('/opportunities/<int:brief_id>/ask-a-question', methods=['GET', 'POST'])
+@login_required
+def ask_brief_clarification_question(brief_id):
+    brief = get_brief(data_api_client, brief_id)
+    check_supplier_is_eligible_for_brief(brief, current_user.supplier_id)
+
+    error_message = None
+    clarification_question_value = None
+
+    if request.method == 'POST':
+        clarification_question = request.form.get('clarification-question', '').strip()
+        if not clarification_question:
+            error_message = "Question cannot be empty"
+        elif len(clarification_question) > 5000:
+            clarification_question_value = clarification_question
+            error_message = "Question cannot be longer than 5000 characters"
+        else:
+            send_brief_clarification_question(brief, clarification_question)
+            flash('message_sent', 'success')
+
+    return render_template(
+        "briefs/clarification_question.html",
+        brief=brief,
+        error_message=error_message,
+        clarification_question_name='clarification-question',
+        clarification_question_value=clarification_question_value,
+        **main.config['BASE_TEMPLATE_DATA']
+    ), 200 if not error_message else 400

--- a/app/main/views/briefs.py
+++ b/app/main/views/briefs.py
@@ -4,7 +4,7 @@ from flask_login import current_user
 from ..helpers import login_required
 from ..helpers.briefs import (
     get_brief,
-    check_supplier_is_eligible_for_brief,
+    ensure_supplier_is_eligible_for_brief,
     send_brief_clarification_question,
 )
 from ...main import main
@@ -15,7 +15,7 @@ from ... import data_api_client
 @login_required
 def ask_brief_clarification_question(brief_id):
     brief = get_brief(data_api_client, brief_id)
-    check_supplier_is_eligible_for_brief(brief, current_user.supplier_id)
+    ensure_supplier_is_eligible_for_brief(brief, current_user.supplier_id)
 
     error_message = None
     clarification_question_value = None

--- a/app/templates/briefs/clarification_question.html
+++ b/app/templates/briefs/clarification_question.html
@@ -26,7 +26,7 @@
   {% with messages = get_flashed_messages(with_categories=true) %}
     {% for category, message in messages %}
       {% if message == 'message_sent' %}
-        {% set message = "Your question has been sent. The answer will be published on the opportunity page." %}
+        {% set message = "Your question has been sent. It will be posted with the buyer’s response on the ‘{}’ page.".format(brief.title) %}
       {% endif %}
       {%
         with
@@ -44,7 +44,7 @@
       errors = [
         {
             "input_name": clarification_question_name,
-            "question": "Ask a {} clarification question".format(brief.title)
+            "question": "Ask a question about ‘{}’".format(brief.title)
         }
     ],
       lede = "There was a problem with your submitted question"
@@ -54,7 +54,7 @@
   {% endif %}
 
   {% with
-    heading = "Ask a question about {}".format(brief.title),
+    heading = "Ask a question about ‘{}’".format(brief.title),
     smaller = true
   %}
     {% include 'toolkit/page-heading.html' %}
@@ -64,7 +64,10 @@
     <div class="column-two-thirds">
 
       <div class="hint">
-        <p>Your questions will be published in full, but anonymously on the Digital Marketplace. Don’t put any confidential information in a question.</p>
+        <p>Your question will be published with the buyers’ response.</p>
+        <p>All questions and answers will be posted on the Digital Marketplace. Your company name won’t be visible.</p>
+        <p>You shouldn’t include any confidential information in your question.</p>
+        <p>Read more about <a href="https://www.gov.uk/guidance/how-to-ask-and-answer-supplier-questions-on-the-digital-marketplace">how supplier questions are managed</a>.</p>
       </div>
 
       <form method="post">
@@ -80,8 +83,6 @@
         %}
           {% include "toolkit/forms/textbox.html" %}
         {% endwith %}
-        <p>
-        </p>
         {%
           with
           label="Ask question",

--- a/app/templates/briefs/clarification_question.html
+++ b/app/templates/briefs/clarification_question.html
@@ -1,0 +1,99 @@
+{% extends "_base_page.html" %}
+{% import "toolkit/summary-table.html" as summary %}
+
+{% block page_title %}Ask a question about {{ brief.title }} – Digital Marketplace{% endblock %}
+
+{% block breadcrumb %}
+  {%
+    with items = [
+      {
+        "link": "/",
+        "label": "Digital Marketplace",
+      },
+      {
+        "link": url_for(".dashboard"),
+        "label": "Your account",
+      },
+    ]
+  %}
+    {% include "toolkit/breadcrumb.html" %}
+  {% endwith %}
+{% endblock %}
+
+{% block main_content %}
+
+<div class="single-question-page">
+  {% with messages = get_flashed_messages(with_categories=true) %}
+    {% for category, message in messages %}
+      {% if message == 'message_sent' %}
+        {% set message = "Your question has been sent. The answer will be published on the opportunity page." %}
+      {% endif %}
+      {%
+        with
+        message = message,
+        type = "destructive" if category == 'error' else "success"
+      %}
+        {% include "toolkit/notification-banner.html" %}
+      {% endwith %}
+    {% endfor %}
+  {% endwith %}
+
+  {% if error_message %}
+    {%
+      with
+      errors = [
+        {
+            "input_name": clarification_question_name,
+            "question": "Ask a {} clarification question".format(brief.title)
+        }
+    ],
+      lede = "There was a problem with your submitted question"
+    %}
+      {% include "toolkit/forms/validation.html" %}
+    {% endwith %}
+  {% endif %}
+
+  {% with
+    heading = "Ask a question about {}".format(brief.title),
+    smaller = true
+  %}
+    {% include 'toolkit/page-heading.html' %}
+  {% endwith %}
+
+  <div class="grid-row">
+    <div class="column-two-thirds">
+
+      <div class="hint">
+        <p>Your questions will be published in full, but anonymously on the Digital Marketplace. Don’t put any confidential information in a question.</p>
+      </div>
+
+      <form method="post">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+        {%
+          with
+          large=true,
+          name = clarification_question_name,
+          question = "Ask a question",
+          error = error_message,
+          value = clarification_question_value,
+          max_length_in_words = 100
+        %}
+          {% include "toolkit/forms/textbox.html" %}
+        {% endwith %}
+        <p>
+        </p>
+        {%
+          with
+          label="Ask question",
+          type="save"
+        %}
+          {% include "toolkit/button.html" %}
+        {% endwith %}
+
+        <a href="/opportunities/{{ brief.id }}">Return to {{ brief.title}}</a>
+
+      </div>
+    </div>
+  </form>
+</div>
+{% endblock %}

--- a/app/templates/emails/brief_clarification_question.html
+++ b/app/templates/emails/brief_clarification_question.html
@@ -4,8 +4,24 @@
     <meta charset="UTF-8">
 </head>
 <body>
-{{ brief_name }} question asked:
-<br />
-{{ message }}
+  Hello,<br />
+  <br />
+  A supplier has asked a question about ‘{{ brief_name }}’.<br />
+  <br />
+  On {{ current_date|dateformat }}, they asked:<br />
+  <br />
+  {{ message }}
+  <br /><br />
+  You need to answer all questions from suppliers and publish both their questions and your answers on the Digital Marketplace at:<br />
+  <a href="https://www.digitalmarketplace.service.gov.uk/buyers/frameworks/{{ framework_slug }}/requirements/{{ lot_slug }}/{{ brief_id }}/answer-question">https://www.digitalmarketplace.service.gov.uk/buyers/frameworks/{{ framework_slug }}/requirements/{{ lot_slug }}/{{ brief_id }}/answer-question</a><br />
+  <br />
+  All questions and answers will be published on the ‘{{ brief_name }}’ requirements page at:<br />
+  <a href="https://www.digitalmarketplace.service.gov.uk/{{ framework_slug }}/opportunities/{{ brief_id }}">https://www.digitalmarketplace.service.gov.uk/{{ framework_slug }}/opportunities/{{ brief_id }}</a><br />
+  <br />
+  Read more about how to manage supplier questions at:<br />
+  <a href="https://www.gov.uk/guidance/how-to-ask-and-answer-supplier-questions-on-the-digital-marketplace">https://www.gov.uk/guidance/how-to-ask-and-answer-supplier-questions-on-the-digital-marketplace</a><br />
+  <br />
+  Thanks,<br />
+  The Digital Marketplace team<br />
 </body>
 </html>

--- a/app/templates/emails/brief_clarification_question.html
+++ b/app/templates/emails/brief_clarification_question.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head lang="en">
+    <meta charset="UTF-8">
+</head>
+<body>
+{{ brief_name }} question asked:
+<br />
+{{ message }}
+</body>
+</html>

--- a/app/templates/emails/brief_clarification_question_confirmation.html
+++ b/app/templates/emails/brief_clarification_question_confirmation.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head lang="en">
+    <meta charset="UTF-8">
+</head>
+<body>
+Your {{ brief_name }} question:
+<br />
+{{ message }}
+</body>
+</html>

--- a/app/templates/emails/brief_clarification_question_confirmation.html
+++ b/app/templates/emails/brief_clarification_question_confirmation.html
@@ -4,8 +4,18 @@
     <meta charset="UTF-8">
 </head>
 <body>
-Your {{ brief_name }} question:
-<br />
-{{ message }}
+  Dear {{ user_name }},<br />
+  <br />
+  Your question about ‘{{ brief_name }}’ has been sent.<br />
+  <br />
+  You asked:<br />
+  <br />
+  {{ message }}
+  <br /><br />
+  Your question will be posted with the buyer’s response on the ‘{{ brief_name }}’ requirements page at:<br />
+  <a href="https://www.digitalmarketplace.service.gov.uk/{{ framework_slug }}/opportunities/{{ brief_id }}">https://www.digitalmarketplace.service.gov.uk/{{ framework_slug }}/opportunities/{{ brief_id }}</a><br />
+  <br />
+  Thanks,<br />
+  The Digital Marketplace team
 </body>
 </html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,6 @@ werkzeug==0.10.4
 python-dateutil==2.4.2
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@17.3.3#egg=digitalmarketplace-utils==17.3.3
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@1.1.0#egg=digitalmarketplace-apiclient==1.1.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@3.0.0#egg=digitalmarketplace-apiclient==3.0.0
 
 markdown==2.6.2

--- a/tests/app/helpers.py
+++ b/tests/app/helpers.py
@@ -261,3 +261,19 @@ class BaseApplicationTest(object):
                 raise AssertionError('nothing flashed')
             assert expected_message in message
             assert expected_category == category
+
+
+class FakeMail(object):
+    """An object that equals strings containing all of the given substrings
+
+    Can be used in mock.call comparisons (eg to verify email templates).
+
+    """
+    def __init__(self, *substrings):
+        self.substrings = substrings
+
+    def __eq__(self, other):
+        return all(substring in other for substring in self.substrings)
+
+    def __repr__(self):
+        return "<FakeMail: {}>".format(self.substrings)

--- a/tests/app/main/test_briefs.py
+++ b/tests/app/main/test_briefs.py
@@ -1,0 +1,134 @@
+import mock
+from dmapiclient import HTTPError
+from dmutils.email import MandrillException
+
+from ..helpers import BaseApplicationTest, FakeMail
+
+
+@mock.patch('app.main.views.briefs.data_api_client', autospec=True)
+class TestBriefClarificationQuestions(BaseApplicationTest):
+    def test_clarification_question_form_requires_login(self, data_api_client):
+        res = self.client.get('/suppliers/opportunities/1/ask-a-question')
+        assert res.status_code == 302
+        assert '/login' in res.headers['Location']
+
+    def test_clarification_question_form(self, data_api_client):
+        self.login()
+        data_api_client.get_brief.return_value = {'briefs': {'status': 'live'}}
+
+        res = self.client.get('/suppliers/opportunities/1/ask-a-question')
+        assert res.status_code == 200
+
+    def test_clarification_question_form_requires_existing_brief_id(self, data_api_client):
+        self.login()
+        data_api_client.get_brief.side_effect = HTTPError(mock.Mock(status_code=404))
+
+        res = self.client.get('/suppliers/opportunities/1/ask-a-question')
+        assert res.status_code == 404
+
+    def test_clarification_question_form_requires_live_brief(self, data_api_client):
+        self.login()
+        data_api_client.get_brief.return_value = {'briefs': {'status': 'expired'}}
+
+        res = self.client.get('/suppliers/opportunities/1/ask-a-question')
+        assert res.status_code == 404
+
+
+@mock.patch('app.main.views.briefs.data_api_client', autospec=True)
+class TestSubmitClarificationQuestions(BaseApplicationTest):
+    def test_submit_clarification_question_requires_login(self, data_api_client):
+        res = self.client.post('/suppliers/opportunities/1/ask-a-question')
+        assert res.status_code == 302
+        assert '/login' in res.headers['Location']
+
+    @mock.patch('app.main.helpers.briefs.send_email')
+    def test_submit_clarification_question(self, send_email, data_api_client):
+        self.login()
+        data_api_client.get_brief.return_value = {'briefs': {
+            'status': 'live',
+            'title': 'Important Opportunity',
+            'users': [
+                {'emailAddress': 'a@user.dmdev', 'active': True},
+                {'emailAddress': 'b@user.dmdev', 'active': False},
+            ],
+            'frameworkName': 'Brief Framework Name',
+        }}
+
+        res = self.client.post('/suppliers/opportunities/1/ask-a-question', data={
+            'clarification-question': "important question",
+        })
+        assert res.status_code == 200
+
+        send_email.assert_has_calls([
+            mock.call(
+                from_name='Brief Framework Name Supplier',
+                tags=['brief-clarification-question'],
+                email_body=FakeMail("important question"),
+                from_email='do-not-reply@digitalmarketplace.service.gov.uk',
+                api_key='MANDRILL',
+                to_email_addresses=['a@user.dmdev'],
+                subject='Important Opportunity clarification question'),
+            mock.call(
+                from_name='Digital Marketplace Admin',
+                tags=['brief-clarification-question-confirmation'],
+                email_body=FakeMail("important question"),
+                from_email='do-not-reply@digitalmarketplace.service.gov.uk',
+                api_key='MANDRILL',
+                to_email_addresses=['email@email.com'],
+                subject='Your Important Opportunity clarification question')
+        ])
+
+    @mock.patch('app.main.helpers.briefs.send_email')
+    def test_submit_clarification_question_fails_on_mandrill_error(self, send_email, data_api_client):
+        self.login()
+        data_api_client.get_brief.return_value = {'briefs': {
+            'id': 1,
+            'status': 'live',
+            'title': 'Important Opportunity',
+            'users': [
+                {'emailAddress': 'a@user.dmdev', 'active': True},
+                {'emailAddress': 'b@user.dmdev', 'active': False},
+            ],
+            'frameworkName': 'Brief Framework Name',
+        }}
+
+        send_email.side_effect = MandrillException
+
+        res = self.client.post('/suppliers/opportunities/1/ask-a-question', data={
+            'clarification-question': "important question",
+        })
+        assert res.status_code == 503
+
+    def test_submit_clarification_question_requires_existing_brief_id(self, data_api_client):
+        self.login()
+        data_api_client.get_brief.side_effect = HTTPError(mock.Mock(status_code=404))
+
+        res = self.client.post('/suppliers/opportunities/1/ask-a-question')
+        assert res.status_code == 404
+
+    def test_submit_clarification_question_requires_live_brief(self, data_api_client):
+        self.login()
+        data_api_client.get_brief.return_value = {'briefs': {'status': 'expired'}}
+
+        res = self.client.post('/suppliers/opportunities/1/ask-a-question')
+        assert res.status_code == 404
+
+    def test_submit_empty_clarification_question_returns_validation_error(self, data_api_client):
+        self.login()
+        data_api_client.get_brief.return_value = {'briefs': {'status': 'live'}}
+
+        res = self.client.post('/suppliers/opportunities/1/ask-a-question', data={
+            'clarification-question': "",
+        })
+        assert res.status_code == 400
+        assert "cannot be empty" in res.get_data(as_text=True)
+
+    def test_submit_empty_clarification_question_has_max_length_limit(self, data_api_client):
+        self.login()
+        data_api_client.get_brief.return_value = {'briefs': {'status': 'live'}}
+
+        res = self.client.post('/suppliers/opportunities/1/ask-a-question', data={
+            'clarification-question': "a" * 5100,
+        })
+        assert res.status_code == 400
+        assert "cannot be longer than" in res.get_data(as_text=True)

--- a/tests/app/main/test_briefs.py
+++ b/tests/app/main/test_briefs.py
@@ -60,7 +60,8 @@ class TestSubmitClarificationQuestions(BaseApplicationTest):
                 from_email='do-not-reply@digitalmarketplace.service.gov.uk',
                 api_key='MANDRILL',
                 to_email_addresses=['buyer@email.com'],
-                subject='Important Opportunity clarification question'),
+                subject=u"You\u2019ve received a new supplier question about \u2018I need a thing to do a thing\u2019"
+            ),
             mock.call(
                 from_name='Digital Marketplace Admin',
                 tags=['brief-clarification-question-confirmation'],
@@ -68,7 +69,8 @@ class TestSubmitClarificationQuestions(BaseApplicationTest):
                 from_email='do-not-reply@digitalmarketplace.service.gov.uk',
                 api_key='MANDRILL',
                 to_email_addresses=['email@email.com'],
-                subject='Your Important Opportunity clarification question')
+                subject=u"Your question about \u2018I need a thing to do a thing\u2019"
+            ),
         ])
 
     @mock.patch('app.main.helpers.briefs.send_email')

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -11,7 +11,7 @@ from dmapiclient.audit import AuditTypes
 from dmutils.email import MandrillException
 from dmutils.s3 import S3ResponseError
 
-from ..helpers import BaseApplicationTest, FULL_G7_SUBMISSION
+from ..helpers import BaseApplicationTest, FULL_G7_SUBMISSION, FakeMail
 
 
 def _return_fake_s3_file_dict(directory, filename, ext, last_modified=None, size=None):
@@ -1245,19 +1245,6 @@ class TestFrameworkUpdatesPage(BaseApplicationTest):
 
             assert response.status_code == 200
             assert_not_in(u'Ask a question about your G-Cloud 7 application', data)
-
-
-class FakeMail(object):
-    """An object that equals strings containing all of the given substrings
-
-    Can be used in mock.call comparisons (eg to verify email templates).
-
-    """
-    def __init__(self, *substrings):
-        self.substrings = substrings
-
-    def __eq__(self, other):
-        return all(substring in other for substring in self.substrings)
 
 
 class TestSendClarificationQuestionEmail(BaseApplicationTest):


### PR DESCRIPTION
Adds a form to submit brief clarification questions.

* Page is only available if brief is currently live.
* The check for supplier eligibility is not connected to the API so
  will always accept the supplier until the filtering is implemented.
* There's no separate "question sent" page, the message is shown on
  the page with the form right now.
* Email sent to the buyer user is sent from "do-not-reply@" with
  anonymised supplier name.
* Failure to send a confirmation to the supplier is ignored. So as long
  as the buyer email was accepted by Mandrill the app will respond with
  200.

:exclamation: This needs some content work on the error/success pages and email templates.

![screen shot 2016-02-25 at 17 15 07](https://cloud.githubusercontent.com/assets/246664/13328051/82922924-dbe4-11e5-83c3-49d74d1665a0.png)

