### PR TITLE
Update toolkit to improve pricing fields

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "jquery": "1.11.2",
     "hogan": "3.0.2",
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
-    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#15.16.1",
+    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#15.16.3",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.14.1/jinja_govuk_template-0.14.1.tgz",
     "digitalmarketplace-frameworks": "git://github.com/alphagov/digitalmarketplace-frameworks#v1.3.14"
   }


### PR DESCRIPTION
Brings in new breakpoint to mitigate the last pricing field dropping onto the second line.
[Relevant pull request in frontend toolkit](https://github.com/alphagov/digitalmarketplace-frontend-toolkit/pull/266).

[>> Bug on Tracker](https://www.pivotaltracker.com/story/show/118469059)