### PR TITLE
[#119993369] Update links in header

### DIFF
--- a/app/templates/_proposition_header.html
+++ b/app/templates/_proposition_header.html
@@ -4,12 +4,12 @@
     <nav id="proposition-menu">
       <a href="/" id="proposition-name">Digital Marketplace</a>
       <ul id="proposition-links">
-        {% if current_user.email_address %}
-        <li><a class="home" href="/logout">Log out</a></li>
+        {% if current_user.is_authenticated() %}
+          <li><a href="{{ url_for('main.dashboard') }}">View your account</a></li>
+          <li><a class="home" href="/logout">Log out</a></li>
         {% else %}
-        <li><a class="home" href="/login">Log in</a></li>
+          <li><a class="home" href="/login">Log in</a></li>
         {% endif %}
-        <li><a href="{{ url_for('main.create_new_supplier') }}">Create supplier account</a></li>
       </ul>
     </nav>
   </div>

--- a/app/templates/frameworks/edit_declaration_section.html
+++ b/app/templates/frameworks/edit_declaration_section.html
@@ -12,7 +12,7 @@
       },
       {
         "link": url_for(".dashboard"),
-        "label": current_user.supplier_name
+        "label": "Your account"
       },
       {
         "link": url_for(".framework_dashboard", framework_slug=framework.slug),

--- a/app/templates/suppliers/edit_supplier.html
+++ b/app/templates/suppliers/edit_supplier.html
@@ -12,7 +12,7 @@
       },
       {
         "link": url_for(".dashboard"),
-        "label": current_user.supplier_name
+        "label": "Your account"
       }
     ]
   %}


### PR DESCRIPTION
### 	Update links in header

Remove "Create supplier account" link from the header.
View your account link comes before the Log out link.
Unlike in the header for the buyer app, we don't have a conditional statement on the "View your account" link because nobody can even get to the supplier app without being logged in with the correct role. So it always sends logged-in users to the supplier dashboard.

We changed from `current_user.email_address` to `current_user.is_authenticated()` because it seems like a better check for if a user is logged in or not.

### Clean up supplier app breadcrumbs 
Most of the breadcrumb links back to the supplier dashboard say "Your account", but there were a couple that had the name of the company (which is wrong).
Changed them all to say "Your account"

[>> Story on Pivotal](https://www.pivotaltracker.com/story/show/119993369)

***

### old header
![image](https://cloud.githubusercontent.com/assets/7228605/16014435/ffefbd4c-3188-11e6-9f06-ab97f20f7648.png)

### new header
![image](https://cloud.githubusercontent.com/assets/7228605/16014329/aa8ee832-3188-11e6-8590-939628bd7763.png)

### old breadcrumbs
![screen shot 2016-06-14 at 11 40 19](https://cloud.githubusercontent.com/assets/2454380/16040141/cdd0f2de-3225-11e6-82c4-a4769c1ce9cc.png)

### new breadcrumbs
![screen shot 2016-06-14 at 11 40 45](https://cloud.githubusercontent.com/assets/2454380/16040147/d056b76e-3225-11e6-84a1-99b9b186ac48.png)



