### PR TITLE
[#128669753] Content updates for when contract variation is agreed by CCS

### DIFF
--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -814,9 +814,10 @@ def contract_review(framework_slug):
 def view_contract_variation(framework_slug, variation_slug):
     framework = get_framework(data_api_client, framework_slug)
     supplier_framework = return_supplier_framework_info_if_on_framework_or_abort(data_api_client, framework_slug)
+    variation_details = framework.get('variations', {}).get(variation_slug)
 
     # 404 if framework doesn't have contract variation
-    if not framework.get('variations', {}).get(variation_slug):
+    if not variation_details:
         abort(404)
 
     # 404 if agreement hasn't been returned yet
@@ -876,6 +877,7 @@ def view_contract_variation(framework_slug, variation_slug):
         form_errors=form_errors,
         framework=framework,
         supplier_framework=supplier_framework,
+        variation_details=variation_details,
         variation=content_loader.get_message(framework_slug, variation_content_name),
         agreed_details=agreed_details,
         supplier_name=supplier_framework['declaration']['nameOfOrganisation']

--- a/app/templates/frameworks/contract_submitted.html
+++ b/app/templates/frameworks/contract_submitted.html
@@ -86,8 +86,16 @@
           <p><a href="{{ url_for('.download_agreement_file', framework_slug=framework.slug, document_name=document_name) }}" target="_blank">Download your framework agreement signature page, signed by your company</a></p>
           {% if 'CONTRACT_VARIATION' is active_feature %}
             {% for variation in framework.variations %}
-              <p><a href="{{ url_for('.view_contract_variation', framework_slug=framework.slug, variation_slug=variation) }}">Read the proposed contract variation</a></p>
-            {% endfor %}
+              <p>
+                <a href="{{ url_for('.view_contract_variation', framework_slug=framework.slug, variation_slug=variation) }}">
+                {% if framework.variations[variation].get('countersignedAt') and supplier_framework.agreedVariations.get(variation).agreedAt %}
+                  View the signed contract variation
+                {% else %}
+                  Read the proposed contract variation
+                {% endif %}
+                </a>
+              </p>
+          {% endfor %}
           {% endif %}
         </div>
 

--- a/app/templates/frameworks/contract_variation.html
+++ b/app/templates/frameworks/contract_variation.html
@@ -68,11 +68,13 @@
           {% endif %}
           
           <div class="section-description">
-            {{ variation.variation_description|replace("[[SUPPLIER_NAME]]", supplier_name)|markdown }}
-          {% if not agreed_details and variation.not_agreed_extra %}
-            {{ variation.not_agreed_extra|replace("[[SUPPLIER_NAME]]", supplier_name)|markdown }}
-          {% elif agreed_details and variation.agreed_extra %}
-            {{ variation.agreed_extra|replace("[[SUPPLIER_NAME]]", supplier_name)|markdown }}
+          {% if variation_details.get('countersignedAt') and agreed_details %}
+            {{ variation.variation_description_in_place|replace("[[SUPPLIER_NAME]]", supplier_name)|markdown }}
+          {% else %}
+            {{ variation.variation_description_not_in_place|replace("[[SUPPLIER_NAME]]", supplier_name)|markdown }}
+            {% if not agreed_details and variation.variation_not_yet_agreed_extra %}
+              {{ variation.not_agreed_extra|replace("[[SUPPLIER_NAME]]", supplier_name)|markdown }}
+            {% endif %}
           {% endif %}
           </div>
           
@@ -144,7 +146,7 @@
             {% call(item) summary.list_table(
               [
                 {"key": "Agreed by", "value": ("%s<br />%s<br />%s" % (agreed_details.agreedUserName, agreed_details.agreedUserEmail, agreed_details.agreedAt|datetimeformat))|safe},
-                {"key": "Countersigned by", "value": "Waiting for CCS to countersign"}
+                {"key": "Countersigned by", "value": ("%s<br />%s<br />%s" % (variation_details.countersignedByName, variation_details.countersignedByRole, variation_details.countersignedAt|dateformat))|safe if variation_details.get('countersignedAt') else "Waiting for CCS to countersign"}
               ],
               caption="Contract variation status",
               field_headings=[

--- a/bower.json
+++ b/bower.json
@@ -7,6 +7,6 @@
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
     "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v17.0.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.17.3/jinja_govuk_template-0.17.3.tgz",
-    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#v2.3.1"
+    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#v3.0.0"
   }
 }


### PR DESCRIPTION
For this story: https://www.pivotaltracker.com/story/show/128669753

Tests won't pass until this is merged:
 - [x] https://github.com/alphagov/digitalmarketplace-frameworks/pull/309

New content is conditional on this migration to set countersigner details:
 - [ ] https://github.com/alphagov/digitalmarketplace-api/pull/462

This can be released whenever because no changes will be visible until the API PR is merged. Once the countersigner details are set by the migration then the following changes happen:
## Link text change on framework dashboard
(Previously "Read the proposed contract variation")
![screen shot 2016-09-29 at 14 15 10](https://cloud.githubusercontent.com/assets/6525554/18957436/f5334f36-8656-11e6-9bd0-12e2d17b43ba.png)

## New top paragraph on variation page
![screen shot 2016-09-29 at 13 33 11](https://cloud.githubusercontent.com/assets/6525554/18957457/0baf9008-8657-11e6-9d71-48d0da7bc423.png)

## CCS countersigner details at the bottom of the page
![screen shot 2016-09-29 at 13 32 58](https://cloud.githubusercontent.com/assets/6525554/18957463/15a5f4f8-8657-11e6-9875-4f80bded17a0.png)
