### PR TITLE
Fix HTML descriptions in supplier registration forms

### DIFF
--- a/app/templates/suppliers/companies_house_number.html
+++ b/app/templates/suppliers/companies_house_number.html
@@ -38,7 +38,7 @@
             question_advice =
             'This is a unique 8-character number given to your organisation by Companies House.
             \n\n<a href="https://beta.companieshouse.gov.uk/">Visit Companies House to get your number</a>
-            '
+            ' | safe
         %}
         {% include "toolkit/forms/textbox.html" %}
         {% endwith %}

--- a/app/templates/suppliers/company_name.html
+++ b/app/templates/suppliers/company_name.html
@@ -35,7 +35,7 @@
             value = form.company_name.data,
             error = form.company_name.errors[0],
             question_advice =
-            'This is how buyers will see your company’s name on the Digital&nbsp;Marketplace.'
+            'This is how buyers will see your company’s name on the Digital&nbsp;Marketplace.' | safe
         %}
         {% include "toolkit/forms/textbox.html" %}
 

--- a/app/templates/suppliers/duns_number.html
+++ b/app/templates/suppliers/duns_number.html
@@ -49,7 +49,7 @@
               question_advice =
               'The Digital Marketplace uses your head office’s 9&#8209;digit DUNS number to see if you’re already a supplier on the G&#8209;Cloud framework.
               \n\n<a href="http://www.dnb.co.uk/dandb-duns-number" rel="external">Find out how to get a DUNS number</a>
-              '
+              ' | safe
           %}
             {% include "toolkit/forms/textbox.html" %}
           {% endwith %}


### PR DESCRIPTION
Supplier registration questions are manually using toolkit form templates, so they were affected by the removal of safe filters from the toolkit.