### PR TITLE
[#119736241] Update utils to include 5xx ERROR logging

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ Flask-WTF==0.12
 werkzeug==0.10.4
 python-dateutil==2.4.2
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@21.3.0#egg=digitalmarketplace-utils==21.3.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@21.5.0#egg=digitalmarketplace-utils==21.5.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@1.2.0#egg=digitalmarketplace-content-loader==1.2.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@6.3.2#egg=digitalmarketplace-apiclient==6.3.2
 


### PR DESCRIPTION
Makes the app log 5xx responses with ERROR level, which is useful for frontend apps since their responses can fail when the API responds with 5xx and no exceptions get logged.

This is the only frontend app that doesn't have the up-to-date utils version yet.