### PR TITLE
Split registered address into three fields

### DIFF
--- a/app/main/helpers/validation.py
+++ b/app/main/helpers/validation.py
@@ -36,12 +36,14 @@ class DeclarationValidator(object):
     def get_error_messages(self):
         raw_errors_map = self.errors()
         errors_map = list()
-        for question_number, question_id in enumerate(self.all_fields()):
+        for question_id in self.all_fields():
             if question_id in raw_errors_map:
+                question_number = self.content.get_question(question_id).get('number')
                 validation_message = self.get_error_message(question_id, raw_errors_map[question_id])
                 errors_map.append((question_id, {
                     'input_name': question_id,
-                    'question': "Question {}".format(question_number + 1),
+                    'question': "Question {}".format(question_number)
+                    if question_number else self.content.get_question(question_id).get('question'),
                     'message': validation_message,
                 }))
 

--- a/app/templates/frameworks/edit_declaration_section.html
+++ b/app/templates/frameworks/edit_declaration_section.html
@@ -51,7 +51,7 @@
               </div>
             {% endif %}
             {% for question in section.questions %}
-              {% if errors and errors[question.id] %}
+              {% if errors and (errors[question.id] or question.type == 'multiquestion') %}
                 {{ forms[question.type](question, declaration_answers, errors, question_number=question.number, get_question=get_question) }}
               {% else %}
                 {{ forms[question.type](question, declaration_answers, {}, question_number=question.number, get_question=get_question) }}

--- a/app/templates/macros/toolkit_forms.html
+++ b/app/templates/macros/toolkit_forms.html
@@ -172,19 +172,21 @@
 {% macro boolean_list(question_content, service_data, errors, question_number=None, get_question=None) -%}
   {% if question_content.boolean_list_questions %}
     <fieldset class="question question-boolean-list" id="{{ question_content.id }}">
+        <legend>
+          <span class="visually-hidden">{{ question_content.name }}</span>
+        </legend>
+
         <span class="question-heading">
           <h2>{{ question_content.question }}</h2>
         </span>
-      <legend>
-        <span class="visually-hidden">{{ question_content.name }}</span>
-      </legend>
+
       {% if question_content.question_advice %}
         <span class="question-advice" id="input-{{ name }}-question-advice">
           {{ question_content.question_advice|markdown }}
         </span>
       {% endif %}
       {% if question_content.hint %}
-        <p class="question-description">{{ question_content.hint|markdown }}</p>
+        <span class="hint">{{ question_content.hint|markdown }}</span>
       {% endif %}
 
       {% for boolean_question in question_content.boolean_list_questions %}
@@ -211,36 +213,34 @@
 {%- endmacro %}
 
 {% macro multiquestion(question_content, service_data, errors, question_number=None, get_question=None) -%}
-<div class="question" id="{{ question_content.id }}">
-  <label for="input-{{ question_content.id }}">
-      <span class="question-heading{% if question_content.hint %}-with-hint{% endif %}">
-          <span class="question-number">
-            {{ question_number }}
-          </span>
-        
-        {{ question_content.question }}
-        
-      </span>
+  <fieldset class="question" id="{{ question_content.id }}">
+    <legend>
+      <span class="visually-hidden">{{ question_content.name }}</span>
+    </legend>
 
-  </label>
-  <legend>
-    <span class="visually-hidden">{{ question_content.name }}</span>
-  </legend>
-  {% if question_content.question_advice %}
-        <span class="question-advice" id="input-{{ name }}-question-advice">
-          {{ question_content.question_advice|markdown }}
+    <span class="question-heading{% if question_content.hint %}-with-hint{% endif %}">
+        <span class="question-number">
+          {{ question_number }}
         </span>
-  {% endif %}
-  {% if question_content.hint %}
-  <p class="question-description">{{ question_content.hint|markdown }}</p>
-  {% endif %}
+        {{ question_content.question }}
+    </span>
 
-  {% for child_question in question_content.questions %}
-    {% if errors and errors[child_question.id] %}
-      {{ text(child_question, service_data, errors) }}
-    {% else %}
-      {{ text(child_question, service_data, {}) }}
+    {% if question_content.question_advice %}
+    <span class="question-advice" id="input-{{ name }}-question-advice">
+      {{ question_content.question_advice|markdown }}
+    </span>
     {% endif %}
-  {% endfor %}
-</div>
+
+    {% if question_content.hint %}
+    <span class="hint">{{ question_content.hint|markdown }}</span>
+    {% endif %}
+
+    {% for child_question in question_content.questions %}
+      {% if errors and errors[child_question.id] %}
+        {{ text(child_question, service_data, errors) }}
+      {% else %}
+        {{ text(child_question, service_data, {}) }}
+      {% endif %}
+    {% endfor %}
+  </fieldset>
 {%- endmacro %}

--- a/app/templates/macros/toolkit_forms.html
+++ b/app/templates/macros/toolkit_forms.html
@@ -209,3 +209,38 @@
     </fieldset>
   {% endif %}
 {%- endmacro %}
+
+{% macro multiquestion(question_content, service_data, errors, question_number=None, get_question=None) -%}
+<div class="question" id="{{ question_content.id }}">
+  <label for="input-{{ question_content.id }}">
+      <span class="question-heading{% if question_content.hint %}-with-hint{% endif %}">
+          <span class="question-number">
+            {{ question_number }}
+          </span>
+        
+        {{ question_content.question }}
+        
+      </span>
+
+  </label>
+  <legend>
+    <span class="visually-hidden">{{ question_content.name }}</span>
+  </legend>
+  {% if question_content.question_advice %}
+        <span class="question-advice" id="input-{{ name }}-question-advice">
+          {{ question_content.question_advice|markdown }}
+        </span>
+  {% endif %}
+  {% if question_content.hint %}
+  <p class="question-description">{{ question_content.hint|markdown }}</p>
+  {% endif %}
+
+  {% for child_question in question_content.questions %}
+    {% if errors and errors[child_question.id] %}
+      {{ text(child_question, service_data, errors) }}
+    {% else %}
+      {{ text(child_question, service_data, {}) }}
+    {% endif %}
+  {% endfor %}
+</div>
+{%- endmacro %}

--- a/bower.json
+++ b/bower.json
@@ -7,6 +7,6 @@
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
     "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v15.13.1",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.14.1/jinja_govuk_template-0.14.1.tgz",
-    "digitalmarketplace-frameworks": "git://github.com/alphagov/digitalmarketplace-frameworks#v1.0.0"
+    "digitalmarketplace-frameworks": "git://github.com/alphagov/digitalmarketplace-frameworks#v1.2.0"
   }
 }


### PR DESCRIPTION
Completes this story: https://www.pivotaltracker.com/story/show/118180095

Depends on updated content being merged: 
 - [x] https://github.com/alphagov/digitalmarketplace-frameworks/pull/265

This introduces a new macro to render multiquestions in the frontend.
It assumes all questions are `text` type.

Look and feel, including validation messaging and wrapping, all OK'd by @ralph-hawkins 

## Question renders like this:

![screen shot 2016-05-04 at 13 54 23](https://cloud.githubusercontent.com/assets/6525554/15014948/e79f4412-1200-11e6-8ea2-4b768e523689.png)

## And if there are validation errors:

![screen shot 2016-05-04 at 13 54 06](https://cloud.githubusercontent.com/assets/6525554/15014950/ea2c8348-1200-11e6-8290-78d63b2a633b.png)

![screen shot 2016-05-04 at 13 53 59](https://cloud.githubusercontent.com/assets/6525554/15014954/eceed946-1200-11e6-836f-3c39e4a5d4c5.png)


