### PR TITLE
Always use https:// protocol for bower dependencies

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,8 +5,8 @@
     "jquery": "1.11.2",
     "hogan": "3.0.2",
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
-    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v17.0.0",
+    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v17.0.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.17.3/jinja_govuk_template-0.17.3.tgz",
-    "digitalmarketplace-frameworks": "git://github.com/alphagov/digitalmarketplace-frameworks#v2.0.0"
+    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#v2.0.0"
   }
 }


### PR DESCRIPTION
git:// is unauthenticated (and we don't pin with commit SHA) so https:// should be preferred.

Since we're downloading from GitHub we need to add `.git` to access the Git endpoint over HTTPS.

This is a duplicate of the following pull requests:
- [#367 on the buyer app](https://github.com/alphagov/digitalmarketplace-buyer-frontend/pull/367/commits)
- [#199 on the admin app](https://github.com/alphagov/digitalmarketplace-admin-frontend/pull/199)