### PR TITLE
Add `question_advice` to question-rendering macros

### DIFF
--- a/app/templates/macros/toolkit_forms.html
+++ b/app/templates/macros/toolkit_forms.html
@@ -3,7 +3,8 @@
     with
     question=question_content.question|question_references(get_question)|markdown,
     question_advice=question_content.question_advice,
-    hint=(question_content.hint or '')|question_references(get_question)|markdown,
+    hint=(question_content.hint or '')|question_references(get_question),
+    optional=question_content.optional,
     name=question_content.id,
     value=service_data[question_content.id],
     unit_in_full=question_content.unit_in_full,
@@ -21,7 +22,8 @@
     with
     question=question_content.question|question_references(get_question)|markdown,
     question_advice=question_content.question_advice,
-    hint=(question_content.hint or '')|question_references(get_question)|markdown,
+    hint=(question_content.hint or '')|question_references(get_question),
+    optional=question_content.optional,
     name=question_content.id,
     value=service_data[question_content.id],
     large=True,
@@ -36,10 +38,11 @@
   {%
     with
     name=question_content.id,
-    question_advice=question_content.question_advice,
     number_of_items=10,
     question=question_content.question|question_references(get_question)|markdown,
-    hint=(question_content.hint or '')|question_references(get_question)|markdown,
+    question_advice=question_content.question_advice,
+    hint=(question_content.hint or '')|question_references(get_question),
+    optional=question_content.optional,
     values=service_data[question_content.id],
     id=question_content.id,
     error=errors.get(question_content.id)['message']|question_references(get_question)
@@ -54,7 +57,8 @@
     name=question_content.id,
     question=question_content.question|question_references(get_question)|markdown,
     question_advice=question_content.question_advice,
-    hint=(question_content.hint or '')|question_references(get_question)|markdown,
+    hint=(question_content.hint or '')|question_references(get_question),
+    optional=question_content.optional,
     value=service_data[question_content.id],
     id=question_content.id,
     options=question_content.options,
@@ -72,8 +76,9 @@
     name=question_content.id,
     question=question_content.question|question_references(get_question)|markdown,
     question_advice=question_content.question_advice,
-    hint=(question_content.hint or '')|question_references(get_question)|markdown,
+    hint=(question_content.hint or '')|question_references(get_question),
     hint_underneath=(question_content.hint_underneath or False),
+    optional=question_content.optional,
     value=service_data[question_content.id],
     id=question_content.id,
     options=question_content.options,
@@ -91,7 +96,8 @@
     name=question_content.id,
     question=question_content.question|question_references(get_question)|markdown,
     question_advice=question_content.question_advice,
-    hint=(question_content.hint or '')|question_references(get_question)|markdown,
+    hint=(question_content.hint or '')|question_references(get_question),
+    optional=question_content.optional,
     value=service_data[question_content.id],
     id=question_content.id,
     type='boolean',
@@ -107,7 +113,8 @@
     with
     question=question_content.question|question_references(get_question)|markdown,
     question_advice=question_content.question_advice,
-    hint=(question_content.hint or '')|question_references(get_question)|markdown,
+    hint=(question_content.hint or '')|question_references(get_question),
+    optional=question_content.optional,
     name=question_content.id,
     value="Document uploaded {}".format(
       service_data[question_content.id]|parse_document_upload_time|datetimeformat
@@ -133,7 +140,8 @@
     price_unit=service_data.get(question_content.fields.price_unit),
     price_interval=service_data.get(question_content.fields.price_interval),
     hours_for_price=service_data.get(question_content.fields.hours_for_price),
-    hint=(question_content.hint or '')|markdown,
+    hint=(question_content.hint or ''),
+    optional=question_content.optional,
     id=question_content.id,
     error=errors.get(question_content.id)['message']|question_references(get_question),
     question_number=question_number
@@ -150,7 +158,8 @@
     unit="%",
     question=question_content.question|question_references(get_question)|markdown,
     question_advice=question_content.question_advice,
-    hint=(question_content.hint or '')|question_references(get_question)|markdown,
+    hint=(question_content.hint or '')|question_references(get_question),
+    optional=question_content.optional,
     name=question_content.id,
     value=service_data[question_content.id],
     error=errors.get(question_content.id)['message']|question_references(get_question),
@@ -174,7 +183,9 @@
           {{ question_content.question_advice|markdown }}
         </span>
       {% endif %}
-      <p class="question-description">{{ question_content.hint }}</p>
+      {% if question_content.hint %}
+        <p class="question-description">{{ question_content.hint|markdown }}</p>
+      {% endif %}
 
       {% for boolean_question in question_content.boolean_list_questions %}
         {% set boolean_question_id = '{}-{}'.format(question_content.id, loop.index0) %}

--- a/app/templates/macros/toolkit_forms.html
+++ b/app/templates/macros/toolkit_forms.html
@@ -2,6 +2,7 @@
   {%
     with
     question=question_content.question|question_references(get_question)|markdown,
+    question_advice=question_content.question_advice,
     hint=(question_content.hint or '')|question_references(get_question)|markdown,
     name=question_content.id,
     value=service_data[question_content.id],
@@ -19,6 +20,7 @@
   {%
     with
     question=question_content.question|question_references(get_question)|markdown,
+    question_advice=question_content.question_advice,
     hint=(question_content.hint or '')|question_references(get_question)|markdown,
     name=question_content.id,
     value=service_data[question_content.id],
@@ -34,6 +36,7 @@
   {%
     with
     name=question_content.id,
+    question_advice=question_content.question_advice,
     number_of_items=10,
     question=question_content.question|question_references(get_question)|markdown,
     hint=(question_content.hint or '')|question_references(get_question)|markdown,
@@ -50,6 +53,7 @@
     with
     name=question_content.id,
     question=question_content.question|question_references(get_question)|markdown,
+    question_advice=question_content.question_advice,
     hint=(question_content.hint or '')|question_references(get_question)|markdown,
     value=service_data[question_content.id],
     id=question_content.id,
@@ -67,6 +71,7 @@
     with
     name=question_content.id,
     question=question_content.question|question_references(get_question)|markdown,
+    question_advice=question_content.question_advice,
     hint=(question_content.hint or '')|question_references(get_question)|markdown,
     hint_underneath=(question_content.hint_underneath or False),
     value=service_data[question_content.id],
@@ -85,6 +90,7 @@
     with
     name=question_content.id,
     question=question_content.question|question_references(get_question)|markdown,
+    question_advice=question_content.question_advice,
     hint=(question_content.hint or '')|question_references(get_question)|markdown,
     value=service_data[question_content.id],
     id=question_content.id,
@@ -100,6 +106,7 @@
   {%
     with
     question=question_content.question|question_references(get_question)|markdown,
+    question_advice=question_content.question_advice,
     hint=(question_content.hint or '')|question_references(get_question)|markdown,
     name=question_content.id,
     value="Document uploaded {}".format(
@@ -117,6 +124,7 @@
     with
     name=question_content.id,
     question=question_content.question,
+    question_advice=question_content.question_advice,
     fields=question_content.fields,
     optional_fields=question_content.optional_fields,
     price=service_data.get(question_content.fields.price),
@@ -141,6 +149,7 @@
     unit_position="after",
     unit="%",
     question=question_content.question|question_references(get_question)|markdown,
+    question_advice=question_content.question_advice,
     hint=(question_content.hint or '')|question_references(get_question)|markdown,
     name=question_content.id,
     value=service_data[question_content.id],
@@ -160,7 +169,12 @@
       <legend>
         <span class="visually-hidden">{{ question_content.name }}</span>
       </legend>
-        <p class="question-description">{{ question_content.hint }}</p>
+      {% if question_content.question_advice %}
+        <span class="question-advice" id="input-{{ name }}-question-advice">
+          {{ question_content.question_advice|markdown }}
+        </span>
+      {% endif %}
+      <p class="question-description">{{ question_content.hint }}</p>
 
       {% for boolean_question in question_content.boolean_list_questions %}
         {% set boolean_question_id = '{}-{}'.format(question_content.id, loop.index0) %}


### PR DESCRIPTION
Completes this: https://www.pivotaltracker.com/story/show/117629721

This is already done in the buyer app, but we also need to show the advice in the supplier app.

Of questions rendered by the supplier app only the `boolean_list` questions Essentials and Nice-to-haves currently have `question_advice` set.  But I've added it to all question-rendering templates, in case other supplier questions have advice in future.

Screenshots of the relevant page once this is applied:
![screen shot 2016-04-27 at 08 07 21](https://cloud.githubusercontent.com/assets/6525554/14844571/29759596-0c50-11e6-827e-002ffa1f2363.png)

![screen shot 2016-04-27 at 08 07 27](https://cloud.githubusercontent.com/assets/6525554/14844575/2d3e037a-0c50-11e6-9511-2d60822ab875.png)

