### PR TITLE
Remove Digital Services Framework footer links

### DIFF
--- a/app/templates/_footer_categories.html
+++ b/app/templates/_footer_categories.html
@@ -30,12 +30,6 @@
         <a href="https://www.gov.uk/guidance/the-crown-hosting-data-centres-framework-on-the-digital-marketplace">Crown Hosting framework</a>
       </li>
       <li>
-        <a href="/digital-services/framework">Digital Services framework</a>
-      </li>
-      <li>
-        <a href="https://www.gov.uk/government/publications/digital-services-store-buyers-guide/digital-services-buyers-guide">Digital Services information</a>
-      </li>
-      <li>
         <a href="https://www.gov.uk/government/organisations/crown-commercial-service">Crown Commercial Service</a>
       </li>
     </ul>


### PR DESCRIPTION
Part of this story: https://www.pivotaltracker.com/story/show/119175733

Will bring footer links in supplier app up to date with those here: https://github.com/alphagov/digitalmarketplace-buyer-frontend/pull/312