### PR TITLE
Updated footer links for DOS launch

### DIFF
--- a/app/templates/_footer_categories.html
+++ b/app/templates/_footer_categories.html
@@ -15,16 +15,16 @@
     </h2>
     <ul>
       <li>
+        <a href="https://www.gov.uk/government/collections/digital-marketplace-buyers-and-suppliers-information">Digital Marketplace information</a>
+      </li>
+      <li>
         <a href="https://digitalmarketplace.blog.gov.uk">Digital Marketplace blog</a>
       </li>
       <li>
-        <a href="/g-cloud/framework">G-Cloud framework</a>
+        <a href="https://www.gov.uk/guidance/the-g-cloud-framework-on-the-digital-marketplace">G-Cloud framework</a>
       </li>
       <li>
-        <a href="/crown-hosting/framework">Crown Hosting framework</a>
-      </li>
-      <li>
-        <a href="/digital-services/framework">Digital Services framework</a>
+        <a href="https://www.gov.uk/guidance/the-crown-hosting-data-centres-framework-on-the-digital-marketplace">Crown Hosting framework</a>
       </li>
       <li>
         <a href="https://www.gov.uk/government/organisations/crown-commercial-service">Crown Commercial Service</a>
@@ -33,34 +33,34 @@
           <a class="home" href="/g-cloud/suppliers">G-Cloud supplier A–Z</a>
       </li>
     </ul>
-    </div>
-    <div class="footer-suppliers">
-        <h2>
-            Guidance
-        </h2>
-        <ul>
-            <li>
-                <a href="/buyers-guide">Digital Marketplace buyers’ guide</a>
-            </li>
-            <li>
-                <a href="https://www.gov.uk/guidance/digital-marketplace-suppliers-guide">Digital Marketplace suppliers’ guide</a>
-            </li>
-            <li>
-                <a href="/g-cloud/buyers-guide">G-Cloud buyers’ guide</a>
-            </li>
-            <li>
-                <a href="/g-cloud/suppliers-guide">G-Cloud suppliers’ guide</a>
-            </li>
-            <li>
-                <a href="https://www.gov.uk/guidance/digital-outcomes-and-specialists-suppliers-guide">Digital Outcomes and Specialists suppliers’ guide</a>
-            </li>
-            <li>
-                <a href="https://www.gov.uk/government/publications/digital-services-store-buyers-guide/digital-services-buyers-guide">Digital Services buyers’ guide</a>
-            </li>
-            <li>
-                <a href="https://www.gov.uk/how-to-use-the-digital-services-store">Digital Services detailed guide</a>
-            </li>
-        </ul>
-    </div>
-    <hr/>
+  </div>
+  <div class="footer-suppliers">
+      <h2>
+          Guidance
+      </h2>
+      <ul>
+          <li>
+              <a href="https://www.gov.uk/guidance/digital-outcomes-and-specialists-buyers-guide">Digital Marketplace buyers’ guide</a>
+          </li>
+          <li>
+              <a href="https://www.gov.uk/guidance/digital-marketplace-suppliers-guide">Digital Marketplace suppliers’ guide</a>
+          </li>
+          <li>
+              <a href="https://www.gov.uk/guidance/g-cloud-buyers-guide">G-Cloud buyers’ guide</a>
+          </li>
+          <li>
+              <a href="https://www.gov.uk/guidance/g-cloud-suppliers-guide">G-Cloud suppliers’ guide</a>
+          </li>
+          <li>
+              <a href="https://www.gov.uk/guidance/digital-outcomes-and-specialists-buyers-guide">Digital Outcomes and Specialists buyers’ guide</a>
+          </li>
+          <li>
+              <a href="https://www.gov.uk/guidance/how-to-hire-user-research-labs-on-the-digital-marketplace">User research labs buyers' guide</a>
+          </li>
+          <li>
+              <a href="https://www.gov.uk/guidance/digital-outcomes-and-specialists-suppliers-guide">Digital Outcomes and Specialists suppliers’ guide</a>
+          </li>
+      </ul>
+  </div>
+  <hr/>
 </div>

--- a/app/templates/_footer_categories.html
+++ b/app/templates/_footer_categories.html
@@ -33,6 +33,9 @@
         <a href="/digital-services/framework">Digital Services framework</a>
       </li>
       <li>
+        <a href="https://www.gov.uk/government/publications/digital-services-store-buyers-guide/digital-services-buyers-guide">Digital Services information</a>
+      </li>
+      <li>
         <a href="https://www.gov.uk/government/organisations/crown-commercial-service">Crown Commercial Service</a>
       </li>
     </ul>

--- a/app/templates/_footer_categories.html
+++ b/app/templates/_footer_categories.html
@@ -30,6 +30,9 @@
         <a href="https://www.gov.uk/government/organisations/crown-commercial-service">Crown Commercial Service</a>
       </li>
       <li>
+        <a href="/digital-services/framework">Digital Services framework</a>
+      </li>
+      <li>
           <a class="home" href="/g-cloud/suppliers">G-Cloud supplier A–Z</a>
       </li>
     </ul>

--- a/app/templates/_footer_categories.html
+++ b/app/templates/_footer_categories.html
@@ -24,16 +24,16 @@
         <a href="https://www.gov.uk/guidance/the-g-cloud-framework-on-the-digital-marketplace">G-Cloud framework</a>
       </li>
       <li>
-        <a href="https://www.gov.uk/guidance/the-crown-hosting-data-centres-framework-on-the-digital-marketplace">Crown Hosting framework</a>
+          <a class="home" href="/g-cloud/suppliers">G-Cloud supplier A–Z</a>
       </li>
       <li>
-        <a href="https://www.gov.uk/government/organisations/crown-commercial-service">Crown Commercial Service</a>
+        <a href="https://www.gov.uk/guidance/the-crown-hosting-data-centres-framework-on-the-digital-marketplace">Crown Hosting framework</a>
       </li>
       <li>
         <a href="/digital-services/framework">Digital Services framework</a>
       </li>
       <li>
-          <a class="home" href="/g-cloud/suppliers">G-Cloud supplier A–Z</a>
+        <a href="https://www.gov.uk/government/organisations/crown-commercial-service">Crown Commercial Service</a>
       </li>
     </ul>
   </div>
@@ -58,7 +58,7 @@
               <a href="https://www.gov.uk/guidance/digital-outcomes-and-specialists-buyers-guide">Digital Outcomes and Specialists buyers’ guide</a>
           </li>
           <li>
-              <a href="https://www.gov.uk/guidance/how-to-hire-user-research-labs-on-the-digital-marketplace">User research labs buyers' guide</a>
+              <a href="https://www.gov.uk/guidance/how-to-hire-user-research-labs-on-the-digital-marketplace">Digital Outcomes and Specialists user research labs buyers' guide</a>
           </li>
           <li>
               <a href="https://www.gov.uk/guidance/digital-outcomes-and-specialists-suppliers-guide">Digital Outcomes and Specialists suppliers’ guide</a>


### PR DESCRIPTION
Brings in new pages on www.gov.uk and removes links made redundant by the launch of the Digital
Outcomes and Specialists framework.

### Before

![old_footer_links](https://cloud.githubusercontent.com/assets/87140/14706958/bcf4fe2e-07b9-11e6-82bf-2abf9d4cad46.png)

### After

![new_footer_links](https://cloud.githubusercontent.com/assets/87140/14714066/78bf0818-07db-11e6-96b3-17276e0dbdbf.png)

Should be merged along with https://github.com/alphagov/digitalmarketplace-buyer-frontend/pull/276