### PR TITLE
[#112216509] Only eligible suppliers can respond to a brief

### DIFF
--- a/app/main/helpers/briefs.py
+++ b/app/main/helpers/briefs.py
@@ -28,10 +28,9 @@ def ensure_supplier_is_eligible_for_brief(brief, supplier_id):
     pass
 
 
-def has_supplier_already_submitted_a_brief_response(data_api_client, supplier_id, brief_id):
-
+def supplier_has_a_brief_response(data_api_client, supplier_id, brief_id):
     brief_responses = data_api_client.find_brief_responses(brief_id=brief_id, supplier_id=supplier_id)['briefResponses']
-    return len(brief_responses) == 0
+    return len(brief_responses) != 0
 
 
 def send_brief_clarification_question(data_api_client, brief, clarification_question):

--- a/app/main/helpers/briefs.py
+++ b/app/main/helpers/briefs.py
@@ -22,10 +22,8 @@ def get_brief(data_api_client, brief_id, allowed_statuses=None):
     return brief
 
 
-def ensure_supplier_is_eligible_for_brief(brief, supplier_id):
-    # TODO connect this with the API endpoint once it exists
-    # Should abort or render an error page if the check fails
-    pass
+def is_supplier_eligible_for_brief(data_api_client, supplier_id, brief):
+    return data_api_client.is_supplier_eligible_for_brief(supplier_id, brief['id'])
 
 
 def supplier_has_a_brief_response(data_api_client, supplier_id, brief_id):

--- a/app/main/views/briefs.py
+++ b/app/main/views/briefs.py
@@ -1,6 +1,5 @@
 # coding: utf-8
 from __future__ import unicode_literals
-from collections import OrderedDict
 
 from flask import render_template, redirect, url_for, request, flash, abort
 from flask_login import current_user
@@ -12,7 +11,7 @@ from ..helpers.briefs import (
     get_brief,
     ensure_supplier_is_eligible_for_brief,
     send_brief_clarification_question,
-    has_supplier_already_submitted_a_brief_response
+    supplier_has_a_brief_response
 )
 from ..helpers.frameworks import get_framework_and_lot
 from ...main import main, content_loader
@@ -57,7 +56,7 @@ def submit_brief_response(brief_id):
     brief = get_brief(data_api_client, brief_id, allowed_statuses=['live'])
     ensure_supplier_is_eligible_for_brief(brief, current_user.supplier_id)
 
-    if not has_supplier_already_submitted_a_brief_response(data_api_client, current_user.supplier_id, brief_id):
+    if supplier_has_a_brief_response(data_api_client, current_user.supplier_id, brief_id):
         # TODO redirect to summary of brief response page with flash message
         abort(404)
 
@@ -89,7 +88,7 @@ def create_new_brief_response(brief_id):
     brief = get_brief(data_api_client, brief_id, allowed_statuses=['live'])
     ensure_supplier_is_eligible_for_brief(brief, current_user.supplier_id)
 
-    if not has_supplier_already_submitted_a_brief_response(data_api_client, current_user.supplier_id, brief_id):
+    if supplier_has_a_brief_response(data_api_client, current_user.supplier_id, brief_id):
         # TODO redirect to summary of brief response page with flash message
         abort(404)
 

--- a/app/main/views/briefs.py
+++ b/app/main/views/briefs.py
@@ -9,7 +9,7 @@ from dmapiclient import HTTPError
 from ..helpers import login_required
 from ..helpers.briefs import (
     get_brief,
-    ensure_supplier_is_eligible_for_brief,
+    is_supplier_eligible_for_brief,
     send_brief_clarification_question,
     supplier_has_a_brief_response
 )
@@ -22,9 +22,12 @@ from ... import data_api_client
 @login_required
 def ask_brief_clarification_question(brief_id):
     brief = get_brief(data_api_client, brief_id, allowed_statuses=['live'])
+
     if brief['clarificationQuestionsAreClosed']:
         abort(404)
-    ensure_supplier_is_eligible_for_brief(brief, current_user.supplier_id)
+
+    if not is_supplier_eligible_for_brief(data_api_client, current_user.supplier_id, brief):
+        abort(400)
 
     error_message = None
     clarification_question_value = None
@@ -54,7 +57,9 @@ def ask_brief_clarification_question(brief_id):
 def submit_brief_response(brief_id):
 
     brief = get_brief(data_api_client, brief_id, allowed_statuses=['live'])
-    ensure_supplier_is_eligible_for_brief(brief, current_user.supplier_id)
+
+    if not is_supplier_eligible_for_brief(data_api_client, current_user.supplier_id, brief):
+        abort(400)
 
     if supplier_has_a_brief_response(data_api_client, current_user.supplier_id, brief_id):
         # TODO redirect to summary of brief response page with flash message
@@ -86,7 +91,9 @@ def create_new_brief_response(brief_id):
     """Hits up the data API to create a new brief response."""
 
     brief = get_brief(data_api_client, brief_id, allowed_statuses=['live'])
-    ensure_supplier_is_eligible_for_brief(brief, current_user.supplier_id)
+
+    if not is_supplier_eligible_for_brief(data_api_client, current_user.supplier_id, brief):
+        abort(400)
 
     if supplier_has_a_brief_response(data_api_client, current_user.supplier_id, brief_id):
         # TODO redirect to summary of brief response page with flash message

--- a/app/main/views/briefs.py
+++ b/app/main/views/briefs.py
@@ -27,7 +27,7 @@ def ask_brief_clarification_question(brief_id):
         abort(404)
 
     if not is_supplier_eligible_for_brief(data_api_client, current_user.supplier_id, brief):
-        return _render_not_eligible_for_brief_error_page(brief)
+        return _render_not_eligible_for_brief_error_page(brief, clarification_question=True)
 
     error_message = None
     clarification_question_value = None
@@ -130,12 +130,13 @@ def create_new_brief_response(brief_id):
     return redirect(url_for(".dashboard"))
 
 
-def _render_not_eligible_for_brief_error_page(brief):
+def _render_not_eligible_for_brief_error_page(brief, clarification_question=False):
     sf = get_supplier_framework_info(data_api_client, brief['frameworkSlug'])
     on_framework = sf.get('onFramework', False) if sf else False
     return render_template(
         "briefs/not_is_supplier_eligible_for_brief_error.html",
         on_framework=on_framework,
+        clarification_question=clarification_question,
         framework_name=brief['frameworkName'],
         **dict(main.config['BASE_TEMPLATE_DATA'])
     ), 400

--- a/app/templates/briefs/not_is_supplier_eligible_for_brief_error.html
+++ b/app/templates/briefs/not_is_supplier_eligible_for_brief_error.html
@@ -4,18 +4,32 @@
 
 {% block main_content %}
 
+{% if clarification_question %}
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <header class="page-heading-smaller">
+      <h1>You can’t submit a question for this opportunity</h1>
+    </header>
+    {% if on_framework %}
+      <p>You don’t provide this type of service so you’re not eligible to ask a question about this opportunity.</p>
+    {% else %}
+      <p>You aren’t a {{ framework_name }} supplier so you’re not eligible to ask a question about this opportunity.</p>
+    {% endif %}
+  </div>
+</div>
+{% else %}
 <div class="grid-row">
   <div class="column-two-thirds">
     <header class="page-heading-smaller">
       <h1>You can’t apply for this opportunity</h1>
     </header>
     {% if on_framework %}
-      <p>You don’t provide this type of service on the {{ framework_name }} framework.</p>
+      <p>You don’t provide this type of service on the {{ framework_name }} framework.
     {% else %}
       <p>You aren’t a {{ framework_name }} supplier.</p>
     {% endif %}
-    </div>
   </div>
 </div>
+{% endif %}
 
 {% endblock %}

--- a/app/templates/briefs/not_is_supplier_eligible_for_brief_error.html
+++ b/app/templates/briefs/not_is_supplier_eligible_for_brief_error.html
@@ -1,0 +1,21 @@
+{% extends "_base_page.html" %}
+
+{% block page_title %}Not eligible for brief – Digital Marketplace{% endblock %}
+
+{% block main_content %}
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <header class="page-heading-smaller">
+      <h1>You can’t apply for this opportunity</h1>
+    </header>
+    {% if on_framework %}
+      <p>You don’t provide this type of service on the {{ framework_name }} framework.</p>
+    {% else %}
+      <p>You aren’t a {{ framework_name }} supplier.</p>
+    {% endif %}
+    </div>
+  </div>
+</div>
+
+{% endblock %}

--- a/tests/app/main/test_briefs.py
+++ b/tests/app/main/test_briefs.py
@@ -47,7 +47,7 @@ class TestBriefClarificationQuestions(BaseApplicationTest):
 
     def test_clarification_question_form(self, data_api_client):
         self.login()
-        data_api_client.get_brief.return_value = api_stubs.brief(status="live")
+        data_api_client.get_brief.return_value = api_stubs.brief(status='live')
 
         res = self.client.get('/suppliers/opportunities/1/ask-a-question')
         assert res.status_code == 200
@@ -59,16 +59,24 @@ class TestBriefClarificationQuestions(BaseApplicationTest):
         res = self.client.get('/suppliers/opportunities/1/ask-a-question')
         assert res.status_code == 404
 
+    def test_clarification_question_checks_supplier_is_eligible(self, data_api_client):
+        self.login()
+        data_api_client.get_brief.return_value = api_stubs.brief(status='live')
+        data_api_client.is_supplier_eligible_for_brief.return_value = False
+
+        res = self.client.get('/suppliers/opportunities/1/ask-a-question')
+        assert res.status_code == 400
+
     def test_clarification_question_form_requires_live_brief(self, data_api_client):
         self.login()
-        data_api_client.get_brief.return_value = api_stubs.brief(status="expired")
+        data_api_client.get_brief.return_value = api_stubs.brief(status='expired')
 
         res = self.client.get('/suppliers/opportunities/1/ask-a-question')
         assert res.status_code == 404
 
     def test_clarification_question_form_requires_questions_to_be_open(self, data_api_client):
         self.login()
-        data_api_client.get_brief.return_value = api_stubs.brief(status="live", clarification_questions_closed=True)
+        data_api_client.get_brief.return_value = api_stubs.brief(status='live', clarification_questions_closed=True)
 
         res = self.client.get('/suppliers/opportunities/1/ask-a-question')
         assert res.status_code == 404
@@ -143,14 +151,26 @@ class TestSubmitClarificationQuestions(BaseApplicationTest):
 
     def test_submit_clarification_question_requires_live_brief(self, data_api_client):
         self.login()
-        data_api_client.get_brief.return_value = api_stubs.brief(status="expired")
+        data_api_client.get_brief.return_value = api_stubs.brief(status='expired')
 
         res = self.client.post('/suppliers/opportunities/1/ask-a-question')
         assert res.status_code == 404
 
+    @mock.patch('app.main.helpers.briefs.send_email')
+    def test_submit_clarification_question_checks_supplier_is_eligible(self, send_email, data_api_client):
+        self.login()
+        data_api_client.get_brief.return_value = api_stubs.brief(status='live')
+        data_api_client.get_brief.return_value['briefs']['frameworkName'] = 'Brief Framework Name'
+        data_api_client.is_supplier_eligible_for_brief.return_value = False
+
+        res = self.client.post('/suppliers/opportunities/1/ask-a-question', data={
+            'clarification-question': "important question",
+        })
+        assert res.status_code == 400
+
     def test_submit_empty_clarification_question_returns_validation_error(self, data_api_client):
         self.login()
-        data_api_client.get_brief.return_value = api_stubs.brief(status="live")
+        data_api_client.get_brief.return_value = api_stubs.brief(status='live')
 
         res = self.client.post('/suppliers/opportunities/1/ask-a-question', data={
             'clarification-question': "",
@@ -158,9 +178,9 @@ class TestSubmitClarificationQuestions(BaseApplicationTest):
         assert res.status_code == 400
         assert "cannot be empty" in res.get_data(as_text=True)
 
-    def test_submit_empty_clarification_question_has_max_length_limit(self, data_api_client):
+    def test_clarification_question_has_max_length_limit(self, data_api_client):
         self.login()
-        data_api_client.get_brief.return_value = api_stubs.brief(status="live")
+        data_api_client.get_brief.return_value = api_stubs.brief(status='live')
 
         res = self.client.post('/suppliers/opportunities/1/ask-a-question', data={
             'clarification-question': "a" * 5100,
@@ -186,7 +206,7 @@ class TestRespondToBrief(BaseApplicationTest):
         with self.app.test_client():
             self.login()
 
-    def test_get_submit_brief_response_page(self, data_api_client):
+    def test_get_brief_response_page(self, data_api_client):
         data_api_client.get_brief.return_value = self.brief
         data_api_client.get_framework.return_value = self.framework
         res = self.client.get('/suppliers/opportunities/1234/responses/create')
@@ -198,7 +218,7 @@ class TestRespondToBrief(BaseApplicationTest):
         assert len(doc.xpath('//h2[contains(text(), "Do you fulfill the following essential requirements")]')) == 1
         assert len(doc.xpath('//h2[contains(text(), "Do you fulfill the following nice-to-have requirements?")]')) == 1
 
-    def test_get_submit_brief_response_page_404_for_not_live_brief(self, data_api_client):
+    def test_get_brief_response_returns_404_for_not_live_brief(self, data_api_client):
         brief = self.brief.copy()
         brief['briefs']['status'] = 'draft'
         data_api_client.get_brief.return_value = brief
@@ -207,7 +227,7 @@ class TestRespondToBrief(BaseApplicationTest):
 
         assert res.status_code == 404
 
-    def test_get_submit_brief_response_page_404_for_not_live_framework(self, data_api_client):
+    def test_get_brief_response_returns_404_for_not_live_framework(self, data_api_client):
         framework = self.framework.copy()
         framework['frameworks']['status'] = 'standstill'
         data_api_client.get_brief.return_value = self.brief
@@ -216,7 +236,15 @@ class TestRespondToBrief(BaseApplicationTest):
 
         assert res.status_code == 404
 
-    def test_get_submit_brief_response_page_404_if_response_already_exists(self, data_api_client):
+    def test_get_brief_response_returns_404_if_supplier_is_not_eligible(self, data_api_client):
+        data_api_client.get_brief.return_value = self.brief
+        data_api_client.get_framework.return_value = self.framework
+        data_api_client.is_supplier_eligible_for_brief.return_value = False
+
+        res = self.client.get('/suppliers/opportunities/1234/responses/create')
+        assert res.status_code == 400
+
+    def test_get_brief_response_returns_404_if_response_already_exists(self, data_api_client):
         data_api_client.get_brief.return_value = self.brief
         data_api_client.get_framework.return_value = self.framework
         data_api_client.find_brief_responses.return_value = {
@@ -229,7 +257,7 @@ class TestRespondToBrief(BaseApplicationTest):
         res = self.client.get('/suppliers/opportunities/1234/responses/create')
         assert res.status_code == 404
 
-    def test_get_submit_brief_response_page_includes_essential_requirements(self, data_api_client):
+    def test_get_brief_response_page_includes_essential_requirements(self, data_api_client):
         data_api_client.get_brief.return_value = self.brief
         data_api_client.get_framework.return_value = self.framework
         res = self.client.get('/suppliers/opportunities/1234/responses/create')
@@ -239,7 +267,7 @@ class TestRespondToBrief(BaseApplicationTest):
         assert len(doc.xpath('//p[contains(text(), "Essential two")]')) == 1
         assert len(doc.xpath('//p[contains(text(), "Essential three")]')) == 1
 
-    def test_get_submit_brief_response_page_includes_nice_to_have_requirements(self, data_api_client):
+    def test_get_brief_response_page_includes_nice_to_have_requirements(self, data_api_client):
         data_api_client.get_brief.return_value = self.brief
         data_api_client.get_framework.return_value = self.framework
         res = self.client.get('/suppliers/opportunities/1234/responses/create')
@@ -249,7 +277,7 @@ class TestRespondToBrief(BaseApplicationTest):
         assert len(doc.xpath('//p[contains(text(), "Nice one")]')) == 1
         assert len(doc.xpath('//p[contains(text(), "Get sorted")]')) == 1
 
-    def test_get_submit_brief_response_page_redirects_to_login_for_buyer(self, data_api_client):
+    def test_get_brief_response_page_redirects_to_login_for_buyer(self, data_api_client):
         data_api_client.get_brief.return_value = self.brief
         data_api_client.get_framework.return_value = self.framework
         self.login_as_buyer()
@@ -259,7 +287,7 @@ class TestRespondToBrief(BaseApplicationTest):
         assert res.location == "http://localhost/login?next=%2Fsuppliers%2Fopportunities%2F1234%2Fresponses%2Fcreate"
         self.assert_flashes("supplier-role-required", "error")
 
-    def test_post_create_new_brief_response(self, data_api_client):
+    def test_create_new_brief_response(self, data_api_client):
         data_api_client.get_brief.return_value = self.brief
         data_api_client.get_framework.return_value = self.framework
 
@@ -273,7 +301,7 @@ class TestRespondToBrief(BaseApplicationTest):
         data_api_client.create_brief_response.assert_called_once_with(
             1234, 1234, processed_brief_submission, 'email@email.com')
 
-    def test_post_create_new_brief_response_error_message_for_boolean_list_question_empty(self, data_api_client):
+    def test_create_new_brief_response_error_message_for_boolean_list_question_empty(self, data_api_client):
         data_api_client.get_brief.return_value = self.brief
         data_api_client.get_framework.return_value = self.framework
         data_api_client.create_brief_response.side_effect = HTTPError(
@@ -294,7 +322,7 @@ class TestRespondToBrief(BaseApplicationTest):
         assert '<a href="#essentialRequirements-2" class="validation-masthead-link">Essential three</a>' \
                in response_text
 
-    def test_post_create_new_brief_response_error_message_for_normal_question_empty(self, data_api_client):
+    def test_create_new_brief_response_error_message_for_normal_question_empty(self, data_api_client):
         data_api_client.get_brief.return_value = self.brief
         data_api_client.get_framework.return_value = self.framework
         data_api_client.create_brief_response.side_effect = HTTPError(
@@ -314,7 +342,7 @@ class TestRespondToBrief(BaseApplicationTest):
         assert 'There was a problem with your answer to the following questions' in response_text
         assert '<a href="#availability" class="validation-masthead-link">Availability</a>' in response_text
 
-    def test_post_create_new_brief_response_404_if_not_live_brief(self, data_api_client):
+    def test_create_new_brief_response_404_if_not_live_brief(self, data_api_client):
         brief = self.brief.copy()
         brief['briefs']['status'] = 'draft'
         data_api_client.get_brief.return_value = brief
@@ -327,7 +355,7 @@ class TestRespondToBrief(BaseApplicationTest):
         assert res.status_code == 404
         assert not data_api_client.create_brief_response.called
 
-    def test_post_create_new_brief_response_404_if_not_live_framework(self, data_api_client):
+    def test_create_new_brief_response_404_if_not_live_framework(self, data_api_client):
         framework = self.framework.copy()
         framework['frameworks']['status'] = 'standstill'
         data_api_client.get_brief.return_value = self.brief
@@ -340,7 +368,7 @@ class TestRespondToBrief(BaseApplicationTest):
         assert res.status_code == 404
         assert not data_api_client.create_brief_response.called
 
-    def test_post_create_new_brief_response_404_if_response_already_exists(self, data_api_client):
+    def test_create_new_brief_response_404_if_response_already_exists(self, data_api_client):
         data_api_client.get_brief.return_value = self.brief
         data_api_client.get_framework.return_value = self.framework
         data_api_client.find_brief_responses.return_value = {
@@ -357,7 +385,19 @@ class TestRespondToBrief(BaseApplicationTest):
         assert res.status_code == 404
         assert not data_api_client.create_brief_response.called
 
-    def test_post_create_new_brief_response_with_api_error_fails(self, data_api_client):
+    def test_create_new_brief_response_404_if_supplier_is_not_eligible(self, data_api_client):
+        data_api_client.get_brief.return_value = self.brief
+        data_api_client.get_framework.return_value = self.framework
+        data_api_client.is_supplier_eligible_for_brief.return_value = False
+
+        res = self.client.post(
+            '/suppliers/opportunities/1234/responses/create',
+            data=brief_form_submission
+        )
+        assert res.status_code == 400
+        assert not data_api_client.create_brief_response.called
+
+    def test_create_new_brief_response_with_api_error_fails(self, data_api_client):
         data_api_client.get_brief.return_value = self.brief
         data_api_client.get_framework.return_value = self.framework
         data_api_client.create_brief_response.side_effect = HTTPError(
@@ -375,7 +415,7 @@ class TestRespondToBrief(BaseApplicationTest):
         data_api_client.create_brief_response.assert_called_once_with(
             1234, 1234, processed_brief_submission, 'email@email.com')
 
-    def test_post_create_new_brief_response_redirects_to_login_for_buyer(self, data_api_client):
+    def test_create_new_brief_response_redirects_to_login_for_buyer(self, data_api_client):
         data_api_client.get_brief.return_value = self.brief
         data_api_client.get_framework.return_value = self.framework
         self.login_as_buyer()

--- a/tests/app/main/test_briefs.py
+++ b/tests/app/main/test_briefs.py
@@ -37,10 +37,16 @@ processed_brief_submission = {
     "specialistName": "Dave",
 }
 
-ERROR_MESSAGE_PAGE_HEADING = 'You can’t apply for this opportunity'
-ERROR_MESSAGE_NOT_ON_FRAMEWORK = 'You aren’t a Digital Outcomes and Specialists supplier.'
-ERROR_MESSAGE_DONT_PROVIDE_THIS_SERVICE = \
+ERROR_MESSAGE_PAGE_HEADING_APPLICATION = 'You can’t apply for this opportunity'
+ERROR_MESSAGE_NOT_ON_FRAMEWORK_APPLICATION = 'You aren’t a Digital Outcomes and Specialists supplier.'
+ERROR_MESSAGE_DONT_PROVIDE_THIS_SERVICE_APPLICATION = \
     'You don’t provide this type of service on the Digital Outcomes and Specialists framework.'
+
+ERROR_MESSAGE_PAGE_HEADING_CLARIFICATION = 'You can’t submit a question for this opportunity'
+ERROR_MESSAGE_NOT_ON_FRAMEWORK_CLARIFICATION = 'You aren’t a Digital Outcomes and Specialists supplier ' \
+    'so you’re not eligible to ask a question about this opportunity.'
+ERROR_MESSAGE_DONT_PROVIDE_THIS_SERVICE_CLARIFICATION = 'You don’t provide this type of service ' \
+    'so you’re not eligible to ask a question about this opportunity.'
 
 
 @mock.patch('app.main.views.briefs.data_api_client', autospec=True)
@@ -176,8 +182,8 @@ class TestSubmitClarificationQuestions(BaseApplicationTest):
             'clarification-question': "important question",
         })
         assert res.status_code == 400
-        assert ERROR_MESSAGE_PAGE_HEADING in res.get_data(as_text=True)
-        assert ERROR_MESSAGE_NOT_ON_FRAMEWORK in res.get_data(as_text=True)
+        assert ERROR_MESSAGE_PAGE_HEADING_CLARIFICATION in res.get_data(as_text=True)
+        assert ERROR_MESSAGE_NOT_ON_FRAMEWORK_CLARIFICATION in res.get_data(as_text=True)
         assert not data_api_client.create_audit_event.called
 
     @mock.patch('app.main.helpers.briefs.send_email')
@@ -194,8 +200,8 @@ class TestSubmitClarificationQuestions(BaseApplicationTest):
             'clarification-question': "important question",
         })
         assert res.status_code == 400
-        assert ERROR_MESSAGE_PAGE_HEADING in res.get_data(as_text=True)
-        assert ERROR_MESSAGE_DONT_PROVIDE_THIS_SERVICE in res.get_data(as_text=True)
+        assert ERROR_MESSAGE_PAGE_HEADING_CLARIFICATION in res.get_data(as_text=True)
+        assert ERROR_MESSAGE_DONT_PROVIDE_THIS_SERVICE_CLARIFICATION in res.get_data(as_text=True)
         assert not data_api_client.create_audit_event.called
 
     def test_submit_empty_clarification_question_returns_validation_error(self, data_api_client):
@@ -276,8 +282,8 @@ class TestRespondToBrief(BaseApplicationTest):
         }
 
         res = self.client.get('/suppliers/opportunities/1234/responses/create')
-        assert ERROR_MESSAGE_PAGE_HEADING in res.get_data(as_text=True)
-        assert ERROR_MESSAGE_NOT_ON_FRAMEWORK in res.get_data(as_text=True)
+        assert ERROR_MESSAGE_PAGE_HEADING_APPLICATION in res.get_data(as_text=True)
+        assert ERROR_MESSAGE_NOT_ON_FRAMEWORK_APPLICATION in res.get_data(as_text=True)
 
     def test_get_brief_response_returns_error_page_if_ineligible_supplier_is_on_framework(self, data_api_client):
         data_api_client.get_brief.return_value = self.brief
@@ -289,8 +295,8 @@ class TestRespondToBrief(BaseApplicationTest):
         }
 
         res = self.client.get('/suppliers/opportunities/1234/responses/create')
-        assert ERROR_MESSAGE_PAGE_HEADING in res.get_data(as_text=True)
-        assert ERROR_MESSAGE_DONT_PROVIDE_THIS_SERVICE in res.get_data(as_text=True)
+        assert ERROR_MESSAGE_PAGE_HEADING_APPLICATION in res.get_data(as_text=True)
+        assert ERROR_MESSAGE_DONT_PROVIDE_THIS_SERVICE_APPLICATION in res.get_data(as_text=True)
 
     def test_get_brief_response_returns_404_if_response_already_exists(self, data_api_client):
         data_api_client.get_brief.return_value = self.brief
@@ -447,8 +453,8 @@ class TestRespondToBrief(BaseApplicationTest):
             data=brief_form_submission
         )
         assert res.status_code == 400
-        assert ERROR_MESSAGE_PAGE_HEADING in res.get_data(as_text=True)
-        assert ERROR_MESSAGE_NOT_ON_FRAMEWORK in res.get_data(as_text=True)
+        assert ERROR_MESSAGE_PAGE_HEADING_APPLICATION in res.get_data(as_text=True)
+        assert ERROR_MESSAGE_NOT_ON_FRAMEWORK_APPLICATION in res.get_data(as_text=True)
         assert not data_api_client.create_brief_response.called
 
     def test_create_new_brief_returns_error_page_if_ineligible_supplier_is_on_framework(self, data_api_client):
@@ -465,8 +471,8 @@ class TestRespondToBrief(BaseApplicationTest):
             data=brief_form_submission
         )
         assert res.status_code == 400
-        assert ERROR_MESSAGE_PAGE_HEADING in res.get_data(as_text=True)
-        assert ERROR_MESSAGE_DONT_PROVIDE_THIS_SERVICE in res.get_data(as_text=True)
+        assert ERROR_MESSAGE_PAGE_HEADING_APPLICATION in res.get_data(as_text=True)
+        assert ERROR_MESSAGE_DONT_PROVIDE_THIS_SERVICE_APPLICATION in res.get_data(as_text=True)
         assert not data_api_client.create_brief_response.called
 
     def test_create_new_brief_response_with_api_error_fails(self, data_api_client):


### PR DESCRIPTION
This pull request throws up an error page if you try to apply for or submit a clarification question for an opportunity that you're not eligible for.  Error pages will tell you what you can't do and if (a) you're not on the framework, or (b) you don't provide the right service.  Hard to be more helpful than that without getting into DOS-specific messaging, which we don't want to do.

@superroz, @ralph-hawkins, and, most recently, @suedavis have all looked at it.


*** 
### Trying to apply, not on the framework
![screen shot 2016-03-30 at 11 29 16](https://cloud.githubusercontent.com/assets/2454380/14139652/3cf7e672-f66c-11e5-9b99-b5b9a92f1433.png)

### Trying to apply, don't provide the right services
![screen shot 2016-03-30 at 11 32 26](https://cloud.githubusercontent.com/assets/2454380/14139641/3358e58a-f66c-11e5-9685-9b4d536327ba.png)

### Trying to submit a clarification question, not on the framework
![screen shot 2016-03-30 at 11 31 46](https://cloud.githubusercontent.com/assets/2454380/14139645/396b593a-f66c-11e5-8be6-bb5209b7a6db.png)

### Trying to submit a clarification question, don't provide the right services
![screen shot 2016-03-30 at 11 32 45](https://cloud.githubusercontent.com/assets/2454380/14139616/0ca8bf1e-f66c-11e5-856f-153e90f9b3c3.png)