### PR TITLE
Save agreement path on upload

### DIFF
--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -651,7 +651,7 @@ def signer_details(framework_slug):
 @login_required
 def signature_upload(framework_slug):
     framework = get_framework(data_api_client, framework_slug)
-    return_supplier_framework_info_if_on_framework_or_abort(data_api_client, framework_slug)
+    supplier_framework = return_supplier_framework_info_if_on_framework_or_abort(data_api_client, framework_slug)
     agreements_bucket = s3.S3(current_app.config['DM_AGREEMENTS_BUCKET'])
     signature_page = get_most_recently_uploaded_agreement_file_or_none(agreements_bucket, framework_slug)
     upload_error = None
@@ -679,6 +679,10 @@ def signature_upload(framework_slug):
                 request.files['signature_page'],
                 acl='private'
             )
+
+            agreement_id = supplier_framework.get("agreementId")
+            data_api_client.update_framework_agreement(agreement_id, {"signedAgreementPath": upload_path},
+                                                       current_user.email_address)
 
             session['signature_page'] = request.files['signature_page'].filename
 

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -523,6 +523,9 @@ def framework_agreement(framework_slug):
 @main.route('/frameworks/<framework_slug>/agreement', methods=['POST'])
 @login_required
 def upload_framework_agreement(framework_slug):
+    """
+    This is the route used to upload agreements for pre-G-Cloud 8 frameworks
+    """
     framework = get_framework(data_api_client, framework_slug, allowed_statuses=['standstill', 'live'])
     supplier_framework = return_supplier_framework_info_if_on_framework_or_abort(data_api_client, framework_slug)
 
@@ -561,8 +564,10 @@ def upload_framework_agreement(framework_slug):
         )
     )
 
-    data_api_client.register_framework_agreement_returned(
+    updated_supplier_framework = data_api_client.register_framework_agreement_returned(
         current_user.supplier_id, framework_slug, current_user.email_address)
+    agreement_id = updated_supplier_framework.get("frameworkInterest", {}).get("agreementId")
+    data_api_client.update_framework_agreement(agreement_id, {"signedAgreementPath": path}, current_user.email_address)
 
     try:
         email_body = render_template(

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,6 @@ python-dateutil==2.4.2
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@21.5.0#egg=digitalmarketplace-utils==21.5.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@1.2.0#egg=digitalmarketplace-content-loader==1.2.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@6.3.2#egg=digitalmarketplace-apiclient==6.3.2
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@6.5.0#egg=digitalmarketplace-apiclient==6.5.0
 
 markdown==2.6.2

--- a/tests/app/helpers.py
+++ b/tests/app/helpers.py
@@ -233,7 +233,8 @@ class BaseApplicationTest(object):
         agreement_returned=False,
         agreement_returned_at=None,
         agreement_details=None,
-        agreed_variations={}
+        agreed_variations={},
+        agreement_id=None
     ):
         if declaration == 'default':
             declaration = FULL_G7_SUBMISSION.copy()
@@ -246,6 +247,7 @@ class BaseApplicationTest(object):
                 'agreementReturned': agreement_returned,
                 'agreementReturnedAt': agreement_returned_at,
                 'agreementDetails': agreement_details,
+                'agreementId': agreement_id,
                 'agreedVariations': agreed_variations
             }
         }

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -1988,7 +1988,9 @@ class TestReturnSignedAgreement(BaseApplicationTest):
             self.login()
 
             data_api_client.get_framework.return_value = get_g_cloud_8()
-            return_supplier_framework.return_value = self.supplier_framework(on_framework=True)['frameworkInterest']
+            return_supplier_framework.return_value = self.supplier_framework(
+                on_framework=True, agreement_id=21
+            )['frameworkInterest']
 
             res = self.client.post(
                 '/suppliers/frameworks/g-cloud-8/signature-upload',
@@ -2001,6 +2003,11 @@ class TestReturnSignedAgreement(BaseApplicationTest):
                 'g-cloud-8/agreements/1234/1234-signed-framework-agreement.jpg',
                 mock.ANY,
                 acl='private'
+            )
+            data_api_client.update_framework_agreement.assert_called_with(
+                21,
+                {"signedAgreementPath": 'g-cloud-8/agreements/1234/1234-signed-framework-agreement.jpg'},
+                'email@email.com'
             )
             assert res.status_code == 302
             assert res.location == 'http://localhost/suppliers/frameworks/g-cloud-8/contract-review'

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -840,6 +840,9 @@ class TestFrameworkAgreementUpload(BaseApplicationTest):
             data_api_client.get_framework.return_value = self.framework(status='standstill')
             data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
                 on_framework=True)
+            data_api_client.register_framework_agreement_returned.return_value = {
+                "frameworkInterest": {"agreementId": 20}
+            }
 
             res = self.client.post(
                 '/suppliers/frameworks/g-cloud-7/agreement',
@@ -853,6 +856,14 @@ class TestFrameworkAgreementUpload(BaseApplicationTest):
                 mock.ANY,
                 acl='private',
                 download_filename='Supplier_Nme-1234-signed-framework-agreement.pdf'
+            )
+            data_api_client.register_framework_agreement_returned.assert_called_with(
+                1234, 'g-cloud-7', 'email@email.com'
+            )
+            data_api_client.update_framework_agreement.assert_called_with(
+                20,
+                {"signedAgreementPath": 'g-cloud-7/agreements/1234/1234-signed-framework-agreement.pdf'},
+                'email@email.com'
             )
             assert_equal(res.status_code, 302)
             assert_equal(res.location, 'http://localhost/suppliers/frameworks/g-cloud-7/agreement')


### PR DESCRIPTION
This ensures that the supplier frontend saves the uploaded agreement file path into our database on upload.

These paths are not yet used by the frontend for rendering things, but they will be soon.