### PR TITLE
Don't assume there is an evaluation type

### DIFF
--- a/app/templates/briefs/view_response_result.html
+++ b/app/templates/briefs/view_response_result.html
@@ -94,7 +94,7 @@
           <div class="explanation-list padding-bottom-small">
             <p class="lead">The buyer will use the assessment methods listed in their requirements to evaluate your evidence. They’ll use:</p>
                 <ul class="list-bullet">
-                {% for eval_type in brief.get('evaluationType') %}
+                {% for eval_type in brief.get('evaluationType', []) %}
                   <li>{{ 'an' if eval_type == 'Interview' else 'a' }} {{ eval_type|lower }}</li>
                 {% endfor %}
                 </ul>


### PR DESCRIPTION
The default evaluation type isn't passed in (as I thought it would be), so for briefs without and additional evaluation types specified the page breaks with 500.  This prevents errors, but still needs more work to show the default evaluation type in the list.