### PR TITLE
Add feature flag to hide contract variation features until ready

### DIFF
--- a/config.py
+++ b/config.py
@@ -70,6 +70,7 @@ class Config(object):
     RAISE_ERROR_ON_MISSING_FEATURES = True
 
     FEATURE_FLAGS_EDIT_SECTIONS = False
+    FEATURE_FLAGS_CONTRACT_VARIATION = False
 
     # Logging
     DM_LOG_LEVEL = 'DEBUG'
@@ -97,6 +98,7 @@ class Test(Config):
     DM_CLARIFICATION_QUESTION_EMAIL = 'digitalmarketplace@mailinator.com'
 
     FEATURE_FLAGS_EDIT_SECTIONS = enabled_since('2015-06-03')
+    FEATURE_FLAGS_CONTRACT_VARIATION = enabled_since('2016-08-11')
 
     DM_DATA_API_AUTH_TOKEN = 'myToken'
 
@@ -113,6 +115,7 @@ class Development(Config):
 
     # Dates not formatted like YYYY-(0)M-(0)D will fail
     FEATURE_FLAGS_EDIT_SECTIONS = enabled_since('2015-06-03')
+    FEATURE_FLAGS_CONTRACT_VARIATION = enabled_since('2016-08-11')
 
     DM_DATA_API_URL = "http://localhost:5000"
     DM_DATA_API_AUTH_TOKEN = "myToken"


### PR DESCRIPTION
This adds a new feature flag `CONTRACT_VARIATION` to the app config, and sets it on for test and development modes.

I'm submitting it as it's own PR now because several stories in the backlog need to use this flag, and we don't want later stories blocked just on waiting for this flag to be merged.

This will allow conditional sections within a page template to be marked as:
```
{% if 'CONTRACT_VARIATION' is active_feature %}
   ...
{% endif %}
```

And entire page routes can be hidden behind the feature flag using the annotation:
```
@flask_featureflags.is_active_feature('CONTRACT_VARIATION')
```

(As described in [the documentation](https://github.com/alphagov/digitalmarketplace-utils#using-featureflags))