### PR TITLE
Update toolkit to 16.0.0

### DIFF
--- a/app/templates/frameworks/agreement.html
+++ b/app/templates/frameworks/agreement.html
@@ -78,11 +78,10 @@ with items = [
               },
               {
                 "body": "Read your framework agreement",
-                "extra": "If you have a question about your framework agreement, contact CCS."
+                "top": "If you have a question about your framework agreement, contact CCS."
               },
               {
                 "body": "Sign your framework agreement",
-                "extra": "Please don't send paper copies to CCS.",
                 "sublist_collection": [
                   {
                     "lead_in": "To digitally sign your framework agreement, you need to:",
@@ -124,7 +123,8 @@ with items = [
                       }
                     ]
                   },
-                ]
+                ],
+                "bottom": "Please don't send paper copies to CCS.",
               },
               {
                 "body": "Upload your signed framework agreement",

--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "jquery": "1.11.2",
     "hogan": "3.0.2",
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
-    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v15.17.0",
+    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v16.0.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.17.3/jinja_govuk_template-0.17.3.tgz",
     "digitalmarketplace-frameworks": "git://github.com/alphagov/digitalmarketplace-frameworks#v1.5.4"
   }


### PR DESCRIPTION
**Note: needs https://github.com/alphagov/digitalmarketplace-frontend-toolkit/pull/269 to be merged first.**

Includes a fix for the changed `instruction-list` pattern, which is only used on the framework agreement page.  No other breaking changes.

