### PR TITLE
[#128509823] Supplier can view their response to a closed brief

### DIFF
--- a/app/main/views/briefs.py
+++ b/app/main/views/briefs.py
@@ -159,7 +159,7 @@ def submit_brief_response(brief_id):
 @main.route('/opportunities/<int:brief_id>/responses/result')
 @login_required
 def view_response_result(brief_id):
-    brief = get_brief(data_api_client, brief_id, allowed_statuses=['live'])
+    brief = get_brief(data_api_client, brief_id, allowed_statuses=['live', 'closed'])
 
     if not is_supplier_eligible_for_brief(data_api_client, current_user.supplier_id, brief):
         return _render_not_eligible_for_brief_error_page(brief)

--- a/tests/app/main/test_briefs.py
+++ b/tests/app/main/test_briefs.py
@@ -811,6 +811,24 @@ class TestResponseResultPage(BaseApplicationTest):
         assert doc.xpath('//h1')[0].text.strip() == \
             "Your response to ‘I need a thing to do a thing’ has been sent"
 
+    def test_view_response_result_submitted_ok_for_closed_brief(self, data_api_client):
+        closed_brief = self.brief.copy()
+        closed_brief['briefs']['status'] = 'closed'
+        data_api_client.get_brief.return_value = closed_brief
+        data_api_client.get_framework.return_value = self.framework
+        data_api_client.is_supplier_eligible_for_brief.return_value = True
+        data_api_client.find_brief_responses.return_value = {
+            "briefResponses": [
+                {"essentialRequirements": [True, True, True]}
+            ]
+        }
+        res = self.client.get('/suppliers/opportunities/1234/responses/result')
+
+        assert res.status_code == 200
+        doc = html.fromstring(res.get_data(as_text=True))
+        assert doc.xpath('//h1')[0].text.strip() == \
+            "Your response to ‘I need a thing to do a thing’ has been sent"
+
     def test_view_response_result_submitted_unsuccessful(self, data_api_client):
         data_api_client.get_brief.return_value = self.brief
         data_api_client.get_framework.return_value = self.framework


### PR DESCRIPTION
Part 3 of this bug fix: https://www.pivotaltracker.com/story/show/128509823

Allows suppliers to continue to see their response after a brief closes.

Depends on:
 - [x] https://github.com/alphagov/digitalmarketplace-api/pull/433

Should be released before: 
 - [ ] https://github.com/alphagov/digitalmarketplace-buyer-frontend/pull/384