### PR TITLE
Services not labs

### DIFF
--- a/app/main/helpers/frameworks.py
+++ b/app/main/helpers/frameworks.py
@@ -127,9 +127,9 @@ def get_frameworks_by_status(frameworks, status, extra_condition=False):
     ]
 
 
-def count_drafts_by_lot(drafts, lot):
+def count_drafts_by_lot(drafts, lotSlug):
     return len([
-        draft for draft in drafts if draft['lot'] == lot
+        draft for draft in drafts if draft['lotSlug'] == lotSlug
     ])
 
 

--- a/app/main/helpers/frameworks.py
+++ b/app/main/helpers/frameworks.py
@@ -256,12 +256,6 @@ def get_status_for_multi_service_lot_and_service_type(
         }
 
 
-def has_one_service_limit(lot_slug, framework_lots):
-    for lot in framework_lots:
-        if lot['slug'] == lot_slug:
-            return lot['oneServiceLimit']
-
-
 def countersigned_framework_agreement_exists_in_bucket(framework_slug, bucket):
     agreements_bucket = s3.S3(bucket)
     countersigned_path = get_agreement_document_path(

--- a/app/main/helpers/services.py
+++ b/app/main/helpers/services.py
@@ -30,8 +30,8 @@ def get_drafts(apiclient, framework_slug):
 def get_lot_drafts(apiclient, framework_slug, lot_slug):
     drafts, complete_drafts = get_drafts(apiclient, framework_slug)
     return (
-        [draft for draft in drafts if draft['lot'] == lot_slug],
-        [draft for draft in complete_drafts if draft['lot'] == lot_slug]
+        [draft for draft in drafts if draft['lotSlug'] == lot_slug],
+        [draft for draft in complete_drafts if draft['lotSlug'] == lot_slug]
     )
 
 

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 import itertools
-from datetime import datetime
 
 from dateutil.parser import parse as date_parse
 from flask import render_template, request, abort, flash, redirect, url_for, current_app
@@ -25,7 +24,7 @@ from ..helpers import hash_email, login_required
 from ..helpers.frameworks import (
     get_declaration_status, get_last_modified_from_first_matching_file, register_interest_in_framework,
     get_supplier_on_framework_from_info, get_declaration_status_from_info, get_supplier_framework_info,
-    get_framework, get_framework_and_lot, count_drafts_by_lot, get_statuses_for_lot, has_one_service_limit,
+    get_framework, get_framework_and_lot, count_drafts_by_lot, get_statuses_for_lot,
     countersigned_framework_agreement_exists_in_bucket
 )
 from ..helpers.validation import get_validator
@@ -153,9 +152,8 @@ def framework_submission_lots(framework_slug):
             declaration_status,
             framework['status'],
             lot['name'],
-            'lab' if framework['slug'] == 'digital-outcomes-and-specialists' else 'service',
-            'labs' if framework['slug'] == 'digital-outcomes-and-specialists' else 'services'
-            # TODO: ^ make this dynamic, eg, lab, service, unit
+            lot['unitSingular'],
+            lot['unitPlural']
         ),
     } for lot in lots if framework["status"] == "open" or (lot['draft_count'] + lot['complete_count']) > 0]
 

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -213,7 +213,7 @@ def create_new_draft_service(framework_slug, lot_slug):
         url_for(
             ".view_service_submission",
             framework_slug=framework['slug'],
-            lot_slug=draft_service['lot'],
+            lot_slug=draft_service['lotSlug'],
             service_id=draft_service['id'],
         )
     )
@@ -242,7 +242,7 @@ def copy_draft_service(framework_slug, lot_slug, service_id):
 
     return redirect(url_for(".edit_service_submission",
                             framework_slug=framework['slug'],
-                            lot_slug=draft['lot'],
+                            lot_slug=draft['lotSlug'],
                             service_id=draft_copy['id'],
                             section_id=content.get_next_editable_section_id(),
                             return_to_summary=1
@@ -312,7 +312,7 @@ def delete_draft_service(framework_slug, lot_slug, service_id):
     else:
         return redirect(url_for(".view_service_submission",
                                 framework_slug=framework['slug'],
-                                lot_slug=draft['lot'],
+                                lot_slug=draft['lotSlug'],
                                 service_id=service_id,
                                 delete_requested=True))
 
@@ -489,13 +489,13 @@ def update_section_submission(framework_slug, lot_slug, service_id, section_id, 
     if next_section and not return_to_summary and request.form.get('continue_to_next_section'):
         return redirect(url_for(".edit_service_submission",
                                 framework_slug=framework['slug'],
-                                lot_slug=draft['lot'],
+                                lot_slug=draft['lotSlug'],
                                 service_id=service_id,
                                 section_id=next_section))
     else:
         return redirect(url_for(".view_service_submission",
                                 framework_slug=framework['slug'],
-                                lot_slug=draft['lot'],
+                                lot_slug=draft['lotSlug'],
                                 service_id=service_id,
                                 _anchor=section_id))
 

--- a/app/templates/services/service_submission.html
+++ b/app/templates/services/service_submission.html
@@ -26,7 +26,7 @@
       {
         "link": url_for(".framework_submission_services", framework_slug=framework.slug, lot_slug=service_data.lot),
         "label": service_data.lotName
-      } if not one_service_limit else {}
+      } if not lot.oneServiceLimit else {}
     ]
   %}
     {% include "toolkit/breadcrumb.html" %}
@@ -76,7 +76,7 @@
     by {{ last_edit.userName }}
   </p>
   {% if framework.status == 'open' %}
-    {% if not one_service_limit and (unanswered_required or unanswered_optional) %}
+    {% if not lot.oneServiceLimit and (unanswered_required or unanswered_optional) %}
       <p class="last-edited">
         {{ submission.multiline_string(
           submission.unanswered_required_text(unanswered_required, unanswered_optional),
@@ -116,7 +116,7 @@
         <input type="hidden" name="delete_confirmed" value="true" />
         <div class="banner-destructive-with-action">
           <p class="banner-message">
-            Are you sure you want to delete {{ service_data.lotName.lower() if one_service_limit else 'this lab' }}?
+            Are you sure you want to delete {{ service_data.lotName.lower() if lot.oneServiceLimit else 'this {}'.format(lot.unitSingular) }}?
           </p>
           <button type="submit" class="button-destructive banner-action">Yes, delete</button>
         </div>
@@ -157,7 +157,7 @@
         </form>
         {% endif %}
       </div>
-      {% if one_service_limit %}
+      {% if lot.oneServiceLimit %}
         {% set back_to_service_url = url_for(".framework_submission_lots", framework_slug=framework.slug) %}
         {% set back_to_service_link_text = 'Back to application' %}
       {% else %}

--- a/tests/app/helpers.py
+++ b/tests/app/helpers.py
@@ -86,19 +86,21 @@ FULL_G7_SUBMISSION = {
     "SQE2a": ["as a prime contractor, using third parties (subcontractors) to provide some services"]
 }
 
-EMPTY_G7_DRAFT = {
-    'id': 1,
-    'supplierId': 1234,
-    'supplierName': 'supplierName',
-    'frameworkName': 'G-Cloud 7',
-    'frameworkSlug': 'g-cloud-7',
-    'lot': 'scs',
-    'lotSlug': 'scs',
-    'lotName': 'Specialist Cloud Services',
-    'status': 'not-submitted',
-    'links': {},
-    'updatedAt': '2015-06-29T15:26:07.650368Z'
-}
+
+def empty_g7_draft():
+    return {
+        'id': 1,
+        'supplierId': 1234,
+        'supplierName': 'supplierName',
+        'frameworkName': 'G-Cloud 7',
+        'frameworkSlug': 'g-cloud-7',
+        'lot': 'scs',
+        'lotSlug': 'scs',
+        'lotName': 'Specialist Cloud Services',
+        'status': 'not-submitted',
+        'links': {},
+        'updatedAt': '2015-06-29T15:26:07.650368Z'
+    }
 
 
 class BaseApplicationTest(object):

--- a/tests/app/helpers.py
+++ b/tests/app/helpers.py
@@ -177,12 +177,15 @@ class BaseApplicationTest(object):
     def framework(status='open', name='G-Cloud 7', slug='g-cloud-7', clarification_questions_open=True):
         if slug == 'g-cloud-7':
             lots = [
-                {'id': 1, 'slug': 'iaas', 'name': 'Infrastructure as a Service', 'oneServiceLimit': False},
-                {'id': 2, 'slug': 'scs', 'name': 'Specialist Cloud Services', 'oneServiceLimit': False},
+                {'id': 1, 'slug': 'iaas', 'name': 'Infrastructure as a Service', 'oneServiceLimit': False,
+                 'unitSingular': 'service', 'unitPlural': 'service'},
+                {'id': 2, 'slug': 'scs', 'name': 'Specialist Cloud Services', 'oneServiceLimit': False,
+                 'unitSingular': 'service', 'unitPlural': 'service'},
             ]
         elif slug == 'digital-outcomes-and-specialists':
             lots = [
-                {'id': 1, 'slug': 'digital-specialists', 'name': 'Digital specialists', 'oneServiceLimit': True},
+                {'id': 1, 'slug': 'digital-specialists', 'name': 'Digital specialists', 'oneServiceLimit': True,
+                 'unitSingular': 'service', 'unitPlural': 'service'},
             ]
 
         return {

--- a/tests/app/helpers.py
+++ b/tests/app/helpers.py
@@ -86,6 +86,20 @@ FULL_G7_SUBMISSION = {
     "SQE2a": ["as a prime contractor, using third parties (subcontractors) to provide some services"]
 }
 
+EMPTY_G7_DRAFT = {
+    'id': 1,
+    'supplierId': 1234,
+    'supplierName': 'supplierName',
+    'frameworkName': 'G-Cloud 7',
+    'frameworkSlug': 'g-cloud-7',
+    'lot': 'scs',
+    'lotSlug': 'scs',
+    'lotName': 'Specialist Cloud Services',
+    'status': 'not-submitted',
+    'links': {},
+    'updatedAt': '2015-06-29T15:26:07.650368Z'
+}
+
 
 class BaseApplicationTest(object):
     def setup(self):

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -147,7 +147,7 @@ class TestFrameworksDashboard(BaseApplicationTest):
             data_api_client.get_framework_interest.return_value = {'frameworks': ['g-cloud-7']}
             data_api_client.find_draft_services.return_value = {
                 "services": [
-                    {'serviceName': 'A service', 'status': 'submitted', 'lot': 'iaas'}
+                    {'serviceName': 'A service', 'status': 'submitted', 'lotSlug': 'iaas'}
                 ]
             }
             data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(declaration=None)
@@ -188,7 +188,7 @@ class TestFrameworksDashboard(BaseApplicationTest):
             data_api_client.get_framework_interest.return_value = {'frameworks': ['g-cloud-7']}
             data_api_client.find_draft_services.return_value = {
                 "services": [
-                    {'serviceName': 'A service', 'status': 'submitted', 'lot': 'iaas'}
+                    {'serviceName': 'A service', 'status': 'submitted', 'lotSlug': 'iaas'}
                 ]
             }
             data_api_client.get_supplier_framework_info.return_value = self.supplier_framework()
@@ -361,7 +361,7 @@ class TestFrameworksDashboard(BaseApplicationTest):
             data_api_client.get_framework.return_value = self.framework(status='standstill')
             data_api_client.find_draft_services.return_value = {
                 "services": [
-                    {'serviceName': 'A service', 'status': 'submitted', 'lot': 'iaas'}
+                    {'serviceName': 'A service', 'status': 'submitted', 'lotSlug': 'iaas'}
                 ]
             }
             data_api_client.get_supplier_framework_info.return_value = self.supplier_framework()
@@ -379,7 +379,7 @@ class TestFrameworksDashboard(BaseApplicationTest):
             data_api_client.get_framework.return_value = self.framework(status='pending')
             data_api_client.find_draft_services.return_value = {
                 "services": [
-                    {'serviceName': 'A service', 'status': 'submitted', 'lot': 'iaas'}
+                    {'serviceName': 'A service', 'status': 'submitted', 'lotSlug': 'iaas'}
                 ]
             }
             data_api_client.get_supplier_framework_info.return_value = self.supplier_framework()
@@ -415,7 +415,7 @@ class TestFrameworksDashboard(BaseApplicationTest):
             data_api_client.get_framework.return_value = self.framework(status='standstill')
             data_api_client.find_draft_services.return_value = {
                 "services": [
-                    {'serviceName': 'A service', 'status': 'submitted', 'lot': 'iaas'}
+                    {'serviceName': 'A service', 'status': 'submitted', 'lotSlug': 'iaas'}
                 ]
             }
             data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
@@ -436,7 +436,7 @@ class TestFrameworksDashboard(BaseApplicationTest):
         data_api_client.get_framework.return_value = self.framework(status='standstill')
         data_api_client.find_draft_services.return_value = {
             "services": [
-                {'serviceName': 'A service', 'status': 'submitted', 'lot': 'iaas'}
+                {'serviceName': 'A service', 'status': 'submitted', 'lotSlug': 'iaas'}
             ]
         }
         data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(on_framework=True)
@@ -465,7 +465,7 @@ class TestFrameworksDashboard(BaseApplicationTest):
 
             data_api_client.find_draft_services.return_value = {
                 "services": [
-                    {'serviceName': 'A service', 'status': 'submitted', 'lot': 'iaas'}
+                    {'serviceName': 'A service', 'status': 'submitted', 'lotSlug': 'iaas'}
                 ]
             }
             data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
@@ -485,7 +485,7 @@ class TestFrameworksDashboard(BaseApplicationTest):
         data_api_client.get_framework.return_value = self.framework(status='standstill')
         data_api_client.find_draft_services.return_value = {
             "services": [
-                {'serviceName': 'A service', 'status': 'submitted', 'lot': 'iaas'}
+                {'serviceName': 'A service', 'status': 'submitted', 'lotSlug': 'iaas'}
             ]
         }
         data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(on_framework=False)
@@ -515,7 +515,7 @@ class TestFrameworksDashboard(BaseApplicationTest):
             data_api_client.get_framework.return_value = self.framework(status='standstill')
             data_api_client.find_draft_services.return_value = {
                 "services": [
-                    {'serviceName': 'A service', 'status': 'submitted', 'lot': 'iaas'}
+                    {'serviceName': 'A service', 'status': 'submitted', 'lotSlug': 'iaas'}
                 ]
             }
             data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
@@ -1479,7 +1479,7 @@ class TestG7ServicesList(BaseApplicationTest):
         data_api_client.get_supplier_declaration.return_value = {'declaration': FULL_G7_SUBMISSION}  # noqa
         data_api_client.find_draft_services.return_value = {
             'services': [
-                {'serviceName': 'draft', 'lot': 'scs', 'status': 'submitted'},
+                {'serviceName': 'draft', 'lotSlug': 'scs', 'status': 'submitted'},
             ]
         }
         count_unanswered.return_value = 0, 1
@@ -1503,7 +1503,7 @@ class TestG7ServicesList(BaseApplicationTest):
         data_api_client.get_framework.return_value = self.framework(status='open')
         data_api_client.find_draft_services.return_value = {
             'services': [
-                {'serviceName': 'draft', 'lot': 'scs', 'status': 'not-submitted'},
+                {'serviceName': 'draft', 'lotSlug': 'scs', 'status': 'not-submitted'},
             ]
         }
 
@@ -1525,7 +1525,7 @@ class TestG7ServicesList(BaseApplicationTest):
         data_api_client.get_framework.return_value = self.framework(status='open')
         data_api_client.find_draft_services.return_value = {
             'services': [
-                {'serviceName': 'draft', 'lot': 'scs', 'status': 'not-submitted'},
+                {'serviceName': 'draft', 'lotSlug': 'scs', 'status': 'not-submitted'},
             ]
         }
 
@@ -1543,7 +1543,7 @@ class TestG7ServicesList(BaseApplicationTest):
         data_api_client.get_framework.return_value = self.framework(status='open')
         data_api_client.find_draft_services.return_value = {
             'services': [
-                {'serviceName': 'draft', 'lot': 'scs', 'status': 'submitted'},
+                {'serviceName': 'draft', 'lotSlug': 'scs', 'status': 'submitted'},
             ]
         }
 
@@ -1569,7 +1569,7 @@ class TestG7ServicesList(BaseApplicationTest):
         }
         data_api_client.find_draft_services.return_value = {
             'services': [
-                {'serviceName': 'draft', 'lot': 'scs', 'status': 'submitted'},
+                {'serviceName': 'draft', 'lotSlug': 'scs', 'status': 'submitted'},
             ]
         }
 
@@ -1591,8 +1591,8 @@ class TestG7ServicesList(BaseApplicationTest):
         }
         data_api_client.find_draft_services.return_value = {
             'services': [
-                {'serviceName': 'draft', 'lot': 'scs', 'status': 'not-submitted'},
-                {'serviceName': 'draft', 'lot': 'scs', 'status': 'submitted'},
+                {'serviceName': 'draft', 'lotSlug': 'scs', 'status': 'not-submitted'},
+                {'serviceName': 'draft', 'lotSlug': 'scs', 'status': 'submitted'},
             ]
         }
 
@@ -1613,7 +1613,7 @@ class TestG7ServicesList(BaseApplicationTest):
         }
         data_api_client.find_draft_services.return_value = {
             'services': [
-                {'serviceName': 'draft', 'lot': 'digital-specialists', 'status': 'submitted'},
+                {'serviceName': 'draft', 'lotSlug': 'digital-specialists', 'status': 'submitted'},
             ]
         }
 
@@ -1636,8 +1636,8 @@ class TestG7ServicesList(BaseApplicationTest):
         }
         data_api_client.find_draft_services.return_value = {
             'services': [
-                {'serviceName': 'draft', 'lot': 'digital-specialists', 'status': 'not-submitted'},
-                {'serviceName': 'draft', 'lot': 'digital-specialists', 'status': 'submitted'},
+                {'serviceName': 'draft', 'lotSlug': 'digital-specialists', 'status': 'not-submitted'},
+                {'serviceName': 'draft', 'lotSlug': 'digital-specialists', 'status': 'submitted'},
             ]
         }
 

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -12,7 +12,7 @@ from lxml import html
 from freezegun import freeze_time
 
 from nose.tools import assert_equal, assert_true, assert_false, assert_in, assert_not_in
-from tests.app.helpers import BaseApplicationTest, EMPTY_G7_DRAFT
+from tests.app.helpers import BaseApplicationTest, empty_g7_draft
 
 
 @pytest.fixture(params=["g-cloud-6", "g-cloud-7"])
@@ -532,7 +532,7 @@ class TestCreateDraftService(BaseApplicationTest):
 
     def _test_post_create_draft_service(self, data, if_error_expected, data_api_client):
         data_api_client.get_framework.return_value = self.framework(status='open')
-        data_api_client.create_new_draft_service.return_value = {"services": EMPTY_G7_DRAFT}
+        data_api_client.create_new_draft_service.return_value = {"services": empty_g7_draft()}
 
         res = self.client.post(
             '/suppliers/frameworks/g-cloud-7/submissions/scs/create',
@@ -587,7 +587,7 @@ class TestCopyDraft(BaseApplicationTest):
         with self.app.test_client():
             self.login()
 
-        self.draft = EMPTY_G7_DRAFT.copy()
+        self.draft = empty_g7_draft()
 
     def test_copy_draft(self, data_api_client):
         data_api_client.get_framework.return_value = self.framework(status='open')
@@ -619,7 +619,7 @@ class TestCompleteDraft(BaseApplicationTest):
         with self.app.test_client():
             self.login()
 
-        self.draft = EMPTY_G7_DRAFT.copy()
+        self.draft = empty_g7_draft()
 
     def test_complete_draft(self, data_api_client):
         data_api_client.get_framework.return_value = self.framework(status='open')
@@ -652,7 +652,7 @@ class TestEditDraftService(BaseApplicationTest):
         with self.app.test_client():
             self.login()
 
-        self.empty_draft = {'services': EMPTY_G7_DRAFT}
+        self.empty_draft = {'services': empty_g7_draft()}
 
         self.multiquestion_draft = {
             'services': {
@@ -1167,7 +1167,7 @@ class TestEditDraftService(BaseApplicationTest):
 @mock.patch('app.main.views.services.data_api_client')
 class TestShowDraftService(BaseApplicationTest):
 
-    draft_service_data = EMPTY_G7_DRAFT.copy()
+    draft_service_data = empty_g7_draft()
     draft_service_data.update({
         'priceMin': '12.50',
         'priceMax': '15',
@@ -1287,7 +1287,7 @@ class TestShowDraftService(BaseApplicationTest):
 @mock.patch('app.main.views.services.data_api_client')
 class TestDeleteDraftService(BaseApplicationTest):
 
-    draft_service_data = EMPTY_G7_DRAFT.copy()
+    draft_service_data = empty_g7_draft()
     draft_service_data.update({
         'serviceName': 'My rubbish draft',
         'serviceSummary': 'This is the worst service ever',

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -12,7 +12,7 @@ from lxml import html
 from freezegun import freeze_time
 
 from nose.tools import assert_equal, assert_true, assert_false, assert_in, assert_not_in
-from tests.app.helpers import BaseApplicationTest
+from tests.app.helpers import BaseApplicationTest, EMPTY_G7_DRAFT
 
 
 @pytest.fixture(params=["g-cloud-6", "g-cloud-7"])
@@ -532,19 +532,7 @@ class TestCreateDraftService(BaseApplicationTest):
 
     def _test_post_create_draft_service(self, data, if_error_expected, data_api_client):
         data_api_client.get_framework.return_value = self.framework(status='open')
-        data_api_client.create_new_draft_service.return_value = {
-            'services': {
-                'id': 1,
-                'supplierId': 1234,
-                'supplierName': "supplierName",
-                'lotSlug': "scs",
-                'lotName': "Specialist Cloud Services",
-                'status': "not-submitted",
-                'frameworkName': "frameworkName",
-                'links': {},
-                'updatedAt': "2015-06-29T15:26:07.650368Z"
-            }
-        }
+        data_api_client.create_new_draft_service.return_value = {"services": EMPTY_G7_DRAFT}
 
         res = self.client.post(
             '/suppliers/frameworks/g-cloud-7/submissions/scs/create',
@@ -599,17 +587,7 @@ class TestCopyDraft(BaseApplicationTest):
         with self.app.test_client():
             self.login()
 
-        self.draft = {
-            'id': 1,
-            'supplierId': 1234,
-            'supplierName': "supplierName",
-            'lotSlug': "scs",
-            'status': "not-submitted",
-            'frameworkName': "frameworkName",
-            'frameworkSlug': 'g-cloud-7',
-            'links': {},
-            'updatedAt': "2015-06-29T15:26:07.650368Z"
-        }
+        self.draft = EMPTY_G7_DRAFT.copy()
 
     def test_copy_draft(self, data_api_client):
         data_api_client.get_framework.return_value = self.framework(status='open')
@@ -641,22 +619,11 @@ class TestCompleteDraft(BaseApplicationTest):
         with self.app.test_client():
             self.login()
 
-        self.draft = {
-            'id': 1,
-            'supplierId': 1234,
-            'supplierName': "supplierName",
-            'lotSlug': "scs",
-            'status': "not-submitted",
-            'frameworkName': "frameworkName",
-            'frameworkSlug': 'g-cloud-7',
-            'links': {},
-            'updatedAt': "2015-06-29T15:26:07.650368Z"
-        }
+        self.draft = EMPTY_G7_DRAFT.copy()
 
     def test_complete_draft(self, data_api_client):
         data_api_client.get_framework.return_value = self.framework(status='open')
         data_api_client.get_draft_service.return_value = {'services': self.draft}
-
         res = self.client.post('/suppliers/frameworks/g-cloud-7/submissions/scs/1/complete')
         assert_equal(res.status_code, 302)
         assert_true('lot=scs' in res.location)
@@ -685,20 +652,7 @@ class TestEditDraftService(BaseApplicationTest):
         with self.app.test_client():
             self.login()
 
-        self.empty_draft = {
-            'services': {
-                'id': 1,
-                'supplierId': 1234,
-                'supplierName': 'supplierName',
-                'lot': 'scs',
-                'lotSlug': 'scs',
-                'status': 'not-submitted',
-                'frameworkSlug': 'g-cloud-7',
-                'frameworkName': 'frameworkName',
-                'links': {},
-                'updatedAt': '2015-06-29T15:26:07.650368Z'
-            }
-        }
+        self.empty_draft = {'services': EMPTY_G7_DRAFT}
 
         self.multiquestion_draft = {
             'services': {
@@ -1213,27 +1167,19 @@ class TestEditDraftService(BaseApplicationTest):
 @mock.patch('app.main.views.services.data_api_client')
 class TestShowDraftService(BaseApplicationTest):
 
+    draft_service_data = EMPTY_G7_DRAFT.copy()
+    draft_service_data.update({
+        'priceMin': '12.50',
+        'priceMax': '15',
+        'priceUnit': 'Person',
+        'priceInterval': 'Second',
+    })
+
     draft_service = {
-        'services': {
-            'id': 1,
-            'supplierId': 1234,
-            'supplierName': 'supplierName',
-            'lot': 'scs',
-            'lotSlug': 'scs',
-            'status': 'not-submitted',
-            'frameworkName': 'frameworkName',
-            'frameworkSlug': 'g-cloud-7',
-            'priceMin': '12.50',
-            'priceMax': '15',
-            'priceUnit': 'Person',
-            'priceInterval': 'Second',
-            'links': {},
-            'updatedAt': '2015-06-29T15:26:07.650368Z'
-        },
+        'services': draft_service_data,
         'auditEvents': {
             'createdAt': '2015-06-29T15:26:07.650368Z',
             'userName': 'Supplier User',
-
         },
         'validationErrors': {}
     }
@@ -1341,21 +1287,13 @@ class TestShowDraftService(BaseApplicationTest):
 @mock.patch('app.main.views.services.data_api_client')
 class TestDeleteDraftService(BaseApplicationTest):
 
+    draft_service_data = EMPTY_G7_DRAFT.copy()
+    draft_service_data.update({
+        'serviceName': 'My rubbish draft',
+        'serviceSummary': 'This is the worst service ever',
+    })
     draft_to_delete = {
-        'services': {
-            'id': 1,
-            'supplierId': 1234,
-            'supplierName': "supplierName",
-            'lotSlug': "scs",
-            'lotName': "Specialist Cloud Services",
-            'status': "not-submitted",
-            'frameworkSlug': 'g-cloud-7',
-            'frameworkName': "frameworkName",
-            'links': {},
-            'serviceName': 'My rubbish draft',
-            'serviceSummary': 'This is the worst service ever',
-            'updatedAt': "2015-06-29T15:26:07.650368Z"
-        },
+        'services': draft_service_data,
         'auditEvents': {
             'createdAt': "2015-06-29T15:26:07.650368Z",
             'userName': "Supplier User",

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -54,7 +54,7 @@ class TestListServices(BaseApplicationTest):
                     'serviceName': 'Service name 123',
                     'status': 'published',
                     'id': '123',
-                    'lot': 'saas',
+                    'lotSlug': 'saas',
                     'lotName': 'Software as a Service',
                     'frameworkName': 'G-Cloud 1',
                     'frameworkSlug': 'g-cloud-1'
@@ -384,10 +384,12 @@ class TestEditService(BaseApplicationTest):
             'serviceName': 'Service name 123',
             'status': 'published',
             'id': '123',
+            'frameworkSlug': 'g-cloud-6',
             'frameworkName': 'G-Cloud 6',
             'supplierId': 1234,
             'supplierName': 'We supply any',
             'lot': 'scs',
+            'lotSlug': 'scs',
             'lotName': "Specialist Cloud Services",
         }
     }
@@ -430,7 +432,7 @@ class TestEditService(BaseApplicationTest):
         res = self.client.post(
             '/suppliers/services/1/edit/service-attributes',
             data={
-                'lot': 'scs',
+                'lotSlug': 'scs',
             })
         assert_equal(res.status_code, 404)
 
@@ -535,7 +537,7 @@ class TestCreateDraftService(BaseApplicationTest):
                 'id': 1,
                 'supplierId': 1234,
                 'supplierName': "supplierName",
-                'lot': "scs",
+                'lotSlug': "scs",
                 'lotName': "Specialist Cloud Services",
                 'status': "not-submitted",
                 'frameworkName': "frameworkName",
@@ -601,9 +603,10 @@ class TestCopyDraft(BaseApplicationTest):
             'id': 1,
             'supplierId': 1234,
             'supplierName': "supplierName",
-            'lot': "scs",
+            'lotSlug': "scs",
             'status': "not-submitted",
             'frameworkName': "frameworkName",
+            'frameworkSlug': 'g-cloud-7',
             'links': {},
             'updatedAt': "2015-06-29T15:26:07.650368Z"
         }
@@ -642,9 +645,10 @@ class TestCompleteDraft(BaseApplicationTest):
             'id': 1,
             'supplierId': 1234,
             'supplierName': "supplierName",
-            'lot': "scs",
+            'lotSlug': "scs",
             'status': "not-submitted",
             'frameworkName': "frameworkName",
+            'frameworkSlug': 'g-cloud-7',
             'links': {},
             'updatedAt': "2015-06-29T15:26:07.650368Z"
         }
@@ -685,13 +689,14 @@ class TestEditDraftService(BaseApplicationTest):
             'services': {
                 'id': 1,
                 'supplierId': 1234,
-                'supplierName': "supplierName",
-                'lot': "scs",
-                'status': "not-submitted",
-                'frameworkSlug': 'g-slug',
-                'frameworkName': "frameworkName",
+                'supplierName': 'supplierName',
+                'lot': 'scs',
+                'lotSlug': 'scs',
+                'status': 'not-submitted',
+                'frameworkSlug': 'g-cloud-7',
+                'frameworkName': 'frameworkName',
                 'links': {},
-                'updatedAt': "2015-06-29T15:26:07.650368Z"
+                'updatedAt': '2015-06-29T15:26:07.650368Z'
             }
         }
 
@@ -699,8 +704,10 @@ class TestEditDraftService(BaseApplicationTest):
             'services': {
                 'id': 1,
                 'supplierId': 1234,
-                'supplierName': "supplierName",
+                'supplierName': 'supplierName',
                 'lot': 'digital-specialists',
+                'lotSlug': 'digital-specialists',
+                'frameworkSlug': 'digital-outcomes-and-specialists',
                 'lotName': 'Digital specialists',
                 'agileCoachLocations': ['Wales'],
                 'agileCoachPriceMax': '200',
@@ -708,11 +715,11 @@ class TestEditDraftService(BaseApplicationTest):
                 'developerLocations': ['Wales'],
                 'developerPriceMax': '250',
                 'developerPriceMin': '150',
-                'status': "not-submitted",
+                'status': 'not-submitted',
             },
             'auditEvents': {
-                'createdAt': "2015-06-29T15:26:07.650368Z",
-                'userName': "Supplier User",
+                'createdAt': '2015-06-29T15:26:07.650368Z',
+                'userName': 'Supplier User',
             },
             'validationErrors': {}
         }
@@ -776,7 +783,7 @@ class TestEditDraftService(BaseApplicationTest):
         res = self.client.post(
             '/suppliers/frameworks/g-cloud-7/submissions/scs/1/edit/service-attributes',
             data={
-                'lot': 'scs',
+                'lotSlug': 'scs',
             })
         assert_equal(res.status_code, 404)
 
@@ -845,13 +852,13 @@ class TestEditDraftService(BaseApplicationTest):
         assert_equal(res.status_code, 302)
         data_api_client.update_draft_service.assert_called_once_with(
             '1', {
-                'serviceDefinitionDocumentURL': 'http://localhost/suppliers/assets/g-slug/submissions/1234/1-service-definition-document-2015-01-02-0304.pdf'  # noqa
+                'serviceDefinitionDocumentURL': 'http://localhost/suppliers/assets/g-cloud-7/submissions/1234/1-service-definition-document-2015-01-02-0304.pdf'  # noqa
             }, 'email@email.com',
             page_questions=['serviceDefinitionDocumentURL']
         )
 
         s3.return_value.save.assert_called_once_with(
-            'g-slug/submissions/1234/1-service-definition-document-2015-01-02-0304.pdf',
+            'g-cloud-7/submissions/1234/1-service-definition-document-2015-01-02-0304.pdf',
             mock.ANY, acl='private'
         )
 
@@ -1070,9 +1077,11 @@ class TestEditDraftService(BaseApplicationTest):
         data_api_client.get_framework.return_value = self.framework(
             status='open', slug='digital-outcomes-and-specialists'
         )
-
-        self.empty_draft['services']['lot'] = 'digital-specialists'
-        data_api_client.get_draft_service.return_value = self.empty_draft
+        draft = self.empty_draft.copy()
+        draft['services']['lot'] = 'digital-specialists'
+        draft['services']['lotSlug'] = 'digital-specialists'
+        draft['services']['frameworkSlug'] = 'digital-outcomes-and-specialists'
+        data_api_client.get_draft_service.return_value = draft
 
         res = self.client.get(
             '/suppliers/frameworks/digital-outcomes-and-specialists/submissions/' +
@@ -1208,20 +1217,22 @@ class TestShowDraftService(BaseApplicationTest):
         'services': {
             'id': 1,
             'supplierId': 1234,
-            'supplierName': "supplierName",
-            'lot': "scs",
-            'status': "not-submitted",
-            'frameworkName': "frameworkName",
+            'supplierName': 'supplierName',
+            'lot': 'scs',
+            'lotSlug': 'scs',
+            'status': 'not-submitted',
+            'frameworkName': 'frameworkName',
+            'frameworkSlug': 'g-cloud-7',
             'priceMin': '12.50',
             'priceMax': '15',
             'priceUnit': 'Person',
             'priceInterval': 'Second',
             'links': {},
-            'updatedAt': "2015-06-29T15:26:07.650368Z"
+            'updatedAt': '2015-06-29T15:26:07.650368Z'
         },
         'auditEvents': {
-            'createdAt': "2015-06-29T15:26:07.650368Z",
-            'userName': "Supplier User",
+            'createdAt': '2015-06-29T15:26:07.650368Z',
+            'userName': 'Supplier User',
 
         },
         'validationErrors': {}
@@ -1335,10 +1346,10 @@ class TestDeleteDraftService(BaseApplicationTest):
             'id': 1,
             'supplierId': 1234,
             'supplierName': "supplierName",
-            'lot': "scs",
+            'lotSlug': "scs",
             'lotName': "Specialist Cloud Services",
             'status': "not-submitted",
-            'frameworkSlug': 'g-slug',
+            'frameworkSlug': 'g-cloud-7',
             'frameworkName': "frameworkName",
             'links': {},
             'serviceName': 'My rubbish draft',
@@ -1367,7 +1378,7 @@ class TestDeleteDraftService(BaseApplicationTest):
         assert_in('/frameworks/g-cloud-7/submissions/scs/1?delete_requested=True', res.location)
         res2 = self.client.get('/suppliers/frameworks/g-cloud-7/submissions/scs/1?delete_requested=True')
         assert_in(
-            b"Are you sure you want to delete this lab?", res2.get_data()
+            b"Are you sure you want to delete this service?", res2.get_data()
         )
 
     def test_cannot_delete_if_not_open(self, data_api_client):


### PR DESCRIPTION
Depends on this version of the API running:
 - [x] https://github.com/alphagov/digitalmarketplace-api/pull/390

Fixes this bug: https://www.pivotaltracker.com/story/show/118986461

I've also done a bit of tidying up:
 * removing the `has_one_service_limit` function in favour of using the `lot['oneServiceLimit']` value directly
 * checking that the `framework_slug` and `lot_slug` in the URL match those of the draft being edited 
 * moving to using `lotSlug` rather than `lot` (they have identical values but we want to phase out using `lot` eventually)

This broke a lot more tests than I thought it would.