### PR TITLE
[#130358101] Update FrameworkAgreements directly 

### DIFF
--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -18,6 +18,7 @@ $path: "/suppliers/static/images/";
 
 /* Blocks shared between multiple selectors */
 @import "shared_placeholders/_temporary-messages.scss";
+@import "shared_placeholders/_dm-typography.scss";
 
 #wrapper, .wrapper {
   @extend %site-width-container;

--- a/app/main/helpers/frameworks.py
+++ b/app/main/helpers/frameworks.py
@@ -268,3 +268,10 @@ def returned_agreement_email_recipients(supplier_framework):
     if supplier_framework['declaration']['primaryContactEmail'].lower() != current_user.email_address.lower():
         email_recipients.append(current_user.email_address)
     return email_recipients
+
+
+def check_agreement_is_related_to_supplier_framework_or_abort(agreement, supplier_framework):
+    if not agreement.get('supplierId') or agreement.get('supplierId') != supplier_framework.get('supplierId'):
+        abort(404)
+    if not agreement.get('frameworkSlug') or agreement.get('frameworkSlug') != supplier_framework.get('frameworkSlug'):
+        abort(404)

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -680,10 +680,7 @@ def signature_upload(framework_slug, agreement_id):
     framework = get_framework(data_api_client, framework_slug, allowed_statuses=['standstill', 'live'])
     supplier_framework = return_supplier_framework_info_if_on_framework_or_abort(data_api_client, framework_slug)
     agreement = data_api_client.get_framework_agreement(agreement_id)['agreement']
-
-    # Need to write a test for this and move this functionality into a helper?
-    if agreement['frameworkSlug'] != framework_slug or agreement['supplierId'] != supplier_framework['supplierId']:
-        abort(404)
+    check_agreement_is_related_to_supplier_framework_or_abort(agreement, supplier_framework)
 
     agreements_bucket = s3.S3(current_app.config['DM_AGREEMENTS_BUCKET'])
     signature_page = agreements_bucket.get_key(agreement.get('signedAgreementPath'))

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -566,19 +566,15 @@ def upload_framework_agreement(framework_slug):
         )
     )
 
-    updated_supplier_framework = data_api_client.register_framework_agreement_returned(
-        current_user.supplier_id, framework_slug, current_user.email_address)
-    agreement_id = updated_supplier_framework.get("frameworkInterest", {}).get("agreementId")
-    try:
-        # If setting the agreement path fails then rollback the retuned agreement and raise error
-        data_api_client.update_framework_agreement(
-            agreement_id, {"signedAgreementPath": path}, current_user.email_address
-        )
-    except Exception as e:
-        data_api_client.unset_framework_agreement_returned(
-            current_user.supplier_id, framework_slug, current_user.email_address
-        )
-        raise e
+    agreement_id = data_api_client.create_framework_agreement(
+        current_user.supplier_id, framework_slug, current_user.email_address
+    )['agreement']['id']
+    data_api_client.update_framework_agreement(
+        agreement_id, {"signedAgreementPath": path}, current_user.email_address
+    )
+    data_api_client.sign_framework_agreement(
+        agreement_id, current_user.email_address, {"uploaderUserId": current_user.id}
+    )
 
     try:
         email_body = render_template(

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -605,6 +605,19 @@ def upload_framework_agreement(framework_slug):
     return redirect(url_for('.framework_agreement', framework_slug=framework_slug))
 
 
+@main.route('/frameworks/<framework_slug>/create-agreement', methods=['POST'])
+@login_required
+def create_framework_agreement(framework_slug):
+    framework = get_framework(data_api_client, framework_slug)
+    return_supplier_framework_info_if_on_framework_or_abort(data_api_client, framework_slug)
+
+    agreement_id = data_api_client.create_framework_agreement(
+        current_user.supplier_id, framework_slug, current_user.email_address
+    )["agreement"]["id"]
+
+    return redirect(url_for('.signer_details', framework_slug=framework_slug, agreement_id=agreement_id))
+
+
 @main.route('/frameworks/<framework_slug>/signer-details', methods=['GET', 'POST'])
 @login_required
 def signer_details(framework_slug):

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -284,7 +284,6 @@ def framework_supplier_declaration(framework_slug, section_id=None):
                     all_answers,
                     current_user.email_address
                 )
-                saved_answers = all_answers
 
                 next_section = content.get_next_editable_section_id(section_id)
                 if next_section:

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -27,7 +27,9 @@ from ..helpers.frameworks import (
     get_declaration_status, get_last_modified_from_first_matching_file, register_interest_in_framework,
     get_supplier_on_framework_from_info, get_declaration_status_from_info, get_supplier_framework_info,
     get_framework, get_framework_and_lot, count_drafts_by_lot, get_statuses_for_lot,
-    return_supplier_framework_info_if_on_framework_or_abort, returned_agreement_email_recipients)
+    return_supplier_framework_info_if_on_framework_or_abort, returned_agreement_email_recipients,
+    check_agreement_is_related_to_supplier_framework_or_abort
+)
 from ..helpers.validation import get_validator
 from ..helpers.services import (
     get_signed_document_url, get_drafts, get_lot_drafts, count_unanswered_questions
@@ -624,9 +626,7 @@ def signer_details(framework_slug, agreement_id):
     framework = get_framework(data_api_client, framework_slug, allowed_statuses=['standstill', 'live'])
     supplier_framework = return_supplier_framework_info_if_on_framework_or_abort(data_api_client, framework_slug)
     agreement = data_api_client.get_framework_agreement(agreement_id)['agreement']
-
-    if agreement['frameworkSlug'] != framework_slug or agreement['supplierId'] != supplier_framework['supplierId']:
-        abort(404)
+    check_agreement_is_related_to_supplier_framework_or_abort(agreement, supplier_framework)
 
     form = SignerDetailsForm()
 

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -647,7 +647,7 @@ def signer_details(framework_slug, agreement_id):
 
             # If they have already uploaded a file then let them go to straight to the contract review
             # page as they are likely editing their signer details
-            if session.get('signature_page'):
+            if agreement.get('signedAgreementPath'):
                 return redirect(url_for(".contract_review", framework_slug=framework_slug, agreement_id=agreement_id))
 
             return redirect(url_for(".signature_upload", framework_slug=framework_slug, agreement_id=agreement_id))

--- a/app/templates/frameworks/contract_review.html
+++ b/app/templates/frameworks/contract_review.html
@@ -60,9 +60,9 @@
     {% call summary.row() %}
       {{ summary.field_name('Person who signed') }}
       {% call summary.field() %}
-        <p>{{ supplier_framework.agreementDetails.signerName }}</p><p>{{ supplier_framework.agreementDetails.signerRole }}</p>
+        <p>{{ agreement.signedAgreementDetails.signerName }}</p><p>{{ agreement.signedAgreementDetails.signerRole }}</p>
       {% endcall %}
-      {{ summary.edit_link("Edit", url_for('.signer_details', framework_slug=framework.slug, agreement_id=agreement_id)) }}
+      {{ summary.edit_link("Edit", url_for('.signer_details', framework_slug=framework.slug, agreement_id=agreement.id)) }}
     {% endcall %}
     {% call summary.row() %}
       {{ summary.field_name('Signature page') }}
@@ -71,7 +71,7 @@
       {% else %}
         {{ summary.field_name( "Uploaded {}".format(signature_page.last_modified|datetimeformat) if signature_page else None) }}
       {% endif %}
-      {{ summary.edit_link("Change", url_for('.signature_upload', framework_slug=framework.slug)) }}
+      {{ summary.edit_link("Change", url_for('.signature_upload', framework_slug=framework.slug, agreement_id=agreement.id)) }}
     {% endcall %}
   {% endcall %}
 </div>
@@ -86,7 +86,7 @@
       <p>You’ll also receive an email to confirm that the signature page has been returned.</p>
     </div>
 
-    <form method="POST" action="{{ url_for('.contract_review', framework_slug=framework.slug) }}">
+    <form method="POST" action="{{ url_for('.contract_review', framework_slug=framework.slug, agreement_id=agreement.id) }}">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
         {%
           with

--- a/app/templates/frameworks/contract_review.html
+++ b/app/templates/frameworks/contract_review.html
@@ -62,7 +62,7 @@
       {% call summary.field() %}
         <p>{{ supplier_framework.agreementDetails.signerName }}</p><p>{{ supplier_framework.agreementDetails.signerRole }}</p>
       {% endcall %}
-      {{ summary.edit_link("Edit", url_for('.signer_details', framework_slug=framework.slug)) }}
+      {{ summary.edit_link("Edit", url_for('.signer_details', framework_slug=framework.slug, agreement_id=agreement_id)) }}
     {% endcall %}
     {% call summary.row() %}
       {{ summary.field_name('Signature page') }}

--- a/app/templates/frameworks/contract_start.html
+++ b/app/templates/frameworks/contract_start.html
@@ -73,6 +73,7 @@
         <h2 class="page-subheading">What you need to do</h2>
 
         <form method="post" action="{{ url_for(".create_framework_agreement", framework_slug=framework.slug) }}">
+          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
           {%
             with
             verbose = true,

--- a/app/templates/frameworks/contract_start.html
+++ b/app/templates/frameworks/contract_start.html
@@ -72,31 +72,33 @@
       <div>
         <h2 class="page-subheading">What you need to do</h2>
 
-        {%
-          with
-          verbose = true,
-          items = [
-            {
-                "body": "Sign your framework agreement signature page.", 
-                "top": "The person signing must have the authority to agree to the framework terms, eg director or company secretary.",
-                "documents": [
-                    {
-                        "title": "Signature page", 
-                        "link": (url_for('.download_agreement_file', framework_slug=framework.slug, document_name=signature_page_filename)), 
-                        "file_type": "PDF",
-                        "download": True
-                    }
-                ],
-                "bottom": "You can review the rest of the <a href='https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/537952/g-cloud-8-framework-agreement.pdf'>framework agreement</a> on GOV.UK."
-            }, 
-            {
-                "body": "Return your signed signature page and give the details of the person who signed it.",
-                "bottom": "<strong><a href='{}'>Return your signed signature page</a></strong>".format(url_for('.signer_details', framework_slug=framework.slug))
-            } 
-          ]
-        %}
-          {% include "toolkit/instruction-list.html" %}
-        {% endwith %}
+        <form method="post" action="{{ url_for(".create_framework_agreement", framework_slug=framework.slug) }}">
+          {%
+            with
+            verbose = true,
+            items = [
+              {
+                  "body": "Sign your framework agreement signature page.", 
+                  "top": "The person signing must have the authority to agree to the framework terms, eg director or company secretary.",
+                  "documents": [
+                      {
+                          "title": "Signature page", 
+                          "link": (url_for('.download_agreement_file', framework_slug=framework.slug, document_name=signature_page_filename)), 
+                          "file_type": "PDF",
+                          "download": True
+                      }
+                  ],
+                  "bottom": "You can review the rest of the <a href='https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/537952/g-cloud-8-framework-agreement.pdf'>framework agreement</a> on GOV.UK."
+              }, 
+              {
+                  "body": "Return your signed signature page and give the details of the person who signed it.",
+                  "bottom": "<input type='submit' class='button-save' value='Return your signed signature page'>"
+              } 
+            ]
+          %}
+            {% include "toolkit/instruction-list.html" %}
+          {% endwith %}
+        </form>
       </div>  
       
     </div>

--- a/app/templates/frameworks/contract_start.html
+++ b/app/templates/frameworks/contract_start.html
@@ -93,7 +93,7 @@
               }, 
               {
                   "body": "Return your signed signature page and give the details of the person who signed it.",
-                  "bottom": "<input type='submit' class='button-save' value='Return your signed signature page'>"
+                  "bottom": "<input type='submit' class='button-save-with-advice' value='Return your signed signature page'>"
               } 
             ]
           %}

--- a/app/templates/frameworks/signature_upload.html
+++ b/app/templates/frameworks/signature_upload.html
@@ -47,7 +47,7 @@
 
   <div class="grid-row">
     <div class="column-two-thirds">
-      <form method="POST" enctype="multipart/form-data" action="{{ url_for('.signature_upload', framework_slug=framework.slug) }}">
+      <form method="POST" enctype="multipart/form-data" action="{{ url_for('.signature_upload', framework_slug=framework.slug, agreement_id=agreement.id) }}">
           <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
           {% set value = None %}
           {% if signature_page %}

--- a/app/templates/frameworks/signer_details.html
+++ b/app/templates/frameworks/signer_details.html
@@ -43,7 +43,7 @@
       {% endwith %}
     {% endif %}
 
-    <form method="POST" action="{{ url_for('.signer_details', framework_slug=framework.slug) }}">
+    <form method="POST" action="{{ url_for('.signer_details', framework_slug=framework.slug, agreement_id=agreement['id']) }}">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
         {% for question_key in question_keys %}
           {%

--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "jquery": "1.11.2",
     "hogan": "3.0.2",
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
-    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v17.0.0",
+    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v17.4.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.17.3/jinja_govuk_template-0.17.3.tgz",
     "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#v3.3.3"
   }

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,6 @@ python-dateutil==2.4.2
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@21.11.0#egg=digitalmarketplace-utils==21.11.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@1.2.0#egg=digitalmarketplace-content-loader==1.2.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@6.5.0#egg=digitalmarketplace-apiclient==6.5.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@7.4.0#egg=digitalmarketplace-apiclient==7.4.0
 
 markdown==2.6.2

--- a/tests/app/helpers.py
+++ b/tests/app/helpers.py
@@ -230,6 +230,7 @@ class BaseApplicationTest(object):
 
     @staticmethod
     def supplier_framework(
+        supplier_id=1234,
         declaration='default',
         status=None,
         on_framework=False,
@@ -250,6 +251,7 @@ class BaseApplicationTest(object):
             declaration['status'] = status
         return {
             'frameworkInterest': {
+                'supplierId': supplier_id,
                 'declaration': declaration,
                 'onFramework': on_framework,
                 'agreementReturned': agreement_returned,
@@ -262,6 +264,22 @@ class BaseApplicationTest(object):
                 'countersignedPath': countersigned_path,
                 'agreementId': agreement_id,
                 'agreedVariations': agreed_variations
+            }
+        }
+
+    @staticmethod
+    def framework_agreement(
+            id=234,
+            supplier_id=1234,
+            framework_slug="g-cloud-8",
+            signed_agreement_details=None
+    ):
+        return {
+            "agreement": {
+                "id": id,
+                "supplierId": supplier_id,
+                "frameworkSlug": framework_slug,
+                "signedAgreementDetails": signed_agreement_details
             }
         }
 

--- a/tests/app/helpers.py
+++ b/tests/app/helpers.py
@@ -272,14 +272,16 @@ class BaseApplicationTest(object):
             id=234,
             supplier_id=1234,
             framework_slug="g-cloud-8",
-            signed_agreement_details=None
+            signed_agreement_details=None,
+            signed_agreement_path=None
     ):
         return {
             "agreement": {
                 "id": id,
                 "supplierId": supplier_id,
                 "frameworkSlug": framework_slug,
-                "signedAgreementDetails": signed_agreement_details
+                "signedAgreementDetails": signed_agreement_details,
+                "signedAgreementPath": signed_agreement_path
             }
         }
 

--- a/tests/app/helpers.py
+++ b/tests/app/helpers.py
@@ -231,6 +231,7 @@ class BaseApplicationTest(object):
     @staticmethod
     def supplier_framework(
         supplier_id=1234,
+        framework_slug=None,
         declaration='default',
         status=None,
         on_framework=False,
@@ -252,6 +253,7 @@ class BaseApplicationTest(object):
         return {
             'frameworkInterest': {
                 'supplierId': supplier_id,
+                'frameworkSlug': framework_slug,
                 'declaration': declaration,
                 'onFramework': on_framework,
                 'agreementReturned': agreement_returned,

--- a/tests/app/main/helpers/test_frameworks.py
+++ b/tests/app/main/helpers/test_frameworks.py
@@ -4,7 +4,10 @@ import mock
 from nose.tools import assert_equal
 from werkzeug.exceptions import HTTPException
 
-from app.main.helpers.frameworks import get_statuses_for_lot, return_supplier_framework_info_if_on_framework_or_abort
+from app.main.helpers.frameworks import (
+    get_statuses_for_lot, return_supplier_framework_info_if_on_framework_or_abort,
+    check_agreement_is_related_to_supplier_framework_or_abort
+)
 
 
 def get_lot_status_examples():
@@ -331,3 +334,37 @@ def test_return_supplier_framework_info_if_on_framework_or_abort_returns_supplie
     data_api_client.get_supplier_framework_info.return_value = supplier_framework_response
     assert return_supplier_framework_info_if_on_framework_or_abort(data_api_client, 'g-cloud-8') == \
         supplier_framework_response['frameworkInterest']
+
+
+def test_check_agreement_is_related_to_supplier_framework_or_abort_does_abort_for_supplier_mismatch():
+    supplier_framework = {"supplierId": 200, "frameworkSlug": 'g-cloud-8'}
+    agreement = {"supplierId": 201, "frameworkSlug": 'g-cloud-8'}
+    with pytest.raises(HTTPException):
+        check_agreement_is_related_to_supplier_framework_or_abort(agreement, supplier_framework)
+
+
+def test_check_agreement_is_related_to_supplier_framework_or_abort_does_abort_for_framework_mismatch():
+    supplier_framework = {"supplierId": 200, "frameworkSlug": 'g-cloud-8'}
+    agreement = {"supplierId": 200, "frameworkSlug": 'g-cloud-7'}
+    with pytest.raises(HTTPException):
+        check_agreement_is_related_to_supplier_framework_or_abort(agreement, supplier_framework)
+
+
+def test_check_agreement_is_related_to_supplier_framework_or_abort_does_abort_if_supplier_ids_are_none():
+    supplier_framework = {"supplierId": None, "frameworkSlug": 'g-cloud-8'}
+    agreement = {"supplierId": None, "frameworkSlug": 'g-cloud-8'}
+    with pytest.raises(HTTPException):
+        check_agreement_is_related_to_supplier_framework_or_abort(agreement, supplier_framework)
+
+
+def test_check_agreement_is_related_to_supplier_framework_or_abort_does_abort_if_framework_slugs_are_none():
+    supplier_framework = {"supplierId": 212, "frameworkSlug": None}
+    agreement = {"supplierId": 212, "frameworkSlug": None}
+    with pytest.raises(HTTPException):
+        check_agreement_is_related_to_supplier_framework_or_abort(agreement, supplier_framework)
+
+
+def test_check_agreement_is_related_to_supplier_framework_or_abort_does_not_abort_for_match():
+    supplier_framework = {"supplierId": 212, "frameworkSlug": 'g-cloud-8'}
+    agreement = {"supplierId": 212, "frameworkSlug": 'g-cloud-8'}
+    check_agreement_is_related_to_supplier_framework_or_abort(agreement, supplier_framework)

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -887,7 +887,7 @@ class TestFrameworkAgreementUpload(BaseApplicationTest):
             )
 
             assert res.status_code == 503
-            send_email.assert_called()
+            assert send_email.called
 
     @mock.patch('app.main.views.frameworks.generate_timestamped_document_upload_path')
     def test_upload_agreement_document(

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -1969,12 +1969,13 @@ class TestCreateFrameworkAgreement(BaseApplicationTest):
         with self.app.test_client():
             self.login()
             # Suppliers can only sign agreements in 'standstill' and 'live' lifecycle statuses
-            data_api_client.get_framework.return_value = self.framework(status='pending')
-            data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
-                on_framework=True)
+            for status in ('coming', 'open', 'pending', 'expired'):
+                data_api_client.get_framework.return_value = self.framework(status=status)
+                data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
+                    on_framework=True)
 
-            res = self.client.post("/suppliers/frameworks/g-cloud-8/create-agreement")
-            assert res.status_code == 404
+                res = self.client.post("/suppliers/frameworks/g-cloud-8/create-agreement")
+                assert res.status_code == 404
 
 
 @mock.patch("app.main.views.frameworks.data_api_client", autospec=True)
@@ -2034,6 +2035,7 @@ class TestSignerDetailsPage(BaseApplicationTest):
         return_supplier_framework.return_value = supplier_framework
 
         res = self.client.get("/suppliers/frameworks/g-cloud-8/234/signer-details")
+        # This call will abort because supplier_framework has mismatched supplier_id 1234
         check_agreement_is_related_to_supplier_framework_or_abort.assert_called_with(
             self.framework_agreement(supplier_id=2345)['agreement'],
             supplier_framework
@@ -2248,6 +2250,7 @@ class TestSignatureUploadPage(BaseApplicationTest):
         s3.return_value.get_key.return_value = None
 
         res = self.client.get("/suppliers/frameworks/g-cloud-8/234/signature-upload")
+        # This call will abort because supplier_framework has mismatched supplier_id 1234
         check_agreement_is_related_to_supplier_framework_or_abort.assert_called_with(
             self.framework_agreement(supplier_id=2345)['agreement'],
             supplier_framework
@@ -2591,6 +2594,7 @@ class TestContractReviewPage(BaseApplicationTest):
         s3.return_value.get_key.return_value = None
 
         res = self.client.get("/suppliers/frameworks/g-cloud-8/234/contract-review")
+        # This call will abort because supplier_framework has mismatched supplier_id 1234
         check_agreement_is_related_to_supplier_framework_or_abort.assert_called_with(
             self.framework_agreement(supplier_id=2345)['agreement'],
             supplier_framework

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -1845,7 +1845,7 @@ class TestSignerDetailsPage(BaseApplicationTest):
         self.login()
         data_api_client.get_framework.return_value = get_g_cloud_8()
         data_api_client.get_framework_agreement.return_value = self.framework_agreement()
-        supplier_framework = self.supplier_framework(on_framework=True)['frameworkInterest']
+        supplier_framework = self.supplier_framework(framework_slug='g-cloud-8', on_framework=True)['frameworkInterest']
         supplier_framework['declaration']['nameOfOrganisation'] = u'£unicodename'
         return_supplier_framework.return_value = supplier_framework
 
@@ -1863,7 +1863,7 @@ class TestSignerDetailsPage(BaseApplicationTest):
                 "signerRole": "Ex funny man"
             }
         )
-        supplier_framework = self.supplier_framework(on_framework=True)['frameworkInterest']
+        supplier_framework = self.supplier_framework(framework_slug='g-cloud-8', on_framework=True)['frameworkInterest']
         return_supplier_framework.return_value = supplier_framework
 
         res = self.client.get("/suppliers/frameworks/g-cloud-8/234/signer-details")
@@ -1873,40 +1873,38 @@ class TestSignerDetailsPage(BaseApplicationTest):
         assert "Ex funny man" in page
 
     def test_404_if_framework_in_wrong_state(self, return_supplier_framework, data_api_client):
-        with self.app.test_client():
-            self.login()
-            # Suppliers can only sign agreements in 'standstill' and 'live' lifecycle statuses
-            data_api_client.get_framework.return_value = self.framework(status='pending')
-            data_api_client.get_framework_agreement.return_value = self.framework_agreement()
-            supplier_framework = self.supplier_framework(on_framework=True)['frameworkInterest']
-            return_supplier_framework.return_value = supplier_framework
+        self.login()
+        # Suppliers can only sign agreements in 'standstill' and 'live' lifecycle statuses
+        data_api_client.get_framework.return_value = self.framework(status='pending')
+        data_api_client.get_framework_agreement.return_value = self.framework_agreement()
+        supplier_framework = self.supplier_framework(framework_slug='g-cloud-8', on_framework=True)['frameworkInterest']
+        return_supplier_framework.return_value = supplier_framework
 
-            res = self.client.get("/suppliers/frameworks/g-cloud-8/234/signer-details")
-            assert res.status_code == 404
+        res = self.client.get("/suppliers/frameworks/g-cloud-8/234/signer-details")
+        assert res.status_code == 404
 
-    def test_should_error_if_agreement_does_not_belong_to_supplier(self, return_supplier_framework, data_api_client):
+    @mock.patch('app.main.views.frameworks.check_agreement_is_related_to_supplier_framework_or_abort')
+    def test_we_abort_if_agreement_does_not_match_supplier_framework(
+        self, check_agreement_is_related_to_supplier_framework_or_abort, return_supplier_framework, data_api_client
+    ):
         self.login()
         data_api_client.get_framework.return_value = get_g_cloud_8()
         data_api_client.get_framework_agreement.return_value = self.framework_agreement(supplier_id=2345)
-        return_supplier_framework.return_value = self.supplier_framework(on_framework=True)['frameworkInterest']
+        supplier_framework = self.supplier_framework(framework_slug='g-cloud-8', on_framework=True)['frameworkInterest']
+        return_supplier_framework.return_value = supplier_framework
 
         res = self.client.get("/suppliers/frameworks/g-cloud-8/234/signer-details")
-        assert res.status_code == 404
-
-    def test_should_error_if_agreement_does_not_belong_to_framework(self, return_supplier_framework, data_api_client):
-        self.login()
-        data_api_client.get_framework.return_value = get_g_cloud_8()
-        data_api_client.get_framework_agreement.return_value = self.framework_agreement(framework_slug="g-cloud-7")
-        return_supplier_framework.return_value = self.supplier_framework(on_framework=True)['frameworkInterest']
-
-        res = self.client.get("/suppliers/frameworks/g-cloud-8/234/signer-details")
-        assert res.status_code == 404
+        check_agreement_is_related_to_supplier_framework_or_abort.assert_called_with(
+            self.framework_agreement(supplier_id=2345)['agreement'],
+            supplier_framework
+        )
 
     def test_should_be_an_error_if_no_full_name(self, return_supplier_framework, data_api_client):
         self.login()
         data_api_client.get_framework.return_value = get_g_cloud_8()
         data_api_client.get_framework_agreement.return_value = self.framework_agreement()
-        return_supplier_framework.return_value = self.supplier_framework(on_framework=True)['frameworkInterest']
+        supplier_framework = self.supplier_framework(framework_slug='g-cloud-8', on_framework=True)['frameworkInterest']
+        return_supplier_framework.return_value = supplier_framework
 
         res = self.client.post(
             "/suppliers/frameworks/g-cloud-8/234/signer-details",
@@ -1922,7 +1920,8 @@ class TestSignerDetailsPage(BaseApplicationTest):
         self.login()
         data_api_client.get_framework.return_value = get_g_cloud_8()
         data_api_client.get_framework_agreement.return_value = self.framework_agreement()
-        return_supplier_framework.return_value = self.supplier_framework(on_framework=True)['frameworkInterest']
+        supplier_framework = self.supplier_framework(framework_slug='g-cloud-8', on_framework=True)['frameworkInterest']
+        return_supplier_framework.return_value = supplier_framework
 
         res = self.client.post(
             "/suppliers/frameworks/g-cloud-8/234/signer-details",
@@ -1940,7 +1939,8 @@ class TestSignerDetailsPage(BaseApplicationTest):
         self.login()
         data_api_client.get_framework.return_value = get_g_cloud_8()
         data_api_client.get_framework_agreement.return_value = self.framework_agreement()
-        return_supplier_framework.return_value = self.supplier_framework(on_framework=True)['frameworkInterest']
+        supplier_framework = self.supplier_framework(framework_slug='g-cloud-8', on_framework=True)['frameworkInterest']
+        return_supplier_framework.return_value = supplier_framework
 
         # 255 characters should be fine
         res = self.client.post(
@@ -1973,7 +1973,8 @@ class TestSignerDetailsPage(BaseApplicationTest):
 
         data_api_client.get_framework.return_value = get_g_cloud_8()
         data_api_client.get_framework_agreement.return_value = self.framework_agreement()
-        return_supplier_framework.return_value = self.supplier_framework(on_framework=True)['frameworkInterest']
+        supplier_framework = self.supplier_framework(framework_slug='g-cloud-8', on_framework=True)['frameworkInterest']
+        return_supplier_framework.return_value = supplier_framework
 
         self.login()
         res = self.client.post(
@@ -1998,7 +1999,8 @@ class TestSignerDetailsPage(BaseApplicationTest):
 
         data_api_client.get_framework.return_value = get_g_cloud_8()
         data_api_client.get_framework_agreement.return_value = self.framework_agreement()
-        return_supplier_framework.return_value = self.supplier_framework(on_framework=True)['frameworkInterest']
+        supplier_framework = self.supplier_framework(framework_slug='g-cloud-8', on_framework=True)['frameworkInterest']
+        return_supplier_framework.return_value = supplier_framework
 
         with self.client as c:
             self.login()
@@ -2025,7 +2027,8 @@ class TestSignerDetailsPage(BaseApplicationTest):
 
         data_api_client.get_framework.return_value = get_g_cloud_8()
         data_api_client.get_framework_agreement.return_value = self.framework_agreement()
-        return_supplier_framework.return_value = self.supplier_framework(on_framework=True)['frameworkInterest']
+        supplier_framework = self.supplier_framework(framework_slug='g-cloud-8', on_framework=True)['frameworkInterest']
+        return_supplier_framework.return_value = supplier_framework
 
         with self.client as c:
             self.login()

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -1943,7 +1943,9 @@ class TestCreateFrameworkAgreement(BaseApplicationTest):
         with self.app.test_client():
             self.login()
 
-            data_api_client.get_framework.return_value = self.framework(slug='g-cloud-8', status='standstill')
+            data_api_client.get_framework.return_value = self.framework(
+                slug='g-cloud-8', status='standstill', framework_agreement_version="1.0"
+            )
             data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
                 on_framework=True)
             data_api_client.create_framework_agreement.return_value = {"agreement": {"id": 789}}


### PR DESCRIPTION
For this story: https://www.pivotaltracker.com/story/show/130358101

** UPDATED WITH SMALLER SPACE ABOVE BUTTON **
Now depends on this being merged before tests will pass: 
 - [x] https://github.com/alphagov/digitalmarketplace-frontend-toolkit/pull/282

These changes make it so that FrameworkAgreements are updated directly rather than via a SupplierFramework.

For pre-G-Cloud-8 frameworks this means making three API calls in a single route (i.e. to  create, add signer details and "sign" the agreement).

For G-Cloud-8 and beyond the new signing agreement flow now creates a FrameworkAgreement when the new "Return your signed signature page" button is first clicked (it's currently a link not a button):

![screen shot 2016-10-26 at 16 58 40](https://cloud.githubusercontent.com/assets/6525554/19733931/8722e996-9b9d-11e6-80c0-d95ea3332ea0.png)

and the ID of the FrameworkAgreement thus created becomes part of the  URL for subsequent pages, allowing the FrameworkAgreement to be updated  directly with first the signer details, then the agreement path (when the  file is uploaded) and finally the "signed_at" timestamp is added when the  final "confirm" button is clicked.

This is the penultimate piece of the puzzle to fix the bug that it was previously  possible for someone to come along and update the signer details for a signed  agreement after it had been countersigned, and without uploading a new document or hitting the "sign" button.

The risk is mitigated by this new flow (a new draft FrameworkAgreement is created  every time the green button is pressed, and existing ones not updated), but  is still susceptible to users navigating directly to the URL for a specific FrameworkAgreement and updating it.  The final piece of the puzzle to block this altogether will come when this API `TODO` is done (coming v. soon!): https://github.com/alphagov/digitalmarketplace-api/blob/master/app/main/views/agreements.py#L94

Note, any users in the middle of the "return a framework agreement" flow when this is deployed will hit a 404 error page and have to start again.  We discussed with @allait and decided that this is fine as it is highly unlikely anyone will be doing that (as nearly all DOS and G-8 agreements are returned already) and if they are then starting over is no great hardship.