### PR TITLE
[#112216471] Supplier responds to a brief -- frontend

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -7,7 +7,6 @@ from flask_wtf.csrf import CsrfProtect
 import dmapiclient
 from dmutils import init_app, flask_featureflags
 from dmutils.user import User
-from dmutils.config import convert_to_boolean
 
 from config import configs
 
@@ -74,10 +73,6 @@ def create_app(config_name):
 
     application.add_template_filter(question_references)
     application.add_template_filter(parse_document_upload_time)
-
-    @application.template_filter('convert_to_boolean')
-    def convert_to_boolean_filter(data):
-        return convert_to_boolean(data)
 
     return application
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -7,6 +7,7 @@ from flask_wtf.csrf import CsrfProtect
 import dmapiclient
 from dmutils import init_app, flask_featureflags
 from dmutils.user import User
+from dmutils.config import convert_to_boolean
 
 from config import configs
 
@@ -73,6 +74,10 @@ def create_app(config_name):
 
     application.add_template_filter(question_references)
     application.add_template_filter(parse_document_upload_time)
+
+    @application.template_filter('convert_to_boolean')
+    def convert_to_boolean_filter(data):
+        return convert_to_boolean(data)
 
     return application
 

--- a/app/assets/scss/_brief-response.scss
+++ b/app/assets/scss/_brief-response.scss
@@ -1,0 +1,16 @@
+@import "_colours.scss";
+@import "_typography.scss";
+
+.question-boolean-list {
+    margin: 15px 0 30px 0;
+
+  .question-heading h2 {
+    @include bold-27;
+  }
+
+  .question-description {
+    @include core-24;
+    margin-bottom: 30px;
+    padding: 0;
+  }
+}

--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -66,6 +66,7 @@ $path: "/suppliers/static/images/";
 @import "_supplier-declaration.scss";
 @import "_updates.scss";
 @import "_service_submission.scss";
+@import "_brief-response.scss";
 
 @import "_create_supplier.scss";
 

--- a/app/main/__init__.py
+++ b/app/main/__init__.py
@@ -12,6 +12,7 @@ content_loader.load_manifest('g-cloud-7', 'declaration', 'declaration')
 content_loader.load_messages('g-cloud-7', ['dates'])
 content_loader.load_manifest('digital-outcomes-and-specialists', 'declaration', 'declaration')
 content_loader.load_manifest('digital-outcomes-and-specialists', 'services', 'edit_submission')
+content_loader.load_manifest('digital-outcomes-and-specialists', 'brief-responses', 'edit_brief_response')
 content_loader.load_messages('digital-outcomes-and-specialists', ['dates'])
 
 

--- a/app/main/helpers/briefs.py
+++ b/app/main/helpers/briefs.py
@@ -90,11 +90,3 @@ def send_brief_clarification_question(brief, clarification_question):
 
 def get_brief_user_emails(brief):
     return [user['emailAddress'] for user in brief['users'] if user['active']]
-
-
-def inject_yes_no_questions_into_section_questions(section, brief):
-
-    # pass all of the brief yes/no questions into the appropriate ContentQuestions
-    for question in section.questions:
-        if question.type == 'boolean_list':
-            question.boolean_list_questions = brief[question.id]

--- a/app/main/helpers/briefs.py
+++ b/app/main/helpers/briefs.py
@@ -27,6 +27,12 @@ def ensure_supplier_is_eligible_for_brief(brief, supplier_id):
     pass
 
 
+def has_supplier_already_submitted_a_brief_response(data_api_client, supplier_id, brief_id):
+
+    brief_responses = data_api_client.find_brief_responses(brief_id=brief_id, supplier_id=supplier_id)['briefResponses']
+    return len(brief_responses) == 0
+
+
 def send_brief_clarification_question(brief, clarification_question):
     # Email the question to brief owners
     email_body = render_template(

--- a/app/main/helpers/frameworks.py
+++ b/app/main/helpers/frameworks.py
@@ -8,17 +8,20 @@ from dmapiclient import APIError
 from dmutils import s3
 
 
-def get_framework(client, framework_slug, open_only=True):
+def get_framework(client, framework_slug, allowed_statuses=None):
+    if allowed_statuses is None:
+        allowed_statuses = ['open', 'pending', 'standstill', 'live']
+
     framework = client.get_framework(framework_slug)['frameworks']
-    allowed_statuses = ['open'] if open_only else ['open', 'pending', 'standstill', 'live']
-    if framework['status'] not in allowed_statuses:
+
+    if allowed_statuses and framework['status'] not in allowed_statuses:
         abort(404)
 
     return framework
 
 
-def get_framework_and_lot(client, framework_slug, lot_slug, open_only=True):
-    framework = get_framework(client, framework_slug, open_only)
+def get_framework_and_lot(client, framework_slug, lot_slug, allowed_statuses=None):
+    framework = get_framework(client, framework_slug, allowed_statuses)
     return framework, get_framework_lot(framework, lot_slug)
 
 

--- a/app/main/views/briefs.py
+++ b/app/main/views/briefs.py
@@ -140,7 +140,7 @@ def create_new_brief_response(brief_id):
         return render_template(
             "services/edit_submission_section.html",
             framework=framework,
-            service_data=request.form,
+            service_data=response_data,
             section=section,
             errors=new_errors,
             **dict(main.config['BASE_TEMPLATE_DATA'])

--- a/app/main/views/briefs.py
+++ b/app/main/views/briefs.py
@@ -1,6 +1,6 @@
 from collections import OrderedDict
 
-from flask import render_template, redirect, url_for, request, flash
+from flask import render_template, redirect, url_for, request, flash, abort
 from flask_login import current_user
 
 from dmapiclient import HTTPError
@@ -10,7 +10,8 @@ from ..helpers.briefs import (
     get_brief,
     ensure_supplier_is_eligible_for_brief,
     send_brief_clarification_question,
-    inject_yes_no_questions_into_section_questions
+    inject_yes_no_questions_into_section_questions,
+    has_supplier_already_submitted_a_brief_response
 )
 from ..helpers.frameworks import get_framework_and_lot
 from ...main import main, content_loader
@@ -53,6 +54,10 @@ def submit_brief_response(brief_id):
     brief = get_brief(data_api_client, brief_id, allowed_statuses=['live'])
     ensure_supplier_is_eligible_for_brief(brief, current_user.supplier_id)
 
+    if not has_supplier_already_submitted_a_brief_response(data_api_client, current_user.supplier_id, brief_id):
+        # TODO redirect to summary of brief response page with flash message
+        abort(404)
+
     framework, lot = get_framework_and_lot(
         data_api_client, brief['frameworkSlug'], brief['lotSlug'], allowed_statuses=['live'])
 
@@ -78,6 +83,10 @@ def create_new_brief_response(brief_id):
 
     brief = get_brief(data_api_client, brief_id, allowed_statuses=['live'])
     ensure_supplier_is_eligible_for_brief(brief, current_user.supplier_id)
+
+    if not has_supplier_already_submitted_a_brief_response(data_api_client, current_user.supplier_id, brief_id):
+        # TODO redirect to summary of brief response page with flash message
+        abort(404)
 
     framework, lot = get_framework_and_lot(
         data_api_client, brief['frameworkSlug'], brief['lotSlug'], allowed_statuses=['live'])

--- a/app/main/views/briefs.py
+++ b/app/main/views/briefs.py
@@ -1,3 +1,5 @@
+# coding: utf-8
+from __future__ import unicode_literals
 from collections import OrderedDict
 
 from flask import render_template, redirect, url_for, request, flash, abort
@@ -64,6 +66,8 @@ def submit_brief_response(brief_id):
     content = content_loader.get_manifest(framework['slug'], 'edit_brief_response').filter({'lot': lot['slug']})
     section = content.get_section(content.get_next_editable_section_id())
 
+    # replace generic 'Apply to opportunity' title with title including the name of the brief
+    section.name = "Apply to ‘{}’".format(brief['title'])
     inject_yes_no_questions_into_section_questions(section, brief)
 
     return render_template(

--- a/app/main/views/briefs.py
+++ b/app/main/views/briefs.py
@@ -52,7 +52,7 @@ def submit_brief_response(brief_id):
     framework_slug = brief['frameworkSlug']
     lot_slug = brief['lotSlug']
 
-    framework, lot = get_framework_and_lot(data_api_client, framework_slug, lot_slug)
+    framework, lot = get_framework_and_lot(data_api_client, framework_slug, lot_slug, allowed_statuses=['live'])
 
     content = content_loader.get_manifest(framework_slug, 'edit_brief_response').filter(
         {'lot': lot_slug}

--- a/app/main/views/briefs.py
+++ b/app/main/views/briefs.py
@@ -52,7 +52,7 @@ def submit_brief_response(brief_id):
     framework_slug = brief['frameworkSlug']
     lot_slug = brief['lotSlug']
 
-    framework, lot = get_framework_and_lot(data_api_client, framework_slug, lot_slug, open_only=False)
+    framework, lot = get_framework_and_lot(data_api_client, framework_slug, lot_slug)
 
     content = content_loader.get_manifest(framework_slug, 'edit_brief_response').filter(
         {'lot': lot_slug}

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -39,7 +39,7 @@ CLARIFICATION_QUESTION_NAME = 'clarification_question'
 @main.route('/frameworks/<framework_slug>', methods=['GET', 'POST'])
 @login_required
 def framework_dashboard(framework_slug):
-    framework = get_framework(data_api_client, framework_slug, open_only=False)
+    framework = get_framework(data_api_client, framework_slug)
 
     if request.method == 'POST':
         register_interest_in_framework(data_api_client, framework_slug)
@@ -123,7 +123,7 @@ def framework_dashboard(framework_slug):
 @main.route('/frameworks/<framework_slug>/submissions', methods=['GET'])
 @login_required
 def framework_submission_lots(framework_slug):
-    framework = get_framework(data_api_client, framework_slug, open_only=False)
+    framework = get_framework(data_api_client, framework_slug)
 
     drafts, complete_drafts = get_drafts(data_api_client, framework_slug)
     declaration_status = get_declaration_status(data_api_client, framework_slug)
@@ -161,7 +161,7 @@ def framework_submission_lots(framework_slug):
 @main.route('/frameworks/<framework_slug>/submissions/<lot_slug>', methods=['GET'])
 @login_required
 def framework_submission_services(framework_slug, lot_slug):
-    framework, lot = get_framework_and_lot(data_api_client, framework_slug, lot_slug, open_only=False)
+    framework, lot = get_framework_and_lot(data_api_client, framework_slug, lot_slug)
 
     drafts, complete_drafts = get_lot_drafts(data_api_client, framework_slug, lot_slug)
     declaration_status = get_declaration_status(data_api_client, framework_slug)
@@ -205,7 +205,7 @@ def framework_submission_services(framework_slug, lot_slug):
 @main.route('/frameworks/<framework_slug>/declaration/<string:section_id>', methods=['GET', 'POST'])
 @login_required
 def framework_supplier_declaration(framework_slug, section_id=None):
-    framework = get_framework(data_api_client, framework_slug, open_only=True)
+    framework = get_framework(data_api_client, framework_slug, allowed_statuses=['open'])
 
     content = content_loader.get_manifest(framework_slug, 'declaration')
     status_code = 200
@@ -316,7 +316,7 @@ def download_agreement_file(framework_slug, document_name):
 @main.route('/frameworks/<framework_slug>/updates', methods=['GET'])
 @login_required
 def framework_updates(framework_slug, error_message=None, default_textbox_value=None):
-    framework = get_framework(data_api_client, framework_slug, open_only=False)
+    framework = get_framework(data_api_client, framework_slug)
 
     current_app.logger.info("{framework_slug}-updates.viewed: user_id {user_id} supplier_id {supplier_id}",
                             extra={'framework_slug': framework_slug,
@@ -350,7 +350,7 @@ def framework_updates(framework_slug, error_message=None, default_textbox_value=
 @main.route('/frameworks/<framework_slug>/updates', methods=['POST'])
 @login_required
 def framework_updates_email_clarification_question(framework_slug):
-    framework = get_framework(data_api_client, framework_slug, open_only=False)
+    framework = get_framework(data_api_client, framework_slug)
 
     # Stripped input should not empty
     clarification_question = request.form.get(CLARIFICATION_QUESTION_NAME, '').strip()
@@ -458,9 +458,7 @@ def framework_updates_email_clarification_question(framework_slug):
 @main.route('/frameworks/<framework_slug>/agreement', methods=['GET'])
 @login_required
 def framework_agreement(framework_slug):
-    framework = data_api_client.get_framework(framework_slug)['frameworks']
-    if framework['status'] not in ['standstill', 'live']:
-        abort(404)
+    framework = get_framework(data_api_client, framework_slug, allowed_statuses=['standstill', 'live'])
 
     supplier_framework = data_api_client.get_supplier_framework_info(
         current_user.supplier_id, framework_slug
@@ -484,9 +482,7 @@ def framework_agreement(framework_slug):
 @main.route('/frameworks/<framework_slug>/agreement', methods=['POST'])
 @login_required
 def upload_framework_agreement(framework_slug):
-    framework = data_api_client.get_framework(framework_slug)['frameworks']
-    if framework['status'] not in ['standstill', 'live']:
-        abort(404)
+    framework = get_framework(data_api_client, framework_slug, allowed_statuses=['standstill', 'live'])
 
     supplier_framework = data_api_client.get_supplier_framework_info(
         current_user.supplier_id, framework_slug

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -162,7 +162,7 @@ def update_section(service_id, section_id):
 def start_new_draft_service(framework_slug, lot_slug):
     """Page to kick off creation of a new service."""
 
-    framework, lot = get_framework_and_lot(data_api_client, framework_slug, lot_slug, open_only=True)
+    framework, lot = get_framework_and_lot(data_api_client, framework_slug, lot_slug, allowed_statuses=['open'])
 
     content = content_loader.get_manifest(framework_slug, 'edit_submission').filter(
         {'lot': lot['slug']}
@@ -183,7 +183,7 @@ def start_new_draft_service(framework_slug, lot_slug):
 def create_new_draft_service(framework_slug, lot_slug):
     """Hits up the data API to create a new draft service."""
 
-    framework, lot = get_framework_and_lot(data_api_client, framework_slug, lot_slug, open_only=True)
+    framework, lot = get_framework_and_lot(data_api_client, framework_slug, lot_slug, allowed_statuses=['open'])
 
     content = content_loader.get_manifest(framework_slug, 'edit_submission').filter(
         {'lot': lot['slug']}
@@ -223,7 +223,7 @@ def create_new_draft_service(framework_slug, lot_slug):
 @main.route('/frameworks/<framework_slug>/submissions/<lot_slug>/<service_id>/copy', methods=['POST'])
 @login_required
 def copy_draft_service(framework_slug, lot_slug, service_id):
-    framework, lot = get_framework_and_lot(data_api_client, framework_slug, lot_slug, open_only=True)
+    framework, lot = get_framework_and_lot(data_api_client, framework_slug, lot_slug, allowed_statuses=['open'])
     draft = data_api_client.get_draft_service(service_id).get('services')
 
     if not is_service_associated_with_supplier(draft):
@@ -248,7 +248,7 @@ def copy_draft_service(framework_slug, lot_slug, service_id):
 @main.route('/frameworks/<framework_slug>/submissions/<lot_slug>/<service_id>/complete', methods=['POST'])
 @login_required
 def complete_draft_service(framework_slug, lot_slug, service_id):
-    framework, lot = get_framework_and_lot(data_api_client, framework_slug, lot_slug, open_only=True)
+    framework, lot = get_framework_and_lot(data_api_client, framework_slug, lot_slug, allowed_statuses=['open'])
     draft = data_api_client.get_draft_service(service_id).get('services')
 
     if not is_service_associated_with_supplier(draft):
@@ -280,7 +280,7 @@ def complete_draft_service(framework_slug, lot_slug, service_id):
 @main.route('/frameworks/<framework_slug>/submissions/<lot_slug>/<service_id>/delete', methods=['POST'])
 @login_required
 def delete_draft_service(framework_slug, lot_slug, service_id):
-    framework, lot = get_framework_and_lot(data_api_client, framework_slug, lot_slug, open_only=True)
+    framework, lot = get_framework_and_lot(data_api_client, framework_slug, lot_slug, allowed_statuses=['open'])
     draft = data_api_client.get_draft_service(service_id).get('services')
 
     if not is_service_associated_with_supplier(draft):
@@ -325,7 +325,7 @@ def service_submission_document(framework_slug, supplier_id, document_name):
 @main.route('/frameworks/<framework_slug>/submissions/<lot_slug>/<service_id>', methods=['GET'])
 @login_required
 def view_service_submission(framework_slug, lot_slug, service_id):
-    framework, lot = get_framework_and_lot(data_api_client, framework_slug, lot_slug, open_only=False)
+    framework, lot = get_framework_and_lot(data_api_client, framework_slug, lot_slug)
 
     try:
         data = data_api_client.get_draft_service(service_id)
@@ -366,7 +366,7 @@ def view_service_submission(framework_slug, lot_slug, service_id):
             methods=['GET'])
 @login_required
 def edit_service_submission(framework_slug, lot_slug, service_id, section_id, question_slug=None):
-    framework, lot = get_framework_and_lot(data_api_client, framework_slug, lot_slug, open_only=True)
+    framework, lot = get_framework_and_lot(data_api_client, framework_slug, lot_slug, allowed_statuses=['open'])
 
     try:
         draft = data_api_client.get_draft_service(service_id)['services']
@@ -401,7 +401,7 @@ def edit_service_submission(framework_slug, lot_slug, service_id, section_id, qu
             methods=['POST'])
 @login_required
 def update_section_submission(framework_slug, lot_slug, service_id, section_id, question_slug=None):
-    framework, lot = get_framework_and_lot(data_api_client, framework_slug, lot_slug, open_only=True)
+    framework, lot = get_framework_and_lot(data_api_client, framework_slug, lot_slug, allowed_statuses=['open'])
 
     try:
         draft = data_api_client.get_draft_service(service_id)['services']

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -140,7 +140,7 @@ def update_section(service_id, section_id):
             posted_data,
             current_user.email_address)
     except HTTPError as e:
-        errors = section.get_error_messages(e.message, service['lot'])
+        errors = section.get_error_messages(e.message)
         if not posted_data.get('serviceName', None):
             posted_data['serviceName'] = service.get('serviceName', '')
         return render_template(
@@ -200,7 +200,7 @@ def create_new_draft_service(framework_slug, lot_slug):
         )['services']
     except HTTPError as e:
         update_data = section.unformat_data(update_data)
-        errors = section.get_error_messages(e.message, lot_slug)
+        errors = section.get_error_messages(e.message)
 
         return render_template(
             "services/edit_submission_section.html",
@@ -429,7 +429,7 @@ def update_section_submission(framework_slug, lot_slug, service_id, section_id, 
         public=False)
 
     if document_errors:
-        errors = section.get_error_messages(document_errors, draft['lot'])
+        errors = section.get_error_messages(document_errors)
     else:
         update_data.update(uploaded_documents)
 
@@ -443,7 +443,7 @@ def update_section_submission(framework_slug, lot_slug, service_id, section_id, 
             )
         except HTTPError as e:
             update_data = section.unformat_data(update_data)
-            errors = section.get_error_messages(e.message, draft['lot'])
+            errors = section.get_error_messages(e.message)
 
     if errors:
         keys_required_for_template = ['serviceName', 'lot', 'lotName']

--- a/app/templates/macros/toolkit_forms.html
+++ b/app/templates/macros/toolkit_forms.html
@@ -145,3 +145,45 @@
     {% include "toolkit/forms/textbox.html" %}
   {% endwith %}
 {%- endmacro %}
+
+{% macro boolean_list(question_content, service_data, errors, question_number=None, get_question=None) -%}
+
+  {% set error = errors.get(question_content.id)['message']|question_references(get_question) %}
+  {% if error %}
+    <div class="validation-wrapper">
+  {% endif %}
+    <fieldset class="question" id="{{ question_content.id }}" style="margin: 20px 0; border-bottom: 2px #F3F3F3 solid;">
+      <legend>
+        <span class="question-heading">
+          <h2 class="heading-for-a-set-of-questions" style="font-size: 28px;">{{ question_content.question }}</h2>
+        </span>
+      </legend>
+      <span class="hint">
+        <p>{{ question_content.hint }}</p>
+      </span>
+
+      {% if error %}
+        <span class="validation-message" id="error-{{ question_content.id }}">
+          {{ error }}
+        </span>
+      {% endif %}
+
+      {% for boolean_question in question_content.boolean_list_questions %}
+        {% set boolean_question_id = '{}-{}'.format(question_content.id, loop.index0) %}
+        {% with
+            boolean_question_content = {
+              'id': boolean_question_id,
+              'question': boolean_question,
+            },
+            data = {
+              boolean_question_id: service_data[boolean_question_id]|convert_to_boolean
+            }
+        %}
+          {{ boolean(boolean_question_content, data, {}) }}
+        {% endwith %}
+      {% endfor %}
+    </fieldset>
+  {% if error %}
+    </div>
+  {% endif %}
+{%- endmacro %}

--- a/app/templates/macros/toolkit_forms.html
+++ b/app/templates/macros/toolkit_forms.html
@@ -152,16 +152,14 @@
   {% if error %}
     <div class="validation-wrapper">
   {% endif %}
-    <fieldset class="question" id="{{ question_content.id }}" style="margin: 20px 0; border-bottom: 2px #F3F3F3 solid;">
+    <fieldset class="question question-boolean-list" id="{{ question_content.id }}">
         <span class="question-heading">
-          <h2 class="heading-for-a-set-of-questions" style="font-size: 28px;">{{ question_content.question }}</h2>
+          <h2>{{ question_content.question }}</h2>
         </span>
       <legend>
         <span class="visually-hidden">{{ question_content.name }}</span>
       </legend>
-      <span class="hint">
-        <p>{{ question_content.hint }}</p>
-      </span>
+        <p class="question-description">{{ question_content.hint }}</p>
 
       {% if error %}
         <span class="validation-message" id="error-{{ question_content.id }}">

--- a/app/templates/macros/toolkit_forms.html
+++ b/app/templates/macros/toolkit_forms.html
@@ -5,6 +5,10 @@
     hint=(question_content.hint or '')|question_references(get_question)|markdown,
     name=question_content.id,
     value=service_data[question_content.id],
+    unit_in_full=question_content.unit_in_full,
+    unit_position=question_content.unit_position,
+    unit=question_content.unit,
+    smaller=question_content.smaller,
     error=errors.get(question_content.id)['message']|question_references(get_question)
   %}
     {% include "toolkit/forms/textbox.html" %}

--- a/app/templates/macros/toolkit_forms.html
+++ b/app/templates/macros/toolkit_forms.html
@@ -153,10 +153,11 @@
     <div class="validation-wrapper">
   {% endif %}
     <fieldset class="question" id="{{ question_content.id }}" style="margin: 20px 0; border-bottom: 2px #F3F3F3 solid;">
-      <legend>
         <span class="question-heading">
           <h2 class="heading-for-a-set-of-questions" style="font-size: 28px;">{{ question_content.question }}</h2>
         </span>
+      <legend>
+        <span class="visually-hidden">{{ question_content.name }}</span>
       </legend>
       <span class="hint">
         <p>{{ question_content.hint }}</p>

--- a/app/templates/macros/toolkit_forms.html
+++ b/app/templates/macros/toolkit_forms.html
@@ -161,21 +161,20 @@
       </legend>
         <p class="question-description">{{ question_content.hint }}</p>
 
-      {% if error %}
-        <span class="validation-message" id="error-{{ question_content.id }}">
-          {{ error }}
-        </span>
-      {% endif %}
-
       {% for boolean_question in question_content.boolean_list_questions %}
         {% set boolean_question_id = '{}-{}'.format(question_content.id, loop.index0) %}
+        {% set
+            existing_value = service_data[question_content.id][loop.index0]
+              if (service_data[question_content.id] and service_data[question_content.id][loop.index0] is defined)
+              else None
+        %}
         {% with
             boolean_question_content = {
               'id': boolean_question_id,
               'question': boolean_question,
             },
             data = {
-              boolean_question_id: service_data[boolean_question_id]|convert_to_boolean
+              boolean_question_id: existing_value
             }
         %}
           {{ boolean(boolean_question_content, data, errors) }}

--- a/app/templates/macros/toolkit_forms.html
+++ b/app/templates/macros/toolkit_forms.html
@@ -148,10 +148,6 @@
 
 {% macro boolean_list(question_content, service_data, errors, question_number=None, get_question=None) -%}
 
-  {% set error = errors.get(question_content.id)['message']|question_references(get_question) %}
-  {% if error %}
-    <div class="validation-wrapper">
-  {% endif %}
     <fieldset class="question question-boolean-list" id="{{ question_content.id }}">
         <span class="question-heading">
           <h2>{{ question_content.question }}</h2>
@@ -178,11 +174,8 @@
               boolean_question_id: service_data[boolean_question_id]|convert_to_boolean
             }
         %}
-          {{ boolean(boolean_question_content, data, {}) }}
+          {{ boolean(boolean_question_content, data, errors) }}
         {% endwith %}
       {% endfor %}
     </fieldset>
-  {% if error %}
-    </div>
-  {% endif %}
 {%- endmacro %}

--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "jquery": "1.11.2",
     "hogan": "3.0.2",
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
-    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v15.0.2",
+    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v15.2.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.14.1/jinja_govuk_template-0.14.1.tgz",
     "digitalmarketplace-frameworks": "git://github.com/alphagov/digitalmarketplace-frameworks#v0.20.0"
   }

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ Flask-WTF==0.12
 werkzeug==0.10.4
 python-dateutil==2.4.2
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@18.0.0#egg=digitalmarketplace-utils==18.0.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@19.0.0#egg=digitalmarketplace-utils==19.0.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@3.0.0#egg=digitalmarketplace-apiclient==3.0.0
 
 markdown==2.6.2

--- a/tests/app/main/test_briefs.py
+++ b/tests/app/main/test_briefs.py
@@ -4,7 +4,6 @@ from __future__ import unicode_literals
 import mock
 from dmapiclient import api_stubs, HTTPError
 from dmutils.email import MandrillException
-from nose.tools import assert_equal, assert_in
 from ..helpers import BaseApplicationTest, FakeMail
 from lxml import html
 
@@ -177,14 +176,11 @@ class TestRespondToBrief(BaseApplicationTest):
         res = self.client.get('/suppliers/opportunities/1234/responses/create')
         doc = html.fromstring(res.get_data(as_text=True))
 
-        assert_equal(res.status_code, 200)
+        assert res.status_code == 200
         data_api_client.get_brief.assert_called_once_with(1234)
-        assert_equal(
-            len(doc.xpath('//h1[contains(text(), "Apply to an opportunity")]')), 1)
-        assert_equal(
-            len(doc.xpath('//h2[contains(text(), "Do you fulfill the following essential requirements")]')), 1)
-        assert_equal(
-            len(doc.xpath('//h2[contains(text(), "Do you fulfill the following nice-to-have requirements?")]')), 1)
+        assert len(doc.xpath('//h1[contains(text(), "Apply to an opportunity")]')) == 1
+        assert len(doc.xpath('//h2[contains(text(), "Do you fulfill the following essential requirements")]')) == 1
+        assert len(doc.xpath('//h2[contains(text(), "Do you fulfill the following nice-to-have requirements?")]')) == 1
 
     def test_get_submit_brief_response_page_404_for_not_live_brief(self, data_api_client):
         brief = self.brief.copy()
@@ -193,7 +189,7 @@ class TestRespondToBrief(BaseApplicationTest):
         data_api_client.get_framework.return_value = self.framework
         res = self.client.get('/suppliers/opportunities/1234/responses/create')
 
-        assert_equal(res.status_code, 404)
+        assert res.status_code == 404
 
     def test_get_submit_brief_response_page_404_for_not_live_framework(self, data_api_client):
         framework = self.framework.copy()
@@ -202,7 +198,7 @@ class TestRespondToBrief(BaseApplicationTest):
         data_api_client.get_framework.return_value = framework
         res = self.client.get('/suppliers/opportunities/1234/responses/create')
 
-        assert_equal(res.status_code, 404)
+        assert res.status_code == 404
 
     def test_get_submit_brief_response_page_404_if_response_already_exists(self, data_api_client):
         data_api_client.get_brief.return_value = self.brief
@@ -215,7 +211,7 @@ class TestRespondToBrief(BaseApplicationTest):
         }
 
         res = self.client.get('/suppliers/opportunities/1234/responses/create')
-        assert_equal(res.status_code, 404)
+        assert res.status_code == 404
 
     def test_get_submit_brief_response_page_includes_essential_requirements(self, data_api_client):
         data_api_client.get_brief.return_value = self.brief
@@ -223,12 +219,9 @@ class TestRespondToBrief(BaseApplicationTest):
         res = self.client.get('/suppliers/opportunities/1234/responses/create')
         doc = html.fromstring(res.get_data(as_text=True))
 
-        assert_equal(
-            len(doc.xpath('//p[contains(text(), "Essential one")]')), 1)
-        assert_equal(
-            len(doc.xpath('//p[contains(text(), "Essential two")]')), 1)
-        assert_equal(
-            len(doc.xpath('//p[contains(text(), "Essential three")]')), 1)
+        assert len(doc.xpath('//p[contains(text(), "Essential one")]')) == 1
+        assert len(doc.xpath('//p[contains(text(), "Essential two")]')) == 1
+        assert len(doc.xpath('//p[contains(text(), "Essential three")]')) == 1
 
     def test_get_submit_brief_response_page_includes_nice_to_have_requirements(self, data_api_client):
         data_api_client.get_brief.return_value = self.brief
@@ -236,12 +229,9 @@ class TestRespondToBrief(BaseApplicationTest):
         res = self.client.get('/suppliers/opportunities/1234/responses/create')
         doc = html.fromstring(res.get_data(as_text=True))
 
-        assert_equal(
-            len(doc.xpath('//p[contains(text(), "Top one")]')), 1)
-        assert_equal(
-            len(doc.xpath('//p[contains(text(), "Nice one")]')), 1)
-        assert_equal(
-            len(doc.xpath('//p[contains(text(), "Get sorted")]')), 1)
+        assert len(doc.xpath('//p[contains(text(), "Top one")]')) == 1
+        assert len(doc.xpath('//p[contains(text(), "Nice one")]')) == 1
+        assert len(doc.xpath('//p[contains(text(), "Get sorted")]')) == 1
 
     def test_get_submit_brief_response_page_redirects_to_login_for_buyer(self, data_api_client):
         data_api_client.get_brief.return_value = self.brief
@@ -249,9 +239,8 @@ class TestRespondToBrief(BaseApplicationTest):
         self.login_as_buyer()
         res = self.client.get('/suppliers/opportunities/1234/responses/create')
 
-        assert_equal(res.status_code, 302)
-        assert_equal(res.location,
-                     "http://localhost/login?next=%2Fsuppliers%2Fopportunities%2F1234%2Fresponses%2Fcreate")
+        assert res.status_code == 302
+        assert res.location == "http://localhost/login?next=%2Fsuppliers%2Fopportunities%2F1234%2Fresponses%2Fcreate"
         self.assert_flashes("supplier-role-required", "error")
 
     def test_post_create_new_brief_response(self, data_api_client):
@@ -262,8 +251,8 @@ class TestRespondToBrief(BaseApplicationTest):
             '/suppliers/opportunities/1234/responses/create',
             data=brief_form_submission
         )
-        assert_equal(res.status_code, 302)
-        assert_equal(res.location, "http://localhost/suppliers")
+        assert res.status_code == 302
+        assert res.location == "http://localhost/suppliers"
         self.assert_flashes("Your response to &lsquo;I need a thing to do a thing&rsquo; has been submitted.")
         data_api_client.create_brief_response.assert_called_once_with(
             1234, 1234, processed_brief_submission, 'email@email.com')
@@ -319,7 +308,7 @@ class TestRespondToBrief(BaseApplicationTest):
             '/suppliers/opportunities/1234/responses/create',
             data=brief_form_submission
         )
-        assert_equal(res.status_code, 404)
+        assert res.status_code == 404
         assert not data_api_client.create_brief_response.called
 
     def test_post_create_new_brief_response_404_if_not_live_framework(self, data_api_client):
@@ -332,7 +321,7 @@ class TestRespondToBrief(BaseApplicationTest):
             '/suppliers/opportunities/1234/responses/create',
             data=brief_form_submission
         )
-        assert_equal(res.status_code, 404)
+        assert res.status_code == 404
         assert not data_api_client.create_brief_response.called
 
     def test_post_create_new_brief_response_404_if_response_already_exists(self, data_api_client):
@@ -349,7 +338,7 @@ class TestRespondToBrief(BaseApplicationTest):
             '/suppliers/opportunities/1234/responses/create',
             data=brief_form_submission
         )
-        assert_equal(res.status_code, 404)
+        assert res.status_code == 404
         assert not data_api_client.create_brief_response.called
 
     def test_post_create_new_brief_response_with_api_error_fails(self, data_api_client):
@@ -365,8 +354,8 @@ class TestRespondToBrief(BaseApplicationTest):
             data=brief_form_submission
         )
 
-        assert_equal(res.status_code, 400)
-        assert_in("You need to answer this question.", res.get_data(as_text=True))
+        assert res.status_code == 400
+        assert "You need to answer this question." in res.get_data(as_text=True)
         data_api_client.create_brief_response.assert_called_once_with(
             1234, 1234, processed_brief_submission, 'email@email.com')
 
@@ -378,7 +367,7 @@ class TestRespondToBrief(BaseApplicationTest):
             '/suppliers/opportunities/1234/responses/create',
             data=brief_form_submission
         )
-        assert_equal(res.status_code, 302)
-        assert_equal(res.location, "http://localhost/login")
+        assert res.status_code == 302
+        assert res.location == "http://localhost/login"
         self.assert_flashes("supplier-role-required", "error")
         assert not data_api_client.get_brief.called

--- a/tests/app/main/test_briefs.py
+++ b/tests/app/main/test_briefs.py
@@ -178,7 +178,7 @@ class TestRespondToBrief(BaseApplicationTest):
 
         assert res.status_code == 200
         data_api_client.get_brief.assert_called_once_with(1234)
-        assert len(doc.xpath('//h1[contains(text(), "Apply to an opportunity")]')) == 1
+        assert len(doc.xpath('//h1[contains(text(), "Apply to ‘I need a thing to do a thing’")]')) == 1
         assert len(doc.xpath('//h2[contains(text(), "Do you fulfill the following essential requirements")]')) == 1
         assert len(doc.xpath('//h2[contains(text(), "Do you fulfill the following nice-to-have requirements?")]')) == 1
 

--- a/tests/app/main/test_briefs.py
+++ b/tests/app/main/test_briefs.py
@@ -204,6 +204,19 @@ class TestRespondToBrief(BaseApplicationTest):
 
         assert_equal(res.status_code, 404)
 
+    def test_get_submit_brief_response_page_404_if_response_already_exists(self, data_api_client):
+        data_api_client.get_brief.return_value = self.brief
+        data_api_client.get_framework.return_value = self.framework
+        data_api_client.find_brief_responses.return_value = {
+            'briefResponses': [{
+                'briefId': self.brief['briefs']['id'],
+                'supplierId': 1234
+            }]
+        }
+
+        res = self.client.get('/suppliers/opportunities/1234/responses/create')
+        assert_equal(res.status_code, 404)
+
     def test_get_submit_brief_response_page_includes_essential_requirements(self, data_api_client):
         data_api_client.get_brief.return_value = self.brief
         data_api_client.get_framework.return_value = self.framework
@@ -314,6 +327,23 @@ class TestRespondToBrief(BaseApplicationTest):
         framework['frameworks']['status'] = 'standstill'
         data_api_client.get_brief.return_value = self.brief
         data_api_client.get_framework.return_value = framework
+
+        res = self.client.post(
+            '/suppliers/opportunities/1234/responses/create',
+            data=brief_form_submission
+        )
+        assert_equal(res.status_code, 404)
+        assert not data_api_client.create_brief_response.called
+
+    def test_post_create_new_brief_response_404_if_response_already_exists(self, data_api_client):
+        data_api_client.get_brief.return_value = self.brief
+        data_api_client.get_framework.return_value = self.framework
+        data_api_client.find_brief_responses.return_value = {
+            'briefResponses': [{
+                'briefId': self.brief['briefs']['id'],
+                'supplierId': 1234
+            }]
+        }
 
         res = self.client.post(
             '/suppliers/opportunities/1234/responses/create',

--- a/tests/app/main/test_briefs.py
+++ b/tests/app/main/test_briefs.py
@@ -252,8 +252,49 @@ class TestRespondToBrief(BaseApplicationTest):
         assert_equal(res.status_code, 302)
         assert_equal(res.location, "http://localhost/suppliers")
         self.assert_flashes("Your response to &lsquo;I need a thing to do a thing&rsquo; has been submitted.")
-        data_api_client.create_brief_response.assert_called_once_with(1234, 1234, processed_brief_submission,
-                                                                      'email@email.com')
+        data_api_client.create_brief_response.assert_called_once_with(
+            1234, 1234, processed_brief_submission, 'email@email.com')
+
+    def test_post_create_new_brief_response_error_message_for_boolean_list_question_empty(self, data_api_client):
+        data_api_client.get_brief.return_value = self.brief
+        data_api_client.get_framework.return_value = self.framework
+        data_api_client.create_brief_response.side_effect = HTTPError(
+            mock.Mock(status_code=400),
+            {'essentialRequirements': 'answer_required'}
+        )
+        incomplete_brief_form_submission = brief_form_submission.copy()
+        incomplete_brief_form_submission.pop('essentialRequirements-2')
+
+        res = self.client.post(
+            '/suppliers/opportunities/1234/responses/create',
+            data=incomplete_brief_form_submission,
+            follow_redirects=True
+        )
+
+        response_text = res.get_data(as_text=True)
+        assert 'There was a problem with your answer to the following questions' in response_text
+        assert '<a href="#essentialRequirements-2" class="validation-masthead-link">Essential three</a>' \
+               in response_text
+
+    def test_post_create_new_brief_response_error_message_for_normal_question_empty(self, data_api_client):
+        data_api_client.get_brief.return_value = self.brief
+        data_api_client.get_framework.return_value = self.framework
+        data_api_client.create_brief_response.side_effect = HTTPError(
+            mock.Mock(status_code=400),
+            {'availability': 'answer_required'}
+        )
+        incomplete_brief_form_submission = brief_form_submission.copy()
+        incomplete_brief_form_submission.pop('availability')
+
+        res = self.client.post(
+            '/suppliers/opportunities/1234/responses/create',
+            data=incomplete_brief_form_submission,
+            follow_redirects=True
+        )
+
+        response_text = res.get_data(as_text=True)
+        assert 'There was a problem with your answer to the following questions' in response_text
+        assert '<a href="#availability" class="validation-masthead-link">Availability</a>' in response_text
 
     def test_post_create_new_brief_response_404_if_not_live_brief(self, data_api_client):
         brief = self.brief.copy()
@@ -296,8 +337,8 @@ class TestRespondToBrief(BaseApplicationTest):
 
         assert_equal(res.status_code, 400)
         assert_in("You need to answer this question.", res.get_data(as_text=True))
-        data_api_client.create_brief_response.assert_called_once_with(1234, 1234, processed_brief_submission,
-                                                                      'email@email.com')
+        data_api_client.create_brief_response.assert_called_once_with(
+            1234, 1234, processed_brief_submission, 'email@email.com')
 
     def test_post_create_new_brief_response_redirects_to_login_for_buyer(self, data_api_client):
         data_api_client.get_brief.return_value = self.brief

--- a/tests/app/main/test_briefs.py
+++ b/tests/app/main/test_briefs.py
@@ -1,8 +1,41 @@
+# coding: utf-8
+from __future__ import unicode_literals
+
 import mock
 from dmapiclient import api_stubs, HTTPError
 from dmutils.email import MandrillException
-
+from nose.tools import assert_equal, assert_in
 from ..helpers import BaseApplicationTest, FakeMail
+from lxml import html
+
+
+brief_form_submission = {
+    "availability": "Next Tuesday",
+    "dayRate": "£200",
+    "essentialRequirements-0": True,
+    "essentialRequirements-1": False,
+    "essentialRequirements-2": True,
+    "niceToHaveRequirements-0": False,
+    "niceToHaveRequirements-1": True,
+    "niceToHaveRequirements-2": False,
+    "specialistName": "Dave",
+}
+
+processed_brief_submission = {
+    "availability": "Next Tuesday",
+    "dayRate": "£200",
+    "essentialRequirements": [
+        True,
+        False,
+        True
+    ],
+    "niceToHaveRequirements": [
+        False,
+        True,
+        False
+    ],
+    "specialistName": "Dave",
+}
 
 
 @mock.patch('app.main.views.briefs.data_api_client', autospec=True)
@@ -119,3 +152,162 @@ class TestSubmitClarificationQuestions(BaseApplicationTest):
         })
         assert res.status_code == 400
         assert "cannot be longer than" in res.get_data(as_text=True)
+
+
+@mock.patch("app.main.views.briefs.data_api_client")
+class TestRespondToBrief(BaseApplicationTest):
+
+    def setup(self):
+        super(TestRespondToBrief, self).setup()
+
+        self.brief = api_stubs.brief(status='live')
+        self.brief['briefs']['essentialRequirements'] = ['Essential one', 'Essential two', 'Essential three']
+        self.brief['briefs']['niceToHaveRequirements'] = ['Nice one', 'Top one', 'Get sorted']
+
+        lots = [api_stubs.lot(slug="digital-specialists", allows_brief=True)]
+        self.framework = api_stubs.framework(status="live", slug="digital-outcomes-and-specialists",
+                                             clarification_questions_open=False, lots=lots)
+
+        with self.app.test_client():
+            self.login()
+
+    def test_get_submit_brief_response_page(self, data_api_client):
+        data_api_client.get_brief.return_value = self.brief
+        data_api_client.get_framework.return_value = self.framework
+        res = self.client.get('/suppliers/opportunities/1234/responses/create')
+        doc = html.fromstring(res.get_data(as_text=True))
+
+        assert_equal(res.status_code, 200)
+        data_api_client.get_brief.assert_called_once_with(1234)
+        assert_equal(
+            len(doc.xpath('//h1[contains(text(), "Apply to an opportunity")]')), 1)
+        assert_equal(
+            len(doc.xpath('//h2[contains(text(), "Do you fulfill the following essential requirements")]')), 1)
+        assert_equal(
+            len(doc.xpath('//h2[contains(text(), "Do you fulfill the following nice-to-have requirements?")]')), 1)
+
+    def test_get_submit_brief_response_page_404_for_not_live_brief(self, data_api_client):
+        brief = self.brief.copy()
+        brief['briefs']['status'] = 'draft'
+        data_api_client.get_brief.return_value = brief
+        data_api_client.get_framework.return_value = self.framework
+        res = self.client.get('/suppliers/opportunities/1234/responses/create')
+
+        assert_equal(res.status_code, 404)
+
+    def test_get_submit_brief_response_page_404_for_not_live_framework(self, data_api_client):
+        framework = self.framework.copy()
+        framework['frameworks']['status'] = 'standstill'
+        data_api_client.get_brief.return_value = self.brief
+        data_api_client.get_framework.return_value = framework
+        res = self.client.get('/suppliers/opportunities/1234/responses/create')
+
+        assert_equal(res.status_code, 404)
+
+    def test_get_submit_brief_response_page_includes_essential_requirements(self, data_api_client):
+        data_api_client.get_brief.return_value = self.brief
+        data_api_client.get_framework.return_value = self.framework
+        res = self.client.get('/suppliers/opportunities/1234/responses/create')
+        doc = html.fromstring(res.get_data(as_text=True))
+
+        assert_equal(
+            len(doc.xpath('//p[contains(text(), "Essential one")]')), 1)
+        assert_equal(
+            len(doc.xpath('//p[contains(text(), "Essential two")]')), 1)
+        assert_equal(
+            len(doc.xpath('//p[contains(text(), "Essential three")]')), 1)
+
+    def test_get_submit_brief_response_page_includes_nice_to_have_requirements(self, data_api_client):
+        data_api_client.get_brief.return_value = self.brief
+        data_api_client.get_framework.return_value = self.framework
+        res = self.client.get('/suppliers/opportunities/1234/responses/create')
+        doc = html.fromstring(res.get_data(as_text=True))
+
+        assert_equal(
+            len(doc.xpath('//p[contains(text(), "Top one")]')), 1)
+        assert_equal(
+            len(doc.xpath('//p[contains(text(), "Nice one")]')), 1)
+        assert_equal(
+            len(doc.xpath('//p[contains(text(), "Get sorted")]')), 1)
+
+    def test_get_submit_brief_response_page_redirects_to_login_for_buyer(self, data_api_client):
+        data_api_client.get_brief.return_value = self.brief
+        data_api_client.get_framework.return_value = self.framework
+        self.login_as_buyer()
+        res = self.client.get('/suppliers/opportunities/1234/responses/create')
+
+        assert_equal(res.status_code, 302)
+        assert_equal(res.location,
+                     "http://localhost/login?next=%2Fsuppliers%2Fopportunities%2F1234%2Fresponses%2Fcreate")
+        self.assert_flashes("supplier-role-required", "error")
+
+    def test_post_create_new_brief_response(self, data_api_client):
+        data_api_client.get_brief.return_value = self.brief
+        data_api_client.get_framework.return_value = self.framework
+
+        res = self.client.post(
+            '/suppliers/opportunities/1234/responses/create',
+            data=brief_form_submission
+        )
+        assert_equal(res.status_code, 302)
+        assert_equal(res.location, "http://localhost/suppliers")
+        self.assert_flashes("Your response to &lsquo;I need a thing to do a thing&rsquo; has been submitted.")
+        data_api_client.create_brief_response.assert_called_once_with(1234, 1234, processed_brief_submission,
+                                                                      'email@email.com')
+
+    def test_post_create_new_brief_response_404_if_not_live_brief(self, data_api_client):
+        brief = self.brief.copy()
+        brief['briefs']['status'] = 'draft'
+        data_api_client.get_brief.return_value = brief
+        data_api_client.get_framework.return_value = self.framework
+
+        res = self.client.post(
+            '/suppliers/opportunities/1234/responses/create',
+            data=brief_form_submission
+        )
+        assert_equal(res.status_code, 404)
+        assert not data_api_client.create_brief_response.called
+
+    def test_post_create_new_brief_response_404_if_not_live_framework(self, data_api_client):
+        framework = self.framework.copy()
+        framework['frameworks']['status'] = 'standstill'
+        data_api_client.get_brief.return_value = self.brief
+        data_api_client.get_framework.return_value = framework
+
+        res = self.client.post(
+            '/suppliers/opportunities/1234/responses/create',
+            data=brief_form_submission
+        )
+        assert_equal(res.status_code, 404)
+        assert not data_api_client.create_brief_response.called
+
+    def test_post_create_new_brief_response_with_api_error_fails(self, data_api_client):
+        data_api_client.get_brief.return_value = self.brief
+        data_api_client.get_framework.return_value = self.framework
+        data_api_client.create_brief_response.side_effect = HTTPError(
+            mock.Mock(status_code=400),
+            {'availability': 'answer_required'}
+        )
+
+        res = self.client.post(
+            '/suppliers/opportunities/1234/responses/create',
+            data=brief_form_submission
+        )
+
+        assert_equal(res.status_code, 400)
+        assert_in("You need to answer this question.", res.get_data(as_text=True))
+        data_api_client.create_brief_response.assert_called_once_with(1234, 1234, processed_brief_submission,
+                                                                      'email@email.com')
+
+    def test_post_create_new_brief_response_redirects_to_login_for_buyer(self, data_api_client):
+        data_api_client.get_brief.return_value = self.brief
+        data_api_client.get_framework.return_value = self.framework
+        self.login_as_buyer()
+        res = self.client.post(
+            '/suppliers/opportunities/1234/responses/create',
+            data=brief_form_submission
+        )
+        assert_equal(res.status_code, 302)
+        assert_equal(res.location, "http://localhost/login")
+        self.assert_flashes("supplier-role-required", "error")
+        assert not data_api_client.get_brief.called

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -167,7 +167,8 @@ class TestSupplierUpdateService(BaseApplicationTest):
         data_api_client.get_framework.return_value = {
             'frameworks': {
                 'name': framework_name,
-                'slug': framework_slug
+                'slug': framework_slug,
+                'status': 'live'
             }
         }
 


### PR DESCRIPTION
This story allows suppliers to submit responses to a briefs/opportunities (hereafter referred to as a 'brief').
All of the questions for a brief response are on one page; some questions are stored entirely in the content but others are a mixture of static content and dynamic (user-submitted) essential/nice to have questions from the brief itself.

Suppliers can only submit one response per brief. (If they try to submit another, they get a 404 page -- in future we might want to redirect them to another page and display a flash message.)

It *does not* check if suppliers are eligible to submit responses to a particular brief (this depends on the [only eligible suppliers can respond to a brief](https://www.pivotaltracker.com/story/show/112216509) story)

[>> Story on Pivotal](https://www.pivotaltracker.com/story/show/112216471)

### Important things

#### boolean_list macro
Introduced a new [`boolean_list`](https://github.com/alphagov/digitalmarketplace-supplier-frontend/blob/pc_supplier_reply_responses/app/templates/macros/toolkit_forms.html#L153) macro which receives a section object injected full of boolean_questions pulled from the buyer brief.  Loops through the boolean questions, calling the `boolean` macro for each one.

#### convert_to_boolean filter
Introduced a new jinja2 filter, [`convert_to_boolean`](https://github.com/alphagov/digitalmarketplace-supplier-frontend/blob/pc_supplier_reply_responses/app/__init__.py#L78).  Logic is imported directly from dmutils.  We're using it to transform `"true"` and `"false"` strings to `True` and `False`  boolean values so that we can preserve submitted boolean questions if validation fails.

#### text macro
Updated the [`text`](https://github.com/alphagov/digitalmarketplace-supplier-frontend/blob/pc_supplier_reply_responses/app/templates/macros/toolkit_forms.html#L1) form field macro to support smaller textboxes and textboxes with prices.

#### per-question validation
`boolean_list` questions are a kind of multiquestion in that they have nested questions, but, unlike in a multiquestion, all boolean questions must be answered for a `boolean_list` question to be valid.  @tombye pointed out that if a particular question wasn't answered, the error message should point to that question, not the entire boolean_list group.  [Wrote a big, fat loop to implements this](https://github.com/alphagov/digitalmarketplace-supplier-frontend/blob/pc_supplier_reply_responses/app/main/views/briefs.py#L83).

#### inject brief questions into ContentQuestions
Since we're displaying all of the questions on one page, we decided to [put the buyer-submitted question
data into the `ContentSection` object](https://github.com/alphagov/digitalmarketplace-supplier-frontend/blob/pc_supplier_reply_responses/app/main/helpers/briefs.py#L25).  It's not ideal, as there's a danger of potentially overwriting other keys unintentionally, as well as the fact that we don't really want the `ContentSection`
object to be any more complicated, but doing it this way allows us to keep our HTML template totally generic and avoid adding anything additional to the toolkit.

#### inject brief name into ContentSection
[Overwrite the default section name to include the name of the brief](https://github.com/alphagov/digitalmarketplace-supplier-frontend/blob/pc_supplier_reply_responses/app/main/views/briefs.py#L40).  If a supplier is applying to lots of briefs, it might be helpful.

***

### brief response page
![screen shot 2016-02-29 at 16 27 37](https://cloud.githubusercontent.com/assets/2454380/13400872/b4c88670-df01-11e5-9642-c4179082b1f4.png)

### brief response page (validation errors)
![screen shot 2016-02-29 at 16 28 13](https://cloud.githubusercontent.com/assets/2454380/13400874/ba2401b2-df01-11e5-8c54-bae99fe9accb.png)

### brief response submitted
![screen shot 2016-02-29 at 16 28 48](https://cloud.githubusercontent.com/assets/2454380/13400885/c0475bd4-df01-11e5-82cf-3a5241a73d11.png)

