### PR TITLE
[#117850243] Update supplier question email content

### DIFF
--- a/app/main/helpers/briefs.py
+++ b/app/main/helpers/briefs.py
@@ -37,7 +37,7 @@ def send_brief_clarification_question(data_api_client, brief, clarification_ques
         "emails/brief_clarification_question.html",
         brief_id=brief['id'],
         brief_name=brief['title'],
-        current_date=datetime.datetime.utcnow(),
+        publish_by_date=brief['clarificationQuestionsPublishedBy'],
         framework_slug=brief['frameworkSlug'],
         lot_slug=brief['lotSlug'],
         message=clarification_question,

--- a/app/templates/emails/brief_clarification_question.html
+++ b/app/templates/emails/brief_clarification_question.html
@@ -4,24 +4,27 @@
     <meta charset="UTF-8">
 </head>
 <body>
-  Hello,<br />
-  <br />
-  A supplier has asked a question about ‘{{ brief_name }}’.<br />
-  <br />
-  On {{ current_date|dateformat }}, they asked:<br />
-  <br />
-  {{ message }}
-  <br /><br />
-  You need to answer all questions from suppliers and publish both their questions and your answers on the Digital Marketplace at:<br />
-  <a href="https://www.digitalmarketplace.service.gov.uk/buyers/frameworks/{{ framework_slug }}/requirements/{{ lot_slug }}/{{ brief_id }}/answer-question">https://www.digitalmarketplace.service.gov.uk/buyers/frameworks/{{ framework_slug }}/requirements/{{ lot_slug }}/{{ brief_id }}/answer-question</a><br />
-  <br />
-  All questions and answers will be published on the ‘{{ brief_name }}’ requirements page at:<br />
-  <a href="https://www.digitalmarketplace.service.gov.uk/{{ framework_slug }}/opportunities/{{ brief_id }}">https://www.digitalmarketplace.service.gov.uk/{{ framework_slug }}/opportunities/{{ brief_id }}</a><br />
-  <br />
-  Read more about how to manage supplier questions at:<br />
-  <a href="https://www.gov.uk/guidance/how-to-ask-and-answer-supplier-questions-on-the-digital-marketplace">https://www.gov.uk/guidance/how-to-ask-and-answer-supplier-questions-on-the-digital-marketplace</a><br />
-  <br />
-  Thanks,<br />
+  Hello,<br /><br />
+  
+  A supplier has asked a question about ‘{{ brief_name }}’.<br /><br />
+  
+  They asked:<br /><br />
+  
+  {{ message }}<br /><br />
+  
+  You must publish this question with your answer on the ‘{{ brief_name }}’ page by {{ publish_by_date|dateformat }} at:<br /><br />
+  
+  <a href="https://www.digitalmarketplace.service.gov.uk/buyers/frameworks/{{ framework_slug }}/requirements/{{ lot_slug }}/{{ brief_id }}/supplier-questions">
+    https://www.digitalmarketplace.service.gov.uk/buyers/frameworks/{{ framework_slug }}/requirements/{{ lot_slug }}/{{ brief_id }}/supplier-questions
+  </a><br /><br />
+
+  Read how to answer supplier questions at:<br /><br />
+  
+  <a href="https://www.gov.uk/guidance/how-to-answer-supplier-questions-about-your-digital-outcomes-and-specialists-requirements">
+    https://www.gov.uk/guidance/how-to-answer-supplier-questions-about-your-digital-outcomes-and-specialists-requirements
+  </a><br /><br />
+  
+  Thanks,<br /><br />
   The Digital Marketplace team<br />
 </body>
 </html>

--- a/tests/app/main/test_briefs.py
+++ b/tests/app/main/test_briefs.py
@@ -150,8 +150,10 @@ class TestSubmitClarificationQuestions(BaseApplicationTest):
     @mock.patch('app.main.helpers.briefs.send_email')
     def test_submit_clarification_question(self, send_email, data_api_client):
         self.login()
-        data_api_client.get_brief.return_value = api_stubs.brief(status="live")
-        data_api_client.get_brief.return_value['briefs']['frameworkName'] = 'Brief Framework Name'
+        brief = api_stubs.brief(status="live")
+        brief['briefs']['frameworkName'] = 'Brief Framework Name'
+        brief['briefs']['clarificationQuestionsPublishedBy'] = '2016-03-29T10:11:13.000000Z'
+        data_api_client.get_brief.return_value = brief
 
         res = self.client.post('/suppliers/opportunities/1234/ask-a-question', data={
             'clarification-question': "important question",
@@ -190,8 +192,10 @@ class TestSubmitClarificationQuestions(BaseApplicationTest):
     @mock.patch('app.main.helpers.briefs.send_email')
     def test_submit_clarification_question_fails_on_mandrill_error(self, send_email, data_api_client):
         self.login()
-        data_api_client.get_brief.return_value = api_stubs.brief(status="live")
-        data_api_client.get_brief.return_value['briefs']['frameworkName'] = 'Framework Name'
+        brief = api_stubs.brief(status="live")
+        brief['briefs']['frameworkName'] = 'Framework Name'
+        brief['briefs']['clarificationQuestionsPublishedBy'] = '2016-03-29T10:11:13.000000Z'
+        data_api_client.get_brief.return_value = brief
 
         send_email.side_effect = MandrillException
 


### PR DESCRIPTION
Completes this story: https://www.pivotaltracker.com/story/show/117850243

Wording change agreed with @superroz : "before" in doc --> "by"

Uses the fancy new URL defined here: https://github.com/alphagov/digitalmarketplace-buyer-frontend/pull/283