### PR TITLE
Show DOS service lot instead of name for one-lot services

### DIFF
--- a/app/templates/services/list_services.html
+++ b/app/templates/services/list_services.html
@@ -59,7 +59,7 @@
     {% call summary.row() %}
 
       {{ summary.service_link(
-          item.serviceName,
+          item.serviceName or item.lotName,
           url_for('.edit_service', service_id=item.id) if 'EDIT_SERVICE_PAGE' is active_feature
           else '/g-cloud/services/{}'.format(item.id)
       ) }}


### PR DESCRIPTION
Since digital-outcomes and other one-service lot servicesdon't have
a serviceName field we need to show the lot name instead, similar
to what we did in the service submission page title.