### PR TITLE
#130018567 Start page for supplier applications

### DIFF
--- a/app/main/views/briefs.py
+++ b/app/main/views/briefs.py
@@ -74,13 +74,23 @@ def ask_brief_clarification_question(brief_id):
     ), 200 if not error_message else 400
 
 
-@main.route('/opportunities/<int:brief_id>/responses/start', methods=['GET'])
+@main.route('/opportunities/<int:brief_id>/responses/start', methods=['GET', 'POST'])
 @login_required
 def start_brief_response(brief_id):
     brief = get_brief(data_api_client, brief_id, allowed_statuses=['live'])
 
     if not is_supplier_eligible_for_brief(data_api_client, current_user.supplier_id, brief):
         return _render_not_eligible_for_brief_error_page(brief)
+
+    if request.method == 'POST':
+        brief_response = data_api_client.create_brief_response(
+            brief_id,
+            current_user.supplier_id,
+            {},
+            current_user.email_address,
+        )['briefResponses']
+        brief_response_id = brief_response['id']
+        return redirect(url_for('.edit_brief_response', brief_response_id=brief_response_id))
 
     brief_response = data_api_client.find_brief_responses(
         brief_id=brief_id,
@@ -102,6 +112,12 @@ def start_brief_response(brief_id):
         brief=brief,
         existing_draft_response=existing_draft_response
     )
+
+
+@main.route('/opportunities/responses/<int:brief_response_id>/edit', methods=['GET'])
+@login_required
+def edit_brief_response(brief_response_id):
+    return 'Hello world'
 
 
 @main.route('/opportunities/<int:brief_id>/responses/create', methods=['GET'])

--- a/app/main/views/briefs.py
+++ b/app/main/views/briefs.py
@@ -5,6 +5,7 @@ import re
 
 from flask import abort, flash, redirect, render_template, request, url_for
 from flask_login import current_user
+import flask_featureflags as feature
 
 from dmapiclient import HTTPError
 
@@ -75,6 +76,7 @@ def ask_brief_clarification_question(brief_id):
 
 
 @main.route('/opportunities/<int:brief_id>/responses/start', methods=['GET', 'POST'])
+@feature.is_active_feature('NEW_SUPPLIER_FLOW')
 @login_required
 def start_brief_response(brief_id):
     brief = get_brief(data_api_client, brief_id, allowed_statuses=['live'])

--- a/app/templates/briefs/start_brief_response.html
+++ b/app/templates/briefs/start_brief_response.html
@@ -1,0 +1,67 @@
+{% extends "_base_page.html" %}
+
+{% block page_title %}Apply for {{ brief.title }} – Digital Marketplace{% endblock %}
+
+{% block main_content %}
+
+  {%
+    set lot_content = {
+      'digital-specialists': ('the specialist', 'has'),
+      'digital-outcomes': ('the team', 'have'),
+      'user-research-participants': ('you', 'have')
+    }
+  %}
+
+  <div class="grid-row">
+    <div class="column-two-thirds dmspeak">
+
+      {%
+        with
+        smaller = true,
+        heading = "Apply for ‘{}’".format(brief.title)
+      %}
+        {% include "toolkit/page-heading.html" %}
+      {% endwith %}
+      
+      <div class="explanation-list">
+        <p class="lead">To apply for this opportunity, you’ll need to:</p>
+        <ul class="list-bullet">
+          <li>give the date {{ lot_content[brief.lotSlug][0] }} will be available to start work</li>
+          {% if brief.lotSlug == "digital-specialists" %}
+            <li>provide the specialist's day rate</li>
+          {% endif %}
+          <li>say which skills and experience {{ lot_content[brief.lotSlug][0] }} {{ lot_content[brief.lotSlug][1] }}</li>
+          <li>give evidence for all the skills and experience {{ lot_content[brief.lotSlug][0] }} {{ lot_content[brief.lotSlug][1] }}</li>
+        </ul>
+      </div>
+
+      <h2 class="heading-xmedium">How to give evidence</h2>
+      <p>The buyer will assess and score your evidence to shortlist the best suppliers.</p>
+      <p>You’ll need to meet or exceed their essential criteria to get through to the next stage.</p>
+
+      <h3 class="heading-small">Evidence structure</h3>
+      <div class="explanation-list padding-bottom-small">
+        <p class="lead">When you write your evidence, you should be specific about:</p>
+        <ul class="list-bullet">
+          <li>what the situation was</li>
+          <li>the work {{ lot_content[brief.lotSlug][0] }} did</li>
+          <li>what the results were</li>
+        </ul>
+      </div>
+      <p>There’s a 100-word maximum for each essential or nice-to-have criteria.</p>
+      <p>You should only provide one example for each essential or nice-to-have criteria (unless the buyer specifies otherwise).</p>
+      <p>You can reuse examples across different essential or nice-to-have criteria if you need to.</p>
+
+      <form action="{{ url_for('.start_brief_response', brief_id=brief['id']) }}" method="post">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+          {%
+            with
+            type = "save",
+            label = "Continue application" if existing_draft_response else "Start application"
+          %}
+            {% include "toolkit/button.html" %}
+          {% endwith %}
+      </form>
+    </div>
+  </div>
+{% endblock %}

--- a/config.py
+++ b/config.py
@@ -71,6 +71,7 @@ class Config(object):
 
     FEATURE_FLAGS_EDIT_SECTIONS = False
     FEATURE_FLAGS_CONTRACT_VARIATION = False
+    FEATURE_FLAGS_NEW_SUPPLIER_FLOW = False
 
     # Logging
     DM_LOG_LEVEL = 'DEBUG'
@@ -99,6 +100,7 @@ class Test(Config):
 
     FEATURE_FLAGS_EDIT_SECTIONS = enabled_since('2015-06-03')
     FEATURE_FLAGS_CONTRACT_VARIATION = enabled_since('2016-08-11')
+    FEATURE_FLAGS_NEW_SUPPLIER_FLOW = enabled_since('2016-11-09')
 
     DM_DATA_API_AUTH_TOKEN = 'myToken'
 
@@ -116,6 +118,7 @@ class Development(Config):
     # Dates not formatted like YYYY-(0)M-(0)D will fail
     FEATURE_FLAGS_EDIT_SECTIONS = enabled_since('2015-06-03')
     FEATURE_FLAGS_CONTRACT_VARIATION = enabled_since('2016-08-11')
+    FEATURE_FLAGS_NEW_SUPPLIER_FLOW = enabled_since('2016-11-09')
 
     DM_DATA_API_URL = "http://localhost:5000"
     DM_DATA_API_AUTH_TOKEN = "myToken"
@@ -144,6 +147,7 @@ class Live(Config):
 class Preview(Live):
     FEATURE_FLAGS_CONTRACT_VARIATION = enabled_since('2016-08-22')
     FEATURE_FLAGS_EDIT_SECTIONS = enabled_since('2016-09-14')
+    FEATURE_FLAGS_NEW_SUPPLIER_FLOW = enabled_since('2016-11-09')
 
 
 class Production(Live):
@@ -153,6 +157,7 @@ class Production(Live):
 class Staging(Production):
     FEATURE_FLAGS_CONTRACT_VARIATION = enabled_since('2016-08-22')
     FEATURE_FLAGS_EDIT_SECTIONS = enabled_since('2016-09-14')
+    FEATURE_FLAGS_NEW_SUPPLIER_FLOW = enabled_since('2016-11-09')
 
 configs = {
     'development': Development,

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,6 @@ python-dateutil==2.4.2
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@21.11.0#egg=digitalmarketplace-utils==21.11.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@2.0.1#egg=digitalmarketplace-content-loader==2.0.1
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@7.8.0#egg=digitalmarketplace-apiclient==7.8.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@7.9.0#egg=digitalmarketplace-apiclient==7.9.0
 
 markdown==2.6.2

--- a/tests/app/main/test_briefs.py
+++ b/tests/app/main/test_briefs.py
@@ -947,6 +947,16 @@ class TestStartBriefResponseApplication(BaseApplicationTest):
 
         assert "provide the specialist's day rate" not in data
 
+    def test_start_page_is_hidden_by_feature_flag(self, data_api_client):
+        self.app.config['FEATURE_FLAGS_NEW_SUPPLIER_FLOW'] = False
+        data_api_client.get_brief.return_value = api_stubs.brief(status='live', lot_slug='digital-outcomes')
+        data_api_client.find_brief_responses.return_value = {
+            'briefResponses': []
+        }
+        res = self.client.get('/suppliers/opportunities/1234/responses/start')
+        assert res.status_code == 404
+
+
 @mock.patch("app.main.views.briefs.data_api_client")
 class TestPostStartBriefResponseApplication(BaseApplicationTest):
     def setup(self):
@@ -982,6 +992,12 @@ class TestPostStartBriefResponseApplication(BaseApplicationTest):
         data_api_client.create_brief_response.assert_called_once_with(1234, 1234, {}, "email@email.com")
         assert res.status_code == 302
         assert res.location == 'http://localhost/suppliers/opportunities/responses/10/edit'
+
+    def test_post_to_start_page_is_hidden_by_feature_flag(self, data_api_client):
+        self.app.config['FEATURE_FLAGS_NEW_SUPPLIER_FLOW'] = False
+        data_api_client.get_brief.return_value = api_stubs.brief(status='live', lot_slug='digital-outcomes')
+        res = self.client.post('/suppliers/opportunities/1234/responses/start')
+        assert res.status_code == 404
 
 
 @mock.patch("app.main.views.briefs.data_api_client")

--- a/tests/app/main/test_briefs.py
+++ b/tests/app/main/test_briefs.py
@@ -818,6 +818,137 @@ class TestRespondToBrief(BaseApplicationTest):
 
 
 @mock.patch("app.main.views.briefs.data_api_client")
+class TestStartBriefResponseApplication(BaseApplicationTest):
+    def setup(self):
+        super(TestStartBriefResponseApplication, self).setup()
+
+        with self.app.test_client():
+            self.login()
+
+    @mock.patch("app.main.views.briefs.is_supplier_eligible_for_brief")
+    def test_will_show_not_eligible_response_if_supplier_is_not_eligible_for_brief(
+        self, is_supplier_eligible_for_brief, data_api_client
+    ):
+        brief = api_stubs.brief(status='live', lot_slug='digital-specialists')
+        data_api_client.get_brief.return_value = brief
+        data_api_client.find_brief_responses.return_value = {
+            'briefResponses': []
+        }
+        is_supplier_eligible_for_brief.return_value = False
+
+        res = self.client.get('/suppliers/opportunities/1234/responses/start')
+        assert res.status_code == 400
+
+        doc = html.fromstring(res.get_data(as_text=True))
+        assert doc.xpath('//title')[0].text == 'Not eligible for opportunity – Digital Marketplace'
+
+    def test_start_application_contains_brief_title(self, data_api_client):
+        data_api_client.get_brief.return_value = api_stubs.brief(status='live', lot_slug='digital-specialists')
+        data_api_client.find_brief_responses.return_value = {
+            'briefResponses': []
+        }
+        res = self.client.get('/suppliers/opportunities/1234/responses/start')
+        assert res.status_code == 200
+
+        doc = html.fromstring(res.get_data(as_text=True))
+        assert doc.xpath('//h1')[0].text.strip() == "Apply for ‘I need a thing to do a thing’"
+
+    def test_start_page_is_viewable_and_has_start_button_if_no_existing_brief_response(
+        self, data_api_client
+    ):
+        data_api_client.get_brief.return_value = api_stubs.brief(status='live', lot_slug='digital-specialists')
+        data_api_client.find_brief_responses.return_value = {
+            'briefResponses': []
+        }
+        res = self.client.get('/suppliers/opportunities/1234/responses/start')
+
+        doc = html.fromstring(res.get_data(as_text=True))
+        assert doc.xpath("//input[@class='button-save']/@value")[0] == 'Start application'
+
+    def test_start_page_is_viewable_and_has_continue_button_if_draft_brief_response_exists(
+        self, data_api_client
+    ):
+        data_api_client.get_brief.return_value = api_stubs.brief(status='live', lot_slug='digital-specialists')
+        data_api_client.find_brief_responses.return_value = {
+            'briefResponses': [
+                {
+                    "id": 2,
+                    "status": "draft",
+                }
+            ]
+        }
+        res = self.client.get('/suppliers/opportunities/1234/responses/start')
+
+        doc = html.fromstring(res.get_data(as_text=True))
+        assert doc.xpath("//input[@class='button-save']/@value")[0] == 'Continue application'
+
+    def test_will_show_not_eligible_response_if_supplier_has_already_submitted_application(self, data_api_client):
+        data_api_client.get_brief.return_value = api_stubs.brief(status='live', lot_slug='digital-specialists')
+        data_api_client.find_brief_responses.return_value = {
+            'briefResponses': [
+                {
+                    "id": 2,
+                    "status": "submitted",
+                    "submittedAt": "2016-07-20T10:34:08.993952Z",
+                }
+            ]
+        }
+        res = self.client.get('/suppliers/opportunities/1234/responses/start')
+        assert res.status_code == 302
+        assert res.location == 'http://localhost/suppliers/opportunities/1234/responses/result'
+
+    def test_start_page_for_specialist_brief_shows_specialist_content(self, data_api_client):
+        data_api_client.get_brief.return_value = api_stubs.brief(status='live', lot_slug='digital-specialists')
+        data_api_client.find_brief_responses.return_value = {
+            'briefResponses': []
+        }
+        res = self.client.get('/suppliers/opportunities/1234/responses/start')
+        assert res.status_code == 200
+
+        data = res.get_data(as_text=True)
+
+        assert 'give the date the specialist will be available to start work' in data
+        assert "provide the specialist's day rate" in data
+        assert "say which skills and experience the specialist has" in data
+        assert "give evidence for all the skills and experience the specialist has" in data
+        assert "the work the specialist did" in data
+
+    def test_start_page_for_outcomes_brief_shows_outcomes_content(self, data_api_client):
+        data_api_client.get_brief.return_value = api_stubs.brief(status='live', lot_slug='digital-outcomes')
+        data_api_client.find_brief_responses.return_value = {
+            'briefResponses': []
+        }
+        res = self.client.get('/suppliers/opportunities/1234/responses/start')
+        assert res.status_code == 200
+
+        data = res.get_data(as_text=True)
+
+        assert 'give the date the team will be available to start work' in data
+        assert "say which skills and experience the team have" in data
+        assert "give evidence for all the skills and experience the team have" in data
+        assert "the work the team did" in data
+
+        assert "provide the specialist's day rate" not in data
+
+    def test_start_page_for_user_research_participants_brief_shows_user_research_content(self, data_api_client):
+        data_api_client.get_brief.return_value = api_stubs.brief(status='live', lot_slug='user-research-participants')
+        data_api_client.find_brief_responses.return_value = {
+            'briefResponses': []
+        }
+        res = self.client.get('/suppliers/opportunities/1234/responses/start')
+        assert res.status_code == 200
+
+        data = res.get_data(as_text=True)
+
+        assert 'give the date you will be available to start work' in data
+        assert "say which skills and experience you have" in data
+        assert "give evidence for all the skills and experience you have" in data
+        assert "the work you did" in data
+
+        assert "provide the specialist's day rate" not in data
+
+
+@mock.patch("app.main.views.briefs.data_api_client")
 class TestResponseResultPage(BaseApplicationTest):
 
     def setup(self):


### PR DESCRIPTION
For [this pivotal story](https://www.pivotaltracker.com/story/show/130018567)

- Adds the start page for applying to a brief response. Content is specific to the lot.
- For the moment, redirects to a temporary holder route but will in future go to the new flow for applying to a brief

- If no brief response exists, then the button says 'Start application' and clicking it will create a new draft brief response
![image](https://cloud.githubusercontent.com/assets/7228605/20141948/a3c32974-a68a-11e6-8c32-f1a2d00d4276.png)

- If a draft brief response exists, then the button says 'Continue application'. When we create the new flow (as part of [this pivotal story](https://www.pivotaltracker.com/story/show/129843611)) this button will need to link to their existing brief response application.
![image](https://cloud.githubusercontent.com/assets/7228605/20141953/acda4984-a68a-11e6-8f2c-a4fca83a6648.png)

- If a brief response already exists then they are redirected to their already submitted brief response.

Will need rebasing after the [content loader filtering pull request](https://github.com/alphagov/digitalmarketplace-supplier-frontend/pull/546) has been merged