### PR TITLE
Add link to contract variation page to framework dashboard

### DIFF
--- a/app/templates/frameworks/contract_submitted.html
+++ b/app/templates/frameworks/contract_submitted.html
@@ -84,6 +84,11 @@
         <div class="isolated-text">
           <p><a href="https://www.gov.uk/government/publications/g-cloud-8-framework-agreement">Read the standard framework agreement</a></p>
           <p><a href="{{ url_for('.download_agreement_file', framework_slug=framework.slug, document_name=document_name) }}" target="_blank">Download your framework agreement signature page, signed by your company</a></p>
+          {% if 'CONTRACT_VARIATION' is active_feature %}
+            {% for variation in framework.variations %}
+              <p><a href="{{ url_for('.view_contract_variation', framework_slug=framework.slug, variation_slug=variation) }}">Read the proposed contract variation</a></p>
+            {% endfor %}
+          {% endif %}
         </div>
 
         <div class="isolated-text">


### PR DESCRIPTION
If a supplier has returned their framework agreement then their documents page will show a link to any proposed contract variations.

Words agreed with Cath and Laurence.

Looks like this:
![screen shot 2016-08-22 at 15 11 48](https://cloud.githubusercontent.com/assets/6525554/17859069/2689a246-6880-11e6-94aa-9ad6d7a27411.png)
