### PR TITLE
Tracking supplier applications to opportunities

### DIFF
--- a/app/main/views/briefs.py
+++ b/app/main/views/briefs.py
@@ -151,7 +151,7 @@ def submit_brief_response(brief_id):
 
     if all(brief_response['essentialRequirements']):
         flash('Your response to ‘{}’ has been submitted.'.format(brief['title']))
-        return redirect(url_for(".dashboard"))
+        return redirect(url_for(".dashboard", applied_for_brief=brief['id']))
     else:
         return redirect(url_for(".view_response_result", brief_id=brief_id))
 

--- a/app/main/views/briefs.py
+++ b/app/main/views/briefs.py
@@ -151,6 +151,7 @@ def submit_brief_response(brief_id):
 
     if all(brief_response['essentialRequirements']):
         flash('Your response to ‘{}’ has been submitted.'.format(brief['title']))
+        # applied_for_brief parameter is used to track brief applications by analytics
         return redirect(url_for(".dashboard", applied_for_brief=brief['id']))
     else:
         return redirect(url_for(".view_response_result", brief_id=brief_id))

--- a/tests/app/main/test_briefs.py
+++ b/tests/app/main/test_briefs.py
@@ -436,7 +436,7 @@ class TestRespondToBrief(BaseApplicationTest):
             data=brief_form_submission
         )
         assert res.status_code == 302
-        assert res.location == "http://localhost/suppliers"
+        assert res.location == "http://localhost/suppliers?applied_for_brief=1234"
         self.assert_flashes("Your response to ‘I need a thing to do a thing’ has been submitted.")
         data_api_client.create_brief_response.assert_called_once_with(
             1234, 1234, processed_brief_submission, 'email@email.com')


### PR DESCRIPTION
A successful application to an opportunity results in a redirect to the supplier's dashboard which has the same URL as normal. 

To track the application in analytics, this marks the request as the result of an application by adding a query string parameter to the URL.

https://www.pivotaltracker.com/story/show/119634783
