### PR TITLE
[#124104671]Revert "global footer: change visible text of support link to email address"

### DIFF
--- a/app/templates/_footer_categories.html
+++ b/app/templates/_footer_categories.html
@@ -5,7 +5,7 @@
     </h2>
     <ul>
       <li>
-        <a href="mailto:enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.service.gov.uk</a>
+        <a href="mailto:enquiries@digitalmarketplace.service.gov.uk">Digital Marketplace support</a>
       </li>
     </ul>
   </div>


### PR DESCRIPTION
This reverts commit 01be2f635a3a3307bb5bdcdacee62992afa0c747. Long email address determined ugly.