### PR TITLE
Add safe tag to "ask a brief question" description

### DIFF
--- a/app/templates/briefs/clarification_question.html
+++ b/app/templates/briefs/clarification_question.html
@@ -81,7 +81,7 @@
            \n\nAll questions and answers will be posted on the Digital Marketplace. Your company name won’t be visible.
            \n\nYou shouldn’t include any confidential information in your question.
            \n\nRead more about <a href="https://www.gov.uk/guidance/how-to-answer-supplier-questions-about-your-digital-outcomes-and-specialists-requirements">how supplier questions are managed</a>.
-          '.format(brief.clarificationQuestionsPublishedBy|dateformat)
+          '.format(brief.clarificationQuestionsPublishedBy|dateformat)|safe
         %}
           {% include "toolkit/forms/textbox.html" %}
         {% endwith %}


### PR DESCRIPTION
This was rendering with the verbatim html tags ever since the `markdown` filter was removed from the toolkit testbox template.

Works now though.

***

### Fixes this: 

![image](https://cloud.githubusercontent.com/assets/2454380/20215360/8edde9ae-a80b-11e6-9fdf-fe82b483415e.png)
