### PR TITLE
[#121577345] Sign and return your framework agreement

### DIFF
--- a/app/assets/scss/_text.scss
+++ b/app/assets/scss/_text.scss
@@ -1,3 +1,5 @@
+@import "toolkit/forms/_summary.scss";
+
 .lede {
   font-size: 100%;
   margin-bottom: 2em;
@@ -9,4 +11,8 @@
 
 .visual-emphasis {
   font-weight: bold;
+}
+
+.page-subheading {
+	@extend %summary-item-heading;
 }

--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -71,7 +71,7 @@ $path: "/suppliers/static/images/";
 
 @import "_create_supplier.scss";
 
-.authority-form-wrapper {
+.authorisation-form-wrapper {
 
   margin-top: 40px;
 

--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -84,6 +84,18 @@ $path: "/suppliers/static/images/";
   }
 }
 
+.isolated-text {
+  margin-bottom: 30px;
+}
+
+.browse-list-borderless {
+  .browse-list-item {
+    border-top: none;
+    padding-top: 0;
+    margin-top: 20px;
+  }
+}
+
 .filter-field-text {
   @include core-16;
   @include box-sizing(border-box);

--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -71,6 +71,19 @@ $path: "/suppliers/static/images/";
 
 @import "_create_supplier.scss";
 
+.authority-form-wrapper {
+
+  margin-top: 40px;
+
+  form .question {
+    margin: 10px 0 15px 0;
+  }
+
+  .button-save {
+    margin-top: 0;
+  }
+}
+
 .filter-field-text {
   @include core-16;
   @include box-sizing(border-box);

--- a/app/main/forms/frameworks.py
+++ b/app/main/forms/frameworks.py
@@ -1,0 +1,19 @@
+from flask.ext.wtf import Form
+from wtforms.validators import DataRequired, Length
+from dmutils.forms import StripWhitespaceStringField
+
+
+class SignerDetailsForm(Form):
+    full_name = StripWhitespaceStringField('Full name', validators=[
+        DataRequired(message="You must provide the full name of the person signing on behalf of the company."),
+        Length(max=255, message="You must provide a name under 256 characters.")
+    ])
+    role = StripWhitespaceStringField(
+        'Role at the company',
+        validators=[
+            DataRequired(message="You must provide the role of the person signing on behalf of the company."),
+            Length(max=255, message="You must provide a role under 256 characters.")
+        ],
+        description='The person signing must have the authority to agree to the framework terms, '
+                    'eg director or company secretary.'
+    )

--- a/app/main/forms/frameworks.py
+++ b/app/main/forms/frameworks.py
@@ -1,4 +1,5 @@
 from flask.ext.wtf import Form
+from wtforms import BooleanField
 from wtforms.validators import DataRequired, Length
 from dmutils.forms import StripWhitespaceStringField
 
@@ -16,4 +17,12 @@ class SignerDetailsForm(Form):
         ],
         description='The person signing must have the authority to agree to the framework terms, '
                     'eg director or company secretary.'
+    )
+
+
+class ContractReviewForm(Form):
+
+    authority = BooleanField(
+        'Authorisation',
+        validators=[DataRequired(message="You must confirm you have the authority to return the agreement.")]
     )

--- a/app/main/forms/frameworks.py
+++ b/app/main/forms/frameworks.py
@@ -21,8 +21,7 @@ class SignerDetailsForm(Form):
 
 
 class ContractReviewForm(Form):
-
-    authority = BooleanField(
+    authorisation = BooleanField(
         'Authorisation',
         validators=[DataRequired(message="You must confirm you have the authority to return the agreement.")]
     )

--- a/app/main/forms/frameworks.py
+++ b/app/main/forms/frameworks.py
@@ -5,11 +5,11 @@ from dmutils.forms import StripWhitespaceStringField
 
 
 class SignerDetailsForm(Form):
-    full_name = StripWhitespaceStringField('Full name', validators=[
+    signerName = StripWhitespaceStringField('Full name', validators=[
         DataRequired(message="You must provide the full name of the person signing on behalf of the company."),
         Length(max=255, message="You must provide a name under 256 characters.")
     ])
-    role = StripWhitespaceStringField(
+    signerRole = StripWhitespaceStringField(
         'Role at the company',
         validators=[
             DataRequired(message="You must provide the role of the person signing on behalf of the company."),

--- a/app/main/helpers/frameworks.py
+++ b/app/main/helpers/frameworks.py
@@ -109,6 +109,16 @@ def get_supplier_on_framework_from_info(supplier_framework_info):
     return bool(supplier_framework_info.get('onFramework'))
 
 
+def return_supplier_framework_info_if_on_framework_or_abort(data_api_client, framework_slug):
+    # returns a supplier_framework or None if not found
+    supplier_framework = get_supplier_framework_info(data_api_client, framework_slug)
+
+    if not get_supplier_on_framework_from_info(supplier_framework):
+        abort(404)
+
+    return supplier_framework
+
+
 def question_references(data, get_question):
     if not data:
         return data

--- a/app/main/helpers/frameworks.py
+++ b/app/main/helpers/frameworks.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from dmutils.documents import get_agreement_document_path, COUNTERSIGNED_AGREEMENT_FILENAME
+from dmutils.documents import get_agreement_document_path, COUNTERSIGNED_AGREEMENT_FILENAME, SIGNED_AGREEMENT_PREFIX
 import re
 
 from flask import abort
@@ -271,3 +271,13 @@ def countersigned_framework_agreement_exists_in_bucket(framework_slug, bucket):
     countersigned_path = get_agreement_document_path(
         framework_slug, current_user.supplier_id, COUNTERSIGNED_AGREEMENT_FILENAME)
     return agreements_bucket.path_exists(countersigned_path)
+
+
+def get_most_recently_uploaded_agreement_file_or_none(bucket, framework_slug):
+    download_path = get_agreement_document_path(
+        framework_slug,
+        current_user.supplier_id,
+        SIGNED_AGREEMENT_PREFIX
+    )
+    files = bucket.list(download_path)
+    return files.pop() if files else None

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -577,6 +577,7 @@ def upload_framework_agreement(framework_slug):
     return redirect(url_for('.framework_agreement', framework_slug=framework_slug))
 
 @main.route('/frameworks/<framework_slug>/signer-details', methods=['GET'])
+@login_required
 def signer_details(framework_slug):
     framework = get_framework(data_api_client, framework_slug)
     return_supplier_framework_info_if_on_framework_or_abort(data_api_client, framework_slug)
@@ -597,6 +598,7 @@ def signer_details(framework_slug):
 
 
 @main.route('/frameworks/<framework_slug>/signer-details', methods=['POST'])
+@login_required
 def submit_signer_details(framework_slug):
     framework = get_framework(data_api_client, framework_slug)
     return_supplier_framework_info_if_on_framework_or_abort(data_api_client, framework_slug)

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -493,6 +493,7 @@ def framework_agreement(framework_slug):
                 'name': lot['name'],
                 'has_completed_draft': (lot in lots_with_completed_drafts)
             } for lot in framework['lots']],
+            supplier_framework=supplier_framework,
         ), 200
 
     return render_template(
@@ -623,6 +624,7 @@ def signer_details(framework_slug):
         form_errors=form_errors,
         framework=framework,
         question_keys=question_keys,
+        supplier_framework=supplier_framework,
     ), 400 if form_errors else 200
 
 
@@ -700,7 +702,7 @@ def submit_contract_review(framework_slug):
 
     form = ContractReviewForm()
     form.authority.description = "I have the authority to return this agreement on behalf of {}".format(
-        current_user.supplier_name
+        supplier_framework['declaration']['nameOfOrganisation']
     )
 
     if form.validate_on_submit():

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -756,7 +756,7 @@ def contract_review(framework_slug):
                 {'question': form['authorisation'].label.text, 'input_name': 'authorisation'}
             ]
 
-    form.authorisation.description = "I have the authority to return this agreement on behalf of {}".format(
+    form.authorisation.description = u"I have the authority to return this agreement on behalf of {}".format(
         supplier_framework['declaration']['nameOfOrganisation']
     )
 

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -692,36 +692,41 @@ def contract_review(framework_slug):
                 current_user.supplier_id, framework_slug, current_user.email_address, current_user.id
             )
 
-            try:
-                email_subject = 'Your {} signature page has been received'.format(framework['name'])
-                email_body = render_template(
-                    'emails/framework_agreement_with_framework_version_returned.html',
-                    framework_name=framework['name'],
-                    framework_slug=framework['slug']
-                )
-                # Not sure who this is sent to
-                # Need to add a from name
-                # I assume no reply to address.
-                # Not sure if tags are needed
-                send_email(
-                    'useremailtogohere',
-                    email_body,
-                    current_app.config['DM_MANDRILL_API_KEY'],
-                    email_subject,
-                    current_app.config["DM_GENERIC_NOREPLY_EMAIL"],
-                    'from name to go here',
-                    []
-                )
-            except MandrillException as e:
-                # current_app.logger.error(
-                #     "Framework agreement email failed to send. "
-                #     "error {error} supplier_id {supplier_id} email_hash {email_hash}",
-                #     extra={'error': six.text_type(e),
-                #            'supplier_id': current_user.supplier_id,
-                #            'email_hash': hash_email(current_user.email_address)})
-                abort(503, "Framework agreement email failed to send")
+            # try:
+            #     email_subject = 'Your {} signature page has been received'.format(framework['name'])
+            #     email_body = render_template(
+            #         'emails/framework_agreement_with_framework_version_returned.html',
+            #         framework_name=framework['name'],
+            #         framework_slug=framework['slug']
+            #     )
+            #     # Not sure who this is sent to
+            #     # Need to add a from name
+            #     # I assume no reply to address.
+            #     # Not sure if tags are needed
+            #     send_email(
+            #         'useremailtogohere',
+            #         email_body,
+            #         current_app.config['DM_MANDRILL_API_KEY'],
+            #         email_subject,
+            #         current_app.config["DM_GENERIC_NOREPLY_EMAIL"],
+            #         'from name to go here',
+            #         []
+            #     )
+            # except MandrillException as e:
+            #     # current_app.logger.error(
+            #     #     "Framework agreement email failed to send. "
+            #     #     "error {error} supplier_id {supplier_id} email_hash {email_hash}",
+            #     #     extra={'error': six.text_type(e),
+            #     #            'supplier_id': current_user.supplier_id,
+            #     #            'email_hash': hash_email(current_user.email_address)})
+            #     abort(503, "Framework agreement email failed to send")
 
-            return redirect(url_for(".contract_review", framework_slug=framework_slug))
+            flash(
+                'Your framework agreement has been returned to the Crown Commercial Service to be countersigned.',
+                'success'
+            )
+
+            return redirect(url_for(".contract_submitted", framework_slug=framework_slug))
 
         else:
             current_app.logger.warning(
@@ -760,3 +765,29 @@ def contract_review(framework_slug):
         signature_page_url=signature_page_url,
         supplier_framework=supplier_framework,
     ), 400 if form_errors else 200
+
+
+@main.route('/frameworks/<framework_slug>/success', methods=['GET'])
+@login_required
+def contract_submitted(framework_slug):
+    framework = get_framework(data_api_client, framework_slug)
+    supplier_framework = return_supplier_framework_info_if_on_framework_or_abort(data_api_client, framework_slug)
+    agreements_bucket = s3.S3(current_app.config['DM_AGREEMENTS_BUCKET'])
+
+    # we could just use some of this stuff to get the filename but we don't know the extension
+    download_path = get_agreement_document_path(
+        framework_slug,
+        current_user.supplier_id,
+        SIGNED_AGREEMENT_PREFIX
+    )
+    files = agreements_bucket.list(download_path)
+    signature_page = files.pop() if files else None
+    # The default view (download_agreement_file) uses the DM_SUBMISSIONS_BUCKET, which doesn't work
+    signature_page_url = get_signed_url(agreements_bucket, signature_page['path'], 'https://{}.s3-eu-west-1.amazonaws.com'.format(current_app.config['DM_AGREEMENTS_BUCKET']))  # noqa
+
+    return render_template(
+        "frameworks/contract_submitted.html",
+        framework=framework,
+        signature_page_url=signature_page_url,
+        supplier_framework=supplier_framework,
+    ), 200

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -747,6 +747,36 @@ def submit_contract_review(framework_slug):
         data_api_client.register_framework_agreement_returned(
             current_user.supplier_id, framework_slug, current_user.email_address, current_user.id)
 
+        try:
+            email_subject = 'Your {} signature page has been received'.format(framework['name'])
+            email_body = render_template(
+                'emails/framework_agreement_with_framework_version_returned.html',
+                framework_name=framework['name'],
+                framework_slug=framework['slug']
+            )
+
+            # Not sure who this is sent to
+            # Need to add a from name
+            # I assume no reply to address.
+            # Not sure if tags are needed
+            send_email(
+                'useremailtogohere',
+                email_body,
+                current_app.config['DM_MANDRILL_API_KEY'],
+                email_subject,
+                current_app.config["DM_GENERIC_NOREPLY_EMAIL"],
+                'from name to go here',
+                []
+            )
+        except MandrillException as e:
+            # current_app.logger.error(
+            #     "Framework agreement email failed to send. "
+            #     "error {error} supplier_id {supplier_id} email_hash {email_hash}",
+            #     extra={'error': six.text_type(e),
+            #            'supplier_id': current_user.supplier_id,
+            #            'email_hash': hash_email(current_user.email_address)})
+            abort(503, "Framework agreement email failed to send")
+
         return redirect(url_for(".contract_review", framework_slug=framework_slug))
 
     else:

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -598,6 +598,11 @@ def signer_details(framework_slug):
                 current_user.supplier_id, framework_slug, agreement_details, current_user.email_address
             )
 
+            # If they have already uploaded a file then let them go to straight to the contract review
+            # page as they are likely editing their signer details
+            if session.get('signature_page'):
+                return redirect(url_for(".contract_review", framework_slug=framework_slug))
+
             return redirect(url_for(".signature_upload", framework_slug=framework_slug))
         else:
             current_app.logger.warning(

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -622,15 +622,6 @@ def signer_details(framework_slug):
 
             return redirect(url_for(".signature_upload", framework_slug=framework_slug))
         else:
-            current_app.logger.warning(
-                "signaturepage.fail: signerName:{signerName} signerRole:{signerRole} {errors}",
-                extra={
-                    'signerName': form['signerName'].data,
-                    'signerRole': form['signerRole'].data,
-                    'errors': ",".join(chain.from_iterable(form.errors.values()))
-                }
-            )
-
             error_keys_in_order = [key for key in question_keys if key in form.errors.keys()]
             form_errors = [
                 {'question': form[key].label.text, 'input_name': key} for key in error_keys_in_order
@@ -761,16 +752,6 @@ def contract_review(framework_slug):
             return redirect(url_for(".framework_dashboard", framework_slug=framework_slug))
 
         else:
-            current_app.logger.warning(
-                "signaturepage.fail: signerName:{signerName} signerRole:{signerRole} signature_page:{signature_page} {errors}",  # noqa
-                extra={
-                    'signerName': supplier_framework['agreementDetails']['signerName'],
-                    'signerRole': supplier_framework['agreementDetails']['signerRole'],
-                    'signature_page': session.get('signature_page'),
-                    'errors': ",".join(chain.from_iterable(form.errors.values()))
-                }
-            )
-
             form_errors = [
                 {'question': form['authorisation'].label.text, 'input_name': 'authorisation'}
             ]

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -715,7 +715,7 @@ def contract_review(framework_slug):
             )
 
             email_recipients = [supplier_framework['declaration']['primaryContactEmail']]
-            if supplier_framework['declaration']['primaryContactEmail'] != current_user.email_address:
+            if supplier_framework['declaration']['primaryContactEmail'].lower() != current_user.email_address.lower():
                 email_recipients.append(current_user.email_address)
 
             try:

--- a/app/templates/emails/framework_agreement_with_framework_version_returned.html
+++ b/app/templates/emails/framework_agreement_with_framework_version_returned.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head lang="en">
+    <meta charset="UTF-8">
+</head>
+<body>
+Dear {{ name }},
+<br /><br />
+Your framework agreement signature page has been sent to the Crown Commercial Service (CCS). They’ll check and countersign the agreement, or contact you if there’s a problem.
+<br /><br />
+You’ll receive an email when CCS have countersigned your agreement.
+<br /><br />
+You don’t need to wait for CCS to countersign the agreement before you start selling {{ framework_name }} services on the Digital Marketplace. You should be able to sell services from {{ start_selling_date }}.
+<br /><br />
+If you need help, you can send a question through the {{ framework_name }} updates page at: <a href="https://www.digitalmarketplace.service.gov.uk/suppliers/frameworks/{{ framework_slug }}/updates">https://www.digitalmarketplace.service.gov.uk/suppliers/frameworks/{{ framework_slug }}/updates</a>
+<br /><br />
+Thanks,
+<br /><br />
+The Digital Marketplace team
+<br />
+</body>
+</html>

--- a/app/templates/emails/framework_agreement_with_framework_version_returned.html
+++ b/app/templates/emails/framework_agreement_with_framework_version_returned.html
@@ -10,7 +10,7 @@ Your framework agreement signature page has been sent to the Crown Commercial Se
 <br /><br />
 You’ll receive an email when CCS have countersigned your agreement.
 <br /><br />
-You don’t need to wait for CCS to countersign the agreement before you start selling {{ framework_name }} services on the Digital Marketplace. You should be able to sell services from {{ start_selling_date }}.
+You don’t need to wait for CCS to countersign the agreement before you start selling {{ framework_name }} services on the Digital Marketplace. You should be able to sell services from {{ framework_live_date }}.
 <br /><br />
 If you need help, you can send a question through the {{ framework_name }} updates page at: <a href="https://www.digitalmarketplace.service.gov.uk/suppliers/frameworks/{{ framework_slug }}/updates">https://www.digitalmarketplace.service.gov.uk/suppliers/frameworks/{{ framework_slug }}/updates</a>
 <br /><br />

--- a/app/templates/emails/framework_agreement_with_framework_version_returned.html
+++ b/app/templates/emails/framework_agreement_with_framework_version_returned.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
 </head>
 <body>
-Dear {{ name }},
+Dear supplier,
 <br /><br />
 Your framework agreement signature page has been sent to the Crown Commercial Service (CCS). They’ll check and countersign the agreement, or contact you if there’s a problem.
 <br /><br />

--- a/app/templates/errors/404.html
+++ b/app/templates/errors/404.html
@@ -10,10 +10,10 @@
   </header>
 
   <p>
-      Check you've entered the correct web address or start again on the Digital Marketplace homepage.
+      Check you’ve entered the correct web address or start again on the Digital Marketplace homepage.
   </p>
   <p>
-      If you can't find what you're looking for, contact us at <a href="mailto:enquiries@digitalmarketplace.service.gov.uk?subject=Digital%20Marketplace%20feedback" title="Please send feedback to enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.service.gov.uk</a>
+      If you can’t find what you’re looking for, contact us at <a href="mailto:enquiries@digitalmarketplace.service.gov.uk?subject=Digital%20Marketplace%20feedback" title="Please send feedback to enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.service.gov.uk</a>
   </p>
 </div>
 

--- a/app/templates/errors/500.html
+++ b/app/templates/errors/500.html
@@ -1,12 +1,12 @@
 {% extends "_base_page.html" %}
 
-{% block page_title %}Sorry, we're experiencing technical difficulties - Digital Marketplace{% endblock %}
+{% block page_title %}Sorry, we’re experiencing technical difficulties - Digital Marketplace{% endblock %}
 
 {% block main_content %}
 
 <div class="error-page">
   <header class="page-heading-smaller">
-    <h1>Sorry, we're experiencing technical difficulties</h1>
+    <h1>Sorry, we’re experiencing technical difficulties</h1>
   </header>
   <p>
       Try again later.

--- a/app/templates/frameworks/_dashboard_lede.html
+++ b/app/templates/frameworks/_dashboard_lede.html
@@ -17,7 +17,7 @@
 
     {% elif framework.status == 'standstill' %}
       {% if supplier_is_on_framework %}
-        <p>Your application was successful. You'll be able to sell services when the {{ framework.name }} framework is live.</p>
+        <p>Your application was successful. You must return a signed framework agreement signature page before you can sell services on the Digital Marketplace.</p>
       {% else %}
         <p>You made your supplier declaration and submitted {{ counts.complete }} {{ 'service' if counts.complete == 1 else 'services' }}.</p>
       {% endif %}

--- a/app/templates/frameworks/_framework_actions.html
+++ b/app/templates/frameworks/_framework_actions.html
@@ -1,15 +1,17 @@
 {% if framework.status in ['standstill', 'live'] and application_made and not countersigned_agreement_file %}
-<li class="browse-list-item">
-  <a class="browse-list-item-link" href="{{ url_for('.download_agreement_file', framework_slug=framework.slug, document_name='result-letter.pdf') }}" download>
-    <span>Download your application {% if supplier_is_on_framework %}award{% else %}result{% endif %} letter (.pdf)</span>
-  </a>
-  {% if supplier_is_on_framework %}
-    <p>This letter is a record of your successful {{ framework.name }} application.</p>
-  {% else %}
-    <p>This letter informs you if your {{ framework.name }} application has been successful.</p>
-  {% endif %}
+  {% if not framework.frameworkAgreementVersion %}
+  <li class="browse-list-item">
+    <a class="browse-list-item-link" href="{{ url_for('.download_agreement_file', framework_slug=framework.slug, document_name='result-letter.pdf') }}" download>
+      <span>Download your application {% if supplier_is_on_framework %}award{% else %}result{% endif %} letter (.pdf)</span>
+    </a>
+    {% if supplier_is_on_framework %}
+      <p>This letter is a record of your successful {{ framework.name }} application.</p>
+    {% else %}
+      <p>This letter informs you if your {{ framework.name }} application has been successful.</p>
+    {% endif %}
 
-</li>
+  </li>
+  {% endif %}
 
   {% if supplier_is_on_framework %}
   <li class="browse-list-item">

--- a/app/templates/frameworks/contract_review.html
+++ b/app/templates/frameworks/contract_review.html
@@ -60,7 +60,7 @@
     {% call summary.row() %}
       {{ summary.field_name('Person who signed') }}
       {% call summary.field() %}
-        <p>{{ session.full_name }}</p><p>{{ session.role }}</p>
+        <p>{{ supplier_framework.agreementDetails.signerName }}</p><p>{{ supplier_framework.agreementDetails.signerRole }}</p>
       {% endcall %}
       {{ summary.edit_link("Edit", url_for('.signer_details', framework_slug=framework.slug)) }}
     {% endcall %}
@@ -101,7 +101,7 @@
     </form>
 
     <div class="dmspeak">
-      <p>Returning the signature page will notify the Crown Commercial Service and the primary contact you gave in your G-Cloud 8 application, {{ declaration.primaryContact }} at {{ declaration.primaryContactEmail }}.</p>
+      <p>Returning the signature page will notify the Crown Commercial Service and the primary contact you gave in your G-Cloud 8 application, {{ supplier_framework.declaration.primaryContact }} at {{ supplier_framework.declaration.primaryContactEmail }}.</p>
 
       <p>You’ll also receive an email to confirm that the signature page has been returned.</p>
     </div>

--- a/app/templates/frameworks/contract_review.html
+++ b/app/templates/frameworks/contract_review.html
@@ -29,7 +29,7 @@
   <div class="column-two-thirds">
     {%
       with
-      heading = "Check the details you’ve given before returning the signature page for {}".format(supplier_framework.declaration.nameOfOrganisation),
+      heading = "Check the details you’ve given before returning the signature page for %s" | format(supplier_framework.declaration.nameOfOrganisation),
       smaller = True
     %}
       {% include "toolkit/page-heading.html" %}

--- a/app/templates/frameworks/contract_review.html
+++ b/app/templates/frameworks/contract_review.html
@@ -1,0 +1,112 @@
+{% extends "_base_page.html" %}
+
+{% block page_title %}Review your contract – Digital Marketplace{% endblock %}
+
+{% block breadcrumb %}
+  {%
+    with items = [
+      {
+        "link": "/",
+        "label": "Digital Marketplace",
+      },
+      {
+        "link": url_for(".dashboard"),
+        "label": "Your account",
+      },
+      {
+        "link": url_for(".framework_dashboard", framework_slug=framework.slug),
+        "label": "Your " + framework.name + " application"
+      }
+    ]
+  %}
+    {% include "toolkit/breadcrumb.html" %}
+  {% endwith %}
+{% endblock %}
+
+{% block main_content %}
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+    {%
+      with
+      heading = "Check the details you’ve given before returning the signature page for {}".format(current_user.supplier_name),
+      smaller = True
+    %}
+      {% include "toolkit/page-heading.html" %}
+    {% endwith %}
+  </div>
+</div>
+
+{% if form.errors %}
+  {%
+    with
+      errors = form_errors
+  %}
+    {% include 'toolkit/forms/validation.html' %}
+  {% endwith %}
+{% endif %}
+
+<div>
+  {% import "toolkit/summary-table.html" as summary %}
+  {% call(item) summary.mapping_table(
+    caption='Supplier information',
+    field_headings=[
+      'Label',
+      'Value',
+      'Action'
+    ],
+    field_headings_visible=False
+  ) %}
+    {% call summary.row() %}
+      {{ summary.field_name('Person who signed') }}
+      {% call summary.field() %}
+        <p>{{ session.full_name }}</p><p>{{ session.role }}</p>
+      {% endcall %}
+      {{ summary.edit_link("Edit", url_for('.signer_details', framework_slug=framework.slug)) }}
+    {% endcall %}
+    {% call summary.row() %}
+      {{ summary.field_name('Signature page') }}
+      {{ summary.text(session.signature_page) }}
+      {{ summary.edit_link("Change", url_for('.signature_upload', framework_slug=framework.slug)) }}
+    {% endcall %}
+  {% endcall %}
+</div>
+
+<div class="single-question-page">
+<div class="grid-row">
+  <div class="column-two-thirds">
+
+    <form method="POST" action="{{ url_for('.submit_contract_review', framework_slug=framework.slug) }}">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+        {%
+          with
+          type = "checkbox",
+          name = "authority",
+          question = form.authority.label,
+          options = [{
+              "label": form.authority.description,
+          }],
+          error=form.authority.errors[0]
+        %}
+          {% include "toolkit/forms/selection-buttons.html" %}
+        {% endwith %}
+
+        {%
+          with
+            type = "save",
+            label = "Return signed signature page"
+        %}
+          {% include "toolkit/button.html" %}
+        {% endwith %}
+    </form>
+
+    <div class="dmspeak">
+      <p>Returning the signature page will notify the Crown Commercial Service and the primary contact you gave in your G-Cloud 8 application, {{ declaration.primaryContact }} at {{ declaration.primaryContactEmail }}.</p>
+
+      <p>You’ll also receive an email to confirm that the signature page has been returned.</p>
+    </div>
+  </div>
+</div>
+</div>
+
+{% endblock %}

--- a/app/templates/frameworks/contract_review.html
+++ b/app/templates/frameworks/contract_review.html
@@ -66,7 +66,11 @@
     {% endcall %}
     {% call summary.row() %}
       {{ summary.field_name('Signature page') }}
-      {{ summary.text(session.signature_page) }}
+      {% if session.signature_page %}
+        {{ summary.field_name(session.signature_page) }}
+      {% else %}
+        {{ summary.field_name( "Uploaded {}".format(signature_page.last_modified|datetimeformat) if signature_page else None) }}
+      {% endif %}
       {{ summary.edit_link("Change", url_for('.signature_upload', framework_slug=framework.slug)) }}
     {% endcall %}
   {% endcall %}

--- a/app/templates/frameworks/contract_review.html
+++ b/app/templates/frameworks/contract_review.html
@@ -72,7 +72,7 @@
   {% endcall %}
 </div>
 
-<div class="single-question-page">
+<div class="single-question-page authority-form-wrapper">
 <div class="grid-row">
   <div class="column-two-thirds">
 

--- a/app/templates/frameworks/contract_review.html
+++ b/app/templates/frameworks/contract_review.html
@@ -72,7 +72,7 @@
   {% endcall %}
 </div>
 
-<div class="single-question-page authority-form-wrapper">
+<div class="single-question-page authorisation-form-wrapper">
 <div class="grid-row">
   <div class="column-two-thirds">
 
@@ -82,17 +82,17 @@
       <p>You’ll also receive an email to confirm that the signature page has been returned.</p>
     </div>
 
-    <form method="POST" action="{{ url_for('.submit_contract_review', framework_slug=framework.slug) }}">
+    <form method="POST" action="{{ url_for('.contract_review', framework_slug=framework.slug) }}">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
         {%
           with
           type = "checkbox",
-          name = "authority",
-          question = form.authority.label,
+          name = "authorisation",
+          question = form.authorisation.label,
           options = [{
-              "label": form.authority.description,
+              "label": form.authorisation.description,
           }],
-          error=form.authority.errors[0]
+          error=form.authorisation.errors[0]
         %}
           {% include "toolkit/forms/selection-buttons.html" %}
         {% endwith %}

--- a/app/templates/frameworks/contract_review.html
+++ b/app/templates/frameworks/contract_review.html
@@ -29,7 +29,7 @@
   <div class="column-two-thirds">
     {%
       with
-      heading = "Check the details you’ve given before returning the signature page for {}".format(current_user.supplier_name),
+      heading = "Check the details you’ve given before returning the signature page for {}".format(supplier_framework.declaration.nameOfOrganisation),
       smaller = True
     %}
       {% include "toolkit/page-heading.html" %}
@@ -76,6 +76,12 @@
 <div class="grid-row">
   <div class="column-two-thirds">
 
+     <div class="dmspeak">
+      <p>Returning the signature page will notify the Crown Commercial Service and the primary contact you gave in your {{ framework.name }} application, {{ supplier_framework.declaration.primaryContact }} at {{ supplier_framework.declaration.primaryContactEmail }}.</p>
+
+      <p>You’ll also receive an email to confirm that the signature page has been returned.</p>
+    </div>
+
     <form method="POST" action="{{ url_for('.submit_contract_review', framework_slug=framework.slug) }}">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
         {%
@@ -100,11 +106,6 @@
         {% endwith %}
     </form>
 
-    <div class="dmspeak">
-      <p>Returning the signature page will notify the Crown Commercial Service and the primary contact you gave in your G-Cloud 8 application, {{ supplier_framework.declaration.primaryContact }} at {{ supplier_framework.declaration.primaryContactEmail }}.</p>
-
-      <p>You’ll also receive an email to confirm that the signature page has been returned.</p>
-    </div>
   </div>
 </div>
 </div>

--- a/app/templates/frameworks/contract_start.html
+++ b/app/templates/frameworks/contract_start.html
@@ -91,7 +91,7 @@
             }, 
             {
                 "body": "Return your signed signature page and give the details of the person who signed it.",
-                "bottom": "<strong><a href='#'>Return your signed signature page</a></strong>"
+                "bottom": "<strong><a href='{}'>Return your signed signature page</a></strong>".format(url_for('.signer_details', framework_slug=framework.slug))
             } 
           ]
         %}

--- a/app/templates/frameworks/contract_start.html
+++ b/app/templates/frameworks/contract_start.html
@@ -52,7 +52,7 @@
       </div>
 
       <div>
-        {{ summary.heading(current_user.supplier_name) }}
+        {{ summary.heading(supplier_framework.declaration.nameOfOrganisation) }}
         {% call(item) summary.list_table(
           lots,
           caption="Lot application status table",

--- a/app/templates/frameworks/contract_start.html
+++ b/app/templates/frameworks/contract_start.html
@@ -1,0 +1,104 @@
+{% extends "_base_page.html" %}
+{% import "toolkit/summary-table.html" as summary %}
+
+{% block page_title %}Apply to {{ framework.name }} – Digital Marketplace{% endblock %}
+
+{% block breadcrumb %}
+  {%
+    with items = [
+      {
+        "link": "/",
+        "label": "Digital Marketplace",
+      },
+      {
+        "link": url_for(".dashboard"),
+        "label": "Your account",
+      },
+      {
+        "link": url_for(".framework_dashboard", framework_slug=framework.slug),
+        "label": "Your " + framework.name + " application"
+      }
+    ]
+  %}
+    {% include "toolkit/breadcrumb.html" %}
+  {% endwith %}
+{% endblock %}
+
+{% block main_content %}
+
+  {% with messages = get_flashed_messages(with_categories=True) %}
+    {% for category, message in messages %}
+      {% if category == 'declaration_complete' %}
+        <div data-analytics="trackPageView"
+          data-url="{{message}}">
+        </div>
+      {% endif %}
+    {% endfor %}
+  {% endwith %}
+
+  <div class="grid-row framework-dashboard">
+    <div class="column-two-thirds">
+      {% with
+         heading = (
+           framework.name + " framework agreement"
+         ),
+         smaller = True
+      %}
+        {% include "toolkit/page-heading.html" %}
+      {% endwith %}
+
+      <div class="summary-item-lede">
+        <p>Your application was successful. You must return a signed framework agreement signature page before you can sell services on the Digital Marketplace.<p/>
+      </div>
+
+      <div>
+        {{ summary.heading(current_user.supplier_name) }}
+        {% call(item) summary.list_table(
+          lots,
+          caption="Lot application status table",
+          field_headings=[
+            "Lot name",
+            "Application status"
+          ],
+          field_headings_visible=False
+        ) %}
+          {% call summary.row() %}
+            {{ summary.text(item.name) }}
+            {{ summary.text('Pass' if item.has_completed_draft else 'No application') }}
+          {% endcall %}
+        {% endcall %}
+      </div>
+
+      <div>
+        <h2 class="page-subheading">What you need to do</h2>
+
+        {%
+          with
+          verbose = true,
+          items = [
+            {
+                "body": "Arrange for the framework agreement signature page to be signed.", 
+                "top": "The person signing must have the authority to agree to the framework terms, eg director or company secretary.",
+                "documents": [
+                    {
+                        "title": "Signature page", 
+                        "link": "#", 
+                        "file_type": "PDF",
+                        "download": True
+                    }
+                ],
+                "bottom": "You can review the <a href='https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/518833/DOS-Framework-Agreement.pdf' download>standard framework agreement</a> on GOV.UK."
+            }, 
+            {
+                "body": "Return your signed signature page and give the details of the person who signed it.",
+                "bottom": "<strong><a href='#'>Return your signed signature page</a></strong>"
+            } 
+          ]
+        %}
+          {% include "toolkit/instruction-list.html" %}
+        {% endwith %}
+      </div>  
+      
+    </div>
+  </div>
+{% endblock %}

--- a/app/templates/frameworks/contract_start.html
+++ b/app/templates/frameworks/contract_start.html
@@ -77,7 +77,7 @@
           verbose = true,
           items = [
             {
-                "body": "Arrange for the framework agreement signature page to be signed.", 
+                "body": "Sign your framework agreement signature page.", 
                 "top": "The person signing must have the authority to agree to the framework terms, eg director or company secretary.",
                 "documents": [
                     {

--- a/app/templates/frameworks/contract_submitted.html
+++ b/app/templates/frameworks/contract_submitted.html
@@ -83,11 +83,11 @@
       <div class="dmspeak">
         <div class="isolated-text">
           <p><a href="https://www.gov.uk/government/publications/digital-outcomes-and-specialists-framework-agreement">Read the standard framework agreement</a></p>
-          <p><a href="{{ signature_page_url }}" target="_blank">Download your framework agreement signature page, signed by your company</a></p>
+          <p><a href="{{ url_for('.download_agreement_file', framework_slug=framework.slug, document_name=document_name) }}" target="_blank">Download your framework agreement signature page, signed by your company</a></p>
         </div>
 
         <div class="isolated-text">
-          <p>You can start selling your {{ framework.name }} services on the Digital Marketplace from 1 August 2016.</p>
+          <p>You can start selling your {{ framework.name }} services on the Digital Marketplace from {{ framework_live_date }}.</p>
         </div>
       </div>
 

--- a/app/templates/frameworks/contract_submitted.html
+++ b/app/templates/frameworks/contract_submitted.html
@@ -1,0 +1,102 @@
+{% extends "_base_page.html" %}
+{% import "toolkit/summary-table.html" as summary %}
+
+{% block page_title %}{{ framework.name }} documents{% endblock %}
+
+{% block breadcrumb %}
+  {%
+    with items = [
+      {
+        "link": "/",
+        "label": "Digital Marketplace",
+      },
+      {
+        "link": url_for(".dashboard"),
+        "label": "Your account",
+      }
+    ]
+  %}
+    {% include "toolkit/breadcrumb.html" %}
+  {% endwith %}
+{% endblock %}
+
+{% block main_content %}
+
+  {% with messages = get_flashed_messages(with_categories=True) %}
+    {% for category, message in messages %}
+      {%
+        with
+        message = message,
+        type = "destructive" if category == 'error' else "success"
+      %}
+        {% include "toolkit/notification-banner.html" %}
+      {% endwith %}
+    {% endfor %}
+  {% endwith %}
+
+  <div class="grid-row framework-dashboard">
+    <div class="column-two-thirds">
+      {% with
+         heading = (
+           framework.name + " documents"
+         ),
+         smaller = True
+      %}
+        {% include "toolkit/page-heading.html" %}
+      {% endwith %}
+
+      <h2 class="page-subheading">Your framework agreement</h2>
+      <div class="summary-item-lede dmspeak">
+        <p>Your framework agreement signature page has been sent to the Crown Commercial Service (<abbr title="Crown Commercial Service">CCS</abbr>).
+          They’ll check and countersign the agreement, or contact you if there’s a problem. You don’t need to wait for <abbr title="Crown Commercial Service">CCS</abbr> to countersign your agreement before you start selling services.<p/>
+      </div>
+
+      {% import "toolkit/summary-table.html" as summary %}
+      {% call(item) summary.mapping_table(
+        caption='Agreement details',
+        field_headings=[
+          'Label',
+          'Value'
+        ],
+        field_headings_visible=False
+      ) %}
+        {% call summary.row() %}
+          {{ summary.field_name('Person who signed') }}
+          {% call summary.field() %}
+            <p>{{ supplier_framework.agreementDetails.signerName }}</p><p>{{ supplier_framework.agreementDetails.signerRole }}</p>
+          {% endcall %}
+        {% endcall %}
+        {% call summary.row() %}
+          {{ summary.field_name('Submitted by') }}
+          {% call summary.field() %}
+            <p>{{ supplier_framework.agreementDetails.uploaderUserName }}</p>
+            <p>{{ supplier_framework.agreementDetails.uploaderUserEmail }}</p>
+            <p>{{ supplier_framework.agreementReturnedAt|datetimeformat }}</p>
+          {% endcall %}
+        {% endcall %}
+        {% call summary.row() %}
+          {{ summary.field_name('Countersignature') }}
+          {{ summary.field_name('Waiting for CCS to countersign') }}
+        {% endcall %}
+      {% endcall %}
+
+      <div class="dmspeak">
+        <div class="isolated-text">
+          <p><a href="https://www.gov.uk/government/publications/digital-outcomes-and-specialists-framework-agreement">Read the standard framework agreement</a></p>
+          <p><a href="{{ signature_page_url }}" target="_blank">Download your framework agreement signature page, signed by your company</a></p>
+        </div>
+
+        <div class="isolated-text">
+          <p>You can start selling your {{ framework.name }} services on the Digital Marketplace from 1 August 2016.</p>
+        </div>
+      </div>
+
+      <nav role="navigation">
+        <ul class="browse-list browse-list-borderless">
+          {% include 'frameworks/_guidance_links.html' %}
+        </ul>
+      </nav>
+
+    </div>
+  </div>
+{% endblock %}

--- a/app/templates/frameworks/signature_upload.html
+++ b/app/templates/frameworks/signature_upload.html
@@ -47,15 +47,16 @@
 
   <div class="grid-row">
     <div class="column-two-thirds">
-      <form method="POST" enctype="multipart/form-data" action="{{ url_for('.submit_signature_upload', framework_slug=framework.slug) }}">
+      <form method="POST" enctype="multipart/form-data" action="{{ url_for('.signature_upload', framework_slug=framework.slug) }}">
           <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
           {%
             with
             question = "Upload your signed signature page",
             name = "signature_page",
             question_advice = 
-            "You only need to return the signed signature page. 
-            \n\nThe file must be saved as a PDF, JPG or PNG.",
+              "You only need to return the signed signature page.
+              \n\nThe file must be saved as a PDF, JPG or PNG.",
+            value="Document uploaded {}".format(signature_page.last_modified|datetimeformat) if signature_page else None,
             error = upload_error
           %}
             {% include "toolkit/forms/upload.html" %}

--- a/app/templates/frameworks/signature_upload.html
+++ b/app/templates/frameworks/signature_upload.html
@@ -1,0 +1,75 @@
+{% extends "_base_page.html" %}
+
+{% block page_title %}Signature upload – Digital Marketplace{% endblock %}
+
+{% block breadcrumb %}
+  {%
+    with items = [
+      {
+        "link": "/",
+        "label": "Digital Marketplace",
+      },
+      {
+        "link": url_for(".dashboard"),
+        "label": "Your account",
+      },
+      {
+        "link": url_for(".framework_dashboard", framework_slug=framework.slug),
+        "label": "Your " + framework.name + " application"
+      }
+    ]
+  %}
+    {% include "toolkit/breadcrumb.html" %}
+  {% endwith %}
+{% endblock %}
+
+{% block main_content %}
+<div class="single-question-page">
+  {%
+    with
+    heading = "Upload your signed signature page",
+    smaller = True
+  %}
+    {% include "toolkit/page-heading.html" %}
+  {% endwith %}
+
+  {% if upload_error %}
+    {%
+      with
+        errors = [{
+          'question': 'Upload your signed signature page',
+          'input_name': 'signature_page'
+        }]
+    %}
+      {% include 'toolkit/forms/validation.html' %}
+    {% endwith %}
+  {% endif %}
+
+  <div class="grid-row">
+    <div class="column-two-thirds">
+      <form method="POST" enctype="multipart/form-data" action="{{ url_for('.submit_signature_upload', framework_slug=framework.slug) }}">
+          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+          {%
+            with
+            question = "Upload your signed signature page",
+            name = "signature_page",
+            question_advice = 
+            "You only need to return the signed signature page. 
+            \n\nThe file must be saved as a PDF, JPG or PNG.",
+            error = upload_error
+          %}
+            {% include "toolkit/forms/upload.html" %}
+          {% endwith %}
+
+          {%
+            with
+              type = "save",
+              label = "Save and continue"
+          %}
+            {% include "toolkit/button.html" %}
+          {% endwith %}
+      </form>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/app/templates/frameworks/signature_upload.html
+++ b/app/templates/frameworks/signature_upload.html
@@ -49,6 +49,14 @@
     <div class="column-two-thirds">
       <form method="POST" enctype="multipart/form-data" action="{{ url_for('.signature_upload', framework_slug=framework.slug) }}">
           <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+          {% set value = None %}
+          {% if signature_page %}
+            {% if session.signature_page %}
+              {% set value = "{}, uploaded {}".format(session.signature_page, signature_page.last_modified|datetimeformat) %}
+            {% else %}
+              {% set value = "Uploaded {}".format(signature_page.last_modified|datetimeformat) %}
+            {% endif %}
+          {% endif %}
           {%
             with
             question = "Upload your signed signature page",
@@ -56,7 +64,7 @@
             question_advice = 
               "You only need to return the signed signature page.
               \n\nThe file must be saved as a PDF, JPG or PNG.",
-            value="Document uploaded {}".format(signature_page.last_modified|datetimeformat) if signature_page else None,
+            value=value,
             error = upload_error
           %}
             {% include "toolkit/forms/upload.html" %}

--- a/app/templates/frameworks/signer_details.html
+++ b/app/templates/frameworks/signer_details.html
@@ -28,7 +28,7 @@
   <div class="column-two-thirds">
     {%
     with
-      heading = "Details of the person who is signing on behalf of {}".format(current_user.supplier_name),
+      heading = "Details of the person who is signing on behalf of {}".format(supplier_framework.declaration.nameOfOrganisation),
       smaller = True
     %}
       {% include "toolkit/page-heading.html" %}

--- a/app/templates/frameworks/signer_details.html
+++ b/app/templates/frameworks/signer_details.html
@@ -28,7 +28,7 @@
   <div class="column-two-thirds">
     {%
     with
-      heading = "Details of the person who is signing on behalf of {}".format(supplier_framework.declaration.nameOfOrganisation),
+      heading = "Details of the person who is signing on behalf of %s" | format(supplier_framework.declaration.nameOfOrganisation),
       smaller = True
     %}
       {% include "toolkit/page-heading.html" %}

--- a/app/templates/frameworks/signer_details.html
+++ b/app/templates/frameworks/signer_details.html
@@ -1,0 +1,74 @@
+{% extends "_base_page.html" %}
+
+{% block page_title %}Signer details – Digital Marketplace{% endblock %}
+
+{% block breadcrumb %}
+  {%
+    with items = [
+      {
+        "link": "/",
+        "label": "Digital Marketplace",
+      },
+      {
+        "link": url_for(".dashboard"),
+        "label": "Your account",
+      },
+      {
+        "link": url_for(".framework_dashboard", framework_slug=framework.slug),
+        "label": "Your " + framework.name + " application"
+      }
+    ]
+  %}
+    {% include "toolkit/breadcrumb.html" %}
+  {% endwith %}
+{% endblock %}
+
+{% block main_content %}
+<div class="grid-row">
+  <div class="column-two-thirds">
+    {%
+    with
+      heading = "Details of the person who is signing on behalf of {}".format(current_user.supplier_name),
+      smaller = True
+    %}
+      {% include "toolkit/page-heading.html" %}
+    {% endwith %}
+
+    {% if form.errors %}
+      {%
+        with
+          errors = form_errors
+      %}
+        {% include 'toolkit/forms/validation.html' %}
+      {% endwith %}
+    {% endif %}
+
+    <form method="POST" action="{{ url_for('.signer_details', framework_slug=framework.slug) }}">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+        {% set question_names = ['full_name', 'role' ]%}
+        {% for question_name in question_names %}
+          {%
+            with
+              question = form[question_name].label,
+              name = question_name,
+              value = form[question_name].data,
+              hint = form[question_name].description,
+              error = form[question_name].errors[0]
+          %}
+            {% include "toolkit/forms/textbox.html" %}
+          {% endwith %}
+
+        {% endfor %}
+
+
+        {%
+          with
+            type = "save",
+            label = "Continue"
+        %}
+          {% include "toolkit/button.html" %}
+        {% endwith %}
+    </form>
+  </div>
+</div>
+{% endblock %}

--- a/app/templates/frameworks/signer_details.html
+++ b/app/templates/frameworks/signer_details.html
@@ -45,15 +45,14 @@
 
     <form method="POST" action="{{ url_for('.signer_details', framework_slug=framework.slug) }}">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
-        {% set question_names = ['full_name', 'role' ]%}
-        {% for question_name in question_names %}
+        {% for question_key in question_keys %}
           {%
             with
-              question = form[question_name].label,
-              name = question_name,
-              value = form[question_name].data,
-              hint = form[question_name].description,
-              error = form[question_name].errors[0]
+              question = form[question_key].label,
+              name = question_key,
+              value = form[question_key].data,
+              hint = form[question_key].description,
+              error = form[question_key].errors[0]
           %}
             {% include "toolkit/forms/textbox.html" %}
           {% endwith %}

--- a/app/templates/suppliers/_frameworks_standstill.html
+++ b/app/templates/suppliers/_frameworks_standstill.html
@@ -36,7 +36,7 @@
           {% endif %}
         {% endcall %}
         {% if not framework.needs_to_complete_declaration %}
-          {{ summary.edit_link('View your application', url_for('.framework_dashboard', framework_slug=framework.slug)) }}
+          {{ summary.edit_link('View your documents', url_for('.framework_dashboard', framework_slug=framework.slug)) }}
         {% else %}
           {% call summary.field() %}
           {% endcall %}

--- a/app/templates/suppliers/companies_house_number.html
+++ b/app/templates/suppliers/companies_house_number.html
@@ -1,5 +1,4 @@
 {% extends "_base_page.html" %}
-{% import "toolkit/summary-table.html" as summary %}
 
 {% block page_title %}Companies House – Create new supplier – Digital Marketplace{% endblock %}
 
@@ -28,7 +27,7 @@
 
   <div class="grid-row">
     <div class="column-two-thirds">
-      <form method="POST" action="{{ url_for('.companies_house_number') }}">
+      <form method="POST" action="{{ url_for('.submit_companies_house_number') }}">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
         {%
           with

--- a/app/templates/suppliers/company_contact_details.html
+++ b/app/templates/suppliers/company_contact_details.html
@@ -1,5 +1,4 @@
 {% extends "_base_page.html" %}
-{% import "toolkit/summary-table.html" as summary %}
 
 {% block page_title %}Company contact details – Create new supplier – Digital Marketplace{% endblock %}
 
@@ -47,7 +46,7 @@ with
 
         <p>You can change it at any time.</p>
 
-        <form method="POST" action="{{ url_for('.company_contact_details') }}">
+        <form method="POST" action="{{ url_for('.submit_company_contact_details') }}">
             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
             {%
                 with

--- a/app/templates/suppliers/company_name.html
+++ b/app/templates/suppliers/company_name.html
@@ -1,5 +1,4 @@
 {% extends "_base_page.html" %}
-{% import "toolkit/summary-table.html" as summary %}
 
 {% block page_title %}Company name – Create new supplier – Digital Marketplace{% endblock %}
 
@@ -27,7 +26,7 @@
   {% endwith %}
   <div class="grid-row">
     <div class="column-two-thirds">
-      <form method="POST" action="{{ url_for('.company_name') }}">
+      <form method="POST" action="{{ url_for('.submit_company_name') }}">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
         {%
           with

--- a/app/templates/suppliers/create_new_supplier.html
+++ b/app/templates/suppliers/create_new_supplier.html
@@ -1,5 +1,4 @@
 {% extends "_base_page.html" %}
-{% import "toolkit/summary-table.html" as summary %}
 
 {% block page_title %}Create supplier account – Digital Marketplace{% endblock %}
 

--- a/app/templates/suppliers/create_your_account_complete.html
+++ b/app/templates/suppliers/create_your_account_complete.html
@@ -1,5 +1,4 @@
 {% extends "_base_page.html" %}
-{% import "toolkit/summary-table.html" as summary %}
 
 {% block page_title %}Activate your account - Create new supplier – Digital Marketplace{% endblock %}
 

--- a/app/templates/suppliers/duns_number.html
+++ b/app/templates/suppliers/duns_number.html
@@ -1,5 +1,4 @@
 {% extends "_base_page.html" %}
-{% import "toolkit/summary-table.html" as summary %}
 
 {% block page_title %}DUNS number – Create new supplier – Digital Marketplace{% endblock %}
 
@@ -39,7 +38,7 @@
 
   <div class="grid-row">
     <div class="column-two-thirds">
-      <form method="POST" action="{{ url_for('.duns_number') }}">
+      <form method="POST" action="{{ url_for('.submit_duns_number') }}">
           <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
           {%
             with

--- a/config.py
+++ b/config.py
@@ -71,8 +71,8 @@ class Config(object):
 
     # Logging
     DM_LOG_LEVEL = 'DEBUG'
+    DM_LOG_PATH = None
     DM_APP_NAME = 'supplier-frontend'
-    DM_LOG_PATH = '/var/log/digitalmarketplace/application.log'
     DM_DOWNSTREAM_REQUEST_ID_HEADER = 'X-Amz-Cf-Id'
 
     @staticmethod
@@ -130,6 +130,7 @@ class Development(Config):
 class Live(Config):
     """Base config for deployed environments"""
     DEBUG = False
+    DM_LOG_PATH = '/var/log/digitalmarketplace/application.log'
     DM_HTTP_PROTO = 'https'
 
     DM_FRAMEWORK_AGREEMENTS_EMAIL = 'enquiries@digitalmarketplace.service.gov.uk'

--- a/config.py
+++ b/config.py
@@ -48,6 +48,8 @@ class Config(object):
     CLARIFICATION_EMAIL_SUBJECT = 'Thanks for your clarification question'
     DM_FOLLOW_UP_EMAIL_TO = 'digitalmarketplace@mailinator.com'
 
+    FRAMEWORK_AGREEMENT_RETURNED_NAME = 'Digital Marketplace Admin'
+
     DM_GENERIC_NOREPLY_EMAIL = 'do-not-reply@digitalmarketplace.service.gov.uk'
 
     CREATE_USER_SUBJECT = 'Create your Digital Marketplace account'

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,6 @@ python-dateutil==2.4.2
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@21.2.2#egg=digitalmarketplace-utils==21.2.2
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@1.1.0#egg=digitalmarketplace-content-loader==1.1.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@3.8.0#egg=digitalmarketplace-apiclient==3.8.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@5.0.0#egg=digitalmarketplace-apiclient==5.0.0
 
 markdown==2.6.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ Flask-WTF==0.12
 werkzeug==0.10.4
 python-dateutil==2.4.2
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@20.0.0#egg=digitalmarketplace-utils==20.0.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@21.2.2#egg=digitalmarketplace-utils==21.2.2
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@1.1.0#egg=digitalmarketplace-content-loader==1.1.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@3.8.0#egg=digitalmarketplace-apiclient==3.8.0
 

--- a/tests/app/helpers.py
+++ b/tests/app/helpers.py
@@ -190,12 +190,22 @@ class BaseApplicationTest(object):
         }
 
     @staticmethod
-    def framework(status='open', name='G-Cloud 7', slug='g-cloud-7', clarification_questions_open=True):
-        if slug == 'g-cloud-7':
+    def framework(
+            status='open',
+            name='G-Cloud 7',
+            slug='g-cloud-7',
+            clarification_questions_open=True,
+            framework_agreement_version=None
+    ):
+        if 'g-cloud-' in slug:
             lots = [
                 {'id': 1, 'slug': 'iaas', 'name': 'Infrastructure as a Service', 'oneServiceLimit': False,
                  'unitSingular': 'service', 'unitPlural': 'service'},
                 {'id': 2, 'slug': 'scs', 'name': 'Specialist Cloud Services', 'oneServiceLimit': False,
+                 'unitSingular': 'service', 'unitPlural': 'service'},
+                {'id': 3, 'slug': 'paas', 'name': 'Platform as a Service', 'oneServiceLimit': False,
+                 'unitSingular': 'service', 'unitPlural': 'service'},
+                {'id': 4, 'slug': 'saas', 'name': 'Software as a Service', 'oneServiceLimit': False,
                  'unitSingular': 'service', 'unitPlural': 'service'},
             ]
         elif slug == 'digital-outcomes-and-specialists':
@@ -211,6 +221,7 @@ class BaseApplicationTest(object):
                 'name': name,
                 'slug': slug,
                 'lots': lots,
+                'frameworkAgreementVersion': framework_agreement_version
             }
         }
 

--- a/tests/app/helpers.py
+++ b/tests/app/helpers.py
@@ -226,8 +226,14 @@ class BaseApplicationTest(object):
         }
 
     @staticmethod
-    def supplier_framework(declaration='default', status=None, on_framework=False,
-                           agreement_returned=False, agreement_returned_at=None):
+    def supplier_framework(
+        declaration='default',
+        status=None,
+        on_framework=False,
+        agreement_returned=False,
+        agreement_returned_at=None,
+        agreement_details=None
+    ):
         if declaration == 'default':
             declaration = FULL_G7_SUBMISSION.copy()
         if status is not None:
@@ -238,6 +244,7 @@ class BaseApplicationTest(object):
                 'onFramework': on_framework,
                 'agreementReturned': agreement_returned,
                 'agreementReturnedAt': agreement_returned_at,
+                'agreementDetails': agreement_details
             }
         }
 

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -1713,10 +1713,13 @@ class TestG7ServicesList(BaseApplicationTest):
 
 
 @mock.patch("app.main.frameworks.data_api_client")
+@mock.patch("app.main.frameworks.return_supplier_framework_info_if_on_framework_or_abort")
 class TestReturnSignedAgreement(BaseApplicationTest):
 
-    def test_should_be_an_error_if_no_full_name(self, data_api_client):
+    def test_should_be_an_error_if_no_full_name(self, return_supplier_framework, data_api_client):
         data_api_client.get_framework.return_value = get_g_cloud_8()
+        return_supplier_framework.return_value = self.supplier_framework(on_framework=True)
+
         res = self.client.post(
             "/suppliers/frameworks/g-cloud-8/signer-details",
             data={
@@ -1727,8 +1730,10 @@ class TestReturnSignedAgreement(BaseApplicationTest):
         page = res.get_data(as_text=True)
         assert "You must provide the full name of the person signing on behalf of the company" in page
 
-    def test_should_be_an_error_if_no_role(self, data_api_client):
+    def test_should_be_an_error_if_no_role(self, return_supplier_framework, data_api_client):
         data_api_client.get_framework.return_value = get_g_cloud_8()
+        return_supplier_framework.return_value = self.supplier_framework(on_framework=True)
+
         res = self.client.post(
             "/suppliers/frameworks/g-cloud-8/signer-details",
             data={
@@ -1739,8 +1744,11 @@ class TestReturnSignedAgreement(BaseApplicationTest):
         page = res.get_data(as_text=True)
         assert "You must provide the role of the person signing on behalf of the company" in page
 
-    def test_should_be_an_error_if_signer_details_fields_more_than_255_characters(self, data_api_client):
+    def test_should_be_an_error_if_signer_details_fields_more_than_255_characters(
+            self, return_supplier_framework, data_api_client
+    ):
         data_api_client.get_framework.return_value = get_g_cloud_8()
+        return_supplier_framework.return_value = self.supplier_framework(on_framework=True)
 
         # 255 characters should be fine
         res = self.client.post(
@@ -1765,13 +1773,14 @@ class TestReturnSignedAgreement(BaseApplicationTest):
         assert "You must provide a name under 256 characters" in page
         assert "You must provide a role under 256 characters" in page
 
-    def test_should_strip_whitespace_on_signer_details_fields(self, data_api_client):
+    def test_should_strip_whitespace_on_signer_details_fields(self, return_supplier_framework, data_api_client):
         signer_details = {
             'full_name': "   Josh Moss   ",
             'role': "   The Boss   "
         }
 
         data_api_client.get_framework.return_value = get_g_cloud_8()
+        return_supplier_framework.return_value = self.supplier_framework(on_framework=True)
 
         with self.client as c:
             res = c.post(
@@ -1784,13 +1793,17 @@ class TestReturnSignedAgreement(BaseApplicationTest):
                 assert key in session
                 assert session.get(key) == value.strip()
 
-    def test_provide_signer_details_form_with_valid_input_redirects_to_upload_page(self, data_api_client):
+    def test_provide_signer_details_form_with_valid_input_redirects_to_upload_page(
+            self, return_supplier_framework, data_api_client
+    ):
         signer_details = {
             'full_name': "Josh Moss",
             'role': "The Boss"
         }
 
         data_api_client.get_framework.return_value = get_g_cloud_8()
+        return_supplier_framework.return_value = self.supplier_framework(on_framework=True)
+
         with self.client as c:
             res = c.post(
                 "/suppliers/frameworks/g-cloud-8/signer-details",

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -1719,7 +1719,7 @@ class TestReturnSignedAgreement(BaseApplicationTest):
     def test_should_be_an_error_if_no_full_name(self, return_supplier_framework, data_api_client):
         self.login()
         data_api_client.get_framework.return_value = get_g_cloud_8()
-        return_supplier_framework.return_value = self.supplier_framework(on_framework=True)
+        return_supplier_framework.return_value = self.supplier_framework(on_framework=True)['frameworkInterest']
 
         res = self.client.post(
             "/suppliers/frameworks/g-cloud-8/signer-details",
@@ -1734,7 +1734,7 @@ class TestReturnSignedAgreement(BaseApplicationTest):
     def test_should_be_an_error_if_no_role(self, return_supplier_framework, data_api_client):
         self.login()
         data_api_client.get_framework.return_value = get_g_cloud_8()
-        return_supplier_framework.return_value = self.supplier_framework(on_framework=True)
+        return_supplier_framework.return_value = self.supplier_framework(on_framework=True)['frameworkInterest']
 
         res = self.client.post(
             "/suppliers/frameworks/g-cloud-8/signer-details",
@@ -1751,7 +1751,7 @@ class TestReturnSignedAgreement(BaseApplicationTest):
     ):
         self.login()
         data_api_client.get_framework.return_value = get_g_cloud_8()
-        return_supplier_framework.return_value = self.supplier_framework(on_framework=True)
+        return_supplier_framework.return_value = self.supplier_framework(on_framework=True)['frameworkInterest']
 
         # 255 characters should be fine
         res = self.client.post(
@@ -1783,7 +1783,7 @@ class TestReturnSignedAgreement(BaseApplicationTest):
         }
 
         data_api_client.get_framework.return_value = get_g_cloud_8()
-        return_supplier_framework.return_value = self.supplier_framework(on_framework=True)
+        return_supplier_framework.return_value = self.supplier_framework(on_framework=True)['frameworkInterest']
 
         with self.client as c:
             self.login()
@@ -1806,7 +1806,7 @@ class TestReturnSignedAgreement(BaseApplicationTest):
         }
 
         data_api_client.get_framework.return_value = get_g_cloud_8()
-        return_supplier_framework.return_value = self.supplier_framework(on_framework=True)
+        return_supplier_framework.return_value = self.supplier_framework(on_framework=True)['frameworkInterest']
 
         with self.client as c:
             self.login()
@@ -1830,7 +1830,7 @@ class TestReturnSignedAgreement(BaseApplicationTest):
             self.login()
 
             data_api_client.get_framework.return_value = get_g_cloud_8()
-            return_supplier_framework.return_value = self.supplier_framework(on_framework=True)
+            return_supplier_framework.return_value = self.supplier_framework(on_framework=True)['frameworkInterest']
             file_is_empty.return_value = True
 
             res = self.client.post(
@@ -1851,7 +1851,7 @@ class TestReturnSignedAgreement(BaseApplicationTest):
             self.login()
 
             data_api_client.get_framework.return_value = get_g_cloud_8()
-            return_supplier_framework.return_value = self.supplier_framework(on_framework=True)
+            return_supplier_framework.return_value = self.supplier_framework(on_framework=True)['frameworkInterest']
             file_is_image.return_value = False
 
             res = self.client.post(
@@ -1872,7 +1872,7 @@ class TestReturnSignedAgreement(BaseApplicationTest):
             self.login()
 
             data_api_client.get_framework.return_value = get_g_cloud_8()
-            return_supplier_framework.return_value = self.supplier_framework(on_framework=True)
+            return_supplier_framework.return_value = self.supplier_framework(on_framework=True)['frameworkInterest']
             file_is_less_than_5mb.return_value = False
 
             res = self.client.post(
@@ -1891,7 +1891,7 @@ class TestReturnSignedAgreement(BaseApplicationTest):
             self.login()
 
             data_api_client.get_framework.return_value = get_g_cloud_8()
-            return_supplier_framework.return_value = self.supplier_framework(on_framework=True)
+            return_supplier_framework.return_value = self.supplier_framework(on_framework=True)['frameworkInterest']
 
             res = self.client.post(
                 '/suppliers/frameworks/g-cloud-8/signature-upload',

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -1717,6 +1717,7 @@ class TestG7ServicesList(BaseApplicationTest):
 class TestReturnSignedAgreement(BaseApplicationTest):
 
     def test_should_be_an_error_if_no_full_name(self, return_supplier_framework, data_api_client):
+        self.login()
         data_api_client.get_framework.return_value = get_g_cloud_8()
         return_supplier_framework.return_value = self.supplier_framework(on_framework=True)
 
@@ -1731,6 +1732,7 @@ class TestReturnSignedAgreement(BaseApplicationTest):
         assert "You must provide the full name of the person signing on behalf of the company" in page
 
     def test_should_be_an_error_if_no_role(self, return_supplier_framework, data_api_client):
+        self.login()
         data_api_client.get_framework.return_value = get_g_cloud_8()
         return_supplier_framework.return_value = self.supplier_framework(on_framework=True)
 
@@ -1747,6 +1749,7 @@ class TestReturnSignedAgreement(BaseApplicationTest):
     def test_should_be_an_error_if_signer_details_fields_more_than_255_characters(
             self, return_supplier_framework, data_api_client
     ):
+        self.login()
         data_api_client.get_framework.return_value = get_g_cloud_8()
         return_supplier_framework.return_value = self.supplier_framework(on_framework=True)
 
@@ -1783,6 +1786,7 @@ class TestReturnSignedAgreement(BaseApplicationTest):
         return_supplier_framework.return_value = self.supplier_framework(on_framework=True)
 
         with self.client as c:
+            self.login()
             res = c.post(
                 "/suppliers/frameworks/g-cloud-8/signer-details",
                 data=signer_details
@@ -1805,6 +1809,7 @@ class TestReturnSignedAgreement(BaseApplicationTest):
         return_supplier_framework.return_value = self.supplier_framework(on_framework=True)
 
         with self.client as c:
+            self.login()
             res = c.post(
                 "/suppliers/frameworks/g-cloud-8/signer-details",
                 data=signer_details

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -456,7 +456,9 @@ class TestFrameworksDashboard(BaseApplicationTest):
         data = res.get_data(as_text=True)
 
         for success_message in [
-            u'Your application was successful. You\'ll be able to sell services when the G-Cloud 7 framework is live',
+            u'Your application was successful. '
+                u'You must return a signed framework agreement signature page before you can '
+                u'sell services on the Digital Marketplace.',
             u'Download your application award letter (.pdf)',
             u'This letter is a record of your successful G-Cloud 7 application.'
         ]:

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -1977,7 +1977,7 @@ class TestReturnSignedAgreement(BaseApplicationTest):
             page_without_whitespace = self.strip_all_whitespace(res.get_data(as_text=True))
             assert '<tdclass="summary-item-field"><span>example.pdf</span></td>' in page_without_whitespace
 
-    def test_should_be_an_error_if_authority_not_checked(self, return_supplier_framework, data_api_client):
+    def test_should_be_an_error_if_authorisation_not_checked(self, return_supplier_framework, data_api_client):
         with self.app.test_client():
             self.login()
             data_api_client.get_framework.return_value = get_g_cloud_8()

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -1907,4 +1907,58 @@ class TestReturnSignedAgreement(BaseApplicationTest):
                 download_filename='Supplier_Name-1234-signed-framework-agreement.jpg'
             )
             assert res.status_code == 302
-            assert res.location == 'http://localhost/suppliers/frameworks/g-cloud-7/agreement'
+            assert res.location == 'http://localhost/suppliers/frameworks/g-cloud-8/contract-review'
+
+    def test_contract_review_page_loads_with_correct_supplier_details(self, return_supplier_framework, data_api_client):
+        with self.app.test_client():
+            self.login()
+            data_api_client.get_framework.return_value = get_g_cloud_8()
+            supplier_framework = self.supplier_framework(on_framework=True)['frameworkInterest']
+            supplier_framework['declaration']['primaryContact'] = 'contact name'
+            supplier_framework['declaration']['primaryContactEmail'] = 'email@email.com'
+            return_supplier_framework.return_value = supplier_framework
+
+            res = self.client.get(
+                "/suppliers/frameworks/g-cloud-8/contract-review"
+            )
+            assert res.status_code == 200
+            page = res.get_data(as_text=True)
+            assert "I have the authority to return this agreement on behalf of Supplier Name" in page
+            assert "Returning the signature page will notify the Crown Commercial Service and the primary contact you "
+            "gave in your G-Cloud 8 application, contact name at email@email.com." in page
+
+    def test_contract_review_page_loads_with_signer_details_and_filename_from_session(
+        self, return_supplier_framework, data_api_client
+    ):
+        with self.app.test_client():
+            self.login()
+            data_api_client.get_framework.return_value = get_g_cloud_8()
+            return_supplier_framework.return_value = self.supplier_framework(on_framework=True)['frameworkInterest']
+
+            with self.client.session_transaction() as sess:
+                sess['full_name'] = "signer_full_name"
+                sess['role'] = "signer_role"
+                sess['signature_page'] = "example.pdf"
+
+            res = self.client.get(
+                "/suppliers/frameworks/g-cloud-8/contract-review"
+            )
+            assert res.status_code == 200
+            page_without_whitespace = self.strip_all_whitespace(res.get_data(as_text=True))
+            assert '<tdclass="summary-item-field"><span><p>signer_full_name</p><p>signer_role</p></span></td>' \
+                in page_without_whitespace
+            assert '<tdclass="summary-item-field"><span>example.pdf</span></td>' in page_without_whitespace
+
+    def test_should_be_an_error_if_authority_not_checked(self, return_supplier_framework, data_api_client):
+        with self.app.test_client():
+            self.login()
+            data_api_client.get_framework.return_value = get_g_cloud_8()
+            return_supplier_framework.return_value = self.supplier_framework(on_framework=True)['frameworkInterest']
+
+            res = self.client.post(
+                "/suppliers/frameworks/g-cloud-8/contract-review",
+                data={}
+            )
+            assert res.status_code == 400
+            page = res.get_data(as_text=True)
+            assert "You must confirm you have the authority to return the agreement" in page

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -97,7 +97,7 @@ class TestFrameworksDashboard(BaseApplicationTest):
 
         assert_equal(res.status_code, 404)
 
-    @mock.patch('app.main.frameworks.send_email')
+    @mock.patch('app.main.views.frameworks.send_email')
     def test_interest_registered_in_framework_on_post(self, send_email, data_api_client, s3):
         with self.app.test_client():
             self.login()
@@ -113,7 +113,7 @@ class TestFrameworksDashboard(BaseApplicationTest):
                 "email@email.com"
             )
 
-    @mock.patch('app.main.frameworks.send_email')
+    @mock.patch('app.main.views.frameworks.send_email')
     def test_email_sent_when_interest_registered_in_framework(self, send_email, data_api_client, s3):
         with self.app.test_client():
             self.login()
@@ -678,7 +678,7 @@ class TestFrameworkAgreement(BaseApplicationTest):
 
 
 @mock.patch('dmutils.s3.S3')
-@mock.patch('app.main.frameworks.send_email')
+@mock.patch('app.main.views.frameworks.send_email')
 @mock.patch('app.main.views.frameworks.data_api_client', autospec=True)
 class TestFrameworkAgreementUpload(BaseApplicationTest):
     def test_page_returns_404_if_framework_in_wrong_state(self, data_api_client, send_email, s3):
@@ -1713,8 +1713,8 @@ class TestG7ServicesList(BaseApplicationTest):
         assert_not_in(u'Apply to provide', submissions.get_data(as_text=True))
 
 
-@mock.patch("app.main.frameworks.data_api_client")
-@mock.patch("app.main.frameworks.return_supplier_framework_info_if_on_framework_or_abort")
+@mock.patch("app.main.views.frameworks.data_api_client")
+@mock.patch("app.main.views.frameworks.return_supplier_framework_info_if_on_framework_or_abort")
 class TestReturnSignedAgreement(BaseApplicationTest):
 
     def test_signer_details_shows_company_name(self, return_supplier_framework, data_api_client):
@@ -2099,7 +2099,7 @@ class TestReturnSignedAgreement(BaseApplicationTest):
             assert res.status_code == 404
 
     @mock.patch('dmutils.s3.S3')
-    @mock.patch('app.main.frameworks.send_email')
+    @mock.patch('app.main.views.frameworks.send_email')
     def test_return_400_response_and_no_email_sent_if_authorisation_not_checked(
             self, send_email, s3, return_supplier_framework, data_api_client
     ):
@@ -2126,7 +2126,7 @@ class TestReturnSignedAgreement(BaseApplicationTest):
             assert "You must confirm you have the authority to return the agreement" in page
 
     @mock.patch('dmutils.s3.S3')
-    @mock.patch('app.main.frameworks.send_email')
+    @mock.patch('app.main.views.frameworks.send_email')
     def test_valid_framework_agreement_returned_sends_confirmation_emails_and_redirects_to_framework_dashboard(
         self, send_email, s3, return_supplier_framework, data_api_client
     ):
@@ -2151,8 +2151,8 @@ class TestReturnSignedAgreement(BaseApplicationTest):
             )
 
             # Delcaration primaryContactEmail and current_user.email_address are different so expect two recipients
-            send_email.assert_called_once(
-                ['email@email.com', 'email2@email.com'],
+            send_email.assert_called_once_with(
+                ['email2@email.com', 'email@email.com'],
                 mock.ANY,
                 'MANDRILL',
                 'Your G-Cloud 8 signature page has been received',
@@ -2165,7 +2165,7 @@ class TestReturnSignedAgreement(BaseApplicationTest):
             assert res.location == 'http://localhost/suppliers/frameworks/g-cloud-8'
 
     @mock.patch('dmutils.s3.S3')
-    @mock.patch('app.main.frameworks.send_email')
+    @mock.patch('app.main.views.frameworks.send_email')
     def test_valid_framework_agreement_returned_sends_only_one_confirmation_email_if_contact_email_addresses_are_equal(
         self, send_email, s3, return_supplier_framework, data_api_client
     ):
@@ -2189,8 +2189,8 @@ class TestReturnSignedAgreement(BaseApplicationTest):
                 }
             )
 
-            send_email.assert_called_once(
-                'email@email.com',
+            send_email.assert_called_once_with(
+                ['email@email.com'],
                 mock.ANY,
                 'MANDRILL',
                 'Your G-Cloud 8 signature page has been received',
@@ -2203,7 +2203,7 @@ class TestReturnSignedAgreement(BaseApplicationTest):
             assert res.location == 'http://localhost/suppliers/frameworks/g-cloud-8'
 
     @mock.patch('dmutils.s3.S3')
-    @mock.patch('app.main.frameworks.send_email')
+    @mock.patch('app.main.views.frameworks.send_email')
     def test_return_503_response_if_mandrill_exception_raised_by_send_email(
             self, send_email, s3, return_supplier_framework, data_api_client
     ):
@@ -2232,7 +2232,7 @@ class TestReturnSignedAgreement(BaseApplicationTest):
             assert res.status_code == 503
 
     @mock.patch('dmutils.s3.S3')
-    @mock.patch('app.main.frameworks.send_email')
+    @mock.patch('app.main.views.frameworks.send_email')
     def test_email_not_sent_if_api_call_fails(
             self, send_email, s3, return_supplier_framework, data_api_client
     ):
@@ -2262,7 +2262,7 @@ class TestReturnSignedAgreement(BaseApplicationTest):
             assert not send_email.called
 
     @mock.patch('dmutils.s3.S3')
-    @mock.patch('app.main.frameworks.get_supplier_framework_info')
+    @mock.patch('app.main.views.frameworks.get_supplier_framework_info')
     def test_framework_dashboard_shows_returned_agreement_details(
             self, get_supplier_framework_info, s3, return_supplier_framework, data_api_client
     ):

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -731,7 +731,7 @@ class TestFrameworkAgreementUpload(BaseApplicationTest):
             assert_in(u'Document must be less than 5Mb', res.get_data(as_text=True))
 
     @mock.patch('app.main.views.frameworks.file_is_empty')
-    def test_page_returns_400_if_file_is_too_large(self, file_is_empty, data_api_client, send_email, s3):
+    def test_page_returns_400_if_file_is_empty(self, file_is_empty, data_api_client, send_email, s3):
         with self.app.test_client():
             self.login()
 
@@ -743,7 +743,7 @@ class TestFrameworkAgreementUpload(BaseApplicationTest):
             res = self.client.post(
                 '/suppliers/frameworks/g-cloud-7/agreement',
                 data={
-                    'agreement': (StringIO(b'doc'), 'test.pdf'),
+                    'agreement': (StringIO(b''), 'test.pdf'),
                 }
             )
 

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -1726,7 +1726,7 @@ class TestReturnSignedAgreement(BaseApplicationTest):
         res = self.client.post(
             "/suppliers/frameworks/g-cloud-8/signer-details",
             data={
-                'role': "The Boss"
+                'signerRole': "The Boss"
             }
         )
         assert res.status_code == 400
@@ -1741,7 +1741,7 @@ class TestReturnSignedAgreement(BaseApplicationTest):
         res = self.client.post(
             "/suppliers/frameworks/g-cloud-8/signer-details",
             data={
-                'full_name': "Josh Moss"
+                'signerName': "Josh Moss"
             }
         )
         assert res.status_code == 400
@@ -1787,18 +1787,19 @@ class TestReturnSignedAgreement(BaseApplicationTest):
         data_api_client.get_framework.return_value = get_g_cloud_8()
         return_supplier_framework.return_value = self.supplier_framework(on_framework=True)['frameworkInterest']
 
-        # this test needs fixing but not sure what we are going to assert as no longer using session
-        with self.client as c:
-            self.login()
-            res = c.post(
-                "/suppliers/frameworks/g-cloud-8/signer-details",
-                data=signer_details
-            )
-            assert res.status_code == 302
+        self.login()
+        res = self.client.post(
+            "/suppliers/frameworks/g-cloud-8/signer-details",
+            data=signer_details
+        )
+        assert res.status_code == 302
 
-            for key, value in signer_details.items():
-                assert key in session
-                assert session.get(key) == value.strip()
+        data_api_client.update_supplier_framework_agreement_details.assert_called_with(
+            1234,
+            'g-cloud-8',
+            {'signerName': u'Josh Moss', 'signerRole': u'The Boss'},
+            'email@email.com'
+        )
 
     def test_provide_signer_details_form_with_valid_input_redirects_to_upload_page(
             self, return_supplier_framework, data_api_client

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -1142,7 +1142,7 @@ class TestFrameworkUpdatesPage(BaseApplicationTest):
 
             assert_equal(response.status_code, 503)
             assert_true(
-                self.strip_all_whitespace("<h1>Sorry, we're experiencing technical difficulties</h1>")
+                self.strip_all_whitespace(u"<h1>Sorry, we’re experiencing technical difficulties</h1>")
                 in self.strip_all_whitespace(response.get_data(as_text=True))
             )
 

--- a/tests/app/main/test_suppliers.py
+++ b/tests/app/main/test_suppliers.py
@@ -593,7 +593,7 @@ class TestSuppliersDashboard(BaseApplicationTest):
                       first_row)
             assert_not_in(u"You must sign the framework agreement to sell these services",
                           first_row)
-            assert_in(u"View your application",
+            assert_in(u"View your documents",
                       first_row)
 
     @mock.patch("app.main.views.suppliers.data_api_client")

--- a/tests/app/test_application.py
+++ b/tests/app/test_application.py
@@ -29,15 +29,15 @@ class TestApplication(BaseApplicationTest):
         res = self.client.get('/service/1234')
         assert_equal(404, res.status_code)
         assert_true(
-            "Check you've entered the correct web "
-            "address or start again on the Digital Marketplace homepage."
+            u"Check you’ve entered the correct web "
+            u"address or start again on the Digital Marketplace homepage."
             in res.get_data(as_text=True))
         assert_true(
-            "If you can't find what you're looking for, contact us at "
-            "<a href=\"mailto:enquiries@digitalmarketplace.service.gov.uk?"
-            "subject=Digital%20Marketplace%20feedback\" title=\"Please "
-            "send feedback to enquiries@digitalmarketplace.service.gov.uk\">"
-            "enquiries@digitalmarketplace.service.gov.uk</a>"
+            u"If you can’t find what you’re looking for, contact us at "
+            u"<a href=\"mailto:enquiries@digitalmarketplace.service.gov.uk?"
+            u"subject=Digital%20Marketplace%20feedback\" title=\"Please "
+            u"send feedback to enquiries@digitalmarketplace.service.gov.uk\">"
+            u"enquiries@digitalmarketplace.service.gov.uk</a>"
             in res.get_data(as_text=True))
 
     @mock.patch('app.main.views.suppliers.data_api_client')
@@ -51,7 +51,7 @@ class TestApplication(BaseApplicationTest):
             res = self.client.get('/suppliers')
             assert_equal(503, res.status_code)
             assert_true(
-                "Sorry, we're experiencing technical difficulties"
+                u"Sorry, we’re experiencing technical difficulties"
                 in res.get_data(as_text=True))
             assert_true(
                 "Try again later."


### PR DESCRIPTION
Built multipage flow to handle signing and returning your framework agreement

## Contract start
- Contains table of which lots you have passed and which you did not apply for
- Instructions for how to return your framework agreement
- The link to download your signature page is to a unique file for each company (TO BE COMPLETED)

![screen shot 2016-07-14 at 16 27 30](https://cloud.githubusercontent.com/assets/2454380/16845413/b88ce9d2-49e0-11e6-9a36-7dc03c52482f.png)

## Signer details
- Form to get `signerName` and `signerRole`
- Form is validated by `form.validate_on_submit` after which values are sent to the API (which also does its own validation)
- If `signerName` and `signerRole` already exist in `agreementDetails` then these are prefilled in the form
- If filename exists in session, when the form is submitted you are taken straight to the contract review page as you have likely been editing your signer details

![screen shot 2016-07-14 at 16 27 42](https://cloud.githubusercontent.com/assets/2454380/16845423/c7383d56-49e0-11e6-893b-4cccc40f094f.png)

## Signature upload
- Upload PDF, JPG or PNG file
- Validation checks that file exists, is of correct format, is not empty and is smaller than 5MB
- File is uploaded to s3 and a new file is uploaded every time. Older files are archived.
- The filename of the uploaded file is stored in the session to be shown on the contract review page
- If you have previously uploaded a file in this session and revisit this page then you will see the filename and upload time for the previously uploaded file (include picture)
- If you have previously uploaded a file but your session has since expired and revisit this page, you will only see the upload time for the previously uploaded file (include picture)
- If you have previously uploaded a file and revisit this page and do not wish to reupload a new one then clicking `Save and continue` will not require you to have chosen a file

![screen shot 2016-07-14 at 16 29 32](https://cloud.githubusercontent.com/assets/2454380/16845441/d619c876-49e0-11e6-8a5f-5318b0f3c194.png)

***
### 1. File uploaded, session exists
![screen shot 2016-07-14 at 16 30 39](https://cloud.githubusercontent.com/assets/2454380/16845682/ae55e922-49e1-11e6-98f3-e03f225956a9.png)
***

### 2. File uploaded, session has expired
![image](https://cloud.githubusercontent.com/assets/2454380/16845630/81acdcc8-49e1-11e6-878b-c1d57ce94f6b.png)
***

## Contract review
- If you do not have `signerName`, `signerRole` and a file in s3 when loading this page, you will be aborted with a 400
- User is required to confirm they have the authority to return the framework agreement
- On submit, if form is valid and API call to mark `agreementReturned` as true succeeds then we send a confirmation email. Emails are sent to the current logged in user and to the primary contact on the declaration. If these people are the same (indicated by the same email address) then only one email is sent.

### 1. File uploaded, session exists

![screen shot 2016-07-14 at 16 30 46](https://cloud.githubusercontent.com/assets/2454380/16845489/f9bf0714-49e0-11e6-9dd2-87299d412b5b.png)
***
### 2. File uploaded, session has expired

![image](https://cloud.githubusercontent.com/assets/2454380/16845774/ff2b0f44-49e1-11e6-886c-79fb244d4824.png)

***

## Contract submitted (replaces framework dashboard)
- Shows details of the returned agreement (who signed it, who it was submitted by and when it was submitted)
- A link is provided to download the previously uploaded framework agreement signature page
- A link is provided to read the full standard framework agreement

![screen shot 2016-07-14 at 16 30 53](https://cloud.githubusercontent.com/assets/2454380/16845491/ff4124ec-49e0-11e6-87e7-ba9dd289393f.png)
