### PR TITLE
Update dmutils to 19.0.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ Flask-WTF==0.12
 werkzeug==0.10.4
 python-dateutil==2.4.2
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@19.0.0#egg=digitalmarketplace-utils==19.0.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@19.0.1#egg=digitalmarketplace-utils==19.0.1
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@3.0.0#egg=digitalmarketplace-apiclient==3.0.0
 
 markdown==2.6.2


### PR DESCRIPTION
Brings in a bugfix around suppliers responding to opportunities (briefs) without any nice-to-have requirements.