### PR TITLE
[#122114497] Bump content loader to 1.2.0 and frameworks to 2.0.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,6 +7,6 @@
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
     "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v17.0.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.17.3/jinja_govuk_template-0.17.3.tgz",
-    "digitalmarketplace-frameworks": "git://github.com/alphagov/digitalmarketplace-frameworks#v1.6.0"
+    "digitalmarketplace-frameworks": "git://github.com/alphagov/digitalmarketplace-frameworks#v2.0.0"
   }
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ werkzeug==0.10.4
 python-dateutil==2.4.2
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@21.3.0#egg=digitalmarketplace-utils==21.3.0
-git+https://github.com/alphagov/digitalmarketplace-content-loader.git@1.1.0#egg=digitalmarketplace-content-loader==1.1.0
+git+https://github.com/alphagov/digitalmarketplace-content-loader.git@1.2.0#egg=digitalmarketplace-content-loader==1.2.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@5.1.0#egg=digitalmarketplace-apiclient==5.1.0
 
 markdown==2.6.2


### PR DESCRIPTION
[This story](https://www.pivotaltracker.com/story/show/122114497) is for the top of the 'apply for this opportunity' page, add content for specialists only that says you can only put one specialist forward for each role.

Now that pull requests for the [copy changes](https://github.com/alphagov/digitalmarketplace-frameworks/pull/293) in the frameworks repo and the [ability to filter descriptions](https://github.com/alphagov/digitalmarketplace-content-loader/pull/6) in the content loader repo have been merged we are able to update our dependencies to bring the new content in to the supplier app.

### Not a digital specialist
<img width="650" alt="screen shot 2016-07-22 at 10 19 45" src="https://cloud.githubusercontent.com/assets/7228605/17054457/2c56102c-4fff-11e6-995e-d205efbb8799.png">

### Digital specialist
<img width="656" alt="screen shot 2016-07-22 at 10 19 35" src="https://cloud.githubusercontent.com/assets/7228605/17054467/3c22e386-4fff-11e6-84e7-cf16d8eb6ae7.png">
