### PR TITLE
Brief responses call submit route on api

### DIFF
--- a/app/main/views/briefs.py
+++ b/app/main/views/briefs.py
@@ -132,6 +132,8 @@ def submit_brief_response(brief_id):
         brief_response = data_api_client.create_brief_response(
             brief_id, current_user.supplier_id, response_data, current_user.email_address
         )['briefResponses']
+        data_api_client.submit_brief_response(brief_response['id'], current_user.email_address)
+
     except HTTPError as e:
         # replace generic 'Apply for opportunity' title with title including the name of the brief
         section.name = "Apply for ‘{}’".format(brief['title'])

--- a/app/main/views/briefs.py
+++ b/app/main/views/briefs.py
@@ -109,7 +109,7 @@ def brief_response(brief_id):
 # Add a create route
 @main.route('/opportunities/<int:brief_id>/responses/create', methods=['POST'])
 @login_required
-def submit_brief_response(brief_id):
+def create_brief_response(brief_id):
     """Hits up the data API to create a new brief response."""
 
     brief = get_brief(data_api_client, brief_id, allowed_statuses=['live'])
@@ -130,7 +130,11 @@ def submit_brief_response(brief_id):
 
     try:
         brief_response = data_api_client.create_brief_response(
-            brief_id, current_user.supplier_id, response_data, current_user.email_address
+            brief_id,
+            current_user.supplier_id,
+            response_data,
+            current_user.email_address,
+            page_questions=section.get_field_names()
         )['briefResponses']
         data_api_client.submit_brief_response(brief_response['id'], current_user.email_address)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,6 @@ python-dateutil==2.4.2
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@21.11.0#egg=digitalmarketplace-utils==21.11.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@1.2.0#egg=digitalmarketplace-content-loader==1.2.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@7.4.0#egg=digitalmarketplace-apiclient==7.4.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@7.8.0#egg=digitalmarketplace-apiclient==7.8.0
 
 markdown==2.6.2

--- a/tests/app/main/test_briefs.py
+++ b/tests/app/main/test_briefs.py
@@ -575,11 +575,18 @@ class TestRespondToBrief(BaseApplicationTest):
         assert res.status_code == 302
         assert res.location == "http://localhost/suppliers/opportunities/1234/responses/result?result=success"
         data_api_client.create_brief_response.assert_called_once_with(
-            1234, 1234, processed_brief_submission, 'email@email.com')
+            1234,
+            1234,
+            processed_brief_submission,
+            'email@email.com',
+            page_questions=[
+                'respondToEmailAddress', 'essentialRequirements', 'niceToHaveRequirements', 'availability', 'dayRate'
+            ]
+        )
         data_api_client.submit_brief_response.assert_called_once_with(
             6, 'email@email.com')
 
-    def test_create_new_brief_response_shows_result_page_for_not_all_essentials(self, data_api_client):
+    def test_create_new_brief_response_redirects_to_result_page_if_not_all_essentials_are_true(self, data_api_client):
         data_api_client.get_brief.return_value = self.brief
         data_api_client.get_framework.return_value = self.framework
         data_api_client.create_brief_response.return_value = {
@@ -593,7 +600,14 @@ class TestRespondToBrief(BaseApplicationTest):
         assert res.status_code == 302
         assert res.location == "http://localhost/suppliers/opportunities/1234/responses/result?result=fail"
         data_api_client.create_brief_response.assert_called_once_with(
-            1234, 1234, processed_brief_submission, 'email@email.com')
+            1234,
+            1234,
+            processed_brief_submission,
+            'email@email.com',
+            page_questions=[
+                'respondToEmailAddress', 'essentialRequirements', 'niceToHaveRequirements', 'availability', 'dayRate'
+            ]
+        )
 
     def test_create_new_brief_response_error_message_for_boolean_list_question_empty(self, data_api_client):
         data_api_client.get_brief.return_value = self.brief
@@ -780,7 +794,14 @@ class TestRespondToBrief(BaseApplicationTest):
         assert res.status_code == 400
         assert "You need to answer this question." in res.get_data(as_text=True)
         data_api_client.create_brief_response.assert_called_once_with(
-            1234, 1234, processed_brief_submission, 'email@email.com')
+            1234,
+            1234,
+            processed_brief_submission,
+            'email@email.com',
+            page_questions=[
+                'respondToEmailAddress', 'essentialRequirements', 'niceToHaveRequirements', 'availability', 'dayRate'
+            ]
+        )
 
     def test_create_new_brief_response_redirects_to_login_for_buyer(self, data_api_client):
         data_api_client.get_brief.return_value = self.brief

--- a/tests/app/main/test_briefs.py
+++ b/tests/app/main/test_briefs.py
@@ -565,7 +565,7 @@ class TestRespondToBrief(BaseApplicationTest):
         data_api_client.get_brief.return_value = self.brief
         data_api_client.get_framework.return_value = self.framework
         data_api_client.create_brief_response.return_value = {
-            'briefResponses': {"essentialRequirements": [True, True, True]}
+            'briefResponses': {"id": 6, "essentialRequirements": [True, True, True]}
         }
 
         res = self.client.post(
@@ -576,12 +576,14 @@ class TestRespondToBrief(BaseApplicationTest):
         assert res.location == "http://localhost/suppliers/opportunities/1234/responses/result?result=success"
         data_api_client.create_brief_response.assert_called_once_with(
             1234, 1234, processed_brief_submission, 'email@email.com')
+        data_api_client.submit_brief_response.assert_called_once_with(
+            6, 'email@email.com')
 
     def test_create_new_brief_response_shows_result_page_for_not_all_essentials(self, data_api_client):
         data_api_client.get_brief.return_value = self.brief
         data_api_client.get_framework.return_value = self.framework
         data_api_client.create_brief_response.return_value = {
-            'briefResponses': {"essentialRequirements": [True, False, True]}
+            'briefResponses': {"id": 6, "essentialRequirements": [True, False, True]}
         }
 
         res = self.client.post(


### PR DESCRIPTION
Will set the brief response to be submitted for our existing one page flow. This will allow us to then do a data migration and set all brief responses as submitted.

Send page questions when creating a brief response. This is a preemptive change as the API will shortly be validating content when creating a brief response based on page questions rather than all questions in the schema as it does at the moment. This is similar to when creating a brief.

Tests will fail until [API client pull request](https://github.com/alphagov/digitalmarketplace-apiclient/pull/55) is merged.
