### PR TITLE
[#127062871] Track account creation using GA virtual page views

### DIFF
--- a/app/main/views/login.py
+++ b/app/main/views/login.py
@@ -90,6 +90,7 @@ def submit_create_user(encoded_token):
                 "auth/create_user_error.html",
                 token=None), 400
 
+        flash('account-created', 'flag')
         return redirect(url_for('.dashboard'))
 
 

--- a/app/templates/suppliers/dashboard.html
+++ b/app/templates/suppliers/dashboard.html
@@ -15,8 +15,7 @@
 {% endblock %}
 
 {% block main_content %}
-
-  {% with messages = get_flashed_messages(with_categories=True) %}
+  {% with messages = get_flashed_messages(with_categories=true, category_filter=["error", "success"]) %}
     {% for category, message in messages %}
       {%
         with
@@ -28,7 +27,12 @@
     {% endfor %}
   {% endwith %}
 
+
+  {% if 'account-created' in get_flashed_messages(category_filter=["flag"]) %}
+  <div class="grid-row" data-analytics="trackPageView" data-url="/suppliers/vpv/?account-created=true">
+  {% else %}
   <div class="grid-row">
+  {% endif %}
     <div class="column-two-thirds">
       {% with
         context = current_user.email_address,

--- a/tests/app/main/test_login.py
+++ b/tests/app/main/test_login.py
@@ -501,6 +501,7 @@ class TestCreateUser(BaseApplicationTest):
 
         assert res.status_code == 302
         assert res.location == 'http://localhost/suppliers'
+        self.assert_flashes('account-created', 'flag')
 
     @mock.patch('app.main.views.login.data_api_client')
     def test_should_return_an_error_if_user_exists(self, data_api_client):


### PR DESCRIPTION
Currently, we are not able to tell using GA how many user accounts have been created. We could try to use a page view of the URL after an account is created to indicate this, however the URL is also accessible from other user flows and will not therefore be an accurate count of how many user accounts have been created. 

Therefore, as part of [this pivotal story](https://www.pivotaltracker.com/story/show/127062871), we wish to send a GA virtual page view every time a supplier account is successfully created. By embedding

`data-analytics="trackPageView" data-url="/suppliers/vpv/?account-created=true"`

into our template, we will send the required virtual page view on the success page(functionality [already exists](https://github.com/alphagov/digitalmarketplace-supplier-frontend/blob/master/app/assets/javascripts/analytics/_virtualPageViews.js) to do this automatically when the required `data` attributes are provided).

This tracking tag will only be embedded if they have come through the account creation process (indicated by setting a flash message).

Note, a similar process [has been created](https://github.com/alphagov/digitalmarketplace-buyer-frontend/pull/374) for the creation of buyer accounts.
