### PR TITLE
Require login to download responses to a brief

### DIFF
--- a/app/main/views/briefs.py
+++ b/app/main/views/briefs.py
@@ -157,6 +157,7 @@ def submit_brief_response(brief_id):
 
 
 @main.route('/opportunities/<int:brief_id>/responses/result')
+@login_required
 def view_response_result(brief_id):
     brief = get_brief(data_api_client, brief_id, allowed_statuses=['live'])
 


### PR DESCRIPTION
Users must be logged in to download brief responses.

Previously if no user was logged in then this route gave a 500 error as no supplier ID could be found for the anonymous user.