### PR TITLE
Fix return-to-brief link on clarification page

### DIFF
--- a/app/templates/briefs/clarification_question.html
+++ b/app/templates/briefs/clarification_question.html
@@ -91,7 +91,7 @@
           {% include "toolkit/button.html" %}
         {% endwith %}
 
-        <a href="/opportunities/{{ brief.id }}">Return to {{ brief.title}}</a>
+        <a href="/{{ brief.frameworkSlug }}/opportunities/{{ brief.id }}">Return to {{ brief.title }}</a>
 
       </div>
     </div>


### PR DESCRIPTION
Sarah found a bug trying to return to a brief after asking a clarification question.   Basically, the URL was pointing to the wrong place. 

Easy fix.  Didn't write any tests or anything because the page it links to is in another app.  But I've manually tested it works. 

[>> Bug on Pivotal](https://www.pivotaltracker.com/story/show/116545029)