### PR TITLE
Fix analytics wrapper for window.location.href

### DIFF
--- a/app/assets/javascripts/analytics/_register.js
+++ b/app/assets/javascripts/analytics/_register.js
@@ -14,7 +14,7 @@
     },
     'location': {
       'href': function () {
-        return root.location.search;
+        return root.location.href;
       },
       'pathname': function () {
         return root.location.pathname;


### PR DESCRIPTION
`window.location.href` is wrapped in an interface to allow easier testing.

When it was implemented, it was done so with this error.