### PR TITLE
Add an audit event for sent brief clarification questions

### DIFF
--- a/app/main/views/briefs.py
+++ b/app/main/views/briefs.py
@@ -36,7 +36,7 @@ def ask_brief_clarification_question(brief_id):
             clarification_question_value = clarification_question
             error_message = "Question cannot be longer than 5000 characters"
         else:
-            send_brief_clarification_question(brief, clarification_question)
+            send_brief_clarification_question(data_api_client, brief, clarification_question)
             flash('message_sent', 'success')
 
     return render_template(

--- a/tests/app/main/test_briefs.py
+++ b/tests/app/main/test_briefs.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 
 import mock
 from dmapiclient import api_stubs, HTTPError
+from dmapiclient.audit import AuditTypes
 from dmutils.email import MandrillException
 from ..helpers import BaseApplicationTest, FakeMail
 from lxml import html
@@ -104,6 +105,14 @@ class TestSubmitClarificationQuestions(BaseApplicationTest):
                 subject=u"Your question about \u2018I need a thing to do a thing\u2019"
             ),
         ])
+
+        data_api_client.create_audit_event.assert_called_with(
+            audit_type=AuditTypes.send_clarification_question,
+            object_type='briefs',
+            data={'briefId': 1234, 'question': u'important question'},
+            user='email@email.com',
+            object_id=1234
+        )
 
     @mock.patch('app.main.helpers.briefs.send_email')
     def test_submit_clarification_question_fails_on_mandrill_error(self, send_email, data_api_client):


### PR DESCRIPTION
Creates an audit event with the clarification question text when a brief question is submitted.

Reuses the existing audit event type from framework clarification questions. Since the related object type is different it is still simple to distinguish the clarification question types when listing events.