### PR TITLE
Replace in-app beta banner with new toolkit version

### DIFF
--- a/app/assets/scss/_phase_banner.scss
+++ b/app/assets/scss/_phase_banner.scss
@@ -1,6 +1,0 @@
-@import "design-patterns/_alpha-beta.scss";
-
-.phase-banner  {
-  @include phase-banner(beta);
-  @extend %site-width-container;
-}

--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -42,6 +42,7 @@ $path: "/suppliers/static/images/";
 @import "toolkit/_link-button";
 @import "toolkit/_notification-banners.scss";
 @import "toolkit/_page-headings.scss";
+@import "toolkit/_phase-banner.scss";
 @import "toolkit/_service-id.scss";
 @import "toolkit/_temporary-message.scss";
 @import "toolkit/forms/_hint.scss";

--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -1,5 +1,4 @@
 // GOVUK Front-end toolkit styles
-@import "_phase_banner.scss";
 @import "_grid_layout.scss";
 @import "_typography.scss";
 @import "_url-helpers.scss";

--- a/app/templates/_base_page.html
+++ b/app/templates/_base_page.html
@@ -15,7 +15,7 @@
 {% endblock %}
 
 {% block content %}
-  {% include "_phase_banner.html" %}
+  {% include "toolkit/phase-banner.html" %}
   {% block breadcrumb %}{% endblock %}
   <div id="wrapper">
     <main id="content" role="main">

--- a/app/templates/_phase_banner.html
+++ b/app/templates/_phase_banner.html
@@ -1,5 +1,0 @@
-<div class="phase-banner">
-  <p>
-     <strong class="phase-tag">BETA</strong> This is a <a href="https://www.gov.uk/help/beta">beta service</a>  – please send your feedback to  <a href="mailto:enquiries@digitalmarketplace.service.gov.uk?subject=Digital%20Marketplace%20feedback" title="Please send feedback to enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.service.gov.uk</a>
-  </p>
-</div>


### PR DESCRIPTION
Replaces the in-app beta banner with the new toolkit version.  
Means we can delete a couple of files.

Largely the same as I'm doing in the [buyer frontend](https://github.com/alphagov/digitalmarketplace-buyer-frontend/pull/399).