### PR TITLE
Adjust tests to run with non-ascii chars in supplier users

### DIFF
--- a/tests/app/helpers.py
+++ b/tests/app/helpers.py
@@ -257,12 +257,12 @@ class BaseApplicationTest(object):
     def login(self):
         with patch('app.main.views.login.data_api_client') as login_api_client:
             login_api_client.authenticate_user.return_value = self.user(
-                123, "email@email.com", 1234, 'Supplier Name', 'Name')
+                123, "email@email.com", 1234, u'Supplier NĀme', u'Năme')
 
             self.get_user_patch = patch.object(
                 data_api_client,
                 'get_user',
-                return_value=self.user(123, "email@email.com", 1234, 'Supplier Name', 'Name')
+                return_value=self.user(123, "email@email.com", 1234, u'Supplier NĀme', u'Năme')
             )
             self.get_user_patch.start()
 
@@ -273,7 +273,7 @@ class BaseApplicationTest(object):
         with patch('app.main.views.login.data_api_client') as login_api_client:
 
             login_api_client.authenticate_user.return_value = self.user(
-                234, "buyer@email.com", None, None, 'Buyer', role='buyer')
+                234, "buyer@email.com", None, None, 'Ā Buyer', role='buyer')
 
             self.get_user_patch = patch.object(
                 data_api_client,

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -774,7 +774,7 @@ class TestFrameworkAgreementUpload(BaseApplicationTest):
                 'g-cloud-7/agreements/1234/1234-signed-framework-agreement.pdf',
                 mock.ANY,
                 acl='private',
-                download_filename='Supplier_Name-1234-signed-framework-agreement.pdf'
+                download_filename='Supplier_Nme-1234-signed-framework-agreement.pdf'
             )
             assert not data_api_client.register_framework_agreement_returned.called
             assert not send_email.called
@@ -800,7 +800,7 @@ class TestFrameworkAgreementUpload(BaseApplicationTest):
                 'g-cloud-7/agreements/1234/1234-signed-framework-agreement.pdf',
                 mock.ANY,
                 acl='private',
-                download_filename='Supplier_Name-1234-signed-framework-agreement.pdf'
+                download_filename='Supplier_Nme-1234-signed-framework-agreement.pdf'
             )
             data_api_client.register_framework_agreement_returned.assert_called_with(
                 1234, 'g-cloud-7', 'email@email.com')
@@ -827,7 +827,7 @@ class TestFrameworkAgreementUpload(BaseApplicationTest):
                 'g-cloud-7/agreements/1234/1234-signed-framework-agreement.pdf',
                 mock.ANY,
                 acl='private',
-                download_filename='Supplier_Name-1234-signed-framework-agreement.pdf'
+                download_filename='Supplier_Nme-1234-signed-framework-agreement.pdf'
             )
             data_api_client.register_framework_agreement_returned.assert_called_with(
                 1234, 'g-cloud-7', 'email@email.com')
@@ -852,7 +852,7 @@ class TestFrameworkAgreementUpload(BaseApplicationTest):
                 'g-cloud-7/agreements/1234/1234-signed-framework-agreement.pdf',
                 mock.ANY,
                 acl='private',
-                download_filename='Supplier_Name-1234-signed-framework-agreement.pdf'
+                download_filename='Supplier_Nme-1234-signed-framework-agreement.pdf'
             )
             assert_equal(res.status_code, 302)
             assert_equal(res.location, 'http://localhost/suppliers/frameworks/g-cloud-7/agreement')
@@ -876,7 +876,7 @@ class TestFrameworkAgreementUpload(BaseApplicationTest):
                 'g-cloud-7/agreements/1234/1234-signed-framework-agreement.jpg',
                 mock.ANY,
                 acl='private',
-                download_filename='Supplier_Name-1234-signed-framework-agreement.jpg'
+                download_filename='Supplier_Nme-1234-signed-framework-agreement.jpg'
             )
             assert_equal(res.status_code, 302)
             assert_equal(res.location, 'http://localhost/suppliers/frameworks/g-cloud-7/agreement')
@@ -2637,7 +2637,7 @@ class TestContractVariation(BaseApplicationTest):
                 "agreedAt": "2016-08-19T15:47:08.116613Z",
                 "agreedUserId": 1,
                 "agreedUserEmail": "agreed@email.com",
-                "agreedUserName": "William Drayton",
+                "agreedUserName": u"William Drăyton",
             }}
         data_api_client.get_framework.return_value = self.g8_framework
         data_api_client.get_supplier_framework_info.return_value = already_agreed
@@ -2648,7 +2648,7 @@ class TestContractVariation(BaseApplicationTest):
 
         assert res.status_code == 200
         assert len(doc.xpath('//h2[contains(text(), "Contract variation status")]')) == 1
-        assert "<span>William Drayton<br />agreed@email.com<br />Friday 19 August 2016 at 16:47</span>" in page_text
+        assert u"<span>William Drăyton<br />agreed@email.com<br />Friday 19 August 2016 at 16:47</span>" in page_text
         assert len(doc.xpath('//label[contains(text(), "I accept these proposed changes")]')) == 0
         assert len(doc.xpath('//input[@value="Save and continue"]')) == 0
 

--- a/tests/app/main/test_login.py
+++ b/tests/app/main/test_login.py
@@ -107,7 +107,7 @@ class TestInviteUser(BaseApplicationTest):
             generate_token.assert_called_once_with(
                 {
                     "supplier_id": 1234,
-                    "supplier_name": "Supplier Name",
+                    "supplier_name": "Supplier NĀme",
                     "email_address": "this@isvalid.com"
                 },
                 'KEY',

--- a/tests/app/main/test_suppliers.py
+++ b/tests/app/main/test_suppliers.py
@@ -767,10 +767,10 @@ class TestSupplierDashboardLogin(BaseApplicationTest):
         with self.app.test_client():
             self.login()
             data_api_client.authenticate_user.return_value = self.user(
-                123, "email@email.com", 1234, "Supplier Name", "Name")
+                123, "email@email.com", 1234, u'Supplier NĀme', u'Năme')
 
             data_api_client.get_user.return_value = self.user(
-                123, "email@email.com", 1234, "Supplier Name", "Name")
+                123, "email@email.com", 1234, u'Supplier NĀme', u'Năme')
 
             data_api_client.find_frameworks.return_value = find_frameworks_return_value
 
@@ -781,7 +781,7 @@ class TestSupplierDashboardLogin(BaseApplicationTest):
             assert_equal(res.status_code, 200)
 
             assert_in(
-                self.strip_all_whitespace("<h1>Supplier Name</h1>"),
+                self.strip_all_whitespace(u"<h1>Supplier NĀme</h1>"),
                 self.strip_all_whitespace(res.get_data(as_text=True))
             )
             assert_in(


### PR DESCRIPTION
We recently ran into a production bug caused by non-ascii characters in a supplier user's name.

This adjusts the tests to login as users with non-ascii characters in their name and supplier name, so hopefully there will be less chance of a similar bug making it through to production in future.