### PR TITLE
Update supplier confirmation email

### DIFF
--- a/app/main/helpers/briefs.py
+++ b/app/main/helpers/briefs.py
@@ -71,7 +71,6 @@ def send_brief_clarification_question(data_api_client, brief, clarification_ques
     supplier_email_body = render_template(
         "emails/brief_clarification_question_confirmation.html",
         brief_id=brief['id'],
-        user_name=current_user.name,
         brief_name=brief['title'],
         framework_slug=brief['frameworkSlug'],
         message=clarification_question

--- a/app/templates/emails/brief_clarification_question_confirmation.html
+++ b/app/templates/emails/brief_clarification_question_confirmation.html
@@ -10,7 +10,7 @@
   <br />
   You asked:<br />
   <br />
-  {{ message }}
+  ‘{{ message }}’
   <br /><br />
   Your question will be posted with the buyer’s answer on the ‘{{ brief_name }}’ page at:<br />
   <a href="https://www.digitalmarketplace.service.gov.uk/{{ framework_slug }}/opportunities/{{ brief_id }}">https://www.digitalmarketplace.service.gov.uk/{{ framework_slug }}/opportunities/{{ brief_id }}</a><br />

--- a/app/templates/emails/brief_clarification_question_confirmation.html
+++ b/app/templates/emails/brief_clarification_question_confirmation.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
 </head>
 <body>
-  Dear {{ user_name }},<br />
+  Dear supplier,<br />
   <br />
   Your question about ‘{{ brief_name }}’ has been sent.<br />
   <br />
@@ -12,7 +12,7 @@
   <br />
   {{ message }}
   <br /><br />
-  Your question will be posted with the buyer’s response on the ‘{{ brief_name }}’ requirements page at:<br />
+  Your question will be posted with the buyer’s answer on the ‘{{ brief_name }}’ page at:<br />
   <a href="https://www.digitalmarketplace.service.gov.uk/{{ framework_slug }}/opportunities/{{ brief_id }}">https://www.digitalmarketplace.service.gov.uk/{{ framework_slug }}/opportunities/{{ brief_id }}</a><br />
   <br />
   Thanks,<br />


### PR DESCRIPTION
For [this](https://www.pivotaltracker.com/story/show/118095523) story in Pivotal.

The content of the email which is sent to a supplier after they ask a question of the buyer has been updated.

Also, a variable which was being assigned and passed in to the email template has been removed as it was no longer required after the content update.