### PR TITLE
Don't show link for DOS services on the supplier dashboard

### DIFF
--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -31,7 +31,6 @@ def list_services():
 
 @main.route('/services/<string:service_id>', methods=['GET'])
 @login_required
-@flask_featureflags.is_active_feature('EDIT_SERVICE_PAGE')
 def edit_service(service_id):
     service = data_api_client.get_service(service_id)
     service_unavailability_information = service.get('serviceMadeUnavailableAuditEvent')
@@ -58,7 +57,6 @@ def edit_service(service_id):
 
 @main.route('/services/<string:service_id>/remove', methods=['POST'])
 @login_required
-@flask_featureflags.is_active_feature('EDIT_SERVICE_PAGE')
 def remove_service(service_id):
     service = data_api_client.get_service(service_id).get('services')
 

--- a/app/templates/services/list_services.html
+++ b/app/templates/services/list_services.html
@@ -58,10 +58,19 @@
   ) %}
     {% call summary.row() %}
 
-      {{ summary.service_link(
-          item.serviceName or item.lotName,
-          url_for('.edit_service', service_id=item.id)
-      ) }}
+     {# TODO this should be removed once we have a manifests for DOS services
+        and a public DOS service page on the buyer frontend (or a way to hide
+        the "View service" link from the supplier service page) #}
+      {% if item.frameworkSlug == 'digital-outcomes-and-specialists' %}
+        {% call summary.field(first=True, wide=wide) -%}
+          {{ item.serviceName or item.lotName }}
+        {%- endcall %}
+      {% else %}
+        {{ summary.service_link(
+            item.serviceName or item.lotName,
+            url_for('.edit_service', service_id=item.id)
+        ) }}
+      {% endif %}
 
       {{ summary.text(item.frameworkName) }}
 

--- a/app/templates/services/list_services.html
+++ b/app/templates/services/list_services.html
@@ -60,8 +60,7 @@
 
       {{ summary.service_link(
           item.serviceName or item.lotName,
-          url_for('.edit_service', service_id=item.id) if 'EDIT_SERVICE_PAGE' is active_feature
-          else '/g-cloud/services/{}'.format(item.id)
+          url_for('.edit_service', service_id=item.id)
       ) }}
 
       {{ summary.text(item.frameworkName) }}

--- a/config.py
+++ b/config.py
@@ -67,7 +67,6 @@ class Config(object):
     # Feature Flags
     RAISE_ERROR_ON_MISSING_FEATURES = True
 
-    FEATURE_FLAGS_EDIT_SERVICE_PAGE = enabled_since('2016-02-02')
     FEATURE_FLAGS_EDIT_SECTIONS = False
 
     # Logging

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -88,7 +88,7 @@ class TestListServices(BaseApplicationTest):
             assert_equal(res.location, 'http://localhost/login?next=%2Fsuppliers%2Fservices')
 
     @mock.patch('app.main.views.services.data_api_client')
-    def test_shows_services_edit_button_with_id(self, data_api_client):
+    def test_shows_service_edit_link_with_id(self, data_api_client):
         with self.app.test_client():
             self.login()
 
@@ -107,6 +107,48 @@ class TestListServices(BaseApplicationTest):
                 supplier_id=1234)
             assert_true(
                 "/suppliers/services/123" in res.get_data(as_text=True))
+
+    @mock.patch('app.main.views.services.data_api_client')
+    def test_services_without_service_name_show_lot_instead(self, data_api_client):
+        with self.app.test_client():
+            self.login()
+
+            data_api_client.find_services.return_value = {
+                'services': [{
+                    'status': 'published',
+                    'id': '123',
+                    'lotName': 'Special Lot Name',
+                    'frameworkSlug': 'digital-outcomes-and-specialists'
+                }]
+            }
+
+            res = self.client.get('/suppliers/services')
+            assert_equal(res.status_code, 200)
+            data_api_client.find_services.assert_called_once_with(supplier_id=1234)
+
+            assert "Special Lot Name" in res.get_data(as_text=True)
+
+    @mock.patch('app.main.views.services.data_api_client')
+    def test_shows_dos_service_name_without_edit_link(self, data_api_client):
+        with self.app.test_client():
+            self.login()
+
+            data_api_client.find_services.return_value = {
+                'services': [{
+                    'serviceName': 'Service name 123',
+                    'lotName': 'Special Lot Name',
+                    'status': 'published',
+                    'id': '123',
+                    'frameworkSlug': 'digital-outcomes-and-specialists'
+                }]
+            }
+
+            res = self.client.get('/suppliers/services')
+            assert_equal(res.status_code, 200)
+            data_api_client.find_services.assert_called_once_with(supplier_id=1234)
+
+            assert "Service name 123" in res.get_data(as_text=True)
+            assert "/suppliers/services/123" not in res.get_data(as_text=True)
 
 
 class TestListServicesLogin(BaseApplicationTest):


### PR DESCRIPTION
### Drop EDIT_SERVICE_PAGE feature flag
Enabled for 2 months on all environments, should be safe to remove.
The fallback link for service page also assumed a g-cloud service.

### Don't show link for DOS services on the supplier dashboard
Since DOS services don't have an edit service manifest or a public service page on the buyer frontend to link to we don't make the service name a link for now.

There's no check in the view, so the page would 500 if visited, but at the same time there's no obvious way to find the DOS service ID required to manually construct a link.