### PR TITLE
framework dashboard: fix pluralization of lot units

### DIFF
--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -116,14 +116,10 @@ def framework_dashboard(framework_slug):
     return render_template(
         "frameworks/dashboard.html",
         application_made=application_made,
-        completed_lots=[{
-            'name': lot['name'],
-            'complete_count': count_drafts_by_lot(complete_drafts, lot['slug']),
-            'one_service_limit': lot['oneServiceLimit'],
-            'unit': 'lab' if framework['slug'] == 'digital-outcomes-and-specialists' else 'service',
-            'unit_plural': 'labs' if framework['slug'] == 'digital-outcomes-and-specialists' else 'service'
-            # TODO: ^ make this dynamic, eg, lab, service, unit
-        } for lot in lots_with_completed_drafts],
+        completed_lots=tuple(
+            dict(lot, complete_count=count_drafts_by_lot(complete_drafts, lot['slug']))
+            for lot in lots_with_completed_drafts
+        ),
         counts={
             "draft": len(drafts),
             "complete": len(complete_drafts)

--- a/app/templates/frameworks/_framework_actions.html
+++ b/app/templates/frameworks/_framework_actions.html
@@ -100,7 +100,7 @@
             {% else %}
             <li>
               {{ lot.complete_count }}
-              {{ lot.unit if (1 == lot.complete_count) else lot.unit_plural }} in
+              {{ lot.unitSingular if (1 == lot.complete_count) else lot.unitPlural }} in
               {{ lot.name|lower }}
             </li>
             {% endif %}

--- a/app/templates/frameworks/_submitted_services.html
+++ b/app/templates/frameworks/_submitted_services.html
@@ -8,7 +8,7 @@
       {% else %}
         <li>
           {{ lot.complete_count }} {{ lot.name }}
-          {{ lot.unit if (1 == lot.complete_count) else lot.unit_plural }}
+          {{ lot.unitSingular if (1 == lot.complete_count) else lot.unitPlural }}
         </li>
       {% endif %}
     {% endfor %}


### PR DESCRIPTION
by rehashing the way we pass lot data to templates. this code seems to have missed out on the addition of `unitSingular` and `unitPlural` to the lots table, so use that. rather than doing laborious cherry-picking of lot dict items we may as well just pass copies of the api-supplied lot dicts themselves with our added data annotated on.

this fell out of #508 