### PR TITLE
Remove custom version of gulp-jasmine-phantom

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: python
 python:
   - "2.7"
   - "3.4"
+before_install:
+  - nvm install 4.2
 install:
   - pip install -r requirements_for_test.txt
   - npm install

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "gulp-shell": "0.2.9",
     "gulp-uglify": "1.4.0",
     "gulp-sourcemaps": "1.5.2",
-    "gulp-jasmine-phantom": "git://github.com/alphagov/gulp-jasmine-phantom#203c1cb2c4e951ff6aac7f3022d0f61111c8d9f4",
+    "gulp-jasmine-phantom": "3.0.0",
     "colors": "1.1.2"
   },
   "scripts": {


### PR DESCRIPTION
We made a custom version to deal with the fact
that the version of Node that Travis uses in the VM
image for Python projects was below that required
for the NPM module (see related [stackoverflow question](http://stackoverflow.com/questions/32461456/travis-ci-can-the-version-of-node-installed-on-all-vm-images-match-the-latest)).

This is no longer the case (it's currently running
at 4.2 (using nvm) so the custom version is no
longer needed.