### PR TITLE
Redirect to contract variation after returning framework agreement

### DIFF
--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -4,6 +4,7 @@ from itertools import chain
 from dateutil.parser import parse as date_parse
 from flask import render_template, request, abort, flash, redirect, url_for, current_app, session
 from flask_login import current_user
+import flask_featureflags as feature
 import six
 
 from dmapiclient import APIError
@@ -754,6 +755,19 @@ def contract_review(framework_slug):
                 'Your framework agreement has been returned to the Crown Commercial Service to be countersigned.',
                 'success'
             )
+
+            if feature.is_active('CONTRACT_VARIATION'):
+                # Redirect to contract variation if it has not been signed
+                if (
+                    framework.get('variations') and
+                    not supplier_framework['agreedVariations']
+                ):
+                    variation_slug = framework['variations'].keys()[0]
+                    return redirect(url_for(
+                        '.view_contract_variation',
+                        framework_slug=framework_slug,
+                        variation_slug=variation_slug
+                    ))
 
             return redirect(url_for(".framework_dashboard", framework_slug=framework_slug))
 

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -762,7 +762,7 @@ def contract_review(framework_slug):
                     framework.get('variations') and
                     not supplier_framework['agreedVariations']
                 ):
-                    variation_slug = framework['variations'].keys()[0]
+                    variation_slug = list(framework['variations'].keys())[0]
                     return redirect(url_for(
                         '.view_contract_variation',
                         framework_slug=framework_slug,

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -2324,7 +2324,7 @@ class TestReturnSignedAgreement(BaseApplicationTest):
             self.app.config['FEATURE_FLAGS_CONTRACT_VARIATION'] = False
 
             framework = get_g_cloud_8()
-            framework['variations'] = {
+            framework['frameworks']['variations'] = {
                 "1": {"createdAt": "2016-06-06T20:01:34.000000Z"}
             }
             data_api_client.get_framework.return_value = framework
@@ -2359,7 +2359,7 @@ class TestReturnSignedAgreement(BaseApplicationTest):
             self.login()
 
             framework = get_g_cloud_8()
-            framework['variations'] = {
+            framework['frameworks']['variations'] = {
                 "1": {"createdAt": "2016-06-06T20:01:34.000000Z"}
             }
             data_api_client.get_framework.return_value = framework
@@ -2381,7 +2381,6 @@ class TestReturnSignedAgreement(BaseApplicationTest):
                     'authorisation': 'I have the authority to return this agreement on behalf of company name'
                 }
             )
-
             assert res.status_code == 302
             assert res.location == 'http://localhost/suppliers/frameworks/g-cloud-8/contract-variation/1'
 


### PR DESCRIPTION
For [this](https://www.pivotaltracker.com/story/show/127807417) story on Pivotal.
Will need rebasing on top of [this](https://github.com/alphagov/digitalmarketplace-supplier-frontend/pull/522) once it's merged before tests can go green.

If a user returns their framework agreement but has not agreed
to the framework variation then redirect them to the variation.

If a user returns their framework agreement and has agreed to the
framework variation then redirect them to the framework dashboard.

If there are no framework agreement variations for a framework then
the user should redirect to the framework dashboard.

Functionality is built under the assumption that a framework will
have no more than one variation. Removing this assumption would
add a reasonable amount of complexity, such as which variation
should be redirected too. At the moment, we have no foresight that
a framework having more than one variation is coming any time soon
so should not be worth investing in.