### PR TITLE
Question and answer session details

### DIFF
--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -85,3 +85,7 @@ $path: "/suppliers/static/images/";
   @include core-19;
   margin: (1.5 * $gutter) 0 (2 * $gutter);
 }
+
+.padding-bottom-small {
+  padding-bottom: 10px;
+}

--- a/app/main/views/briefs.py
+++ b/app/main/views/briefs.py
@@ -20,6 +20,23 @@ from ...main import main, content_loader
 from ... import data_api_client
 
 
+@main.route('/opportunities/<int:brief_id>/question-and-answer-session', methods=['GET'])
+@login_required
+def question_and_answer_session(brief_id):
+    brief = get_brief(data_api_client, brief_id, allowed_statuses=['live'])
+
+    if brief['clarificationQuestionsAreClosed']:
+        abort(404)
+
+    if not is_supplier_eligible_for_brief(data_api_client, current_user.supplier_id, brief):
+        return _render_not_eligible_for_brief_error_page(brief, clarification_question=True)
+
+    return render_template(
+        "briefs/question_and_answer_session.html",
+        brief=brief,
+    ), 200
+
+
 @main.route('/opportunities/<int:brief_id>/ask-a-question', methods=['GET', 'POST'])
 @login_required
 def ask_brief_clarification_question(brief_id):

--- a/app/templates/briefs/clarification_question.html
+++ b/app/templates/briefs/clarification_question.html
@@ -26,7 +26,7 @@
   {% with messages = get_flashed_messages(with_categories=true) %}
     {% for category, message in messages %}
       {% if message == 'message_sent' %}
-        {% set message = "Your question has been sent. It will be posted with the buyer’s response on the ‘{}’ page.".format(brief.title) %}
+        {% set message = "Your question has been sent. The buyer will post your question and their answer on the ‘{}’ page.".format(brief.title) %}
       {% endif %}
       {%
         with

--- a/app/templates/briefs/clarification_question.html
+++ b/app/templates/briefs/clarification_question.html
@@ -53,15 +53,16 @@
     {% endwith %}
   {% endif %}
 
-  {% with
-    heading = "Ask a question about ‘{}’".format(brief.title),
-    smaller = true
-  %}
-    {% include 'toolkit/page-heading.html' %}
-  {% endwith %}
-
   <div class="grid-row">
     <div class="column-two-thirds">
+
+      {% with
+        heading = "Ask a question about ‘{}’".format(brief.title),
+        smaller = true
+      %}
+        {% include 'toolkit/page-heading.html' %}
+      {% endwith %}
+
 
       <div class="hint">
         <p>Your question will be published with the buyers’ response by {{ brief.clarificationQuestionsClosedAt | dateformat }}.</p>
@@ -90,11 +91,11 @@
         %}
           {% include "toolkit/button.html" %}
         {% endwith %}
+      </form>
 
-        <a href="/{{ brief.frameworkSlug }}/opportunities/{{ brief.id }}">Return to {{ brief.title }}</a>
+      <a href="/{{ brief.frameworkSlug }}/opportunities/{{ brief.id }}">Return to {{ brief.title }}</a>
 
-      </div>
     </div>
-  </form>
+  </div>
 </div>
 {% endblock %}

--- a/app/templates/briefs/question_and_answer_session.html
+++ b/app/templates/briefs/question_and_answer_session.html
@@ -1,0 +1,44 @@
+{% extends "_base_page.html" %}
+{% import "toolkit/summary-table.html" as summary %}
+
+{% block page_title %}{{ brief.title }} question and answer session details – Digital Marketplace{% endblock %}
+
+{% block breadcrumb %}
+  {%
+    with items = [
+      {
+        "link": "/",
+        "label": "Digital Marketplace",
+      },
+      {
+        "link": url_for(".dashboard"),
+        "label": "Your account",
+      },
+    ]
+  %}
+    {% include "toolkit/breadcrumb.html" %}
+  {% endwith %}
+{% endblock %}
+
+{% block main_content %}
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+    {% with
+      heading = "‘{}’ question and answer session details".format(brief.title),
+      smaller = true
+    %}
+      {% include 'toolkit/page-heading.html' %}
+    {% endwith %}
+
+    <div class="padding-bottom-small">
+      <p>
+        {{ brief.questionAndAnswerSessionDetails }}
+      </p>
+    </div>
+
+
+    <a href="/{{ brief.frameworkSlug }}/opportunities/{{ brief.id }}">Return to {{ brief.title }}</a>
+  </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
### Add question and answer session details page
Adds a page with brief "webinar" details only visible to eligible suppliers. The page displays Q and A session details from the brief.

If the details weren't set the link from the brief page should be hidden, and this view URL will show an empty page with a "Return to brief" link.

### Add CSS rule for .padding-bottom-small
Class is already used by frameworks/agreement.html template and the same class is defined and used in the buyer frontend.

### Fix ask brief clarification question header width
Moves header inside the 2/3 div and fixes the order of closing tags.

#### [#117296475] Update brief clarification question sent confirmation banner