### PR TITLE
[#116127657] No clarification questions after deadline

### DIFF
--- a/app/main/views/briefs.py
+++ b/app/main/views/briefs.py
@@ -23,6 +23,8 @@ from ... import data_api_client
 @login_required
 def ask_brief_clarification_question(brief_id):
     brief = get_brief(data_api_client, brief_id, allowed_statuses=['live'])
+    if brief['clarificationQuestionsAreClosed']:
+        abort(404)
     ensure_supplier_is_eligible_for_brief(brief, current_user.supplier_id)
 
     error_message = None

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,6 @@ werkzeug==0.10.4
 python-dateutil==2.4.2
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@19.0.1#egg=digitalmarketplace-utils==19.0.1
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@3.0.0#egg=digitalmarketplace-apiclient==3.0.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@3.6.0#egg=digitalmarketplace-apiclient==3.6.0
 
 markdown==2.6.2

--- a/tests/app/main/test_briefs.py
+++ b/tests/app/main/test_briefs.py
@@ -47,7 +47,7 @@ class TestBriefClarificationQuestions(BaseApplicationTest):
 
     def test_clarification_question_form(self, data_api_client):
         self.login()
-        data_api_client.get_brief.return_value = {'briefs': {'status': 'live'}}
+        data_api_client.get_brief.return_value = api_stubs.brief(status="live")
 
         res = self.client.get('/suppliers/opportunities/1/ask-a-question')
         assert res.status_code == 200
@@ -61,7 +61,14 @@ class TestBriefClarificationQuestions(BaseApplicationTest):
 
     def test_clarification_question_form_requires_live_brief(self, data_api_client):
         self.login()
-        data_api_client.get_brief.return_value = {'briefs': {'status': 'expired'}}
+        data_api_client.get_brief.return_value = api_stubs.brief(status="expired")
+
+        res = self.client.get('/suppliers/opportunities/1/ask-a-question')
+        assert res.status_code == 404
+
+    def test_clarification_question_form_requires_questions_to_be_open(self, data_api_client):
+        self.login()
+        data_api_client.get_brief.return_value = api_stubs.brief(status="live", clarification_questions_closed=True)
 
         res = self.client.get('/suppliers/opportunities/1/ask-a-question')
         assert res.status_code == 404
@@ -136,14 +143,14 @@ class TestSubmitClarificationQuestions(BaseApplicationTest):
 
     def test_submit_clarification_question_requires_live_brief(self, data_api_client):
         self.login()
-        data_api_client.get_brief.return_value = {'briefs': {'status': 'expired'}}
+        data_api_client.get_brief.return_value = api_stubs.brief(status="expired")
 
         res = self.client.post('/suppliers/opportunities/1/ask-a-question')
         assert res.status_code == 404
 
     def test_submit_empty_clarification_question_returns_validation_error(self, data_api_client):
         self.login()
-        data_api_client.get_brief.return_value = {'briefs': {'status': 'live'}}
+        data_api_client.get_brief.return_value = api_stubs.brief(status="live")
 
         res = self.client.post('/suppliers/opportunities/1/ask-a-question', data={
             'clarification-question': "",
@@ -153,7 +160,7 @@ class TestSubmitClarificationQuestions(BaseApplicationTest):
 
     def test_submit_empty_clarification_question_has_max_length_limit(self, data_api_client):
         self.login()
-        data_api_client.get_brief.return_value = {'briefs': {'status': 'live'}}
+        data_api_client.get_brief.return_value = api_stubs.brief(status="live")
 
         res = self.client.post('/suppliers/opportunities/1/ask-a-question', data={
             'clarification-question': "a" * 5100,


### PR DESCRIPTION
Prevent clarification questions from being submitted after the deadline.
This change also bumps the apiclient to get the latest API stub for briefs which includes the `clarificationQuestionsAreClosed` flag.

- [x] Depends on https://github.com/alphagov/digitalmarketplace-apiclient/pull/22