### PR TITLE
Add full stop to day rate validation message

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,6 +7,6 @@
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
     "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#15.16.1",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.14.1/jinja_govuk_template-0.14.1.tgz",
-    "digitalmarketplace-frameworks": "git://github.com/alphagov/digitalmarketplace-frameworks#v1.3.13"
+    "digitalmarketplace-frameworks": "git://github.com/alphagov/digitalmarketplace-frameworks#v1.3.14"
   }
 }


### PR DESCRIPTION
For [this](https://www.pivotaltracker.com/story/show/118391123) story on Pivotal.

This PR updates the framework version used to 1.3.14. This version has a full stop on the end of the validation message that a supplier sees if they overstate their day rate when applying for an opportunity.

[This](https://github.com/alphagov/digitalmarketplace-frameworks/pull/281) PR is the update to the framework.

Screenshot of new message below:

![screen shot 2016-05-24 at 16 12 39](https://cloud.githubusercontent.com/assets/13836290/15509142/5fa1daf0-21ca-11e6-8265-f30b191373c2.png)
