### PR TITLE
[#127807161] Display contract variation page

### DIFF
--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -112,3 +112,14 @@ $path: "/suppliers/static/images/";
 .padding-bottom-small {
   padding-bottom: 10px;
 }
+
+ins {
+    text-decoration: none;
+    background-color: #cce0d6;
+    padding: 0 3px;
+}
+
+del {
+    background-color: #efcfd1;
+    padding: 0 3px;
+}

--- a/app/main/forms/frameworks.py
+++ b/app/main/forms/frameworks.py
@@ -31,6 +31,6 @@ class AcceptAgreementVariationForm(Form):
     accept_changes = BooleanField(
         'I accept these proposed changes',
         validators=[
-            DataRequired(message="If you agree to the proposed changes then you must check the box before saving.")
+            DataRequired(message="You can only save and continue if you agree to the proposed changes.")
         ]
     )

--- a/app/main/forms/frameworks.py
+++ b/app/main/forms/frameworks.py
@@ -25,3 +25,12 @@ class ContractReviewForm(Form):
         'Authorisation',
         validators=[DataRequired(message="You must confirm you have the authority to return the agreement.")]
     )
+
+
+class AcceptAgreementVariationForm(Form):
+    accept_changes = BooleanField(
+        'I accept these proposed changes',
+        validators=[
+            DataRequired(message="If you agree to the proposed changes then you must check the box before saving.")
+        ]
+    )

--- a/app/main/helpers/frameworks.py
+++ b/app/main/helpers/frameworks.py
@@ -281,3 +281,10 @@ def get_most_recently_uploaded_agreement_file_or_none(bucket, framework_slug):
     )
     files = bucket.list(download_path)
     return files.pop() if files else None
+
+
+def returned_agreement_email_recipients(supplier_framework):
+    email_recipients = [supplier_framework['declaration']['primaryContactEmail']]
+    if supplier_framework['declaration']['primaryContactEmail'].lower() != current_user.email_address.lower():
+        email_recipients.append(current_user.email_address)
+    return email_recipients

--- a/app/main/helpers/frameworks.py
+++ b/app/main/helpers/frameworks.py
@@ -110,7 +110,6 @@ def get_supplier_on_framework_from_info(supplier_framework_info):
 
 
 def return_supplier_framework_info_if_on_framework_or_abort(data_api_client, framework_slug):
-    # returns a supplier_framework or None if not found
     supplier_framework = get_supplier_framework_info(data_api_client, framework_slug)
 
     if not get_supplier_on_framework_from_info(supplier_framework):

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -841,5 +841,6 @@ def view_contract_variation(framework_slug, variation_slug):
         supplier_framework=supplier_framework,
         variation=content_loader.get_message(framework_slug, variation_content_name),
         already_agreed=already_agreed,
+        agreed_details=supplier_framework['agreedVariations'].get(variation_slug),
         supplier_name=supplier_framework['declaration']['nameOfOrganisation']
     ), 400 if form_errors else 200

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -799,13 +799,13 @@ def view_contract_variation(framework_slug, variation_slug):
 
     if request.method == 'POST':
         if form.validate_on_submit():
-            # FIXME: Set the agreement as accepted in the API
-            # data_api_client.set_variation_agreed(
-            #     current_user.id,
-            #     current_user.supplier_id,
-            #     framework_slug,
-            #     variation_slug
-            # )
+            data_api_client.agree_framework_variation(
+                current_user.supplier_id,
+                framework_slug,
+                variation_slug,
+                current_user.id,
+                current_user.email_address
+            )
 
             # Send email confirming accepted
             try:
@@ -827,6 +827,7 @@ def view_contract_variation(framework_slug, variation_slug):
                     extra={'error': six.text_type(e), 'supplier_id': current_user.supplier_id}
                 )
             flash('variation_accepted')
+            already_agreed = True
         else:
             form_errors = [
                 {'question': form['accept_changes'].label.text, 'input_name': 'agreement'}

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -830,7 +830,7 @@ def view_contract_variation(framework_slug, variation_slug):
             already_agreed = True
         else:
             form_errors = [
-                {'question': form['accept_changes'].label.text, 'input_name': 'agreement'}
+                {'question': form['accept_changes'].label.text, 'input_name': 'accept_changes'}
             ]
 
     return render_template(

--- a/app/templates/emails/g-cloud-8_variation_1_agreed.html
+++ b/app/templates/emails/g-cloud-8_variation_1_agreed.html
@@ -9,14 +9,17 @@
     Thanks for accepting the proposed ‘contract variation’ to the G-Cloud 8 (G8) framework agreement and call-off contract.
     <br /><br />
     The contract variation has not yet come into effect.
-    When all suppliers have agreed, the Crown Commercial Service will countersign the variation to bring it into effect.
+    When all suppliers have agreed, the Crown Commercial Service will countersign it.
     <br /><br />
     We’ll let G8 suppliers and buyers know as soon as the contract variation comes into effect.
-    Until then, you must sell your services using the published framework agreement and call-off contract.
-    <br /><br />
-    You can view all your G8 documents at:<br />
-    <a href="https://www.digitalmarketplace.service.gov.uk/suppliers/frameworks/g-cloud-8">
-        https://www.digitalmarketplace.service.gov.uk/suppliers/frameworks/g-cloud-8
+    Until then, you must use the published framework agreement and call-off contract to sell your services:
+    <br />
+    <a href="https://www.gov.uk/government/publications/g-cloud-8-framework-agreement">
+        https://www.gov.uk/government/publications/g-cloud-8-framework-agreement
+    </a>
+    <br />
+    <a href="https://www.gov.uk/government/publications/g-cloud-8-call-off-contract">
+        https://www.gov.uk/government/publications/g-cloud-8-call-off-contract
     </a>
     <br /><br />
     Thanks,

--- a/app/templates/emails/g-cloud-8_variation_1_agreed.html
+++ b/app/templates/emails/g-cloud-8_variation_1_agreed.html
@@ -9,12 +9,12 @@
     Thanks for accepting the proposed ‘contract variation’ to the G-Cloud 8 (G8) framework agreement and call-off contract.
     <br /><br />
     The contract variation has not yet come into effect.
-    When all suppliers have agreed to it, the Crown Commercial Service will countersign it. 
-    We will then let G8 suppliers and buyers know.
+    When all suppliers have agreed, the Crown Commercial Service will countersign the variation to bring it into effect.
     <br /><br />
-    Until we let you know, you must sell your services using the published framework agreement and call-off contract.
+    We’ll let G8 suppliers and buyers know as soon as the contract variation comes into effect.
+    Until then, you must sell your services using the published framework agreement and call-off contract.
     <br /><br />
-    You can view all your G8 documents here:<br />
+    You can view all your G8 documents at:<br />
     <a href="https://www.digitalmarketplace.service.gov.uk/suppliers/frameworks/g-cloud-8">
         https://www.digitalmarketplace.service.gov.uk/suppliers/frameworks/g-cloud-8
     </a>

--- a/app/templates/emails/g-cloud-8_variation_1_agreed.html
+++ b/app/templates/emails/g-cloud-8_variation_1_agreed.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head lang="en">
+   <meta charset="UTF-8">
+</head>
+<body style="font-size:120%;">
+    Dear supplier,
+    <br /><br />
+    Thanks for accepting the proposed ‘contract variation’ to the G-Cloud 8 (G8) framework agreement and call-off contract.
+    <br /><br />
+    The contract variation has not yet come into effect.
+    When all suppliers have agreed to it, the Crown Commercial Service will countersign it. 
+    We will then let G8 suppliers and buyers know.
+    <br /><br />
+    Until we let you know, you must sell your services using the published framework agreement and call-off contract.
+    <br /><br />
+    You can view all your G8 documents here:<br />
+    <a href="https://www.digitalmarketplace.service.gov.uk/suppliers/frameworks/g-cloud-8">
+        https://www.digitalmarketplace.service.gov.uk/suppliers/frameworks/g-cloud-8
+    </a>
+    <br /><br />
+    Thanks,
+    <br />
+    The Digital Marketplace team
+</body>
+</html>

--- a/app/templates/frameworks/contract_variation.html
+++ b/app/templates/frameworks/contract_variation.html
@@ -72,9 +72,9 @@
           
           <div class="section-description">
             {{ variation.variation_description|replace("[[SUPPLIER_NAME]]", supplier_name)|markdown }}
-          {% if not already_agreed and variation.not_agreed_extra %}
+          {% if not agreed_details and variation.not_agreed_extra %}
             {{ variation.not_agreed_extra|replace("[[SUPPLIER_NAME]]", supplier_name)|markdown }}
-          {% elif already_agreed and variation.agreed_extra %}
+          {% elif agreed_details and variation.agreed_extra %}
             {{ variation.agreed_extra|replace("[[SUPPLIER_NAME]]", supplier_name)|markdown }}
           {% endif %}
           </div>
@@ -113,7 +113,7 @@
             {% endcall %}
           {% endcall %}
           
-          {% if not already_agreed %}
+          {% if not agreed_details %}
 
             <form method="post" class="supplier-declaration">
               <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />

--- a/app/templates/frameworks/contract_variation.html
+++ b/app/templates/frameworks/contract_variation.html
@@ -1,0 +1,170 @@
+{% extends "_base_page.html" %}
+{% import "macros/toolkit_forms.html" as forms %}
+{% import "toolkit/summary-table.html" as summary %}
+
+{% block page_title %}{{ framework.name }} contract variation – Digital Marketplace{% endblock %}
+
+{% block breadcrumb %}
+  {%
+    with items = [
+      {
+        "link": "/",
+        "label": "Digital Marketplace"
+      },
+      {
+        "link": url_for(".dashboard"),
+        "label": "Your account"
+      },
+      {
+        "link": url_for(".framework_dashboard", framework_slug=framework.slug),
+        "label": framework.name
+      },
+      {
+        "label": "Contract variation"
+      }
+    ]
+  %}
+    {% include "toolkit/breadcrumb.html" %}
+  {% endwith %}
+{% endblock %}
+
+{% block main_content %}
+
+  {% if errors %}
+    {% with errors = errors.values() %}
+      {% include 'toolkit/forms/validation.html' %}
+    {% endwith %}
+  {% endif %}
+
+  {% with messages = get_flashed_messages(with_categories=true) %}
+    {% for category, message in messages %}
+      {% if message == 'variation_accepted' %}
+        {% set message = variation.confirmation_message %}
+      {% endif %}
+      {%
+        with
+        message = message,
+        type = "destructive" if category == 'error' else "success"
+      %}
+      {% include "toolkit/notification-banner.html" %}
+      {% endwith %}
+    {% endfor %}
+  {% endwith %}
+
+
+    <div class="grid-row">
+        <div class="column-two-thirds">
+            {% with
+              heading = framework.name + ": proposed contract variation",
+              smaller = True
+            %}
+              {% include 'toolkit/page-heading.html' %}
+            {% endwith %}
+
+          {% if form.errors %}
+            {%
+              with
+              errors = form_errors
+            %}
+              {% include 'toolkit/forms/validation.html' %}
+            {% endwith %}
+          {% endif %}
+          
+          <div class="section-description">
+            {{ variation.variation_description|replace("[[SUPPLIER_NAME]]", supplier_name)|markdown }}
+          {% if not already_agreed and variation.not_agreed_extra %}
+            {{ variation.not_agreed_extra|replace("[[SUPPLIER_NAME]]", supplier_name)|markdown }}
+          {% elif already_agreed and variation.agreed_extra %}
+            {{ variation.agreed_extra|replace("[[SUPPLIER_NAME]]", supplier_name)|markdown }}
+          {% endif %}
+          </div>
+          
+          {{ summary.heading("Framework agreement", id="framework_agreement_changes") }}
+          {% call(item) summary.list_table(
+            variation.framework_agreement_changes,
+            caption="Framework agreement",
+            empty_message="There are no changes to the framework agreement",
+            field_headings=[
+            "Clause",
+            "Change"
+            ],
+            field_headings_visible=True
+            ) %}
+            {% call summary.row() %}
+              {{ summary.field_name(item.clause) }}
+              {{ summary.text(item.change|markdown) }}
+            {% endcall %}
+          {% endcall %}
+
+          {{ summary.heading("Call-off contract", id="call_off_contract_changes") }}
+          {% call(item) summary.list_table(
+            variation.call_off_contract_changes,
+            caption="Call-off contract",
+            empty_message="There are no changes to the call-off contract",
+            field_headings=[
+            "Clause",
+            "Change"
+            ],
+            field_headings_visible=True
+            ) %}
+            {% call summary.row() %}
+              {{ summary.field_name(item.clause) }}
+              {{ summary.text(item.change|markdown) }}
+            {% endcall %}
+          {% endcall %}
+          
+          {% if not already_agreed %}
+
+            <form method="post" class="supplier-declaration">
+              <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+              {%
+                with
+                type = "checkbox",
+                name = "accept_changes",
+                options = [
+                { "label": form.accept_changes.label,
+                  "value": "Yes, I accept the changes"
+                }
+                ],
+                error=form.accept_changes.errors[0]
+              %}
+              {% include "toolkit/forms/selection-buttons.html" %}
+              {% endwith %}
+              
+              <p>We will notify you when CCS has countersigned the changes and they come into effect.</p>
+                {%
+                  with
+                  label="Save and continue",
+                  type="save"
+                %}
+                  {% include "toolkit/button.html" %}
+                {% endwith %}
+              </form>
+          
+          {% else %}
+          
+            {{ summary.heading("Contract variation status", id="contract_variation_status") }}
+            {% call(item) summary.list_table(
+              [
+                {"key": "Agreed by", "value": "agreed by details"},
+                {"key": "Countersigned by", "value": "ccs details or Waiting for CCS to countersign"}
+              ],
+              caption="Contract variation status",
+              field_headings=[
+              "Field",
+              "Value"
+              ],
+              field_headings_visible=False
+            ) %}
+              {% call summary.row() %}
+                {{ summary.field_name(item.key) }}
+                {{ summary.text(item.value) }}
+              {% endcall %}
+            {% endcall %}
+          {% endif %}
+          
+          </div>
+      </div>
+
+
+{% endblock %}

--- a/app/templates/frameworks/contract_variation.html
+++ b/app/templates/frameworks/contract_variation.html
@@ -146,8 +146,8 @@
             {{ summary.heading("Contract variation status", id="contract_variation_status") }}
             {% call(item) summary.list_table(
               [
-                {"key": "Agreed by", "value": "agreed by details"},
-                {"key": "Countersigned by", "value": "ccs details or Waiting for CCS to countersign"}
+                {"key": "Agreed by", "value": "{}<br />{}<br />{}".format(agreed_details.agreedUserName, agreed_details.agreedUserEmail, agreed_details.agreedAt|datetimeformat)|safe},
+                {"key": "Countersigned by", "value": "Waiting for CCS to countersign"}
               ],
               caption="Contract variation status",
               field_headings=[

--- a/app/templates/frameworks/contract_variation.html
+++ b/app/templates/frameworks/contract_variation.html
@@ -131,7 +131,7 @@
               {% include "toolkit/forms/selection-buttons.html" %}
               {% endwith %}
               
-              <p>We will notify you when CCS has countersigned the changes and they come into effect.</p>
+              <p>We’ll tell you when CCS has countersigned the changes and they come into effect.</p>
                 {%
                   with
                   label="Save and continue",
@@ -161,10 +161,19 @@
                 {{ summary.text(item.value) }}
               {% endcall %}
             {% endcall %}
+
+            <p class="padding-bottom-small">&nbsp;</p>
+
+            {%
+              with
+                url = url_for(".framework_dashboard", framework_slug=framework.slug),
+                text = "Return to your documents page"
+            %}
+              {% include "toolkit/secondary-action-link.html" %}
+            {% endwith %}
           {% endif %}
           
           </div>
       </div>
-
 
 {% endblock %}

--- a/app/templates/frameworks/contract_variation.html
+++ b/app/templates/frameworks/contract_variation.html
@@ -18,9 +18,6 @@
       {
         "link": url_for(".framework_dashboard", framework_slug=framework.slug),
         "label": framework.name
-      },
-      {
-        "label": "Contract variation"
       }
     ]
   %}

--- a/bower.json
+++ b/bower.json
@@ -7,6 +7,6 @@
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
     "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v17.0.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.17.3/jinja_govuk_template-0.17.3.tgz",
-    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#v2.3.0"
+    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#v2.3.1"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -7,6 +7,6 @@
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
     "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v17.0.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.17.3/jinja_govuk_template-0.17.3.tgz",
-    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#v2.0.0"
+    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#v2.3.0"
   }
 }

--- a/config.py
+++ b/config.py
@@ -142,6 +142,7 @@ class Live(Config):
 
 
 class Preview(Live):
+    FEATURE_FLAGS_CONTRACT_VARIATION = enabled_since('2016-08-22')
     pass
 
 
@@ -150,6 +151,7 @@ class Production(Live):
 
 
 class Staging(Production):
+    FEATURE_FLAGS_CONTRACT_VARIATION = enabled_since('2016-08-22')
     pass
 
 configs = {

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,6 @@ python-dateutil==2.4.2
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@21.3.0#egg=digitalmarketplace-utils==21.3.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@1.2.0#egg=digitalmarketplace-content-loader==1.2.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@5.1.0#egg=digitalmarketplace-apiclient==5.1.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@6.3.0#egg=digitalmarketplace-apiclient==6.3.0
 
 markdown==2.6.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,6 @@ python-dateutil==2.4.2
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@21.3.0#egg=digitalmarketplace-utils==21.3.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@1.2.0#egg=digitalmarketplace-content-loader==1.2.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@6.3.1#egg=digitalmarketplace-apiclient==6.3.1
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@6.3.2#egg=digitalmarketplace-apiclient==6.3.2
 
 markdown==2.6.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,6 @@ python-dateutil==2.4.2
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@21.3.0#egg=digitalmarketplace-utils==21.3.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@1.2.0#egg=digitalmarketplace-content-loader==1.2.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@6.3.0#egg=digitalmarketplace-apiclient==6.3.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@6.3.1#egg=digitalmarketplace-apiclient==6.3.1
 
 markdown==2.6.2

--- a/tests/app/helpers.py
+++ b/tests/app/helpers.py
@@ -232,7 +232,8 @@ class BaseApplicationTest(object):
         on_framework=False,
         agreement_returned=False,
         agreement_returned_at=None,
-        agreement_details=None
+        agreement_details=None,
+        agreed_variations={}
     ):
         if declaration == 'default':
             declaration = FULL_G7_SUBMISSION.copy()
@@ -244,7 +245,8 @@ class BaseApplicationTest(object):
                 'onFramework': on_framework,
                 'agreementReturned': agreement_returned,
                 'agreementReturnedAt': agreement_returned_at,
-                'agreementDetails': agreement_details
+                'agreementDetails': agreement_details,
+                'agreedVariations': agreed_variations
             }
         }
 

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -2337,7 +2337,7 @@ class TestContractVariation(BaseApplicationTest):
             status='live',
             framework_agreement_version='3.1'
         )
-        self.g8_framework['frameworks']['variations'] = {1: {"createdAt": "2018-08-16"}}
+        self.g8_framework['frameworks']['variations'] = {"1": {"createdAt": "2018-08-16"}}
 
         with self.app.test_client():
             self.login()
@@ -2352,16 +2352,6 @@ class TestContractVariation(BaseApplicationTest):
         assert_equal(
             len(doc.xpath('//h1[contains(text(), "G-Cloud 8: proposed contract variation")]')), 1)
 
-    def test_get_page_renders_with_default_variation_number(self, data_api_client):
-        data_api_client.get_framework.return_value = self.g8_framework
-        data_api_client.get_supplier_framework_info.return_value = self.good_supplier_framework
-        res = self.client.get("/suppliers/frameworks/g-cloud-8/contract-variation")
-
-        assert_equal(res.status_code, 200)
-        doc = html.fromstring(res.get_data(as_text=True))
-        assert_equal(
-            len(doc.xpath('//h1[contains(text(), "G-Cloud 8: proposed contract variation")]')), 1)
-
     def test_supplier_must_be_on_framework(self, data_api_client):
         supplier_not_on_framework = self.good_supplier_framework.copy()
         supplier_not_on_framework['frameworkInterest']['onFramework'] = False
@@ -2369,7 +2359,7 @@ class TestContractVariation(BaseApplicationTest):
         data_api_client.get_framework.return_value = self.g8_framework
         data_api_client.get_supplier_framework_info.return_value = supplier_not_on_framework
 
-        res = self.client.get("/suppliers/frameworks/g-cloud-8/contract-variation")
+        res = self.client.get("/suppliers/frameworks/g-cloud-8/contract-variation/1")
 
         assert_equal(res.status_code, 404)
 
@@ -2388,14 +2378,14 @@ class TestContractVariation(BaseApplicationTest):
         data_api_client.get_framework.return_value = self.g8_framework
         data_api_client.get_supplier_framework_info.return_value = agreement_not_returned
 
-        res = self.client.get("/suppliers/frameworks/g-cloud-8/contract-variation")
+        res = self.client.get("/suppliers/frameworks/g-cloud-8/contract-variation/1")
 
         assert_equal(res.status_code, 404)
 
     def test_shows_form_if_not_yet_agreed(self, data_api_client):
         data_api_client.get_framework.return_value = self.g8_framework
         data_api_client.get_supplier_framework_info.return_value = self.good_supplier_framework
-        res = self.client.get("/suppliers/frameworks/g-cloud-8/contract-variation")
+        res = self.client.get("/suppliers/frameworks/g-cloud-8/contract-variation/1")
 
         assert_equal(res.status_code, 200)
         doc = html.fromstring(res.get_data(as_text=True))
@@ -2406,10 +2396,10 @@ class TestContractVariation(BaseApplicationTest):
 
     def test_shows_signer_details_and_no_form_if_already_agreed(self, data_api_client):
         already_agreed = self.good_supplier_framework.copy()
-        already_agreed['frameworkInterest']['agreedVariations'] = {1: {"agreedAt": "Already"}}
+        already_agreed['frameworkInterest']['agreedVariations'] = {"1": {"agreedAt": "Already"}}
         data_api_client.get_framework.return_value = self.g8_framework
         data_api_client.get_supplier_framework_info.return_value = already_agreed
-        res = self.client.get("/suppliers/frameworks/g-cloud-8/contract-variation")
+        res = self.client.get("/suppliers/frameworks/g-cloud-8/contract-variation/1")
 
         assert_equal(res.status_code, 200)
         doc = html.fromstring(res.get_data(as_text=True))
@@ -2423,7 +2413,7 @@ class TestContractVariation(BaseApplicationTest):
     def test_api_is_called_to_agree(self, data_api_client):
         data_api_client.get_framework.return_value = self.g8_framework
         data_api_client.get_supplier_framework_info.return_value = self.good_supplier_framework
-        res = self.client.post("/suppliers/frameworks/g-cloud-8/contract-variation",
+        res = self.client.post("/suppliers/frameworks/g-cloud-8/contract-variation/1",
                                data={"accept_changes": "Yes"}
                                )
 
@@ -2435,7 +2425,7 @@ class TestContractVariation(BaseApplicationTest):
     def test_email_is_sent_to_correct_users(self, send_email, data_api_client):
         data_api_client.get_framework.return_value = self.g8_framework
         data_api_client.get_supplier_framework_info.return_value = self.good_supplier_framework
-        res = self.client.post("/suppliers/frameworks/g-cloud-8/contract-variation",
+        res = self.client.post("/suppliers/frameworks/g-cloud-8/contract-variation/1",
                                data={"accept_changes": "Yes"}
                                )
 
@@ -2456,7 +2446,7 @@ class TestContractVariation(BaseApplicationTest):
         same_email_as_current_user['frameworkInterest']['declaration']['primaryContactEmail'] = 'email@email.com'
         data_api_client.get_framework.return_value = self.g8_framework
         data_api_client.get_supplier_framework_info.return_value = same_email_as_current_user
-        res = self.client.post("/suppliers/frameworks/g-cloud-8/contract-variation",
+        res = self.client.post("/suppliers/frameworks/g-cloud-8/contract-variation/1",
                                data={"accept_changes": "Yes"}
                                )
 
@@ -2474,22 +2464,21 @@ class TestContractVariation(BaseApplicationTest):
     def test_success_message_is_displayed_on_success(self, data_api_client):
         data_api_client.get_framework.return_value = self.g8_framework
         data_api_client.get_supplier_framework_info.return_value = self.good_supplier_framework
-        res = self.client.post("/suppliers/frameworks/g-cloud-8/contract-variation",
+        res = self.client.post("/suppliers/frameworks/g-cloud-8/contract-variation/1",
                                data={"accept_changes": "Yes"}
                                )
 
         assert_equal(res.status_code, 200)
         doc = html.fromstring(res.get_data(as_text=True))
         assert_equal(
-            len(doc.xpath('//p[@class="banner-message"][contains(text(), "You have accepted the proposed changes.")]')), 1)
-        
+            len(doc.xpath('//p[@class="banner-message"][contains(text(), "You have accepted the proposed changes.")]')), 1)  # noqa
 
     def test_error_if_box_not_ticked(self, data_api_client):
         data_api_client.get_framework.return_value = self.g8_framework
         data_api_client.get_supplier_framework_info.return_value = self.good_supplier_framework
-        res = self.client.post("/suppliers/frameworks/g-cloud-8/contract-variation", data={})
+        res = self.client.post("/suppliers/frameworks/g-cloud-8/contract-variation/1", data={})
 
         assert_equal(res.status_code, 400)
         doc = html.fromstring(res.get_data(as_text=True))
         assert_equal(
-            len(doc.xpath('//p[@class="banner-message"][contains(text(), "You have accepted the proposed changes.")]')), 1)
+            len(doc.xpath('//span[@class="validation-message"][contains(text(), "If you agree to the proposed changes then you must check the box before saving.")]')), 1)  # noqa

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -2509,5 +2509,5 @@ class TestContractVariation(BaseApplicationTest):
 
         assert res.status_code == 400
         assert len(
-            doc.xpath('//span[@class="validation-message"][contains(text(), "If you agree to the proposed changes then you must check the box before saving.")]')  # noqa
+            doc.xpath('//span[@class="validation-message"][contains(text(), "You can only save and continue if you agree to the proposed changes")]')  # noqa
         ) == 1

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -2418,8 +2418,9 @@ class TestContractVariation(BaseApplicationTest):
                                )
 
         assert_equal(res.status_code, 200)
-        # FIXME: when API client method exists
-        # data_api_client.set_variation_agreed.assert_called_once_with(1234, "g-cloud-8", 1)
+        data_api_client.agree_framework_variation.assert_called_once_with(
+            1234, 'g-cloud-8', '1', 123, 'email@email.com'
+        )
 
     @mock.patch('app.main.views.frameworks.send_email')
     def test_email_is_sent_to_correct_users(self, send_email, data_api_client):

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -2396,15 +2396,23 @@ class TestContractVariation(BaseApplicationTest):
 
     def test_shows_signer_details_and_no_form_if_already_agreed(self, data_api_client):
         already_agreed = self.good_supplier_framework.copy()
-        already_agreed['frameworkInterest']['agreedVariations'] = {"1": {"agreedAt": "Already"}}
+        already_agreed['frameworkInterest']['agreedVariations'] = {
+            "1": {
+                "agreedAt": "2016-08-19T15:47:08.116613Z",
+                "agreedUserId": 1,
+                "agreedUserEmail": "agreed@email.com",
+                "agreedUserName": "William Drayton",
+            }}
         data_api_client.get_framework.return_value = self.g8_framework
         data_api_client.get_supplier_framework_info.return_value = already_agreed
         res = self.client.get("/suppliers/frameworks/g-cloud-8/contract-variation/1")
 
         assert_equal(res.status_code, 200)
-        doc = html.fromstring(res.get_data(as_text=True))
+        page_text = res.get_data(as_text=True)
+        doc = html.fromstring(page_text)
         assert_equal(
             len(doc.xpath('//h2[contains(text(), "Contract variation status")]')), 1)
+        assert "<span>William Drayton<br />agreed@email.com<br />Friday 19 August 2016 at 16:47</span>" in page_text
         assert_equal(
             len(doc.xpath('//label[contains(text(), "I accept these proposed changes")]')), 0)
         assert_equal(


### PR DESCRIPTION
For this story: https://www.pivotaltracker.com/story/show/127807161

Depends on API changes here: 
 - [x] https://github.com/alphagov/digitalmarketplace-api/pull/435

~~There are minor content updates to come on Monday morning, but worth getting this up now for people to take a look.~~

Content updated to latest from document on 21/8/2016, screenshots here updated.

UPDATE: New validation message screenshot updated.

## Variation not yet signed
![g-cloud 8 unsigned contract variation](https://cloud.githubusercontent.com/assets/6525554/17836446/13c4eabc-678b-11e6-9fe5-bbb54ff0fe66.png)


## Error message if you don't check the box
![screen shot 2016-08-22 at 13 38 38](https://cloud.githubusercontent.com/assets/6525554/17854964/c96fd7a4-686d-11e6-90a9-bd7879ffbed4.png)


## Success message if you check the box and submit
![screen shot 2016-08-21 at 10 35 01](https://cloud.githubusercontent.com/assets/6525554/17836451/327b0b58-678b-11e6-8698-ecea4521e48d.png)


## Email sent, which looks like this in G-Mail:
![screen shot 2016-08-21 at 10 39 30](https://cloud.githubusercontent.com/assets/6525554/17836462/a9256a5a-678b-11e6-91e2-bf1c64c6111c.png)


# Once agreed the page looks like this
![g-cloud 8 signed contract variation](https://cloud.githubusercontent.com/assets/6525554/17836464/b4029f24-678b-11e6-87ff-72753bdf12e7.png)

