### PR TITLE
Fix framework dashboard bug

### DIFF
--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -88,7 +88,7 @@ def framework_dashboard(framework_slug):
 
     return render_template(
         "frameworks/dashboard.html",
-        application_made=(len(complete_drafts) > 0 and declaration_status == 'complete'),
+        application_made=supplier_is_on_framework or (len(complete_drafts) > 0 and declaration_status == 'complete'),
         completed_lots=[{
             'name': lot['name'],
             'complete_count': count_drafts_by_lot(complete_drafts, lot['slug']),


### PR DESCRIPTION
The decision for whether an application has been made to a framework currently checks whether there are complete drafts and a complete declaration.  This is fine for frameworks that are not yet live.

However, once a framework is made live we may at some point delete the old draft, at which point the page would show "You did not make an application" even though the supplier is on the framework.

This adds the logic that if the supplier is currently on the framework then they must have made an application to it.