### PR TITLE
[#129454097]Brief eligibility error messages fix

### DIFF
--- a/app/main/views/briefs.py
+++ b/app/main/views/briefs.py
@@ -203,25 +203,25 @@ def _render_not_eligible_for_brief_error_page(brief, clarification_question=Fals
     common_kwargs = {
         "supplier_id": current_user.supplier_id,
         "framework": brief['frameworkSlug'],
+        "status": "published",
     }
-    has_framework_service = bool(data_api_client.find_services(**common_kwargs)["services"])
-    has_framework_lot_service = has_framework_service and bool(data_api_client.find_services(
-        **dict(common_kwargs, lot=brief['lotSlug'])
-    )["services"])
 
-    if has_framework_service:
-        # if has_framework_lot_service is true, we can deduce that the problem is that the roles don't match.
-        reason = "supplier-not-on-role" if has_framework_lot_service else "supplier-not-on-lot"
+    if data_api_client.find_services(**common_kwargs)["services"]:
+        if data_api_client.find_services(**dict(common_kwargs, lot=brief["lotSlug"]))["services"]:
+            # deduce that the problem is that the roles don't match.
+            reason = data_reason_slug = "supplier-not-on-role"
+        else:
+            reason = data_reason_slug = "supplier-not-on-lot"
     else:
-        reason = "supplier-not-on-{}".format(brief['frameworkFramework'])
+        reason = "supplier-not-on-framework"
+        data_reason_slug = "supplier-not-on-{}".format(brief['frameworkFramework'])
 
     return render_template(
         "briefs/not_is_supplier_eligible_for_brief_error.html",
         clarification_question=clarification_question,
-        has_framework_service=has_framework_service,
-        has_framework_lot_service=has_framework_lot_service,
         framework_name=brief['frameworkName'],
         lot=brief['lotSlug'],
         reason=reason,
+        data_reason_slug=data_reason_slug,
         **dict(main.config['BASE_TEMPLATE_DATA'])
     ), 400

--- a/app/templates/briefs/not_is_supplier_eligible_for_brief_error.html
+++ b/app/templates/briefs/not_is_supplier_eligible_for_brief_error.html
@@ -5,18 +5,18 @@
 {% block main_content %}
 
 {% with inhibited_action="ask a question about" if clarification_question else "apply for" %}
-<div class="grid-row" data-reason="{{ reason }}">
+<div class="grid-row" data-reason="{{ data_reason_slug }}">
   <div class="column-two-thirds">
     <header class="page-heading-smaller">
       <h1>You can’t {{ inhibited_action }} this opportunity</h1>
     </header>
     <p>
       You can’t {{ inhibited_action }} this opportunity because
-      {% if has_framework_service %}
+      {% if reason == "supplier-not-on-role" or reason == "supplier-not-on-lot" %}
         you didn’t say you could provide
-        {{ "this specialist role" if has_framework_lot_service else "services in this category" }}
+        {{ "this specialist role" if reason == "supplier-not-on-role" else "services in this category" }}
         when you applied to the Digital Outcomes and Specialists framework.
-      {% else %}
+      {% elif reason == "supplier-not-on-framework" %}
         you’re not a {{ framework_name }} supplier.
       {% endif %}
     </p>

--- a/tests/app/main/test_briefs.py
+++ b/tests/app/main/test_briefs.py
@@ -415,6 +415,7 @@ class TestRespondToBrief(BaseApplicationTest):
                 ERROR_MESSAGE_NO_SERVICE_ON_LOT_APPLICATION
             )
         )) == 1
+        assert len(doc.xpath('//*[@data-reason="supplier-not-on-lot"]')) == 1
         assert not data_api_client.create_audit_event.called
 
     def test_get_brief_response_returns_error_page_if_supplier_has_no_services_on_framework(self, data_api_client):
@@ -434,6 +435,7 @@ class TestRespondToBrief(BaseApplicationTest):
                 ERROR_MESSAGE_NO_SERVICE_ON_FRAMEWORK_APPLICATION
             )
         )) == 1
+        assert len(doc.xpath('//*[@data-reason="supplier-not-on-dos"]')) == 1
         assert not data_api_client.create_audit_event.called
 
     def test_get_brief_response_returns_error_page_if_supplier_has_no_services_with_role(self, data_api_client):
@@ -453,6 +455,7 @@ class TestRespondToBrief(BaseApplicationTest):
                 ERROR_MESSAGE_NO_SERVICE_WITH_ROLE_APPLICATION
             )
         )) == 1
+        assert len(doc.xpath('//*[@data-reason="supplier-not-on-role"]')) == 1
         assert not data_api_client.create_audit_event.called
 
     def test_get_brief_response_does_not_contain_data_reason_if_supplier_is_eligible(self, data_api_client):
@@ -462,46 +465,6 @@ class TestRespondToBrief(BaseApplicationTest):
 
         assert res.status_code == 200
         assert 'data-reason='not in res.get_data(as_text=True)
-
-    def test_get_brief_response_has_correct_data_reason_if_supplier_has_no_services_on_lot(self, data_api_client):
-        data_api_client.get_brief.return_value = self.brief
-        data_api_client.get_framework.return_value = self.framework
-        data_api_client.is_supplier_eligible_for_brief.return_value = False
-        data_api_client.find_services.side_effect = lambda *args, **kwargs: (
-            {"services": [{"something": "nonempty"}]} if kwargs.get("lot") is None else {"services": []}
-        )
-
-        res = self.client.get('/suppliers/opportunities/1234/responses/create')
-        data = res.get_data(as_text=True)
-
-        assert res.status_code == 400
-        assert 'data-reason="supplier-not-on-lot"' in data
-
-    def test_get_brief_response_has_correct_data_reason_if_supplier_has_no_services_on_framework(self, data_api_client):
-        data_api_client.get_brief.return_value = self.brief
-        data_api_client.get_brief.return_value['briefs']['frameworkFramework'] = 'dos'
-        data_api_client.get_framework.return_value = self.framework
-        data_api_client.is_supplier_eligible_for_brief.return_value = False
-        data_api_client.find_services.return_value = {"services": []}
-
-        res = self.client.get('/suppliers/opportunities/1234/responses/create')
-        data = res.get_data(as_text=True)
-
-        assert res.status_code == 400
-        assert 'data-reason="supplier-not-on-dos"' in data
-
-    def test_get_brief_response_has_correct_data_reason_if_supplier_has_no_services_with_role(self, data_api_client):
-        data_api_client.get_brief.return_value = self.brief
-        data_api_client.get_brief.return_value['briefs']['frameworkFramework'] = 'dos'
-        data_api_client.get_framework.return_value = self.framework
-        data_api_client.is_supplier_eligible_for_brief.return_value = False
-        data_api_client.find_services.return_value = {"services": [{"something": "nonempty"}]}
-
-        res = self.client.get('/suppliers/opportunities/1234/responses/create')
-        data = res.get_data(as_text=True)
-
-        assert res.status_code == 400
-        assert 'data-reason="supplier-not-on-role"' in data
 
     def test_get_brief_response_flashes_error_on_result_page_if_response_already_exists(self, data_api_client):
         data_api_client.get_brief.return_value = self.brief


### PR DESCRIPTION
Story https://www.pivotaltracker.com/story/show/129454097

We weren't filtering a supplier's services by those `published` when determining the reason for their non-eligibility, hence might make false deductions. So instead now filter all these queries for `published` services.

First created regression tests that fail with existing code, then added fix.

Also @idavidmcdonald I merged most of your separated `data-reason`-checking tests into their corresponding standard tests - if you can get away with testing for something by adding an assert to an existing test, there's no reason not to do it that way. Here I needed to create two new variants of the standard tests - if the asserts for the `data-reason` are included, when I copy the tests to create the new variants I get the `data-reason`-checking "for free", as opposed to having to remember to create _yet another_ two tests to cover it properly...