### PR TITLE
Fix issues with supplier question tracking

### DIFF
--- a/app/assets/javascripts/analytics/_virtualPageViews.js
+++ b/app/assets/javascripts/analytics/_virtualPageViews.js
@@ -10,13 +10,13 @@
   };
 
   GOVUK.GDM.analytics.virtualPageViews = function() {
-    var $flashMessage;
+    var $messageSent;
 
     $('[data-analytics=trackPageView]').each(sendVirtualPageView);
     if (GOVUK.GDM.analytics.location.pathname().match(/^\/suppliers\/opportunities\/\d+\/ask-a-question/) !== null) {
-      $flashMessage = $('.banner-success-without-action .banner-message');
+      $messageSent = $('#content form').attr('data-message-sent') === 'true';
 
-      if ($flashMessage.text().replace(/^\s+|\s+$/g, '').match(/^Your question has been sent/) !== null) {
+      if ($messageSent) {
         GOVUK.analytics.trackPageview(GOVUK.GDM.analytics.location.href() + '?submitted=true');
       }
     }

--- a/app/assets/javascripts/analytics/_virtualPageViews.js
+++ b/app/assets/javascripts/analytics/_virtualPageViews.js
@@ -16,7 +16,7 @@
     if (GOVUK.GDM.analytics.location.pathname().match(/^\/suppliers\/opportunities\/\d+\/ask-a-question/) !== null) {
       $flashMessage = $('.banner-success-without-action .banner-message');
 
-      if ($flashMessage.text().match(/^Your question has been sent/) !== null) {
+      if ($flashMessage.text().replace(/^\s+|\s+$/g, '').match(/^Your question has been sent/) !== null) {
         GOVUK.analytics.trackPageview(GOVUK.GDM.analytics.location.href() + '?submitted=true');
       }
     }

--- a/app/templates/briefs/clarification_question.html
+++ b/app/templates/briefs/clarification_question.html
@@ -1,6 +1,8 @@
 {% extends "_base_page.html" %}
 {% import "toolkit/summary-table.html" as summary %}
 
+{% set message_sent = 'message_sent' in get_flashed_messages() %}
+
 {% block page_title %}Ask a question about {{ brief.title }} – Digital Marketplace{% endblock %}
 
 {% block breadcrumb %}
@@ -63,7 +65,8 @@
         {% include 'toolkit/page-heading.html' %}
       {% endwith %}
 
-      <form method="post">
+      <!-- data-message-sent is used for analytics tracking -->
+      <form method="post" data-message-sent="{{ message_sent|lower }}">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
         {%
           with

--- a/spec/javascripts/unit/AnalyticsSpec.js
+++ b/spec/javascripts/unit/AnalyticsSpec.js
@@ -181,7 +181,7 @@ describe("GOVUK.Analytics", function () {
       it("Should send a pageview with a query string if the flash message is absent", function () {
         $flashMessage = $('<div class="banner-success-without-action">' +
                             '<p class="banner-message">' +
-                              'Your question has been sent. The buyer will post your question and their answer on the ‘Contracts finder’ page.' +
+                              '\n    Your question has been sent. The buyer will post your question and their answer on the ‘Dissolve a company’ page.\n' +
                             '</p>' +
                           '</div>');
         $(document.body).append($flashMessage);

--- a/spec/javascripts/unit/AnalyticsSpec.js
+++ b/spec/javascripts/unit/AnalyticsSpec.js
@@ -166,9 +166,23 @@ describe("GOVUK.Analytics", function () {
     });
 
     describe("When the clarification question for an opportunity page is loaded", function () {
-      var $flashMessage;
+      var $form,
+          $content;
 
-      it("Should not send a pageview if the flash message is absent", function () {
+      beforeEach(function () {
+        $content = $('<div id="content" />');
+        $form = $('<form />');
+        $content.append($form);
+        $(document.body).append($content);
+      });
+
+      afterEach(function () {
+        $content.remove();
+      });
+
+      it("Should not send a pageview if question not sent", function () {
+        $form.attr('data-message-sent', 'false');
+
         spyOn(GOVUK.GDM.analytics.location, "pathname")
           .and
           .callFake(function () {
@@ -178,13 +192,8 @@ describe("GOVUK.Analytics", function () {
         expect(window.ga.calls.any()).toEqual(false);
       });
 
-      it("Should send a pageview with a query string if the flash message is present", function () {
-        $flashMessage = $('<div class="banner-success-without-action">' +
-                            '<p class="banner-message">' +
-                              '\n    Your question has been sent. The buyer will post your question and their answer on the ‘Dissolve a company’ page.\n' +
-                            '</p>' +
-                          '</div>');
-        $(document.body).append($flashMessage);
+      it("Should send a pageview with a query string if question sent", function () {
+        $form.attr('data-message-sent', 'true');
 
         spyOn(GOVUK.GDM.analytics.location, "pathname")
           .and
@@ -199,7 +208,6 @@ describe("GOVUK.Analytics", function () {
         });
         window.GOVUK.GDM.analytics.virtualPageViews();
 
-        $flashMessage.remove();
         expect(window.ga.calls.first().args).toEqual([ 'send', 'pageview', { page: "https://www.digitalmarketplace.service.gov.uk/suppliers/opportunities/1/ask-a-question?submitted=true" } ]);
       });
     });

--- a/spec/javascripts/unit/AnalyticsSpec.js
+++ b/spec/javascripts/unit/AnalyticsSpec.js
@@ -178,7 +178,7 @@ describe("GOVUK.Analytics", function () {
         expect(window.ga.calls.any()).toEqual(false);
       });
 
-      it("Should send a pageview with a query string if the flash message is absent", function () {
+      it("Should send a pageview with a query string if the flash message is present", function () {
         $flashMessage = $('<div class="banner-success-without-action">' +
                             '<p class="banner-message">' +
                               '\n    Your question has been sent. The buyer will post your question and their answer on the ‘Dissolve a company’ page.\n' +


### PR DESCRIPTION
Change needed for this story:

https://www.pivotaltracker.com/story/show/119634865

...and fixes problems with the code merged in https://github.com/alphagov/digitalmarketplace-supplier-frontend/pull/487.

The regexp that looks for the banner telling users their question was submitted didn't take whitespace into consideration so wasn't finding it. This didn't show up in the unit tests because the HTML mock used had no whitespace in its banner text:

## Banner text in the page

```
\n\s\s\s\sYour question has been sent. The buyer will post your question and their answer on the ‘Dissolve a company’ page.\n
```

## Banner test in our HTML mock

```
Your question has been sent. The buyer will post your question and their answer on the ‘Dissolve a company’ page.
```