### PR TITLE
Add audit event for signature page uploads

### DIFF
--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -680,6 +680,16 @@ def signature_upload(framework_slug):
 
             session['signature_page'] = request.files['signature_page'].filename
 
+            data_api_client.create_audit_event(
+                audit_type=AuditTypes.upload_signed_agreement,
+                user=current_user.email_address,
+                object_type="suppliers",
+                object_id=current_user.supplier_id,
+                data={
+                    "upload_signed_agreement": request.files['signature_page'].filename,
+                    "upload_path": upload_path
+                })
+
             return redirect(url_for(".contract_review", framework_slug=framework_slug))
 
     return render_template(

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,6 @@ python-dateutil==2.4.2
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@21.3.0#egg=digitalmarketplace-utils==21.3.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@1.1.0#egg=digitalmarketplace-content-loader==1.1.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@5.0.0#egg=digitalmarketplace-apiclient==5.0.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@5.1.0#egg=digitalmarketplace-apiclient==5.1.0
 
 markdown==2.6.2

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -1994,6 +1994,17 @@ class TestReturnSignedAgreement(BaseApplicationTest):
             assert res.status_code == 302
             assert res.location == 'http://localhost/suppliers/frameworks/g-cloud-8/contract-review'
 
+            data_api_client.create_audit_event.assert_called_once_with(
+                audit_type=AuditTypes.upload_signed_agreement,
+                user='email@email.com',
+                object_type='suppliers',
+                object_id=1234,
+                data={
+                    'upload_signed_agreement': u'test.jpg',
+                    'upload_path': 'g-cloud-8/agreements/1234/1234-signed-framework-agreement.jpg'
+                }
+            )
+
     @mock.patch('dmutils.s3.S3')
     def test_signature_page_allows_continuation_without_file_chosen_to_be_uploaded_if_an_uploaded_file_already_exists(
             self, s3, return_supplier_framework, data_api_client


### PR DESCRIPTION
We want to be able to track whenever changes are made to signature pages.
Through the API, we can track all changes to things we store in agreementDetails, but we don't know anything about file uploads.
This audit event tells us when files are uploaded, who did the uploading, and what their original filenames were.