### PR TITLE
Fix validation messages

### DIFF
--- a/app/main/forms/suppliers.py
+++ b/app/main/forms/suppliers.py
@@ -39,11 +39,11 @@ class EditContactInformationForm(Form):
     website = StripWhitespaceStringField()
     phoneNumber = StripWhitespaceStringField('Phone number')
     email = StripWhitespaceStringField('Email address', validators=[
-        DataRequired(message="Email can not be empty"),
+        DataRequired(message="You must provide an email address"),
         Email(message="Please enter a valid email address")
     ])
     contactName = StripWhitespaceStringField('Contact name', validators=[
-        DataRequired(message="Contact name can not be empty"),
+        DataRequired(message="You must provide a contact name"),
     ])
 
 

--- a/app/templates/suppliers/edit_supplier.html
+++ b/app/templates/suppliers/edit_supplier.html
@@ -42,7 +42,7 @@
   {% if supplier_form.errors or contact_form.errors %}
       <div class="validation-masthead" aria-labelledby="validation-masthead-heading">
           <h3 class="validation-masthead-heading" id="validation-masthead-heading">
-              There was a problem with your answer to the following questions
+              There was a problem with the details you gave for:
           </h3>
           {% if supplier_form.errors %}
           <ul>

--- a/app/templates/suppliers/edit_supplier.html
+++ b/app/templates/suppliers/edit_supplier.html
@@ -44,17 +44,25 @@
           <h3 class="validation-masthead-heading" id="validation-masthead-heading">
               There was a problem with your answer to the following questions
           </h3>
+          {% if supplier_form.errors %}
+          <ul>
           {% for field_name, field_errors in supplier_form.errors|dictsort %}
             {% for error in field_errors %}
-              <a href="#{{ field_name }}-label" class="validation-masthead-link">{{ supplier_form[field_name].label }}</a>
+              <li><a href="#{{ field_name }}" class="validation-masthead-link">{{ supplier_form[field_name].label.text }}</a>
             {% endfor %}
           {% endfor %}
+          </ul>
+          {% endif %}
 
+          {% if contact_form.errors %}
+          <ul>
           {% for field_name, field_errors in contact_form.errors|dictsort %}
             {% for error in field_errors %}
-            <a href="#contact_{{ field_name }}-label" class="validation-masthead-link">{{ contact_form[field_name].label }}</a>
+            <li><a href="#contact_{{ field_name }}" class="validation-masthead-link">{{ contact_form[field_name].label.text }}</a></li>
             {% endfor %}
           {% endfor %}
+          </ul>
+          {% endif %}
       </div>
   {% endif %}
 

--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "jquery": "1.11.2",
     "hogan": "3.0.2",
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
-    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v15.11.3",
+    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v15.11.6",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.14.1/jinja_govuk_template-0.14.1.tgz",
     "digitalmarketplace-frameworks": "git://github.com/alphagov/digitalmarketplace-frameworks#v1.0.0"
   }

--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "jquery": "1.11.2",
     "hogan": "3.0.2",
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
-    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v15.11.6",
+    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v15.13.1",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.14.1/jinja_govuk_template-0.14.1.tgz",
     "digitalmarketplace-frameworks": "git://github.com/alphagov/digitalmarketplace-frameworks#v1.0.0"
   }

--- a/tests/app/main/test_briefs.py
+++ b/tests/app/main/test_briefs.py
@@ -476,7 +476,7 @@ class TestRespondToBrief(BaseApplicationTest):
 
         assert len(doc.xpath(
             '//*[@id="validation-masthead-heading"]'
-            '[contains(text(), "There was a problem with your answer to the following questions")]')) == 1
+            '[contains(text(), "There was a problem with your answer to:")]')) == 1
         assert doc.xpath(
             '//*[@id="content"]//a[@href="#essentialRequirements-2"]')[0].text_content() == 'Essential three'
         assert len(doc.xpath('//h1[contains(text(), "Apply for ‘I need a thing to do a thing’")]')) == 1
@@ -504,7 +504,7 @@ class TestRespondToBrief(BaseApplicationTest):
 
         assert len(doc.xpath(
             '//*[@id="validation-masthead-heading"]'
-            '[contains(text(), "There was a problem with your answer to the following questions")]')) == 1
+            '[contains(text(), "There was a problem with your answer to:")]')) == 1
         assert doc.xpath(
             '//*[@id="content"]//a[@href="#availability"]')[0].text_content() == 'Date the specialist can start work'
         assert len(doc.xpath('//h1[contains(text(), "Apply for ‘I need a thing to do a thing’")]')) == 1

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -508,7 +508,7 @@ class TestCreateDraftService(BaseApplicationTest):
     def setup(self):
         super(TestCreateDraftService, self).setup()
         self._answer_required = 'Answer is required'
-        self._validation_error = 'There was a problem with your answer to the following questions'
+        self._validation_error = 'There was a problem with your answer to:'
 
         with self.app.test_client():
             self.login()

--- a/tests/app/main/test_suppliers.py
+++ b/tests/app/main/test_suppliers.py
@@ -902,7 +902,7 @@ class TestSupplierUpdate(BaseApplicationTest):
         })
 
         assert_equal(status, 200)
-        assert_in('Email can not be empty', resp)
+        assert_in('You must provide an email address', resp)
 
         assert_false(data_api_client.update_supplier.called)
         assert_false(


### PR DESCRIPTION
Originally intended to bring in the correct text for validation summaries (from [#245](https://github.com/alphagov/digitalmarketplace-frontend-toolkit/pull/245) in the DM Toolkit), this now also contains the following fixes:

- fixes for the [Validation summary links don't work](https://www.pivotaltracker.com/story/show/118185295) story
- corrections to the HTML of validation summaries, replacing label tags for their text in the links and wrapping links in a list

### New validation summary copy

![validation_copy_changes](https://cloud.githubusercontent.com/assets/87140/14782378/d96811f2-0ae0-11e6-8baf-3e731e00842d.png)

![validation_copy_changes_1](https://cloud.githubusercontent.com/assets/87140/14782377/d962d35e-0ae0-11e6-99ac-62e0bda6cc48.png)

### Validation summary HTML

#### Old

![image](https://cloud.githubusercontent.com/assets/87140/14782435/43c689f2-0ae1-11e6-9831-6c0f2f7782cb.png)

#### New

![image](https://cloud.githubusercontent.com/assets/87140/14782403/08479c5e-0ae1-11e6-910c-d4a4a9b72a7a.png)
