### PR TITLE
Transmogrify percentage macro into number macro

### DIFF
--- a/app/templates/macros/toolkit_forms.html
+++ b/app/templates/macros/toolkit_forms.html
@@ -150,12 +150,12 @@
   {% endwith %}
 {%- endmacro %}
 
-{% macro percentage(question_content, service_data, errors, question_number=None, get_question=None) -%}
+{% macro number(question_content, service_data, errors, question_number=None, get_question=None) -%}
   {%
     with
-    unit_in_full="percent",
-    unit_position="after",
-    unit="%",
+    unit=question_content.unit,
+    unit_in_full=question_content.unit_in_full,
+    unit_position=question_content.unit_position,
     question=question_content.question|question_references(get_question)|markdown,
     question_advice=question_content.question_advice,
     hint=(question_content.hint or '')|question_references(get_question),
@@ -163,7 +163,8 @@
     name=question_content.id,
     value=service_data[question_content.id],
     error=errors.get(question_content.id)['message']|question_references(get_question),
-    question_number=question_number
+    question_number=question_number,
+    smaller=True
   %}
     {% include "toolkit/forms/textbox.html" %}
   {% endwith %}

--- a/bower.json
+++ b/bower.json
@@ -5,8 +5,8 @@
     "jquery": "1.11.2",
     "hogan": "3.0.2",
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
-    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v15.13.1",
+    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v15.14.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.14.1/jinja_govuk_template-0.14.1.tgz",
-    "digitalmarketplace-frameworks": "git://github.com/alphagov/digitalmarketplace-frameworks#v1.2.0"
+    "digitalmarketplace-frameworks": "git://github.com/alphagov/digitalmarketplace-frameworks#v1.3.1"
   }
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ Flask-WTF==0.12
 werkzeug==0.10.4
 python-dateutil==2.4.2
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@19.7.2#egg=digitalmarketplace-utils==19.7.2
+git+https://github.com/alphagov/digitalmarketplace-utils.git@19.9.0#egg=digitalmarketplace-utils==19.9.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@3.6.0#egg=digitalmarketplace-apiclient==3.6.0
 
 markdown==2.6.2

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -280,14 +280,14 @@ class TestFrameworksDashboard(BaseApplicationTest):
                 {
                     'text': "Download guidance and legal documentation (.zip)",
                     'time': {
-                        'text': 'Thursday 01 January 2015',
+                        'text': 'Thursday 1 January 2015',
                         'datetime': '2015-01-01T14:00:00.000Z'
                     }
                 },
                 {
                     'text': "Read updates and ask clarification questions",
                     'time': {
-                        'text': 'Monday 02 February 2015',
+                        'text': 'Monday 2 February 2015',
                         'datetime': '2015-02-02T14:00:00.000Z'
                     }
                 }
@@ -317,7 +317,7 @@ class TestFrameworksDashboard(BaseApplicationTest):
                 {
                     'text': "Download guidance and legal documentation (.zip)",
                     'time': {
-                        'text': 'Thursday 01 January 2015',
+                        'text': 'Thursday 1 January 2015',
                         'datetime': '2015-01-01T14:00:00.000Z'
                     }
                 },
@@ -586,7 +586,7 @@ class TestFrameworkAgreement(BaseApplicationTest):
                 u'/suppliers/frameworks/g-cloud-7/agreement',
                 doc.xpath('//form')[0].action
             )
-            assert_in(u'Document uploaded Monday 02 November 2015 at 15:25', data)
+            assert_in(u'Document uploaded Monday 2 November 2015 at 15:25', data)
             assert_in(u'Your document has been uploaded', data)
 
     def test_upload_message_if_agreement_is_not_returned(self, data_api_client):


### PR DESCRIPTION
This is part of the [Validate 'how many suppliers you'll evaluate'](https://www.pivotaltracker.com/story/show/118392265) story, which changes `percentage` type questions into `number` types.
Also updated the frontend-toolkit, utils, and frameworks repository.

Needs:
- [x] [PR #266 digitalmarketplace-frameworks](https://github.com/alphagov/digitalmarketplace-frameworks/pull/266)
- [x] [PR #263 digitalmarketplace-utils](https://github.com/alphagov/digitalmarketplace-utils/pull/263)
- [x] [PR #255 in frontend-toolkit](https://github.com/alphagov/digitalmarketplace-frontend-toolkit/pull/255)