### PR TITLE
[#121577345] QA fixes frontend and copy fixes

### DIFF
--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -745,6 +745,8 @@ def contract_review(framework_slug):
                            'email_hash': hash_email(current_user.email_address)})
                 abort(503, "Framework agreement email failed to send")
 
+            session.pop('signature_page', None)
+
             flash(
                 'Your framework agreement has been returned to the Crown Commercial Service to be countersigned.',
                 'success'

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -757,7 +757,7 @@ def contract_review(framework_slug):
                 {'question': form['authorisation'].label.text, 'input_name': 'authorisation'}
             ]
 
-    form.authorisation.description = u"I have the authority to return this agreement on behalf of {}".format(
+    form.authorisation.description = u"I have the authority to return this agreement on behalf of {}.".format(
         supplier_framework['declaration']['nameOfOrganisation']
     )
 

--- a/app/templates/frameworks/contract_submitted.html
+++ b/app/templates/frameworks/contract_submitted.html
@@ -82,7 +82,7 @@
 
       <div class="dmspeak">
         <div class="isolated-text">
-          <p><a href="https://www.gov.uk/government/publications/digital-outcomes-and-specialists-framework-agreement">Read the standard framework agreement</a></p>
+          <p><a href="https://www.gov.uk/government/publications/g-cloud-8-framework-agreement">Read the standard framework agreement</a></p>
           <p><a href="{{ url_for('.download_agreement_file', framework_slug=framework.slug, document_name=document_name) }}" target="_blank">Download your framework agreement signature page, signed by your company</a></p>
         </div>
 

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -2143,6 +2143,9 @@ class TestReturnSignedAgreement(BaseApplicationTest):
                 'last_modified': '2016-07-10T21:18:00.000000Z'
             }]
 
+            with self.client.session_transaction() as sess:
+                sess['signature_page'] = 'test.pdf'
+
             res = self.client.post(
                 "/suppliers/frameworks/g-cloud-8/contract-review",
                 data={
@@ -2160,6 +2163,10 @@ class TestReturnSignedAgreement(BaseApplicationTest):
                 'Digital Marketplace Admin',
                 ['g-cloud-8-framework-agreement']
             )
+
+            # Check 'signature_page' has been removed from session
+            with self.client.session_transaction() as sess:
+                assert 'signature_page' not in sess
 
             assert res.status_code == 302
             assert res.location == 'http://localhost/suppliers/frameworks/g-cloud-8'


### PR DESCRIPTION
Fixes three issues thrown up in testing by @andrewchong 

- Add missing "." 
- Replace link to DOS with G-Cloud 8 link
- Remove `signature_page` from session after a framework agreement as a) no longer needed and b) to minimise the risk of old incorrect data being shown to a user 