### PR TITLE
G8 service submission

### DIFF
--- a/app/assets/scss/_service_submission.scss
+++ b/app/assets/scss/_service_submission.scss
@@ -23,6 +23,11 @@
     color: $secondary-text-colour;
 }
 
+.next-page-message {
+  color: $secondary-text-colour;
+  margin: -10px 0 $gutter 0;
+}
+
 .delete-draft-button {
 
   margin-top: $gutter;

--- a/app/main/helpers/services.py
+++ b/app/main/helpers/services.py
@@ -63,3 +63,10 @@ def parse_document_upload_time(data):
     match = re.search("(\d{4}-\d{2}-\d{2}-\d{2}\d{2})\..{2,3}$", data)
     if match:
         return datetime.strptime(match.group(1), "%Y-%m-%d-%H%M")
+
+
+def get_next_section_name(content, current_section_id):
+    if content.get_next_editable_section_id(current_section_id):
+        return content.get_section(
+            content.get_next_editable_section_id(current_section_id)
+        ).name

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -156,7 +156,7 @@ def framework_submission_lots(framework_slug):
             'labs' if framework['slug'] == 'digital-outcomes-and-specialists' else 'service'
             # TODO: ^ make this dynamic, eg, lab, service, unit
         ),
-    } for lot in lots if (lot['draft_count'] + lot['complete_count']) > 0]
+    } for lot in lots if framework["status"] == "open" or (lot['draft_count'] + lot['complete_count']) > 0]
 
     return render_template(
         "frameworks/submission_lots.html",

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -153,7 +153,7 @@ def framework_submission_lots(framework_slug):
             framework['status'],
             lot['name'],
             'lab' if framework['slug'] == 'digital-outcomes-and-specialists' else 'service',
-            'labs' if framework['slug'] == 'digital-outcomes-and-specialists' else 'service'
+            'labs' if framework['slug'] == 'digital-outcomes-and-specialists' else 'services'
             # TODO: ^ make this dynamic, eg, lab, service, unit
         ),
     } for lot in lots if framework["status"] == "open" or (lot['draft_count'] + lot['complete_count']) > 0]

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -308,7 +308,7 @@ def delete_draft_service(framework_slug, lot_slug, service_id):
                                 delete_requested=True))
 
 
-@main.route('/frameworks/<framework_slug>/submissions/documents/<int:supplier_id>/<document_name>', methods=['GET'])
+@main.route('/frameworks/submissions/<framework_slug>/submissions/<int:supplier_id>/<document_name>', methods=['GET'])
 @login_required
 def service_submission_document(framework_slug, supplier_id, document_name):
     if current_user.supplier_id != supplier_id:
@@ -316,7 +316,7 @@ def service_submission_document(framework_slug, supplier_id, document_name):
 
     uploader = s3.S3(current_app.config['DM_SUBMISSIONS_BUCKET'])
     s3_url = get_signed_document_url(uploader,
-                                     "{}/{}/{}".format(framework_slug, supplier_id, document_name))
+                                     "{}/submissions/{}/{}".format(framework_slug, supplier_id, document_name))
     if not s3_url:
         abort(404)
 
@@ -426,7 +426,7 @@ def update_section_submission(framework_slug, lot_slug, service_id, section_id, 
     update_data = section.get_data(request.form)
 
     uploader = s3.S3(current_app.config['DM_SUBMISSIONS_BUCKET'])
-    documents_url = url_for('.dashboard', _external=True) + '/submission/documents/'
+    documents_url = url_for('.dashboard', _external=True) + '/frameworks/submissions/'
     uploaded_documents, document_errors = upload_service_documents(
         uploader, documents_url, draft, request.files, section,
         public=False)

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -308,7 +308,7 @@ def delete_draft_service(framework_slug, lot_slug, service_id):
                                 delete_requested=True))
 
 
-@main.route('/frameworks/submissions/<framework_slug>/submissions/<int:supplier_id>/<document_name>', methods=['GET'])
+@main.route('/assets/<framework_slug>/submissions/<int:supplier_id>/<document_name>', methods=['GET'])
 @login_required
 def service_submission_document(framework_slug, supplier_id, document_name):
     if current_user.supplier_id != supplier_id:
@@ -426,7 +426,7 @@ def update_section_submission(framework_slug, lot_slug, service_id, section_id, 
     update_data = section.get_data(request.form)
 
     uploader = s3.S3(current_app.config['DM_SUBMISSIONS_BUCKET'])
-    documents_url = url_for('.dashboard', _external=True) + '/frameworks/submissions/'
+    documents_url = url_for('.dashboard', _external=True) + '/assets/'
     uploaded_documents, document_errors = upload_service_documents(
         uploader, documents_url, draft, request.files, section,
         public=False)

--- a/app/templates/services/edit_submission_section.html
+++ b/app/templates/services/edit_submission_section.html
@@ -35,14 +35,39 @@
 
 {% block save_button %}
 
-  {%
+  {% if next_section_name and not return_to_summary %}
+    {%
+      with
+      label="Save and continue",
+      name = "continue_to_next_section",
+      type="save"
+    %}
+      {% include "toolkit/button.html" %}
+    {% endwith %}
+
+    <p class="next-page-message">
+      Next: {{ next_section_name }}
+    </p>
+
+    {%
     with
-    label="Save and continue",
-    type="save",
-    name = "return_to_overview"
-  %}
-    {% include "toolkit/button.html" %}
-  {% endwith %}
+      type = "secondary",
+      label = "Save and return to service overview",
+      name = "return_to_overview"
+    %}
+      {% include "toolkit/button.html" %}
+    {% endwith %}
+
+  {% else %}
+    {%
+      with
+      label="Save and continue",
+      type="save",
+      name = "return_to_overview"
+    %}
+      {% include "toolkit/button.html" %}
+    {% endwith %}
+  {% endif %}
 
 {% endblock %}
 {% block return_to_service_link %} {% endblock %}

--- a/app/templates/suppliers/_frameworks_open.html
+++ b/app/templates/suppliers/_frameworks_open.html
@@ -8,7 +8,7 @@
             "title":
             "Continue your {} application".format(framework.name),
             "link": url_for(".framework_dashboard", framework_slug=framework.slug),
-            "body": framework.deadline,
+            "body": framework.deadline|markdown,
           }]
         %}
           {% include "toolkit/browse-list.html" %}

--- a/bower.json
+++ b/bower.json
@@ -7,6 +7,6 @@
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
     "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v15.11.3",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.14.1/jinja_govuk_template-0.14.1.tgz",
-    "digitalmarketplace-frameworks": "git://github.com/alphagov/digitalmarketplace-frameworks#v0.32.4"
+    "digitalmarketplace-frameworks": "git://github.com/alphagov/digitalmarketplace-frameworks#v1.0.0"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -7,6 +7,6 @@
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
     "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v15.11.3",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.14.1/jinja_govuk_template-0.14.1.tgz",
-    "digitalmarketplace-frameworks": "git://github.com/alphagov/digitalmarketplace-frameworks#v0.31.3"
+    "digitalmarketplace-frameworks": "git://github.com/alphagov/digitalmarketplace-frameworks#v0.32.4"
   }
 }

--- a/config.py
+++ b/config.py
@@ -116,9 +116,9 @@ class Development(Config):
     DM_DATA_API_AUTH_TOKEN = "myToken"
     DM_API_AUTH_TOKEN = "myToken"
 
-    DM_SUBMISSIONS_BUCKET = "digitalmarketplace-documents-dev-dev"
-    DM_COMMUNICATIONS_BUCKET = "digitalmarketplace-documents-dev-dev"
-    DM_AGREEMENTS_BUCKET = "digitalmarketplace-documents-dev-dev"
+    DM_SUBMISSIONS_BUCKET = "digitalmarketplace-submissions-dev-dev"
+    DM_COMMUNICATIONS_BUCKET = "digitalmarketplace-communications-dev-dev"
+    DM_AGREEMENTS_BUCKET = "digitalmarketplace-agreements-dev-dev"
     DM_DOCUMENTS_BUCKET = "digitalmarketplace-documents-dev-dev"
     DM_ASSETS_URL = "https://{}.s3-eu-west-1.amazonaws.com".format(DM_SUBMISSIONS_BUCKET)
 

--- a/tests/app/main/test_briefs.py
+++ b/tests/app/main/test_briefs.py
@@ -506,7 +506,7 @@ class TestRespondToBrief(BaseApplicationTest):
             '//*[@id="validation-masthead-heading"]'
             '[contains(text(), "There was a problem with your answer to the following questions")]')) == 1
         assert doc.xpath(
-            '//*[@id="content"]//a[@href="#availability"]')[0].text_content() == 'Availability'
+            '//*[@id="content"]//a[@href="#availability"]')[0].text_content() == 'Date the specialist can start work'
         assert len(doc.xpath('//h1[contains(text(), "Apply for ‘I need a thing to do a thing’")]')) == 1
         assert len(doc.xpath('//h2[contains(text(), "Do you have the essential skills and experience?")]')) == 1
         assert len(doc.xpath(

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -845,7 +845,7 @@ class TestEditDraftService(BaseApplicationTest):
         assert_equal(res.status_code, 302)
         data_api_client.update_draft_service.assert_called_once_with(
             '1', {
-                'serviceDefinitionDocumentURL': 'http://localhost/suppliers/frameworks/submissions/g-slug/submissions/1234/1-service-definition-document-2015-01-02-0304.pdf'  # noqa
+                'serviceDefinitionDocumentURL': 'http://localhost/suppliers/assets/g-slug/submissions/1234/1-service-definition-document-2015-01-02-0304.pdf'  # noqa
             }, 'email@email.com',
             page_questions=['serviceDefinitionDocumentURL']
         )
@@ -1415,7 +1415,7 @@ class TestSubmissionDocuments(BaseApplicationTest):
         s3.return_value.get_signed_url.return_value = 'http://example.com/document.pdf'
 
         res = self.client.get(
-            '/suppliers/frameworks/submissions/g-cloud-7/submissions/1234/document.pdf'
+            '/suppliers/assets/g-cloud-7/submissions/1234/document.pdf'
         )
 
         assert_equal(res.status_code, 302)

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -929,7 +929,55 @@ class TestEditDraftService(BaseApplicationTest):
         )
         assert_equal(404, res.status_code)
 
-    def test_update_redirects_to_summary(self, data_api_client, s3):
+    def test_update_redirects_to_next_editable_section(self, data_api_client, s3):
+        s3.return_value.bucket_short_name = 'submissions'
+        data_api_client.get_framework.return_value = self.framework(status='open')
+        data_api_client.get_draft_service.return_value = self.empty_draft
+        data_api_client.update_draft_service.return_value = None
+
+        res = self.client.post(
+            '/suppliers/frameworks/g-cloud-7/submissions/scs/1/edit/service-description',
+            data={
+                'continue_to_next_section': 'Save and continue'
+            })
+
+        assert_equal(302, res.status_code)
+        assert_equal('http://localhost/suppliers/frameworks/g-cloud-7/submissions/scs/1/edit/service-type',
+                     res.headers['Location'])
+
+    def test_update_redirects_to_edit_submission_if_no_next_editable_section(self, data_api_client, s3):
+        s3.return_value.bucket_short_name = 'submissions'
+        data_api_client.get_framework.return_value = self.framework(status='open')
+        data_api_client.get_draft_service.return_value = self.empty_draft
+        data_api_client.update_draft_service.return_value = None
+
+        res = self.client.post(
+            '/suppliers/frameworks/g-cloud-7/submissions/scs/1/edit/sfia-rate-card',
+            data={})
+
+        assert_equal(302, res.status_code)
+        assert_equal(
+            'http://localhost/suppliers/frameworks/g-cloud-7/submissions/scs/1#sfia-rate-card',
+            res.headers['Location']
+        )
+
+    def test_update_redirects_to_edit_submission_if_return_to_summary(self, data_api_client, s3):
+        s3.return_value.bucket_short_name = 'submissions'
+        data_api_client.get_framework.return_value = self.framework(status='open')
+        data_api_client.get_draft_service.return_value = self.empty_draft
+        data_api_client.update_draft_service.return_value = None
+
+        res = self.client.post(
+            '/suppliers/frameworks/g-cloud-7/submissions/scs/1/edit/service-description?return_to_summary=1',
+            data={})
+
+        assert_equal(302, res.status_code)
+        assert_equal(
+            'http://localhost/suppliers/frameworks/g-cloud-7/submissions/scs/1#service-description',
+            res.headers['Location']
+        )
+
+    def test_update_redirects_to_edit_submission_if_save_and_return_grey_button_clicked(self, data_api_client, s3):
         s3.return_value.bucket_short_name = 'submissions'
         data_api_client.get_framework.return_value = self.framework(status='open')
         data_api_client.get_draft_service.return_value = self.empty_draft

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -845,7 +845,7 @@ class TestEditDraftService(BaseApplicationTest):
         assert_equal(res.status_code, 302)
         data_api_client.update_draft_service.assert_called_once_with(
             '1', {
-                'serviceDefinitionDocumentURL': 'http://localhost/suppliers/submission/documents/g-slug/submissions/1234/1-service-definition-document-2015-01-02-0304.pdf'  # noqa
+                'serviceDefinitionDocumentURL': 'http://localhost/suppliers/frameworks/submissions/g-slug/submissions/1234/1-service-definition-document-2015-01-02-0304.pdf'  # noqa
             }, 'email@email.com',
             page_questions=['serviceDefinitionDocumentURL']
         )
@@ -1415,7 +1415,7 @@ class TestSubmissionDocuments(BaseApplicationTest):
         s3.return_value.get_signed_url.return_value = 'http://example.com/document.pdf'
 
         res = self.client.get(
-            '/suppliers/frameworks/g-cloud-7/submissions/documents/1234/document.pdf'
+            '/suppliers/frameworks/submissions/g-cloud-7/submissions/1234/document.pdf'
         )
 
         assert_equal(res.status_code, 302)


### PR DESCRIPTION
Completes this story: https://www.pivotaltracker.com/story/show/118178641
And this story: https://www.pivotaltracker.com/story/show/118178637

This seems to be everything needed to get G-Cloud service submissions looking reasonably peachy:
 * Show links for lots without any draft services for live frameworks
 * Reinstate the save-and-continue-to-next-question flow through submissions
 * Fix document download URLs (document uploads were fine, but the generated download links were wrong)

There is a bug (again! I'm sure we've fixed this about three times now...) with the validation wrapper around questions with assurance.  I've raised it as a bug rather than fix it right away, because there are other higher priorities, like getting the functional tests running again: https://www.pivotaltracker.com/story/show/118388103