### PR TITLE
[#118103013] Fix breadcrumbs for brief response page

### DIFF
--- a/app/main/views/briefs.py
+++ b/app/main/views/briefs.py
@@ -93,8 +93,8 @@ def brief_response(brief_id):
     content = content_loader.get_manifest(framework['slug'], 'edit_brief_response').filter({'lot': lot['slug']})
     section = content.get_section(content.get_next_editable_section_id())
 
-    # replace generic 'Apply to opportunity' title with title including the name of the brief
-    section.name = "Apply to ‘{}’".format(brief['title'])
+    # replace generic 'Apply for opportunity' title with title including the name of the brief
+    section.name = "Apply for ‘{}’".format(brief['title'])
     section.inject_brief_questions_into_boolean_list_question(brief)
 
     return render_template(
@@ -133,8 +133,8 @@ def submit_brief_response(brief_id):
             brief_id, current_user.supplier_id, response_data, current_user.email_address
         )['briefResponses']
     except HTTPError as e:
-        # replace generic 'Apply to opportunity' title with title including the name of the brief
-        section.name = "Apply to ‘{}’".format(brief['title'])
+        # replace generic 'Apply for opportunity' title with title including the name of the brief
+        section.name = "Apply for ‘{}’".format(brief['title'])
         section.inject_brief_questions_into_boolean_list_question(brief)
         section_summary = section.summary(response_data)
 

--- a/app/main/views/briefs.py
+++ b/app/main/views/briefs.py
@@ -99,7 +99,8 @@ def brief_response(brief_id):
 
     return render_template(
         "briefs/brief_response.html",
-        service_data=brief,
+        brief=brief,
+        service_data={},
         section=section,
         **dict(main.config['BASE_TEMPLATE_DATA'])
     ), 200
@@ -132,14 +133,16 @@ def submit_brief_response(brief_id):
             brief_id, current_user.supplier_id, response_data, current_user.email_address
         )['briefResponses']
     except HTTPError as e:
+        # replace generic 'Apply to opportunity' title with title including the name of the brief
+        section.name = "Apply to ‘{}’".format(brief['title'])
         section.inject_brief_questions_into_boolean_list_question(brief)
         section_summary = section.summary(response_data)
 
         errors = section_summary.get_error_messages(e.message)
 
         return render_template(
-            "services/edit_submission_section.html",
-            framework=framework,
+            "briefs/brief_response.html",
+            brief=brief,
             service_data=response_data,
             section=section,
             errors=errors,
@@ -172,10 +175,11 @@ def view_response_result(brief_id):
     else:
         result_state = 'submitted_unsuccessful'
 
-    return render_template('briefs/view_response_result.html',
-                           brief=brief,
-                           result_state=result_state
-                           )
+    return render_template(
+        'briefs/view_response_result.html',
+        brief=brief,
+        result_state=result_state
+    )
 
 
 def _render_not_eligible_for_brief_error_page(brief, clarification_question=False):

--- a/app/main/views/briefs.py
+++ b/app/main/views/briefs.py
@@ -98,9 +98,8 @@ def brief_response(brief_id):
     section.inject_brief_questions_into_boolean_list_question(brief)
 
     return render_template(
-        "services/edit_submission_section.html",
-        framework=framework,
-        service_data={},
+        "briefs/brief_response.html",
+        service_data=brief,
         section=section,
         **dict(main.config['BASE_TEMPLATE_DATA'])
     ), 200

--- a/app/templates/briefs/brief_response.html
+++ b/app/templates/briefs/brief_response.html
@@ -9,12 +9,12 @@
         "label": "Digital Marketplace"
       },
       {
-        "link": "/{}/opportunities".format(service_data.frameworkSlug),
+        "link": "/{}/opportunities".format(brief.frameworkSlug),
         "label": "Supplier opportunities"
       },
       {
-        "link": "/{}/opportunities/{}".format(service_data.frameworkSlug, service_data.id),
-        "label": service_data.title
+        "link": "/{}/opportunities/{}".format(brief.frameworkSlug, brief.id),
+        "label": brief.title
       },
     ]
   %}

--- a/app/templates/briefs/brief_response.html
+++ b/app/templates/briefs/brief_response.html
@@ -1,0 +1,37 @@
+{% extends "services/_base_edit_section_page.html" %}
+
+{% block breadcrumb %}
+
+  {%
+    with items = [
+      {
+        "link": "/",
+        "label": "Digital Marketplace"
+      },
+      {
+        "link": "/{}/opportunities".format(service_data.frameworkSlug),
+        "label": "Supplier opportunities"
+      },
+      {
+        "link": "/{}/opportunities/{}".format(service_data.frameworkSlug, service_data.id),
+        "label": service_data.title
+      },
+    ]
+  %}
+    {% include "toolkit/breadcrumb.html" %}
+  {% endwith %}
+{% endblock %}
+
+{% block save_button %}
+
+  {%
+    with
+    label="Save and continue",
+    type="save",
+    name = "return_to_overview"
+  %}
+    {% include "toolkit/button.html" %}
+  {% endwith %}
+
+{% endblock %}
+{% block return_to_service_link %}{% endblock %}

--- a/app/templates/briefs/brief_response.html
+++ b/app/templates/briefs/brief_response.html
@@ -26,7 +26,7 @@
 
   {%
     with
-    label="Save and continue",
+    label="Apply for this opportunity",
     type="save",
     name = "return_to_overview"
   %}

--- a/tests/app/main/test_briefs.py
+++ b/tests/app/main/test_briefs.py
@@ -329,7 +329,7 @@ class TestRespondToBrief(BaseApplicationTest):
 
         assert res.status_code == 200
         data_api_client.get_brief.assert_called_once_with(1234)
-        assert len(doc.xpath('//h1[contains(text(), "Apply to ‘I need a thing to do a thing’")]')) == 1
+        assert len(doc.xpath('//h1[contains(text(), "Apply for ‘I need a thing to do a thing’")]')) == 1
         assert len(doc.xpath('//h2[contains(text(), "Do you have the essential skills and experience?")]')) == 1
         assert len(doc.xpath(
             '//h2[contains(text(), "Do you have any of the nice-to-have skills and experience?")]')) == 1
@@ -479,7 +479,7 @@ class TestRespondToBrief(BaseApplicationTest):
             '[contains(text(), "There was a problem with your answer to the following questions")]')) == 1
         assert doc.xpath(
             '//*[@id="content"]//a[@href="#essentialRequirements-2"]')[0].text_content() == 'Essential three'
-        assert len(doc.xpath('//h1[contains(text(), "Apply to ‘I need a thing to do a thing’")]')) == 1
+        assert len(doc.xpath('//h1[contains(text(), "Apply for ‘I need a thing to do a thing’")]')) == 1
         assert len(doc.xpath('//h2[contains(text(), "Do you have the essential skills and experience?")]')) == 1
         assert len(doc.xpath(
             '//h2[contains(text(), "Do you have any of the nice-to-have skills and experience?")]')) == 1
@@ -507,7 +507,7 @@ class TestRespondToBrief(BaseApplicationTest):
             '[contains(text(), "There was a problem with your answer to the following questions")]')) == 1
         assert doc.xpath(
             '//*[@id="content"]//a[@href="#availability"]')[0].text_content() == 'Availability'
-        assert len(doc.xpath('//h1[contains(text(), "Apply to ‘I need a thing to do a thing’")]')) == 1
+        assert len(doc.xpath('//h1[contains(text(), "Apply for ‘I need a thing to do a thing’")]')) == 1
         assert len(doc.xpath('//h2[contains(text(), "Do you have the essential skills and experience?")]')) == 1
         assert len(doc.xpath(
             '//h2[contains(text(), "Do you have any of the nice-to-have skills and experience?")]')) == 1


### PR DESCRIPTION
Fixes the breadcrumbs on the brief response page and adds the right title if you're returned to the response page after getting a form error.

Adds a few more tests; pretty exciting.

[>> Bug on Pivotal](https://www.pivotaltracker.com/story/show/118103013)

***

### 🍞  > 🍞  > 🍞 

![screen shot 2016-04-22 at 12 25 21](https://cloud.githubusercontent.com/assets/2454380/14741716/203c54ce-0890-11e6-87ac-0ae438f9da81.png)
