### PR TITLE
Enable Travis cache for pip, npm and bower

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,9 @@
 language: python
+cache:
+  pip: true
+  directories:
+    - node_modules
+    - bower_components
 python:
   - "2.7"
   - "3.4"


### PR DESCRIPTION
We've seen travis builds fail sometimes during npm install, so maybe [caching the dependency paths][1] will help to avoid this.

This might introduce other issues though, with stale cache causing the build to run outdated code, so keep in mind you might need to clear the travis cache if the build fails unexpectedly.

[1]: https://docs.travis-ci.com/user/caching