### PR TITLE
Send page pathname rather than whole URL

### DIFF
--- a/app/assets/javascripts/analytics/_virtualPageViews.js
+++ b/app/assets/javascripts/analytics/_virtualPageViews.js
@@ -17,7 +17,7 @@
       $messageSent = $('#content form').attr('data-message-sent') === 'true';
 
       if ($messageSent) {
-        GOVUK.analytics.trackPageview(GOVUK.GDM.analytics.location.href() + '?submitted=true');
+        GOVUK.analytics.trackPageview(GOVUK.GDM.analytics.location.pathname() + '?submitted=true');
       }
     }
   };

--- a/spec/javascripts/unit/AnalyticsSpec.js
+++ b/spec/javascripts/unit/AnalyticsSpec.js
@@ -208,7 +208,7 @@ describe("GOVUK.Analytics", function () {
         });
         window.GOVUK.GDM.analytics.virtualPageViews();
 
-        expect(window.ga.calls.first().args).toEqual([ 'send', 'pageview', { page: "https://www.digitalmarketplace.service.gov.uk/suppliers/opportunities/1/ask-a-question?submitted=true" } ]);
+        expect(window.ga.calls.first().args).toEqual([ 'send', 'pageview', { page: "/suppliers/opportunities/1/ask-a-question?submitted=true" } ]);
       });
     });
 


### PR DESCRIPTION
We hypothesise that Google Analytics needs to be sent the `pathname` of the current URL for a pageview rather than the full URL so this enables that change.