### PR TITLE
Display the default evaluation type for brief responded to

### DIFF
--- a/app/main/__init__.py
+++ b/app/main/__init__.py
@@ -14,6 +14,7 @@ content_loader.load_messages('g-cloud-7', ['dates'])
 
 content_loader.load_manifest('digital-outcomes-and-specialists', 'declaration', 'declaration')
 content_loader.load_manifest('digital-outcomes-and-specialists', 'services', 'edit_submission')
+content_loader.load_manifest('digital-outcomes-and-specialists', 'briefs', 'edit_brief')
 content_loader.load_manifest('digital-outcomes-and-specialists', 'brief-responses', 'edit_brief_response')
 content_loader.load_manifest('digital-outcomes-and-specialists', 'brief-responses', 'display_brief_response')
 content_loader.load_messages('digital-outcomes-and-specialists', ['dates'])

--- a/app/main/views/briefs.py
+++ b/app/main/views/briefs.py
@@ -179,16 +179,22 @@ def view_response_result(brief_id):
     framework, lot = get_framework_and_lot(
         data_api_client, brief['frameworkSlug'], brief['lotSlug'], allowed_statuses=['live'])
 
-    content = content_loader.get_manifest(framework['slug'], 'display_brief_response').filter({'lot': lot['slug']})
-
-    for section in content:
+    response_content = content_loader.get_manifest(
+        framework['slug'], 'display_brief_response').filter({'lot': lot['slug']})
+    for section in response_content:
         section.inject_brief_questions_into_boolean_list_question(brief)
+
+    brief_content = content_loader.get_manifest(
+        framework['slug'], 'edit_brief').filter({'lot': lot['slug']})
+    brief_summary = brief_content.summary(brief)
+
     return render_template(
         'briefs/view_response_result.html',
         brief=brief,
+        brief_summary=brief_summary,
         brief_response=brief_response,
         result_state=result_state,
-        content=content
+        response_content=response_content
     )
 
 

--- a/app/templates/briefs/_brief_response_data.html
+++ b/app/templates/briefs/_brief_response_data.html
@@ -1,5 +1,5 @@
 {% import "toolkit/summary-table.html" as summary %}
-{% for section in content.summary(brief_response) %}
+{% for section in response_content.summary(brief_response) %}
     {% if not (section.id == 'your-nice-to-have-skills-and-experience' and not section.get_question('niceToHaveRequirements').boolean_list_questions) %}
         {{ summary.heading(section.name, id="opportunity-attributes-{}".format(loop.index)) }}
         {% call(item) summary.list_table(

--- a/app/templates/briefs/view_response_result.html
+++ b/app/templates/briefs/view_response_result.html
@@ -94,7 +94,7 @@
           <div class="explanation-list padding-bottom-small">
             <p class="lead">The buyer will use the assessment methods listed in their requirements to evaluate your evidence. They’ll use:</p>
                 <ul class="list-bullet">
-                {% for eval_type in brief.get('evaluationType', []) %}
+                {% for eval_type in brief_summary.get_question('evaluationType').value %}
                   <li>{{ 'an' if eval_type == 'Interview' else 'a' }} {{ eval_type|lower }}</li>
                 {% endfor %}
                 </ul>


### PR DESCRIPTION
Should hopefully be the final bugfix for: https://www.pivotaltracker.com/story/show/121479497

The default evaluation types defined in the frameworks content are not stored in the brief object JSON at all, and are only added to the brief when `.summary` is called in the content loader.
So in order to be able to display all evaluation methods that will be used, including the defaults, we need to load the `edit_brief` manifest and call `.summary` with the current brief.

Here you can see the default "a work history" is displayed, despite not being stored in the brief data:
![result-page-with-default-evaluation-type-shown](https://cloud.githubusercontent.com/assets/6525554/16616176/6d39859e-4373-11e6-8918-c5ac025da8f5.png)
