### PR TITLE
[#130297677] Unicode bugfix plus supplier editing pre-live

### DIFF
--- a/app/templates/frameworks/contract_variation.html
+++ b/app/templates/frameworks/contract_variation.html
@@ -143,7 +143,7 @@
             {{ summary.heading("Contract variation status", id="contract_variation_status") }}
             {% call(item) summary.list_table(
               [
-                {"key": "Agreed by", "value": "{}<br />{}<br />{}".format(agreed_details.agreedUserName, agreed_details.agreedUserEmail, agreed_details.agreedAt|datetimeformat)|safe},
+                {"key": "Agreed by", "value": ("%s<br />%s<br />%s" % (agreed_details.agreedUserName, agreed_details.agreedUserEmail, agreed_details.agreedAt|datetimeformat))|safe},
                 {"key": "Countersigned by", "value": "Waiting for CCS to countersign"}
               ],
               caption="Contract variation status",

--- a/config.py
+++ b/config.py
@@ -143,6 +143,7 @@ class Live(Config):
 
 class Preview(Live):
     FEATURE_FLAGS_CONTRACT_VARIATION = enabled_since('2016-08-22')
+    FEATURE_FLAGS_EDIT_SECTIONS = enabled_since('2016-09-14')
 
 
 class Production(Live):
@@ -151,6 +152,7 @@ class Production(Live):
 
 class Staging(Production):
     FEATURE_FLAGS_CONTRACT_VARIATION = enabled_since('2016-08-22')
+    FEATURE_FLAGS_EDIT_SECTIONS = enabled_since('2016-09-14')
 
 configs = {
     'development': Development,


### PR DESCRIPTION
Two for the price of one...
This bugfix: https://www.pivotaltracker.com/story/show/130297677

Plus turning on existing supplier service editing in Pre-Live environments, so we can see what still needs building.