### PR TITLE
Update content on 'Ask a question page'

### DIFF
--- a/app/templates/briefs/clarification_question.html
+++ b/app/templates/briefs/clarification_question.html
@@ -74,7 +74,7 @@
           value = clarification_question_value,
           max_length_in_words = 100,
           question_advice =
-          'Your question will be published with the buyers’ response by {}.
+          'Your question will be published with the buyer’s answer by {}.
            \n\nAll questions and answers will be posted on the Digital Marketplace. Your company name won’t be visible.
            \n\nYou shouldn’t include any confidential information in your question.
            \n\nRead more about <a href="https://www.gov.uk/guidance/how-to-answer-supplier-questions-about-your-digital-outcomes-and-specialists-requirements">how supplier questions are managed</a>.


### PR DESCRIPTION
## Updates the content on the 'Ask a question' page

For [this](https://www.pivotaltracker.com/story/show/118095247) story on Pivotal.

Old: "buyers' response"

New: "buyer's answer"

<img width="618" alt="screen shot 2016-05-19 at 17 01 28" src="https://cloud.githubusercontent.com/assets/13836290/15400657/31b327d2-1de4-11e6-9439-0b5ade85c8d2.png">

