### PR TITLE
Validate brief clarification question word limit

### DIFF
--- a/app/main/views/briefs.py
+++ b/app/main/views/briefs.py
@@ -1,6 +1,8 @@
 # coding: utf-8
 from __future__ import unicode_literals
 
+import re
+
 from flask import render_template, redirect, url_for, request, flash, abort
 from flask_login import current_user
 
@@ -39,6 +41,9 @@ def ask_brief_clarification_question(brief_id):
         elif len(clarification_question) > 5000:
             clarification_question_value = clarification_question
             error_message = "Question cannot be longer than 5000 characters"
+        elif not re.match("^$|(^(?:\\S+\\s+){0,99}\\S+$)", clarification_question):
+            clarification_question_value = clarification_question
+            error_message = "Question must be no more than 100 words"
         else:
             send_brief_clarification_question(data_api_client, brief, clarification_question)
             flash('message_sent', 'success')

--- a/tests/app/main/test_briefs.py
+++ b/tests/app/main/test_briefs.py
@@ -224,6 +224,17 @@ class TestSubmitClarificationQuestions(BaseApplicationTest):
         assert res.status_code == 400
         assert "cannot be longer than" in res.get_data(as_text=True)
 
+    @mock.patch('app.main.helpers.briefs.send_email')
+    def test_clarification_question_has_max_word_limit(self, send_email, data_api_client):
+        self.login()
+        data_api_client.get_brief.return_value = api_stubs.brief(status='live')
+
+        res = self.client.post('/suppliers/opportunities/1/ask-a-question', data={
+            'clarification-question': "a " * 101,
+        })
+        assert res.status_code == 400
+        assert "must be no more than 100 words" in res.get_data(as_text=True)
+
 
 @mock.patch("app.main.views.briefs.data_api_client")
 class TestRespondToBrief(BaseApplicationTest):


### PR DESCRIPTION
Adds word length validation to clarification questions in addition to the character length check. Word length check is using the same expression we use in JSON schemas.