### PR TITLE
Always call .filter before displaying section data

### DIFF
--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -261,7 +261,7 @@ def framework_submission_services(framework_slug, lot_slug):
 def framework_supplier_declaration(framework_slug, section_id=None):
     framework = get_framework(data_api_client, framework_slug, allowed_statuses=['open'])
 
-    content = content_loader.get_manifest(framework_slug, 'declaration')
+    content = content_loader.get_manifest(framework_slug, 'declaration').filter({})
     status_code = 200
 
     if section_id is None:

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -935,6 +935,11 @@ def view_contract_variation(framework_slug, variation_slug):
                 {'question': form['accept_changes'].label.text, 'input_name': 'accept_changes'}
             ]
 
+    supplier_name = supplier_framework['declaration']['nameOfOrganisation']
+    variation_content = content_loader.get_message(framework_slug, variation_content_name).filter(
+        {'supplier_name': supplier_name}
+    )
+
     return render_template(
         "frameworks/contract_variation.html",
         form=form,
@@ -942,7 +947,7 @@ def view_contract_variation(framework_slug, variation_slug):
         framework=framework,
         supplier_framework=supplier_framework,
         variation_details=variation_details,
-        variation=content_loader.get_message(framework_slug, variation_content_name),
+        variation=variation_content,
         agreed_details=agreed_details,
-        supplier_name=supplier_framework['declaration']['nameOfOrganisation'],
+        supplier_name=supplier_name,
     ), 400 if form_errors else 200

--- a/app/templates/frameworks/agreement.html
+++ b/app/templates/frameworks/agreement.html
@@ -87,7 +87,7 @@ with items = [
                     "lead_in": "To digitally sign your framework agreement, you need to:",
                     "sublists": [
                       {
-                          "body": "Use <strong>Adobe Reader</strong> to open your Digital Outcomes and Specialists framework agreement. You can download it for free from the <a class='external-link-default' href='https://get.adobe.com/uk/reader/' rel='external'>Adobe Reader</a> Website."
+                          "body": "Use <strong>Adobe Reader</strong> to open your Digital Outcomes and Specialists framework agreement. You can download it for free from the <a class='external-link-default' href='https://get.adobe.com/uk/reader/' rel='external'>Adobe Reader</a> Website."|safe
                       },
                       {
                           "body": "Go to page 5 and click the first signature box."

--- a/app/templates/frameworks/contract_start.html
+++ b/app/templates/frameworks/contract_start.html
@@ -89,17 +89,18 @@
                           "download": True
                       }
                   ],
-                  "bottom": "You can review the rest of the <a href='https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/537952/g-cloud-8-framework-agreement.pdf'>framework agreement</a> on GOV.UK."
+                  "bottom": "You can review the rest of the <a href='https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/537952/g-cloud-8-framework-agreement.pdf'>framework agreement</a> on GOV.UK."|safe
               }, 
               {
                   "body": "Return your signed signature page and give the details of the person who signed it.",
-                  "bottom": "<input type='submit' class='button-save-with-advice' value='Return your signed signature page'>"
+                  "bottom": "<input type='submit' class='button-save-with-advice' value='Return your signed signature page'>"|safe
               } 
             ]
           %}
             {% include "toolkit/instruction-list.html" %}
           {% endwith %}
         </form>
+
       </div>  
       
     </div>

--- a/app/templates/frameworks/contract_variation.html
+++ b/app/templates/frameworks/contract_variation.html
@@ -66,18 +66,18 @@
               {% include 'toolkit/forms/validation.html' %}
             {% endwith %}
           {% endif %}
-          
+
           <div class="section-description">
           {% if variation_details.get('countersignedAt') and agreed_details %}
-            {{ variation.variation_description_in_place|replace("[[SUPPLIER_NAME]]", supplier_name)|markdown }}
+            {{ variation.variation_description_in_place }}
           {% else %}
-            {{ variation.variation_description_not_in_place|replace("[[SUPPLIER_NAME]]", supplier_name)|markdown }}
+            {{ variation.variation_description_not_in_place }}
             {% if not agreed_details and variation.variation_not_yet_agreed_extra %}
-              {{ variation.not_agreed_extra|replace("[[SUPPLIER_NAME]]", supplier_name)|markdown }}
+              {{ variation.not_agreed_extra }}
             {% endif %}
           {% endif %}
           </div>
-          
+
           {{ summary.heading("Framework agreement", id="framework_agreement_changes") }}
           {% call(item) summary.list_table(
             variation.framework_agreement_changes,
@@ -111,7 +111,7 @@
               {{ summary.text(item.change|markdown) }}
             {% endcall %}
           {% endcall %}
-          
+
           {% if not agreed_details %}
 
             <form method="post" class="supplier-declaration">
@@ -129,7 +129,7 @@
               %}
               {% include "toolkit/forms/selection-buttons.html" %}
               {% endwith %}
-              
+
               <p>We’ll tell you when CCS has countersigned the changes and they come into effect.</p>
                 {%
                   with
@@ -139,9 +139,9 @@
                   {% include "toolkit/button.html" %}
                 {% endwith %}
               </form>
-          
+
           {% else %}
-          
+
             {{ summary.heading("Contract variation status", id="contract_variation_status") }}
             {% call(item) summary.list_table(
               [
@@ -171,7 +171,7 @@
               {% include "toolkit/secondary-action-link.html" %}
             {% endwith %}
           {% endif %}
-          
+
           </div>
       </div>
 

--- a/app/templates/frameworks/contract_variation.html
+++ b/app/templates/frameworks/contract_variation.html
@@ -91,7 +91,7 @@
             ) %}
             {% call summary.row() %}
               {{ summary.field_name(item.clause) }}
-              {{ summary.text(item.change|markdown) }}
+              {{ summary.text(item.change) }}
             {% endcall %}
           {% endcall %}
 
@@ -108,7 +108,7 @@
             ) %}
             {% call summary.row() %}
               {{ summary.field_name(item.clause) }}
-              {{ summary.text(item.change|markdown) }}
+              {{ summary.text(item.change) }}
             {% endcall %}
           {% endcall %}
 

--- a/app/templates/frameworks/edit_declaration_section.html
+++ b/app/templates/frameworks/edit_declaration_section.html
@@ -47,7 +47,7 @@
             {% endwith %}
             {% if section.description %}
               <div class="section-description">
-                {{ section.description|question_references(get_question)|markdown }}
+                {{ section.description|question_references(get_question) }}
               </div>
             {% endif %}
             {% for question in section.questions %}

--- a/app/templates/frameworks/services.html
+++ b/app/templates/frameworks/services.html
@@ -49,7 +49,7 @@
   {% if complete_drafts and declaration_status != 'complete' and framework.status == 'open' %}
     {%
       with
-      message = 'You need to <a href="' + url_for('.framework_supplier_declaration', framework_slug=framework.slug) + '">make the supplier&nbsp;declaration</a> before any services can be submitted',
+      message = 'You need to <a href="' + url_for('.framework_supplier_declaration', framework_slug=framework.slug) + '">make the supplier&nbsp;declaration</a> before any services can be submitted'|safe,
       type = 'warning'
     %}
       {% include 'toolkit/notification-banner.html' %}

--- a/app/templates/frameworks/services.html
+++ b/app/templates/frameworks/services.html
@@ -49,7 +49,7 @@
   {% if complete_drafts and declaration_status != 'complete' and framework.status == 'open' %}
     {%
       with
-      message = 'You need to <a href="' + url_for('.framework_supplier_declaration', framework_slug=framework.slug) + '">make the supplier&nbsp;declaration</a> before any services can be submitted'|safe,
+      message = 'You need to <a href="'|safe + url_for('.framework_supplier_declaration', framework_slug=framework.slug) + '">make the supplier&nbsp;declaration</a> before any services can be submitted'|safe,
       type = 'warning'
     %}
       {% include 'toolkit/notification-banner.html' %}

--- a/app/templates/frameworks/submission_lots.html
+++ b/app/templates/frameworks/submission_lots.html
@@ -45,7 +45,7 @@
   {% if complete_drafts and declaration_status != 'complete' and framework.status == 'open' %}
     {%
       with
-      message = 'You need to <a href="' + url_for('.framework_supplier_declaration', framework_slug=framework.slug) + '">make the supplier&nbsp;declaration</a> before any services can be submitted',
+      message = 'You need to <a href="' + url_for('.framework_supplier_declaration', framework_slug=framework.slug) + '">make the supplier&nbsp;declaration</a> before any services can be submitted' | safe,
       type = 'destructive'
     %}
       {% include 'toolkit/notification-banner.html' %}

--- a/app/templates/frameworks/submission_lots.html
+++ b/app/templates/frameworks/submission_lots.html
@@ -45,7 +45,7 @@
   {% if complete_drafts and declaration_status != 'complete' and framework.status == 'open' %}
     {%
       with
-      message = 'You need to <a href="' + url_for('.framework_supplier_declaration', framework_slug=framework.slug) + '">make the supplier&nbsp;declaration</a> before any services can be submitted' | safe,
+      message = 'You need to <a href="'|safe + url_for('.framework_supplier_declaration', framework_slug=framework.slug) + '">make the supplier&nbsp;declaration</a> before any services can be submitted' | safe,
       type = 'destructive'
     %}
       {% include 'toolkit/notification-banner.html' %}

--- a/app/templates/macros/toolkit_forms.html
+++ b/app/templates/macros/toolkit_forms.html
@@ -1,7 +1,7 @@
 {% macro text(question_content, service_data, errors, question_number=None, get_question=None) -%}
   {%
     with
-    question=question_content.question|question_references(get_question)|markdown,
+    question=question_content.question|question_references(get_question),
     question_advice=question_content.question_advice,
     hint=(question_content.hint or '')|question_references(get_question),
     optional=question_content.optional,
@@ -20,7 +20,7 @@
 {% macro textbox_large(question_content, service_data, errors, question_number=None, get_question=None) -%}
   {%
     with
-    question=question_content.question|question_references(get_question)|markdown,
+    question=question_content.question|question_references(get_question),
     question_advice=question_content.question_advice,
     hint=(question_content.hint or '')|question_references(get_question),
     optional=question_content.optional,
@@ -39,7 +39,7 @@
     with
     name=question_content.id,
     number_of_items=10,
-    question=question_content.question|question_references(get_question)|markdown,
+    question=question_content.question|question_references(get_question),
     question_advice=question_content.question_advice,
     hint=(question_content.hint or '')|question_references(get_question),
     optional=question_content.optional,
@@ -55,7 +55,7 @@
   {%
     with
     name=question_content.id,
-    question=question_content.question|question_references(get_question)|markdown,
+    question=question_content.question|question_references(get_question),
     question_advice=question_content.question_advice,
     hint=(question_content.hint or '')|question_references(get_question),
     optional=question_content.optional,
@@ -74,7 +74,7 @@
   {%
     with
     name=question_content.id,
-    question=question_content.question|question_references(get_question)|markdown,
+    question=question_content.question|question_references(get_question),
     question_advice=question_content.question_advice,
     hint=(question_content.hint or '')|question_references(get_question),
     hint_underneath=(question_content.hint_underneath or False),
@@ -94,7 +94,7 @@
   {%
     with
     name=question_content.id,
-    question=question_content.question|question_references(get_question)|markdown,
+    question=question_content.question|question_references(get_question),
     question_advice=question_content.question_advice,
     hint=(question_content.hint or '')|question_references(get_question),
     optional=question_content.optional,
@@ -111,7 +111,7 @@
 {% macro upload(question_content, service_data, errors, question_number=None, get_question=None) -%}
   {%
     with
-    question=question_content.question|question_references(get_question)|markdown,
+    question=question_content.question|question_references(get_question),
     question_advice=question_content.question_advice,
     hint=(question_content.hint or '')|question_references(get_question),
     optional=question_content.optional,
@@ -156,7 +156,7 @@
     unit=question_content.unit,
     unit_in_full=question_content.unit_in_full,
     unit_position=question_content.unit_position,
-    question=question_content.question|question_references(get_question)|markdown,
+    question=question_content.question|question_references(get_question),
     question_advice=question_content.question_advice,
     hint=(question_content.hint or '')|question_references(get_question),
     optional=question_content.optional,
@@ -183,11 +183,11 @@
 
       {% if question_content.question_advice %}
         <span class="question-advice" id="input-{{ name }}-question-advice">
-          {{ question_content.question_advice|markdown }}
+          {{ question_content.question_advice }}
         </span>
       {% endif %}
       {% if question_content.hint %}
-        <span class="hint">{{ question_content.hint|markdown }}</span>
+        <span class="hint">{{ question_content.hint }}</span>
       {% endif %}
 
       {% for boolean_question in question_content.boolean_list_questions %}
@@ -228,12 +228,12 @@
 
     {% if question_content.question_advice %}
     <span class="question-advice" id="input-{{ name }}-question-advice">
-      {{ question_content.question_advice|markdown }}
+      {{ question_content.question_advice }}
     </span>
     {% endif %}
 
     {% if question_content.hint %}
-    <span class="hint">{{ question_content.hint|markdown }}</span>
+    <span class="hint">{{ question_content.hint }}</span>
     {% endif %}
 
     {% for child_question in question_content.questions %}

--- a/app/templates/partials/service_warning.html
+++ b/app/templates/partials/service_warning.html
@@ -1,7 +1,7 @@
 {% if true %}
   {%
     with
-    message = 'This service will not be submitted at the deadline because the <a href="' + url_for('.framework_supplier_declaration', framework_slug=framework.slug) + '">supplier&nbsp;declaration</a> hasn’t been made.' | safe,
+    message = 'This service will not be submitted at the deadline because the <a href="'|safe + url_for('.framework_supplier_declaration', framework_slug=framework.slug) + '">supplier&nbsp;declaration</a> hasn’t been made.' | safe,
     type = 'warning'
   %}
     {% include 'toolkit/notification-banner.html' %}

--- a/app/templates/partials/service_warning.html
+++ b/app/templates/partials/service_warning.html
@@ -1,7 +1,7 @@
 {% if true %}
   {%
     with
-    message = 'This service will not be submitted at the deadline because the <a href="' + url_for('.framework_supplier_declaration', framework_slug=framework.slug) + '">supplier&nbsp;declaration</a> hasn’t been made.',
+    message = 'This service will not be submitted at the deadline because the <a href="' + url_for('.framework_supplier_declaration', framework_slug=framework.slug) + '">supplier&nbsp;declaration</a> hasn’t been made.' | safe,
     type = 'warning'
   %}
     {% include 'toolkit/notification-banner.html' %}

--- a/app/templates/services/_base_edit_section_page.html
+++ b/app/templates/services/_base_edit_section_page.html
@@ -18,7 +18,7 @@
 
       {% if section.description %}
         <div class="section-description">
-          {{ section.description|markdown }}
+          {{ section.description }}
         </div>
       {% endif %}
 

--- a/app/templates/services/service.html
+++ b/app/templates/services/service.html
@@ -26,7 +26,7 @@
     {% if service_data.status != 'published' and service_unavailability_information %}
       {%
         with
-        message = "If you don’t know why this service was removed or you want to reinstate it, contact <a href='mailto:enquiries@digitalmarketplace.service.gov.uk'>enquiries@digitalmarketplace.service.gov.uk</a>.",
+        message = "If you don’t know why this service was removed or you want to reinstate it, contact <a href='mailto:enquiries@digitalmarketplace.service.gov.uk'>enquiries@digitalmarketplace.service.gov.uk</a>." | safe,
         type = "temporary-message",
         heading = "This service was removed on {}".format(service_unavailability_information.createdAt|dateformat)
       %}

--- a/app/templates/services/service_submission.html
+++ b/app/templates/services/service_submission.html
@@ -35,7 +35,7 @@
     <div class="wrapper">
       {%
         with
-        message = 'You need to <a href="' + url_for('.framework_supplier_declaration', framework_slug=framework.slug) + '">make the supplier&nbsp;declaration</a> before ' + service_data.get('serviceName', service_data['lotName'])|lower + ' can be submitted',
+        message = 'You need to <a href="' + url_for('.framework_supplier_declaration', framework_slug=framework.slug) + '">make the supplier&nbsp;declaration</a> before '|safe + service_data.get('serviceName', service_data['lotName'])|lower + ' can be submitted',
         type = 'warning'
       %}
         {% include 'toolkit/notification-banner.html' %}

--- a/app/templates/services/service_submission.html
+++ b/app/templates/services/service_submission.html
@@ -35,7 +35,7 @@
     <div class="wrapper">
       {%
         with
-        message = 'You need to <a href="' + url_for('.framework_supplier_declaration', framework_slug=framework.slug) + '">make the supplier&nbsp;declaration</a> before '|safe + service_data.get('serviceName', service_data['lotName'])|lower + ' can be submitted',
+        message = 'You need to <a href="'|safe + url_for('.framework_supplier_declaration', framework_slug=framework.slug) + '">make the supplier&nbsp;declaration</a> before '|safe + service_data.get('serviceName', service_data['lotName'])|lower + ' can be submitted',
         type = 'warning'
       %}
         {% include 'toolkit/notification-banner.html' %}

--- a/app/templates/suppliers/_frameworks_coming.html
+++ b/app/templates/suppliers/_frameworks_coming.html
@@ -4,7 +4,7 @@
       with
       messages = [
         "We’ll email you when you can apply to Digital Outcomes and Specialists.",
-        "<a href='https://digitalmarketplace.blog.gov.uk/2015/11/12/digital-outcomes-and-specialists-suitable-suppliers-and-services/'>Find out if your services are suitable</a>"
+        "<a href='https://digitalmarketplace.blog.gov.uk/2015/11/12/digital-outcomes-and-specialists-suitable-suppliers-and-services/'>Find out if your services are suitable</a>"|safe
       ],
       heading = "{} will be open for applications soon".format(framework.name)
     %}

--- a/app/templates/suppliers/_frameworks_open.html
+++ b/app/templates/suppliers/_frameworks_open.html
@@ -5,8 +5,7 @@
         {%
           with
           items = [{
-            "title":
-            "Continue your {} application".format(framework.name),
+            "title": "Continue your %s application" | format(framework.name),
             "link": url_for(".framework_dashboard", framework_slug=framework.slug),
             "body": framework.deadline|markdown,
           }]

--- a/app/templates/suppliers/_frameworks_open.html
+++ b/app/templates/suppliers/_frameworks_open.html
@@ -7,7 +7,7 @@
           items = [{
             "title": "Continue your %s application" | format(framework.name),
             "link": url_for(".framework_dashboard", framework_slug=framework.slug),
-            "body": framework.deadline|markdown,
+            "body": framework.deadline,
           }]
         %}
           {% include "toolkit/browse-list.html" %}

--- a/bower.json
+++ b/bower.json
@@ -7,6 +7,6 @@
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
     "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v18.0.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.17.3/jinja_govuk_template-0.17.3.tgz",
-    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#v4.0.0"
+    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#v4.0.2"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -5,8 +5,8 @@
     "jquery": "1.11.2",
     "hogan": "3.0.2",
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
-    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v17.4.0",
+    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v18.0.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.17.3/jinja_govuk_template-0.17.3.tgz",
-    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#v3.5.0"
+    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#v4.0.0"
   }
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ werkzeug==0.10.4
 python-dateutil==2.4.2
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@21.11.0#egg=digitalmarketplace-utils==21.11.0
-git+https://github.com/alphagov/digitalmarketplace-content-loader.git@1.2.0#egg=digitalmarketplace-content-loader==1.2.0
+git+https://github.com/alphagov/digitalmarketplace-content-loader.git@2.0.1#egg=digitalmarketplace-content-loader==2.0.1
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@7.8.0#egg=digitalmarketplace-apiclient==7.8.0
 
 markdown==2.6.2

--- a/tests/app/main/test_briefs.py
+++ b/tests/app/main/test_briefs.py
@@ -537,9 +537,9 @@ class TestRespondToBrief(BaseApplicationTest):
         res = self.client.get('/suppliers/opportunities/1234/responses/create')
         doc = html.fromstring(res.get_data(as_text=True))
 
-        assert len(doc.xpath('//p[contains(text(), "Essential one")]')) == 1
-        assert len(doc.xpath('//p[contains(text(), "Essential two")]')) == 1
-        assert len(doc.xpath('//p[contains(text(), "Essential three")]')) == 1
+        assert len(doc.xpath('//span[contains(text(), "Essential one")]')) == 1
+        assert len(doc.xpath('//span[contains(text(), "Essential two")]')) == 1
+        assert len(doc.xpath('//span[contains(text(), "Essential three")]')) == 1
 
     def test_get_brief_response_page_includes_nice_to_have_requirements(self, data_api_client):
         data_api_client.get_brief.return_value = self.brief
@@ -547,9 +547,9 @@ class TestRespondToBrief(BaseApplicationTest):
         res = self.client.get('/suppliers/opportunities/1234/responses/create')
         doc = html.fromstring(res.get_data(as_text=True))
 
-        assert len(doc.xpath('//p[contains(text(), "Top one")]')) == 1
-        assert len(doc.xpath('//p[contains(text(), "Nice one")]')) == 1
-        assert len(doc.xpath('//p[contains(text(), "Get sorted")]')) == 1
+        assert len(doc.xpath('//span[contains(text(), "Top one")]')) == 1
+        assert len(doc.xpath('//span[contains(text(), "Nice one")]')) == 1
+        assert len(doc.xpath('//span[contains(text(), "Get sorted")]')) == 1
 
     def test_get_brief_response_page_redirects_to_login_for_buyer(self, data_api_client):
         data_api_client.get_brief.return_value = self.brief

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -2493,7 +2493,7 @@ class TestSendClarificationQuestionEmail(BaseApplicationTest):
 
         assert_equal(response.status_code, 200)
         assert_in(
-            self.strip_all_whitespace('<p class="banner-message">Your question has been sent. You\'ll get a reply from the Crown Commercial Service soon.</p>'),  # noqa
+            self.strip_all_whitespace('<p class="banner-message">Your question has been sent. You&#39;ll get a reply from the Crown Commercial Service soon.</p>'),  # noqa
             self.strip_all_whitespace(response.get_data(as_text=True))
         )
 
@@ -4001,7 +4001,7 @@ class TestContractVariation(BaseApplicationTest):
         assert res.status_code == 200
         assert len(
             doc.xpath('//p[@class="banner-message"][contains(text(), "You have accepted the proposed changes.")]')
-        ) == 1
+        ) == 1, res.get_data(as_text=True)
 
     @mock.patch('app.main.views.frameworks.send_email')
     def test_api_is_not_called_and_no_email_sent_for_subsequent_posts(self, send_email, data_api_client):

--- a/tests/app/main/test_suppliers.py
+++ b/tests/app/main/test_suppliers.py
@@ -219,8 +219,7 @@ class TestSuppliersDashboard(BaseApplicationTest):
                       message[0].xpath('h3/text()')[0])
             assert_in(u"We’ll email you when you can apply to Digital Outcomes and Specialists",
                       message[0].xpath('p/text()')[0])
-            assert_in(u"Find out if your services are suitable",
-                      message[0].xpath('p/a/text()')[0])
+            assert u"Find out if your services are suitable" in message[0].xpath('p/a/text()')[0]
 
     @mock.patch("app.main.views.suppliers.data_api_client")
     @mock.patch("app.main.views.suppliers.get_current_suppliers_users")


### PR DESCRIPTION
Since section fields can go through additional processing with Jinja we need to ensure we're always calling .filter before displaying them to the user so that we don't accidentally display template source.
