### PR TITLE
framework dashboard guidance links: minor fix for html

### DIFF
--- a/app/templates/frameworks/_guidance_links.html
+++ b/app/templates/frameworks/_guidance_links.html
@@ -1,48 +1,47 @@
-{% if framework.status in ['standstill', 'live'] and countersigned_agreement_file %}
-<ul class="list-no-bullet">
-  <li>
-    <a href="{{ url_for('.download_agreement_file', framework_slug=framework.slug, document_name=countersigned_agreement_file) }}">
-      <span>Download your countersigned framework agreement (.pdf)</span>
-    </a>
-  </li>
-
-  <li>
-    <a href="{{ url_for('.download_agreement_file', framework_slug=framework.slug, document_name=result_letter_filename) }}">
-      <span>Download your application result letter (.pdf)</span>
-    </a>
-  </li>
-
-  <li>
-    <a href="{{ url_for('.download_supplier_file', filepath=supplier_pack_filename, framework_slug=framework.slug) }}">
-      <span>Download guidance and legal documentation (.zip)</span>
-    </a>
-    {% if last_modified.supplier_pack %}
-    <div class="hint">
-      Last updated
-      <time datetime="{{ last_modified.supplier_pack }}">
-        {{ last_modified.supplier_pack|dateformat }}
-      </time>
-    </div>
-    {% endif %}
-  </li>
-
-  <li>
-    <a href="{{ url_for('.framework_updates', framework_slug=framework.slug) }}">
-      <span>Read updates and clarification question responses</span>
-    </a>
-    {% if last_modified.supplier_updates %}
-    <div class="hint">
-      Last updated
-      <time datetime="{{ last_modified.supplier_updates }}">
-        {{ last_modified.supplier_updates|dateformat }}
-      </time>
-    </div>
-    {% endif %}
-  </li>
-</ul>
-
-{% else %}
 <li class="browse-list-item">
+{% if framework.status in ['standstill', 'live'] and countersigned_agreement_file %}
+  <ul class="list-no-bullet">
+    <li>
+        <a href="{{ url_for('.download_agreement_file', framework_slug=framework.slug, document_name=countersigned_agreement_file) }}">
+        <span>Download your countersigned framework agreement (.pdf)</span>
+        </a>
+    </li>
+
+    <li>
+        <a href="{{ url_for('.download_agreement_file', framework_slug=framework.slug, document_name=result_letter_filename) }}">
+        <span>Download your application result letter (.pdf)</span>
+        </a>
+    </li>
+
+    <li>
+        <a href="{{ url_for('.download_supplier_file', filepath=supplier_pack_filename, framework_slug=framework.slug) }}">
+        <span>Download guidance and legal documentation (.zip)</span>
+        </a>
+        {% if last_modified.supplier_pack %}
+        <div class="hint">
+        Last updated
+        <time datetime="{{ last_modified.supplier_pack }}">
+            {{ last_modified.supplier_pack|dateformat }}
+        </time>
+        </div>
+        {% endif %}
+    </li>
+
+    <li>
+        <a href="{{ url_for('.framework_updates', framework_slug=framework.slug) }}">
+        <span>Read updates and clarification question responses</span>
+        </a>
+        {% if last_modified.supplier_updates %}
+        <div class="hint">
+        Last updated
+        <time datetime="{{ last_modified.supplier_updates }}">
+            {{ last_modified.supplier_updates|dateformat }}
+        </time>
+        </div>
+        {% endif %}
+    </li>
+  </ul>
+{% else %}
   <h2>
     Guidance, updates and questions
   </h2>
@@ -81,5 +80,5 @@
       {% endif %}
     </li>
   </ul>
-</li>
 {% endif %}
+</li>

--- a/app/templates/frameworks/_guidance_links.html
+++ b/app/templates/frameworks/_guidance_links.html
@@ -1,5 +1,8 @@
 <li class="browse-list-item">
 {% if framework.status in ['standstill', 'live'] and countersigned_agreement_file %}
+  <h2>
+    Documents, updates and questions
+  </h2>
   <ul class="list-no-bullet">
     <li>
         <a href="{{ url_for('.download_agreement_file', framework_slug=framework.slug, document_name=countersigned_agreement_file) }}">


### PR DESCRIPTION
was previously outputting an `ul` directly within another `ul` in the live/standstill state. instead put both possible blocks in a `li.browse-list-item`.

spotted this while digging in the wrong place for another story. all this patch does is move the `li.browse-list-item` outside the `{% if %}` block.