### PR TITLE
[#117922093] Hide boolean list question section if there are no questions

### DIFF
--- a/app/templates/macros/toolkit_forms.html
+++ b/app/templates/macros/toolkit_forms.html
@@ -152,7 +152,7 @@
 {%- endmacro %}
 
 {% macro boolean_list(question_content, service_data, errors, question_number=None, get_question=None) -%}
-
+  {% if question_content.boolean_list_questions %}
     <fieldset class="question question-boolean-list" id="{{ question_content.id }}">
         <span class="question-heading">
           <h2>{{ question_content.question }}</h2>
@@ -182,4 +182,5 @@
         {% endwith %}
       {% endfor %}
     </fieldset>
+  {% endif %}
 {%- endmacro %}


### PR DESCRIPTION
Hides the 'nice to have requirements' question header if there are not questions defined in the brief.