### PR TITLE
Analytics to tell if a supplier is eligible to apply for a brief

### DIFF
--- a/app/assets/javascripts/analytics/_pageViews.js
+++ b/app/assets/javascripts/analytics/_pageViews.js
@@ -1,7 +1,23 @@
 (function (GOVUK) {
   GOVUK.GDM.analytics.pageViews = {
     'init': function () {
+      this.setCustomDimensions()
       GOVUK.analytics.trackPageview();
+    },
+
+    'setCustomDimensions': function() {
+      var eligibility;
+      
+      if (/^\/suppliers\/opportunities\/(\d+)\/responses\/create$/.test(GOVUK.GDM.analytics.location.pathname())) {
+        eligibility = $('[data-reason]').first().data('reason');
+
+        // If we do not find a reason for ineligibility then we will assume that they are able to apply
+        if (!eligibility) {
+          eligibility = 'supplier-able-to-apply';
+        }
+        
+        GOVUK.analytics.setDimension(25, eligibility);
+      }
     }
   };
 })(window.GOVUK);

--- a/app/main/views/briefs.py
+++ b/app/main/views/briefs.py
@@ -208,7 +208,12 @@ def _render_not_eligible_for_brief_error_page(brief, clarification_question=Fals
     has_framework_lot_service = has_framework_service and bool(data_api_client.find_services(
         **dict(common_kwargs, lot=brief['lotSlug'])
     )["services"])
-    # if has_framework_lot_service is true, we can deduce that the problem is that the roles don't match.
+
+    if has_framework_service:
+        # if has_framework_lot_service is true, we can deduce that the problem is that the roles don't match.
+        reason = "supplier-not-on-role" if has_framework_lot_service else "supplier-not-on-lot"
+    else:
+        reason = "supplier-not-on-{}".format(brief['frameworkFramework'])
 
     return render_template(
         "briefs/not_is_supplier_eligible_for_brief_error.html",
@@ -217,5 +222,6 @@ def _render_not_eligible_for_brief_error_page(brief, clarification_question=Fals
         has_framework_lot_service=has_framework_lot_service,
         framework_name=brief['frameworkName'],
         lot=brief['lotSlug'],
+        reason=reason,
         **dict(main.config['BASE_TEMPLATE_DATA'])
     ), 400

--- a/app/templates/briefs/not_is_supplier_eligible_for_brief_error.html
+++ b/app/templates/briefs/not_is_supplier_eligible_for_brief_error.html
@@ -5,7 +5,7 @@
 {% block main_content %}
 
 {% with inhibited_action="ask a question about" if clarification_question else "apply for" %}
-<div class="grid-row">
+<div class="grid-row" data-reason="{{ reason }}">
   <div class="column-two-thirds">
     <header class="page-heading-smaller">
       <h1>You can’t {{ inhibited_action }} this opportunity</h1>

--- a/spec/javascripts/unit/AnalyticsSpec.js
+++ b/spec/javascripts/unit/AnalyticsSpec.js
@@ -213,4 +213,52 @@ describe("GOVUK.Analytics", function () {
     });
 
   });
+
+  describe("Supplier eligible to apply for brief", function() {
+    var $notOnFrameworkString = $('<div class="grid-row" data-reason="supplier-not-on-dos">');
+    
+    afterEach(function () {
+      $notOnFrameworkString.remove();
+    });
+    
+    it('should send custom dimension if data-reason', function() {
+      spyOn(GOVUK.GDM.analytics.location, "pathname")
+          .and
+          .callFake(function () {
+            return "/suppliers/opportunities/1/responses/create";
+        });
+
+      $(document.body).append($notOnFrameworkString);
+
+      window.GOVUK.GDM.analytics.pageViews.init();
+
+      expect(window.ga.calls.first().args).toEqual(['set', 'dimension25', 'supplier-not-on-dos']);
+      expect(window.ga.calls.count()).toEqual(2);
+    });
+
+    it('should send eligible to apply custom dimension if no data-reason', function() {
+      spyOn(GOVUK.GDM.analytics.location, "pathname")
+          .and
+          .callFake(function () {
+            return "/suppliers/opportunities/123/responses/create";
+        });
+
+      window.GOVUK.GDM.analytics.pageViews.init();
+
+      expect(window.ga.calls.first().args).toEqual(['set', 'dimension25', 'supplier-able-to-apply']);
+      expect(window.ga.calls.count()).toEqual(2);
+    });
+
+    it('should not send custom dimension if not on the create response page', function() {
+      spyOn(GOVUK.GDM.analytics.location, "pathname")
+          .and
+          .callFake(function () {
+            return "/suppliers/opportunities/1/responses/result";
+        });
+
+      window.GOVUK.GDM.analytics.pageViews.setCustomDimensions();
+
+      expect(window.ga.calls.any()).toEqual(false);
+    });
+  });
 });

--- a/tests/app/main/test_briefs.py
+++ b/tests/app/main/test_briefs.py
@@ -256,7 +256,7 @@ class TestSubmitClarificationQuestions(BaseApplicationTest):
             self, send_email, data_api_client):
         self.login()
         data_api_client.get_brief.return_value = api_stubs.brief(status='live', lot_slug='digital-specialists')
-        data_api_client.get_brief.return_value['briefs']['frameworkName'] = 'Digital Outcomes and Specialists'
+        data_api_client.get_brief.return_value['briefs']['frameworkFramework'] = 'dos'
         data_api_client.is_supplier_eligible_for_brief.return_value = False
         data_api_client.find_services.return_value = {"services": []}
 
@@ -419,7 +419,7 @@ class TestRespondToBrief(BaseApplicationTest):
 
     def test_get_brief_response_returns_error_page_if_supplier_has_no_services_on_framework(self, data_api_client):
         data_api_client.get_brief.return_value = self.brief
-        data_api_client.get_brief.return_value['briefs']['frameworkName'] = 'Digital Outcomes and Specialists'
+        data_api_client.get_brief.return_value['briefs']['frameworkFramework'] = 'dos'
         data_api_client.get_framework.return_value = self.framework
         data_api_client.is_supplier_eligible_for_brief.return_value = False
         data_api_client.find_services.return_value = {"services": []}
@@ -454,6 +454,54 @@ class TestRespondToBrief(BaseApplicationTest):
             )
         )) == 1
         assert not data_api_client.create_audit_event.called
+
+    def test_get_brief_response_does_not_contain_data_reason_if_supplier_is_eligible(self, data_api_client):
+        data_api_client.get_brief.return_value = self.brief
+        data_api_client.get_framework.return_value = self.framework
+        res = self.client.get('/suppliers/opportunities/1234/responses/create')
+
+        assert res.status_code == 200
+        assert 'data-reason='not in res.get_data(as_text=True)
+
+    def test_get_brief_response_has_correct_data_reason_if_supplier_has_no_services_on_lot(self, data_api_client):
+        data_api_client.get_brief.return_value = self.brief
+        data_api_client.get_framework.return_value = self.framework
+        data_api_client.is_supplier_eligible_for_brief.return_value = False
+        data_api_client.find_services.side_effect = lambda *args, **kwargs: (
+            {"services": [{"something": "nonempty"}]} if kwargs.get("lot") is None else {"services": []}
+        )
+
+        res = self.client.get('/suppliers/opportunities/1234/responses/create')
+        data = res.get_data(as_text=True)
+
+        assert res.status_code == 400
+        assert 'data-reason="supplier-not-on-lot"' in data
+
+    def test_get_brief_response_has_correct_data_reason_if_supplier_has_no_services_on_framework(self, data_api_client):
+        data_api_client.get_brief.return_value = self.brief
+        data_api_client.get_brief.return_value['briefs']['frameworkFramework'] = 'dos'
+        data_api_client.get_framework.return_value = self.framework
+        data_api_client.is_supplier_eligible_for_brief.return_value = False
+        data_api_client.find_services.return_value = {"services": []}
+
+        res = self.client.get('/suppliers/opportunities/1234/responses/create')
+        data = res.get_data(as_text=True)
+
+        assert res.status_code == 400
+        assert 'data-reason="supplier-not-on-dos"' in data
+
+    def test_get_brief_response_has_correct_data_reason_if_supplier_has_no_services_with_role(self, data_api_client):
+        data_api_client.get_brief.return_value = self.brief
+        data_api_client.get_brief.return_value['briefs']['frameworkFramework'] = 'dos'
+        data_api_client.get_framework.return_value = self.framework
+        data_api_client.is_supplier_eligible_for_brief.return_value = False
+        data_api_client.find_services.return_value = {"services": [{"something": "nonempty"}]}
+
+        res = self.client.get('/suppliers/opportunities/1234/responses/create')
+        data = res.get_data(as_text=True)
+
+        assert res.status_code == 400
+        assert 'data-reason="supplier-not-on-role"' in data
 
     def test_get_brief_response_flashes_error_on_result_page_if_response_already_exists(self, data_api_client):
         data_api_client.get_brief.return_value = self.brief
@@ -659,7 +707,7 @@ class TestRespondToBrief(BaseApplicationTest):
 
     def test_create_new_brief_returns_error_page_if_supplier_has_no_services_on_framework(self, data_api_client):
         data_api_client.get_brief.return_value = self.brief
-        data_api_client.get_brief.return_value['briefs']['frameworkName'] = 'Digital Outcomes and Specialists'
+        data_api_client.get_brief.return_value['briefs']['frameworkFramework'] = 'dos'
         data_api_client.get_framework.return_value = self.framework
         data_api_client.is_supplier_eligible_for_brief.return_value = False
         data_api_client.find_services.return_value = {"services": []}


### PR DESCRIPTION
### Overview
[Pivotal story](https://www.pivotaltracker.com/story/show/126116679)

When a supplier clicks to apply for a brief they can be one of 4 states:
1. are eligible and can apply
2. are not eligible as they are not on the framework
3. are not eligible as they are not on the lot
4. are not eligible as they can not provide the specialist role

After clicking the button to apply for a brief, in all of the above cases, they are taken to the same URL. In the success case (eligible) they are shown the form to apply. In the failure case (not eligible) they are shown the relevant message for why they can not apply to this brief. We wish to add analytics to this page so we can track the 4 cases. This is done by setting a Google Analytics custom dimension with a value related to one of the 4 cases.

### Approach
- For the non eligible case, the `not_is_supplier_eligible_for_brief_error` template is used. We add a `data-reason` attribute to the page that stores the reason for ineligibility such as "supplier-not-on-dos". 

- For the success case (where the supplier is eligible to apply) we add nothing to the template.

- When visiting the route to apply for a brief, we check the html content to see if a `data-reason` is present. If so, we send that value. If not then we can assume that they are viewing the page to apply and are eligible, so we send "supplier-able-to-apply". Note, the javascript acts as the gateway by checking the page url to make sure we only send this custom dimension on the required route (as our templates may be shared by several pages, we may have `data-reason`s present on different routes). 