### PR TITLE
Fix supplier view of submissions

### DIFF
--- a/app/main/helpers/frameworks.py
+++ b/app/main/helpers/frameworks.py
@@ -183,8 +183,7 @@ def get_statuses_for_lot(
 def get_status_for_one_service_lot(
     drafts_count, complete_drafts_count, declaration_complete, framework_is_open, lot_name, unit, unit_plural
 ):
-
-    if drafts_count:
+    if (drafts_count and framework_is_open) or (drafts_count and not complete_drafts_count):
         return {
             'title': u'Started but not complete' if framework_is_open else u'Not completed',
             'type': u'quiet'

--- a/app/templates/frameworks/submission_lots.html
+++ b/app/templates/frameworks/submission_lots.html
@@ -17,7 +17,7 @@
       },
       {
         "link": url_for(".framework_dashboard", framework_slug=framework.slug),
-        "label": "Apply to " + framework.name,
+        "label": ("Apply to " + framework.name) if framework.status == "open" else ("Your " + framework.name + " services"),
       }
     ]
   %}


### PR DESCRIPTION
[#113766617](https://www.pivotaltracker.com/story/show/113766617)

Before this change the supplier view of their submissions (the lot selection page) does not make a lot of sense after the framework is no longer open. In the case of Digital Outcomes and Specialists the lot titles were things like 'Apply for Digital Specialists' and link through to add a service of that type. This doesn't make sense after the framework is no longer open for submissions.

This is a bit of a hack but it solving it more correctly does not seem like a priority right now.

## Before
![screen shot 2016-03-23 at 11 26 30](https://cloud.githubusercontent.com/assets/14287/13984509/8fccdea8-f0ee-11e5-9085-ed2ed0001aed.png)

## After
Here labs isn't shown because the user didn't create any draft services for it.
![screen shot 2016-03-23 at 11 55 21](https://cloud.githubusercontent.com/assets/14287/13984495/7b8eb34e-f0ee-11e5-924f-96caca9318c5.png)
