### PR TITLE
Don't mark dates down

### DIFF
--- a/app/templates/frameworks/_dashboard_lede.html
+++ b/app/templates/frameworks/_dashboard_lede.html
@@ -1,6 +1,6 @@
 {% if framework.status == 'open' %}
 <aside role="complementary" class="framework-application-status" aria-label="{{ framework.name }} status">
-  Deadline: <strong>{{ dates.framework_close_date|markdown }}</strong>
+  Deadline: <strong>{{ dates.framework_close_date }}</strong>
 </aside>
 
 {% elif framework.status in ['pending', 'standstill', 'live'] %}
@@ -13,7 +13,7 @@
     {% elif framework.status == 'pending' %}
       {# supplier_is_on_framework should never be true before standstill #}
       <p>You made your supplier declaration and submitted {{ counts.complete }} {{ 'service' if counts.complete == 1 else 'services' }} for consideration.</p>
-      <p>A letter informing you whether your application was successful or not will be posted on your {{ framework.name }} updates page by {{ dates.intention_to_award_date|markdown }}.</p>
+      <p>A letter informing you whether your application was successful or not will be posted on your {{ framework.name }} updates page by {{ dates.intention_to_award_date }}.</p>
 
     {% elif framework.status == 'standstill' %}
       {% if supplier_is_on_framework %}

--- a/app/templates/frameworks/updates.html
+++ b/app/templates/frameworks/updates.html
@@ -113,7 +113,7 @@
           All clarification questions and answers will be published here regularly. You’ll receive an email when new answers are available.
         {% else %}
           The deadline for asking clarification questions has now passed.
-          All clarification questions and answers will be published by {{ dates.clarifications_publish_date|markdown }}.
+          All clarification questions and answers will be published by {{ dates.clarifications_publish_date }}.
           You'll receive an email when new answers are posted.
         {% endif %}
       </p>
@@ -138,7 +138,7 @@
                 {% include "toolkit/forms/textbox.html" %}
               {% endwith %}
               <p>
-                The deadline for clarification questions is {{ dates.clarifications_close_date|markdown }}. All responses will be published by {{ dates.clarifications_publish_date|markdown }}.
+                The deadline for clarification questions is {{ dates.clarifications_close_date }}. All responses will be published by {{ dates.clarifications_publish_date }}.
               </p>
               {%
                 with

--- a/app/templates/services/service_submission.html
+++ b/app/templates/services/service_submission.html
@@ -85,7 +85,7 @@
       </p>
     {% endif %}
     {% if service_data.status == 'submitted' and declaration_status == 'complete' %}
-      <span class="service-status-published">This service is marked as complete and will be submitted at {{ dates.framework_close_date|markdown }}</span>
+      <span class="service-status-published">This service is marked as complete and will be submitted at {{ dates.framework_close_date }}</span>
     {% endif %}
     {% if service_data.status == 'not-submitted' and can_mark_complete and framework.status == 'open' %}
       {% include "partials/complete_service.html" %}

--- a/app/templates/suppliers/_frameworks_open.html
+++ b/app/templates/suppliers/_frameworks_open.html
@@ -20,7 +20,7 @@
                 Apply to {{ framework.name }} 
               </h2>
               <p>
-                Deadline: {{ framework.dates.framework_close_date|markdown }}
+                Deadline: {{ framework.dates.framework_close_date }}
               </p>
               {%
               with

--- a/app/templates/suppliers/_frameworks_standstill.html
+++ b/app/templates/suppliers/_frameworks_standstill.html
@@ -19,7 +19,7 @@
           </p>
           {% if framework.onFramework and framework.dates.framework_live_date %}
             <p class='second-line'>
-              Live from {{ framework.dates.framework_live_date|markdown }}
+              Live from {{ framework.dates.framework_live_date }}
             </p>
           {% endif %}
         {% endcall %}

--- a/bower.json
+++ b/bower.json
@@ -7,6 +7,6 @@
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
     "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v15.14.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.14.1/jinja_govuk_template-0.14.1.tgz",
-    "digitalmarketplace-frameworks": "git://github.com/alphagov/digitalmarketplace-frameworks#v1.3.3"
+    "digitalmarketplace-frameworks": "git://github.com/alphagov/digitalmarketplace-frameworks#v1.3.4"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -7,6 +7,6 @@
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
     "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v15.14.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.14.1/jinja_govuk_template-0.14.1.tgz",
-    "digitalmarketplace-frameworks": "git://github.com/alphagov/digitalmarketplace-frameworks#v1.3.1"
+    "digitalmarketplace-frameworks": "git://github.com/alphagov/digitalmarketplace-frameworks#v1.3.3"
   }
 }

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -1112,8 +1112,7 @@ class TestFrameworkUpdatesPage(BaseApplicationTest):
             data = response.get_data(as_text=True)
 
             assert response.status_code == 200
-            assert 'All clarification questions and answers will be published by ' \
-                   '<p>5pm <abbr title="British Summer Time">BST</abbr>, 29 September 2015</p>.' in data
+            assert 'All clarification questions and answers will be published by 5pm BST, 29 September 2015.' in data
             assert "The deadline for clarification questions is" not in data
 
     def test_dates_for_open_framework_open_for_questions(self, s3, data_api_client):
@@ -1128,8 +1127,7 @@ class TestFrameworkUpdatesPage(BaseApplicationTest):
 
             assert response.status_code == 200
             assert "All clarification questions and answers will be published by" not in data
-            assert 'The deadline for clarification questions is ' \
-                   '<p>5pm <abbr title="British Summer Time">BST</abbr>, 22 September 2015</p>.' in data
+            assert 'The deadline for clarification questions is 5pm BST, 22 September 2015.' in data
 
     def test_the_tables_should_be_displayed_correctly(self, s3, data_api_client):
         data_api_client.get_framework.return_value = self.framework('open')


### PR DESCRIPTION
Required to fix:
 - https://www.pivotaltracker.com/story/show/119086793
 - https://www.pivotaltracker.com/story/show/119075005

Depends on: 
 - [x] https://github.com/alphagov/digitalmarketplace-frameworks/pull/269
 - [x] Now also needs: https://github.com/alphagov/digitalmarketplace-frameworks/pull/272

The markdown filter wraps values in `<p>` tags but we generally want to use dates inline and the `<p>` breaks the page layouts in the frontend.  So we're not going to use markdown for date strings.

# BEFORE
![screen shot 2016-05-10 at 13 33 45](https://cloud.githubusercontent.com/assets/6525554/15146856/6c85d520-16b5-11e6-843f-c6de1477814b.png)
---------------------------
![screen shot 2016-05-10 at 13 35 33](https://cloud.githubusercontent.com/assets/6525554/15146863/73056fbe-16b5-11e6-806e-6607307051af.png)
---------------------------
![screen shot 2016-05-10 at 13 40 24](https://cloud.githubusercontent.com/assets/6525554/15146871/7a6190bc-16b5-11e6-9073-5957b2ed9c1c.png)

# AFTER
![screen shot 2016-05-10 at 13 34 32](https://cloud.githubusercontent.com/assets/6525554/15146860/6fe9910c-16b5-11e6-9a30-ac1e96637f3c.png)
---------------------------
![screen shot 2016-05-10 at 13 34 51](https://cloud.githubusercontent.com/assets/6525554/15146866/76872f56-16b5-11e6-9904-fd5df69c2cb4.png)
---------------------------
![screen shot 2016-05-10 at 13 41 15](https://cloud.githubusercontent.com/assets/6525554/15146875/7e754810-16b5-11e6-8188-7ee58bdde178.png)
