### PR TITLE
[#118112493] Update content and frontend toolkit versions to latest

### DIFF
--- a/app/templates/frameworks/_dashboard_lede.html
+++ b/app/templates/frameworks/_dashboard_lede.html
@@ -1,6 +1,6 @@
 {% if framework.status == 'open' %}
 <aside role="complementary" class="framework-application-status" aria-label="{{ framework.name }} status">
-  Deadline: <strong>{{ dates.framework_close_date|safe }}</strong>
+  Deadline: <strong>{{ dates.framework_close_date|markdown }}</strong>
 </aside>
 
 {% elif framework.status in ['pending', 'standstill', 'live'] %}
@@ -13,7 +13,7 @@
     {% elif framework.status == 'pending' %}
       {# supplier_is_on_framework should never be true before standstill #}
       <p>You made your supplier declaration and submitted {{ counts.complete }} {{ 'service' if counts.complete == 1 else 'services' }} for consideration.</p>
-      <p>A letter informing you whether your application was successful or not will be posted on your {{ framework.name }} updates page by {{ dates.intention_to_award_date|safe }}.</p>
+      <p>A letter informing you whether your application was successful or not will be posted on your {{ framework.name }} updates page by {{ dates.intention_to_award_date|markdown }}.</p>
 
     {% elif framework.status == 'standstill' %}
       {% if supplier_is_on_framework %}

--- a/app/templates/frameworks/updates.html
+++ b/app/templates/frameworks/updates.html
@@ -113,7 +113,7 @@
           All clarification questions and answers will be published here regularly. You’ll receive an email when new answers are available.
         {% else %}
           The deadline for asking clarification questions has now passed.
-          All clarification questions and answers will be published by {{ dates.clarifications_publish_date|safe }}.
+          All clarification questions and answers will be published by {{ dates.clarifications_publish_date|markdown }}.
           You'll receive an email when new answers are posted.
         {% endif %}
       </p>
@@ -138,7 +138,7 @@
                 {% include "toolkit/forms/textbox.html" %}
               {% endwith %}
               <p>
-                The deadline for clarification questions is {{ dates.clarifications_close_date|safe }}. All responses will be published by {{ dates.clarifications_publish_date|safe }}.
+                The deadline for clarification questions is {{ dates.clarifications_close_date|markdown }}. All responses will be published by {{ dates.clarifications_publish_date|markdown }}.
               </p>
               {%
                 with

--- a/app/templates/services/service_submission.html
+++ b/app/templates/services/service_submission.html
@@ -85,7 +85,7 @@
       </p>
     {% endif %}
     {% if service_data.status == 'submitted' and declaration_status == 'complete' %}
-      <span class="service-status-published">This service is marked as complete and will be submitted at {{ dates.framework_close_date|safe }}</span>
+      <span class="service-status-published">This service is marked as complete and will be submitted at {{ dates.framework_close_date|markdown }}</span>
     {% endif %}
     {% if service_data.status == 'not-submitted' and can_mark_complete and framework.status == 'open' %}
       {% include "partials/complete_service.html" %}

--- a/app/templates/suppliers/_frameworks_open.html
+++ b/app/templates/suppliers/_frameworks_open.html
@@ -20,7 +20,7 @@
                 Apply to {{ framework.name }} 
               </h2>
               <p>
-                Deadline: {{ framework.dates.framework_close_date|safe }}
+                Deadline: {{ framework.dates.framework_close_date|markdown }}
               </p>
               {%
               with

--- a/app/templates/suppliers/_frameworks_standstill.html
+++ b/app/templates/suppliers/_frameworks_standstill.html
@@ -19,7 +19,7 @@
           </p>
           {% if framework.onFramework and framework.dates.framework_live_date %}
             <p class='second-line'>
-              Live from {{ framework.dates.framework_live_date|safe }}
+              Live from {{ framework.dates.framework_live_date|markdown }}
             </p>
           {% endif %}
         {% endcall %}

--- a/bower.json
+++ b/bower.json
@@ -5,8 +5,8 @@
     "jquery": "1.11.2",
     "hogan": "3.0.2",
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
-    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v15.5.0",
+    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v15.11.3",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.14.1/jinja_govuk_template-0.14.1.tgz",
-    "digitalmarketplace-frameworks": "git://github.com/alphagov/digitalmarketplace-frameworks#v0.26.0"
+    "digitalmarketplace-frameworks": "git://github.com/alphagov/digitalmarketplace-frameworks#v0.30.2"
   }
 }

--- a/tests/app/main/test_briefs.py
+++ b/tests/app/main/test_briefs.py
@@ -18,7 +18,6 @@ brief_form_submission = {
     "niceToHaveRequirements-0": False,
     "niceToHaveRequirements-1": True,
     "niceToHaveRequirements-2": False,
-    "specialistName": "Dave",
 }
 
 processed_brief_submission = {
@@ -34,7 +33,6 @@ processed_brief_submission = {
         True,
         False
     ],
-    "specialistName": "Dave",
 }
 
 ERROR_MESSAGE_PAGE_HEADING_APPLICATION = 'You can’t apply for this opportunity'
@@ -310,8 +308,9 @@ class TestRespondToBrief(BaseApplicationTest):
         assert res.status_code == 200
         data_api_client.get_brief.assert_called_once_with(1234)
         assert len(doc.xpath('//h1[contains(text(), "Apply to ‘I need a thing to do a thing’")]')) == 1
-        assert len(doc.xpath('//h2[contains(text(), "Do you fulfill the following essential requirements")]')) == 1
-        assert len(doc.xpath('//h2[contains(text(), "Do you fulfill the following nice-to-have requirements?")]')) == 1
+        assert len(doc.xpath('//h2[contains(text(), "Do you have the essential skills and experience?")]')) == 1
+        assert len(doc.xpath(
+            '//h2[contains(text(), "Do you have any of the nice-to-have skills and experience?")]')) == 1
 
     def test_get_brief_response_returns_404_for_not_live_brief(self, data_api_client):
         brief = self.brief.copy()

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -200,10 +200,11 @@ class TestFrameworksDashboard(BaseApplicationTest):
             assert_true(len(heading) > 0)
             assert_in(u"G-Cloud 7 is closed for applications",
                       heading[0].xpath('text()')[0])
+            lede = doc.xpath('//div[@class="summary-item-lede"]')
             assert_in(u"You made your supplier declaration and submitted 1 service for consideration.",
-                      heading[0].xpath('../p[1]/text()')[0])
-            assert_in(u"A letter informing you whether your application was successful or not will be posted on your G-Cloud 7 updates page by 9 November 2015.",  # noqa
-                      heading[0].xpath('../p[2]/text()')[0])  # noqa
+                      lede[0].xpath('./p[1]/text()')[0])
+            assert_in(u"A letter informing you whether your application was successful or not will be posted on your G-Cloud 7 updates page by",  # noqa
+                      lede[0].xpath('./p[2]/text()')[0])  # noqa
 
     def test_declaration_status_when_complete(self, data_api_client, s3):
         with self.app.test_client():
@@ -1111,9 +1112,9 @@ class TestFrameworkUpdatesPage(BaseApplicationTest):
             data = response.get_data(as_text=True)
 
             assert response.status_code == 200
-            assert "All clarification questions and answers will be published by " \
-                   "5pm <abbr title=\"British Summer Time\">BST</abbr>, 29 September 2015" in data
-            assert "The deadline for clarification questions is 5pm, 22 September 2015" not in data
+            assert 'All clarification questions and answers will be published by ' \
+                   '<p>5pm <abbr title="British Summer Time">BST</abbr>, 29 September 2015</p>.' in data
+            assert "The deadline for clarification questions is" not in data
 
     def test_dates_for_open_framework_open_for_questions(self, s3, data_api_client):
         data_api_client.get_framework.return_value = self.framework('open', clarification_questions_open=True)
@@ -1126,9 +1127,9 @@ class TestFrameworkUpdatesPage(BaseApplicationTest):
             data = response.get_data(as_text=True)
 
             assert response.status_code == 200
-            assert "All clarification questions and answers will be published by 5pm, 29 September 2015" not in data
-            assert "The deadline for clarification questions is " \
-                   "5pm <abbr title=\"British Summer Time\">BST</abbr>, 22 September 2015" in data
+            assert "All clarification questions and answers will be published by" not in data
+            assert 'The deadline for clarification questions is ' \
+                   '<p>5pm <abbr title="British Summer Time">BST</abbr>, 22 September 2015</p>.' in data
 
     def test_the_tables_should_be_displayed_correctly(self, s3, data_api_client):
         data_api_client.get_framework.return_value = self.framework('open')

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -472,7 +472,7 @@ class TestEditService(BaseApplicationTest):
         document = html.fromstring(res.get_data(as_text=True))
         assert_equal(
             "You need to answer this question.",
-            document.xpath('//span[@id="error-serviceSummary"]/text()')[0].strip())
+            document.xpath('//span[@class="validation-message"]/text()')[0].strip())
 
     def test_update_with_under_50_words_error(self, data_api_client):
         data_api_client.get_service.return_value = self.empty_service
@@ -487,7 +487,7 @@ class TestEditService(BaseApplicationTest):
         document = html.fromstring(res.get_data(as_text=True))
         assert_equal(
             "Your description must be no more than 50 words.",
-            document.xpath('//span[@id="error-serviceSummary"]/text()')[0].strip())
+            document.xpath('//span[@class="validation-message"]/text()')[0].strip())
 
     def test_update_non_existent_service_returns_404(self, data_api_client):
         data_api_client.get_service.return_value = None
@@ -960,7 +960,7 @@ class TestEditDraftService(BaseApplicationTest):
         document = html.fromstring(res.get_data(as_text=True))
         assert_equal(
             "You need to answer this question.",
-            document.xpath('//span[@id="error-serviceSummary"]/text()')[0].strip())
+            document.xpath('//span[@class="validation-message"]/text()')[0].strip())
 
     def test_update_with_under_50_words_error(self, data_api_client, s3):
         s3.return_value.bucket_short_name = 'submissions'
@@ -977,7 +977,7 @@ class TestEditDraftService(BaseApplicationTest):
         document = html.fromstring(res.get_data(as_text=True))
         assert_equal(
             "Your description must be no more than 50 words.",
-            document.xpath('//span[@id="error-serviceSummary"]/text()')[0].strip())
+            document.xpath('//span[@class="validation-message"]/text()')[0].strip())
 
     def test_update_with_pricing_errors(self, data_api_client, s3):
         s3.return_value.bucket_short_name = 'submissions'
@@ -1002,7 +1002,7 @@ class TestEditDraftService(BaseApplicationTest):
             assert_equal(res.status_code, 200)
             document = html.fromstring(res.get_data(as_text=True))
             assert_equal(
-                message, document.xpath('//span[@id="error-priceString"]/text()')[0].strip())
+                message, document.xpath('//span[@class="validation-message"]/text()')[0].strip())
 
     def test_update_non_existent_draft_service_returns_404(self, data_api_client, s3):
         data_api_client.get_draft_service.side_effect = HTTPError(mock.Mock(status_code=404))

--- a/tests/app/main/test_suppliers.py
+++ b/tests/app/main/test_suppliers.py
@@ -1278,8 +1278,8 @@ class TestCreateSupplier(BaseApplicationTest):
         res = self.client.get("/suppliers/duns-number")
         assert_equal(res.status_code, 200)
         assert_equal(
-            '<input type="text" name="duns_number" id="input-duns_number" class="text-box" value="999" />'
-            in res.get_data(as_text=True),
+            '<inputtype="text"name="duns_number"id="input-duns_number"class="text-box"value="999"/>'
+            in self.strip_all_whitespace(res.get_data(as_text=True)),
             True)
 
     def test_should_populate_companies_house_from_session(self):
@@ -1287,14 +1287,19 @@ class TestCreateSupplier(BaseApplicationTest):
             sess['companies_house_number'] = "999"
         res = self.client.get("/suppliers/companies-house-number")
         assert_equal(res.status_code, 200)
-        assert_true('<input type="text" name="companies_house_number" id="input-companies_house_number" class="text-box" value="999" />' in res.get_data(as_text=True))  # noqa
+        assert_true(
+            '<inputtype="text"name="companies_house_number"id="input-companies_house_number"class="text-box"value="999"/>'  # noqa
+            in self.strip_all_whitespace(res.get_data(as_text=True))
+        )
 
     def test_should_populate_company_name_from_session(self):
         with self.client.session_transaction() as sess:
             sess['company_name'] = "Name"
         res = self.client.get("/suppliers/company-name")
         assert_equal(res.status_code, 200)
-        assert_true('<input type="text" name="company_name" id="input-company_name" class="text-box" value="Name" />' in res.get_data(as_text=True))  # noqa
+        assert_true(
+            '<inputtype="text"name="company_name"id="input-company_name"class="text-box"value="Name"/>'
+            in self.strip_all_whitespace(res.get_data(as_text=True)))
 
     def test_should_populate_contact_details_from_session(self):
         with self.client.session_transaction() as sess:
@@ -1303,11 +1308,21 @@ class TestCreateSupplier(BaseApplicationTest):
             sess['phone_number'] = "phone_number"
         res = self.client.get("/suppliers/company-contact-details")
         assert_equal(res.status_code, 200)
-        assert_true('<input type="text" name="email_address" id="input-email_address" class="text-box" value="email_address" />' in res.get_data(as_text=True))  # noqa
+        stripped_page = self.strip_all_whitespace(res.get_data(as_text=True))
+        assert_true(
+            '<inputtype="text"name="email_address"id="input-email_address"class="text-box"value="email_address"/>'
+            in stripped_page
+        )
 
-        assert_true('<input type="text" name="contact_name" id="input-contact_name" class="text-box" value="contact_name" />' in res.get_data(as_text=True))  # noqa
+        assert_true(
+            '<inputtype="text"name="contact_name"id="input-contact_name"class="text-box"value="contact_name"/>'
+            in stripped_page
+        )
 
-        assert_true('<input type="text" name="phone_number" id="input-phone_number" class="text-box" value="phone_number" />' in res.get_data(as_text=True))  # noqa
+        assert_true(
+            '<inputtype="text"name="phone_number"id="input-phone_number"class="text-box"value="phone_number"/>'
+            in stripped_page
+        )
 
     def test_should_be_an_error_to_be_submit_company_with_incomplete_session(self):
         res = self.client.post("/suppliers/company-summary")


### PR DESCRIPTION
Fixes this bug: https://www.pivotaltracker.com/story/show/118112493

We already bumped content in buyer app to be in line with schemas, but supplier app is behind, so brief-responses don't match the schema in the API.