### PR TITLE
Make 'Accept changes' field use correct property

### DIFF
--- a/app/templates/frameworks/contract_variation.html
+++ b/app/templates/frameworks/contract_variation.html
@@ -119,7 +119,7 @@
                 type = "checkbox",
                 name = "accept_changes",
                 options = [
-                { "label": form.accept_changes.label,
+                { "label": form.accept_changes.label.text,
                   "value": "Yes, I accept the changes"
                 }
                 ],


### PR DESCRIPTION
The 'I accept these proposed changes' button on the contract variations page has a `<label>` tag nested inside its `<label>` tag instead of just a text string.

```
<label class="selection-button" for="input-accept_changes-1">
    <label for="accept_changes">I accept these proposed changes</label>
    <input type="checkbox" name="accept_changes" id="input-accept_changes-1" value="Yes, I accept the changes">
</label>
```

This is because `form.accept_changes.label` is assumed to be a string in the template whereas it is actually an instance of the`wtforms.fields.Label` helper class:

http://wtforms.readthedocs.io/en/latest/fields.html#wtforms.fields.Label

This changes the reference to point to the `text` property instead which is a string:

http://wtforms.readthedocs.io/en/latest/fields.html#wtforms.fields.Label.text

...resulting in the following HTML:

```
<label class="selection-button" for="input-accept_changes-1">
    I accept these proposed changes      
    <input type="checkbox" name="accept_changes" id="input-accept_changes-1" value="Yes, I accept the changes">
</label>
```