### PR TITLE
Removed deprecated redirect for file download

### DIFF
--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -317,22 +317,6 @@ def download_agreement_file(framework_slug, document_name):
     return redirect(url)
 
 
-@main.route('/frameworks/<any("g-cloud-7"):framework_slug>/<path:filepath>.zip', methods=['GET'])
-@deprecated(dies_at=datetime(2015, 11, 9))
-def g7_download_zip_redirect_zip(framework_slug, filepath):
-    return redirect(url_for('.download_supplier_file',
-                            framework_slug='g-cloud-7',
-                            filepath='{}.zip'.format(filepath)), 301)
-
-
-@main.route('/frameworks/<any("g-cloud-7"):framework_slug>/<path:filepath>.pdf', methods=['GET'])
-@deprecated(dies_at=datetime(2015, 11, 9))
-def g7_download_zip_redirect_pdf(framework_slug, filepath):
-    return redirect(url_for('.download_supplier_file',
-                            framework_slug='g-cloud-7',
-                            filepath='{}.pdf'.format(filepath)), 301)
-
-
 @main.route('/frameworks/<framework_slug>/updates', methods=['GET'])
 @login_required
 def framework_updates(framework_slug, error_message=None, default_textbox_value=None):

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -901,18 +901,6 @@ class TestFrameworkDocumentDownload(BaseApplicationTest):
 
             assert_equal(res.status_code, 404)
 
-    def test_redirect_g7_document_downloads(self, s3):
-
-        for filename in ['foo.pdf', 'foo.zip', 'foo/bar.pdf']:
-            with self.app.test_client():
-                self.login()
-
-                res = self.client.get('/suppliers/frameworks/g-cloud-7/{}'.format(filename))
-
-                assert_equal(res.status_code, 301)
-                assert_equal(res.location,
-                             'http://localhost/suppliers/frameworks/g-cloud-7/files/{}'.format(filename))
-
 
 @mock.patch('app.main.views.frameworks.data_api_client', autospec=True)
 class TestSupplierDeclaration(BaseApplicationTest):


### PR DESCRIPTION
@kevkeenoy and I noticed these deprecated redirects, so we heroically deleted them and an associated test.

Seems fairly unlikely that anyone's still using them.