### PR TITLE
Make `G-Cloud X` non-breaking on all pages

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -71,11 +71,13 @@ def create_app(config_name):
         session.permanent = True
         session.modified = True
 
+    G_CLOUD_REGEX = re.compile(r"(G-Cloud )(\d)")
+
     @application.after_request
     def dont_break_gcloud(response):
         if "text/html" in response.content_type:
-            page = response.get_data()
-            page = re.sub("(G-Cloud )(\d)", r'G&#8209;Cloud&nbsp;\2', page)
+            page = response.get_data(as_text=True)
+            page = G_CLOUD_REGEX.sub(r'G&#8209;Cloud&nbsp;\2', page)
             response.set_data(page)
         return response
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -71,6 +71,14 @@ def create_app(config_name):
         session.permanent = True
         session.modified = True
 
+    @application.after_request
+    def dont_break_gcloud(response):
+        if "text/html" in response.content_type:
+            page = response.get_data()
+            page = re.sub("(G-Cloud )(\d)", r'G&#8209;Cloud&nbsp;\2', page)
+            response.set_data(page)
+        return response
+
     application.add_template_filter(question_references)
     application.add_template_filter(parse_document_upload_time)
 

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -60,9 +60,10 @@ class TestFrameworksDashboard(BaseApplicationTest):
         res = self.client.get("/suppliers/frameworks/g-cloud-7")
 
         assert_equal(res.status_code, 200)
-        doc = html.fromstring(res.get_data(as_text=True))
-        assert_equal(
-            len(doc.xpath('//h1[contains(text(), "Your G-Cloud 7 application")]')), 1)
+        self.assert_in_strip_whitespace(
+            u"<h1>Your G&#8209;Cloud&nbsp;7 application</h1>",
+            res.get_data(as_text=True)
+        )
 
     def test_framework_dashboard_shows_for_live_if_declaration_exists(self, data_api_client, s3):
         with self.app.test_client():
@@ -74,8 +75,10 @@ class TestFrameworksDashboard(BaseApplicationTest):
 
         assert_equal(res.status_code, 200)
         doc = html.fromstring(res.get_data(as_text=True))
-        assert_equal(
-            len(doc.xpath('//h1[contains(text(), "Your G-Cloud 7 documents")]')), 1)
+        self.assert_in_strip_whitespace(
+            u"<h1>Your G&#8209;Cloud&nbsp;7 documents</h1>",
+            res.get_data(as_text=True)
+        )
 
     def test_does_not_show_for_live_if_no_declaration(self, data_api_client, s3):
         with self.app.test_client():
@@ -175,7 +178,7 @@ class TestFrameworksDashboard(BaseApplicationTest):
 
             heading = doc.xpath('//div[@class="summary-item-lede"]//h2[@class="summary-item-heading"]')
             assert_true(len(heading) > 0)
-            assert_in(u"G-Cloud 7 is closed for applications",
+            assert_in(u"G\u2011Cloud\xa07 is closed for applications",
                       heading[0].xpath('text()')[0])
             assert_in(u"You didn't submit an application.",
                       heading[0].xpath('../p[1]/text()')[0])
@@ -198,12 +201,12 @@ class TestFrameworksDashboard(BaseApplicationTest):
             doc = html.fromstring(res.get_data(as_text=True))
             heading = doc.xpath('//div[@class="summary-item-lede"]//h2[@class="summary-item-heading"]')
             assert_true(len(heading) > 0)
-            assert_in(u"G-Cloud 7 is closed for applications",
+            assert_in(u"G\u2011Cloud\xa07 is closed for applications",
                       heading[0].xpath('text()')[0])
             lede = doc.xpath('//div[@class="summary-item-lede"]')
             assert_in(u"You made your supplier declaration and submitted 1 service for consideration.",
                       lede[0].xpath('./p[1]/text()')[0])
-            assert_in(u"A letter informing you whether your application was successful or not will be posted on your G-Cloud 7 updates page by",  # noqa
+            assert_in(u"A letter informing you whether your application was successful or not will be posted on your G\u2011Cloud\xa07 updates page by",  # noqa
                       lede[0].xpath('./p[2]/text()')[0])  # noqa
 
     def test_declaration_status_when_complete(self, data_api_client, s3):
@@ -446,16 +449,17 @@ class TestFrameworksDashboard(BaseApplicationTest):
         data = res.get_data(as_text=True)
 
         for success_message in [
-            u'Your application was successful. You\'ll be able to sell services when the G-Cloud 7 framework is live',
+            u'Your application was successful. '
+            u'You\'ll be able to sell services when the G&#8209;Cloud&nbsp;7 framework is live.',
             u'Download your application award letter (.pdf)',
-            u'This letter is a record of your successful G-Cloud 7 application.'
+            u'This letter is a record of your successful G&#8209;Cloud&nbsp;7 application.'
         ]:
             assert_in(success_message, data)
 
         for equivocal_message in [
             u'You made your supplier declaration and submitted 1 service.',
             u'Download your application result letter (.pdf)',
-            u'This letter informs you if your G-Cloud 7 application has been successful.'
+            u'This letter informs you if your G&#8209;Cloud&nbsp;7 application has been successful.'
         ]:
             assert_not_in(equivocal_message, data)
 
@@ -495,16 +499,17 @@ class TestFrameworksDashboard(BaseApplicationTest):
         data = res.get_data(as_text=True)
 
         for success_message in [
-            u'Your application was successful. You\'ll be able to sell services when the G-Cloud 7 framework is live',
+            u'Your application was successful. '
+            u'You\'ll be able to sell services when the G&#8209;Cloud&nbsp;7 framework is live',
             u'Download your application award letter (.pdf)',
-            u'This letter is a record of your successful G-Cloud 7 application.'
+            u'This letter is a record of your successful G&#8209;Cloud&nbsp;7 application.'
         ]:
             assert_not_in(success_message, data)
 
         for equivocal_message in [
             u'You made your supplier declaration and submitted 1 service.',
             u'Download your application result letter (.pdf)',
-            u'This letter informs you if your G-Cloud 7 application has been successful.'
+            u'This letter informs you if your G&#8209;Cloud&nbsp;7 application has been successful.'
         ]:
             assert_in(equivocal_message, data)
 
@@ -1035,7 +1040,7 @@ class TestFrameworkUpdatesPage(BaseApplicationTest):
     def _assert_page_title_and_table_headings(self, doc, tables_exist=True):
 
         assert_true(
-            self.strip_all_whitespace('G-Cloud 7 updates')
+            self.strip_all_whitespace(u'G\u2011Cloud\xa07 updates')
             in self.strip_all_whitespace(doc.xpath('//h1')[0].text)
         )
 
@@ -1230,7 +1235,7 @@ class TestFrameworkUpdatesPage(BaseApplicationTest):
             data = response.get_data(as_text=True)
 
             assert response.status_code == 200
-            assert_in(u'Ask a question about your G-Cloud 7 application', data)
+            assert_in(u'Ask a question about your G&#8209;Cloud&nbsp;7 application', data)
 
     def test_no_question_box_shown_if_countersigned_agreement_is_returned(self, s3, data_api_client):
         data_api_client.get_framework.return_value = self.framework('live', clarification_questions_open=False)
@@ -1243,7 +1248,7 @@ class TestFrameworkUpdatesPage(BaseApplicationTest):
             data = response.get_data(as_text=True)
 
             assert response.status_code == 200
-            assert_not_in(u'Ask a question about your G-Cloud 7 application', data)
+            assert_not_in(u'Ask a question about your G&#8209;Cloud&nbsp;7 application', data)
 
 
 class TestSendClarificationQuestionEmail(BaseApplicationTest):
@@ -1488,7 +1493,7 @@ class TestG7ServicesList(BaseApplicationTest):
         assert_equal(response.status_code, 200)
         heading = doc.xpath('//div[@class="summary-item-lede"]//h2[@class="summary-item-heading"]')
         assert_true(len(heading) > 0)
-        assert_in(u"G-Cloud 7 is closed for applications",
+        assert_in(u"G\u2011Cloud\xa07 is closed for applications",
                   heading[0].xpath('text()')[0])
         assert_in(u"You made your supplier declaration and submitted 1 complete service.",
                   heading[0].xpath('../p[1]/text()')[0])

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -67,7 +67,7 @@ class TestListServices(BaseApplicationTest):
                 supplier_id=1234)
             assert_true("Service name 123" in res.get_data(as_text=True))
             assert_true("Software as a Service" in res.get_data(as_text=True))
-            assert_true("G-Cloud 1" in res.get_data(as_text=True))
+            assert_true("G&#8209;Cloud&nbsp;1" in res.get_data(as_text=True))
 
     @mock.patch('app.data_api_client')
     def test_should_not_be_able_to_see_page_if_made_inactive(self, services_data_api_client):
@@ -1280,7 +1280,7 @@ class TestShowDraftService(BaseApplicationTest):
         assert_true(len(message) > 0)
         assert_in(u"This service was submitted",
                   message[0].xpath('h2[@class="temporary-message-heading"]/text()')[0])
-        assert_in(u"If your application is successful, it will be available on the Digital Marketplace when G-Cloud 7 goes live.",  # noqa
+        assert_in(u"If your application is successful, it will be available on the Digital Marketplace when G\u2011Cloud\xa07 goes live.",  # noqa
                   message[0].xpath('p[@class="temporary-message-message"]/text()')[0])
 
 

--- a/tests/app/main/test_suppliers.py
+++ b/tests/app/main/test_suppliers.py
@@ -213,7 +213,7 @@ class TestSuppliersDashboard(BaseApplicationTest):
             assert_equal(res.status_code, 200)
 
             assert_in(
-                'Apply to G-Cloud 7',
+                u'Apply to G\u2011Cloud\xa07',
                 doc.xpath('//h2[@class="summary-item-heading"]/text()')[0]
             )
 
@@ -241,7 +241,7 @@ class TestSuppliersDashboard(BaseApplicationTest):
 
             assert_equal(res.status_code, 200)
             assert_equal(doc.xpath('//a[@href="/suppliers/frameworks/g-cloud-7"]/span/text()')[0],
-                         "Continue your G-Cloud 7 application")
+                         u"Continue your G\u2011Cloud\xa07 application")
 
     @mock.patch("app.main.views.suppliers.data_api_client")
     @mock.patch("app.main.views.suppliers.get_current_suppliers_users")
@@ -267,7 +267,7 @@ class TestSuppliersDashboard(BaseApplicationTest):
 
             message = doc.xpath('//aside[@class="temporary-message"]')
             assert_true(len(message) > 0)
-            assert_in(u"G-Cloud 7 is closed for applications",
+            assert_in(u"G\u2011Cloud\xa07 is closed for applications",
                       message[0].xpath('h2/text()')[0])
             assert_true(len(message[0].xpath('p[1]/a[@href="https://digitalmarketplace.blog.gov.uk/"]')) > 0)
 
@@ -304,7 +304,7 @@ class TestSuppliersDashboard(BaseApplicationTest):
 
             message = doc.xpath('//aside[@class="temporary-message"]')
             assert_true(len(message) > 0)
-            assert_in(u"G-Cloud 7 is closed for applications",
+            assert_in(u"G\u2011Cloud\xa07 is closed for applications",
                       message[0].xpath('h2/text()')[0])
             assert_in(u"You didn’t submit an application",
                       message[0].xpath('p[1]/text()')[0])
@@ -342,7 +342,7 @@ class TestSuppliersDashboard(BaseApplicationTest):
             doc = html.fromstring(res.get_data(as_text=True))
             headings = doc.xpath('//h2[@class="summary-item-heading"]')
             assert_true(len(headings) > 0)
-            assert_in(u"G-Cloud 7 is closed for applications",
+            assert_in(u"G\u2011Cloud\xa07 is closed for applications",
                       headings[0].xpath('text()')[0])
             assert_in(u"You submitted 99 services for consideration",
                       headings[0].xpath('../p[1]/text()')[0])
@@ -397,7 +397,7 @@ class TestSuppliersDashboard(BaseApplicationTest):
                       first_table[0].xpath('caption/text()')[0])
 
             first_row = "".join(first_table[0].xpath('tbody/descendant::*/text()'))
-            assert_in(u"G-Cloud 7",
+            assert_in(u"G\u2011Cloud\xa07",
                       first_row)
             assert_in(u"Live from 23 November 2015",
                       first_row)
@@ -452,7 +452,7 @@ class TestSuppliersDashboard(BaseApplicationTest):
                       first_table[0].xpath('caption/text()')[0])
 
             first_row = "".join(first_table[0].xpath('tbody/descendant::*/text()'))
-            assert_in(u"G-Cloud 7",
+            assert_in(u"G\u2011Cloud\xa07",
                       first_row)
             assert_not_in(
                 u"Live from",
@@ -503,7 +503,7 @@ class TestSuppliersDashboard(BaseApplicationTest):
                       first_table[0].xpath('caption/text()')[0])
 
             first_row = "".join(first_table[0].xpath('tbody/descendant::*/text()'))
-            assert_in(u"G-Cloud 7",
+            assert_in(u"G\u2011Cloud\xa07",
                       first_row)
             assert_in(u"Live from 23 November 2015",
                       first_row)
@@ -585,7 +585,7 @@ class TestSuppliersDashboard(BaseApplicationTest):
                       first_table[0].xpath('caption/text()')[0])
 
             first_row = "".join(first_table[0].xpath('tbody/descendant::*/text()'))
-            assert_in(u"G-Cloud 7",
+            assert_in(u"G\u2011Cloud\xa07",
                       first_row)
             assert_not_in(u"Live from 23 November 2015",
                           first_row)
@@ -641,7 +641,7 @@ class TestSuppliersDashboard(BaseApplicationTest):
                       first_table[0].xpath('caption/text()')[0])
 
             first_row = "".join(first_table[0].xpath('tbody/descendant::*/text()'))
-            assert_in(u"G-Cloud 7",
+            assert_in(u"G\u2011Cloud\xa07",
                       first_row)
             assert_in(u"Live from 23 November 2015",
                       first_row)


### PR DESCRIPTION
Work done with @carolinegreen to address this issue: https://www.pivotaltracker.com/story/show/118404225

This adds an `after_request` handler that (for HTML responses only) searches for occurrences of `G-Cloud x` (where `x` is a digit) and replaces it with a non-breaking version of the same string.

We first tried wrapping the base Jinja template with a filter to do the same thing, but unless we make everything `|safe` Jinja escapes the HTML entities and it all looks a mess.  By restricting the `after_request` handler to HTML responses only this seems like a reasonable alternative. 

It seems pretty crazy to me, but I can't think of any compelling reasons why this will break things.  The regular expression is short and contains no greedy quantifiers or anything fancy, so should be efficient even over big pages I think.  It's also very specific, and I can't think of any cases where it would match something that we don't want to transform. (But you should have a good think about this too before agreeing to this madness.)

If we like this then we should add the same thing to the buyer app.  We decided against adding it to the  base `flask_init` in utils (it could fit right here: https://github.com/alphagov/digitalmarketplace-utils/blob/master/dmutils/flask_init.py#L49) because we don't necessarily want it operating in the API and admin apps, although with it limited to HTML responses only it might not be so bad there.  Opinions welcome.