### PR TITLE
Add brief clarification question closing date to form help

### DIFF
--- a/app/templates/briefs/clarification_question.html
+++ b/app/templates/briefs/clarification_question.html
@@ -64,7 +64,7 @@
     <div class="column-two-thirds">
 
       <div class="hint">
-        <p>Your question will be published with the buyers’ response.</p>
+        <p>Your question will be published with the buyers’ response by {{ brief.clarificationQuestionsClosedAt | dateformat }}.</p>
         <p>All questions and answers will be posted on the Digital Marketplace. Your company name won’t be visible.</p>
         <p>You shouldn’t include any confidential information in your question.</p>
         <p>Read more about <a href="https://www.gov.uk/guidance/how-to-ask-and-answer-supplier-questions-on-the-digital-marketplace">how supplier questions are managed</a>.</p>


### PR DESCRIPTION
Adds a closing date for brief clarification question answers to the
question form help text.

Requires https://github.com/alphagov/digitalmarketplace-api/pull/357.