### PR TITLE
[#118392929] Update error message if supplier isn't eligible

### DIFF
--- a/app/templates/briefs/not_is_supplier_eligible_for_brief_error.html
+++ b/app/templates/briefs/not_is_supplier_eligible_for_brief_error.html
@@ -4,40 +4,24 @@
 
 {% block main_content %}
 
-{% if clarification_question %}
+{% with inhibited_action="ask a question about" if clarification_question else "apply for" %}
 <div class="grid-row">
   <div class="column-two-thirds">
     <header class="page-heading-smaller">
-      <h1>You can’t ask a question about this opportunity</h1>
+      <h1>You can’t {{ inhibited_action }} this opportunity</h1>
     </header>
-    {% if on_framework %}
-      <p>
-        You can’t ask a question about this opportunity because you don’t provide
-        {{ "this digital specialist role" if lot == 'digital-specialists' else "a service in this category" }}
-        at this location.
-      </p>
-    {% else %}
-      <p>You can’t ask a question about this opportunity because you’re not a {{ framework_name }} supplier.</p>
-    {% endif %}
+    <p>
+      You can’t {{ inhibited_action }} this opportunity because
+      {% if has_framework_service %}
+        you didn’t say you could provide
+        {{ "this specialist role" if has_framework_lot_service else "services in this category" }}
+        when you applied to the Digital Outcomes and Specialists framework.
+      {% else %}
+        you’re not a {{ framework_name }} supplier.
+      {% endif %}
+    </p>
   </div>
 </div>
-{% else %}
-<div class="grid-row">
-  <div class="column-two-thirds">
-    <header class="page-heading-smaller">
-      <h1>You can’t apply for this opportunity</h1>
-    </header>
-    {% if on_framework %}
-      <p>
-        You can’t apply for this opportunity because you don’t provide
-        {{ "this digital specialist role" if lot == 'digital-specialists' else "a service in this category" }}
-        at this location.
-      </p>
-    {% else %}
-      <p>You can’t apply for this opportunity because you’re not a {{ framework_name }} supplier.</p>
-    {% endif %}
-  </div>
-</div>
-{% endif %}
+{% endwith %}
 
 {% endblock %}

--- a/app/templates/briefs/not_is_supplier_eligible_for_brief_error.html
+++ b/app/templates/briefs/not_is_supplier_eligible_for_brief_error.html
@@ -1,6 +1,6 @@
 {% extends "_base_page.html" %}
 
-{% block page_title %}Not eligible for brief – Digital Marketplace{% endblock %}
+{% block page_title %}Not eligible for opportunity – Digital Marketplace{% endblock %}
 
 {% block main_content %}
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,6 @@ python-dateutil==2.4.2
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@20.0.0#egg=digitalmarketplace-utils==20.0.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@1.0.2#egg=digitalmarketplace-content-loader==1.0.2
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@3.6.0#egg=digitalmarketplace-apiclient==3.6.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@3.8.0#egg=digitalmarketplace-apiclient==3.8.0
 
 markdown==2.6.2


### PR DESCRIPTION
Ok a few caveats here:

- In this case we've switched from using the `SupplierFramework.onFramework` to determine the supplier's "on framework"-ness to poking the api to see if the supplier has any published services on the lot or framework. However, there are still a few bits of this frontend that do use `onFramework` for various things. So I guess there's some possibility of an incongruence here. From what I can tell the only functional difference will be for suppliers who've had services removed for some reason. And most of the other places `onFramework` is used in this frontend seem to be during the pre-live phase. So maybe... it's... all... ok?
- Depends on `digitalmarketplace-apiclient` 3.8.0, which isn't merged yet.
- Tests had to be changed a bit, and I hope I still captured the _intent_ of them properly.