### PR TITLE
Do not send email from unverified domains

### DIFF
--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -406,9 +406,10 @@ def framework_updates_email_clarification_question(framework_slug):
             email_body,
             current_app.config['DM_MANDRILL_API_KEY'],
             subject,
-            from_address,
+            current_app.config["DM_GENERIC_NOREPLY_EMAIL"],
             "{} Supplier".format(framework['name']),
-            tags
+            tags,
+            reply_to=from_address,
         )
     except MandrillException as e:
         current_app.logger.error(
@@ -552,9 +553,10 @@ def upload_framework_agreement(framework_slug):
             email_body,
             current_app.config['DM_MANDRILL_API_KEY'],
             '{} framework agreement'.format(framework['name']),
-            current_user.email_address,
+            current_app.config["DM_GENERIC_NOREPLY_EMAIL"],
             '{} Supplier'.format(framework['name']),
-            ['{}-framework-agreement'.format(framework_slug)]
+            ['{}-framework-agreement'.format(framework_slug)],
+            reply_to=current_user.email_address,
         )
     except MandrillException as e:
         current_app.logger.error(

--- a/config.py
+++ b/config.py
@@ -48,6 +48,8 @@ class Config(object):
     CLARIFICATION_EMAIL_SUBJECT = 'Thanks for your clarification question'
     DM_FOLLOW_UP_EMAIL_TO = 'digitalmarketplace@mailinator.com'
 
+    DM_GENERIC_NOREPLY_EMAIL = 'do-not-reply@digitalmarketplace.service.gov.uk'
+
     CREATE_USER_SUBJECT = 'Create your Digital Marketplace account'
     SECRET_KEY = None
     SHARED_EMAIL_KEY = None

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ Flask-WTF==0.12
 werkzeug==0.10.4
 python-dateutil==2.4.2
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@19.0.1#egg=digitalmarketplace-utils==19.0.1
+git+https://github.com/alphagov/digitalmarketplace-utils.git@19.3.0#egg=digitalmarketplace-utils==19.3.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@3.6.0#egg=digitalmarketplace-apiclient==3.6.0
 
 markdown==2.6.2

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -1275,9 +1275,10 @@ class TestSendClarificationQuestionEmail(BaseApplicationTest):
                 FakeMail('Supplier name:', 'User name:'),
                 "MANDRILL",
                 "Test Framework clarification question",
-                "suppliers+g-cloud-7@digitalmarketplace.service.gov.uk",
+                "do-not-reply@digitalmarketplace.service.gov.uk",
                 "Test Framework Supplier",
-                ["clarification-question"]
+                ["clarification-question"],
+                reply_to="suppliers+g-cloud-7@digitalmarketplace.service.gov.uk",
             )
         if succeeds:
             send_email.assert_any_call(
@@ -1303,9 +1304,10 @@ class TestSendClarificationQuestionEmail(BaseApplicationTest):
                 FakeMail('Test Framework question asked'),
                 "MANDRILL",
                 "Test Framework application question",
-                "email@email.com",
+                "do-not-reply@digitalmarketplace.service.gov.uk",
                 "Test Framework Supplier",
-                ["application-question"]
+                ["application-question"],
+                reply_to="email@email.com",
             )
 
     @mock.patch('app.main.views.frameworks.data_api_client')


### PR DESCRIPTION
Mandrill is going to start preventing emails from unverified domains.
This means that we will no longer be able to send emails with the From
field set to supplier email addresses. This change sets the From field
to a no-reply address on our domain and uses the Reply-To field for the
supplier email address.