### PR TITLE
Fix missing `supplier_pack_filename` variable from template

### DIFF
--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -109,6 +109,7 @@ def framework_dashboard(framework_slug):
             framework_live_date=content_loader.get_message(framework_slug, 'dates')['framework_live_date'],
             document_name='{}.{}'.format(SIGNED_AGREEMENT_PREFIX, signature_page['ext']),
             supplier_framework=supplier_framework_info,
+            supplier_pack_filename=supplier_pack_filename,
             last_modified=last_modified
         ), 200
 


### PR DESCRIPTION
`supplier_pack_filename` had been forgotten from our variables passed through to the template, causing the 'Download guidance and legal documentation (.zip)' link to break.