### PR TITLE
New supplier flow for responding to briefs

### DIFF
--- a/app/main/__init__.py
+++ b/app/main/__init__.py
@@ -16,6 +16,7 @@ content_loader.load_manifest('digital-outcomes-and-specialists', 'declaration', 
 content_loader.load_manifest('digital-outcomes-and-specialists', 'services', 'edit_submission')
 content_loader.load_manifest('digital-outcomes-and-specialists', 'briefs', 'edit_brief')
 content_loader.load_manifest('digital-outcomes-and-specialists', 'brief-responses', 'edit_brief_response')
+content_loader.load_manifest('digital-outcomes-and-specialists', 'brief-responses', 'new_edit_brief_response')
 content_loader.load_manifest('digital-outcomes-and-specialists', 'brief-responses', 'display_brief_response')
 content_loader.load_messages('digital-outcomes-and-specialists', ['dates', 'urls'])
 

--- a/app/main/views/briefs.py
+++ b/app/main/views/briefs.py
@@ -92,7 +92,7 @@ def start_brief_response(brief_id):
             current_user.email_address,
         )['briefResponses']
         brief_response_id = brief_response['id']
-        return redirect(url_for('.edit_brief_response', brief_response_id=brief_response_id))
+        return redirect(url_for('.edit_brief_response', brief_id=brief_id, brief_response_id=brief_response_id))
 
     brief_response = data_api_client.find_brief_responses(
         brief_id=brief_id,
@@ -105,7 +105,7 @@ def start_brief_response(brief_id):
             flash('already_applied', 'error')
             return redirect(url_for(".view_response_result", brief_id=brief_id))
         if brief_response[0].get('status') == 'draft':
-            existing_draft_response = True
+            existing_draft_response = brief_response[0]
     else:
         existing_draft_response = False
 

--- a/app/templates/briefs/edit_brief_response.html
+++ b/app/templates/briefs/edit_brief_response.html
@@ -1,0 +1,37 @@
+{% extends "services/_base_edit_section_page.html" %}
+
+{% block breadcrumb %}
+
+  {%
+    with items = [
+      {
+        "link": "/",
+        "label": "Digital Marketplace"
+      },
+      {
+        "link": "/{}/opportunities".format(brief.frameworkSlug),
+        "label": "Supplier opportunities"
+      },
+      {
+        "link": "/{}/opportunities/{}".format(brief.frameworkSlug, brief.id),
+        "label": brief.title
+      },
+    ]
+  %}
+    {% include "toolkit/breadcrumb.html" %}
+  {% endwith %}
+{% endblock %}
+
+{% block save_button %}
+
+  {%
+    with
+    label="Continue" if not is_last_page else "Submit application",
+    type="save",
+    name = "what goes here?"
+  %}
+    {% include "toolkit/button.html" %}
+  {% endwith %}
+
+{% endblock %}
+{% block return_to_service_link %}{% endblock %}

--- a/app/templates/briefs/start_brief_response.html
+++ b/app/templates/briefs/start_brief_response.html
@@ -52,16 +52,32 @@
       <p>You should only provide one example for each essential or nice-to-have criteria (unless the buyer specifies otherwise).</p>
       <p>You can reuse examples across different essential or nice-to-have criteria if you need to.</p>
 
-      <form action="{{ url_for('.start_brief_response', brief_id=brief['id']) }}" method="post">
-        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
-          {%
-            with
-            type = "save",
-            label = "Continue application" if existing_draft_response else "Start application"
-          %}
-            {% include "toolkit/button.html" %}
-          {% endwith %}
-      </form>
+      {% if not existing_draft_response %}
+        <form action="{{ url_for('.start_brief_response', brief_id=brief['id']) }}" method="post">
+          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+            {%
+              with
+              type = "save",
+              label = "Start application"
+            %}
+              {% include "toolkit/button.html" %}
+            {% endwith %}
+        </form>
+      {% endif %}
     </div>
   </div>
+
+  {% if existing_draft_response %}
+    <div class="grid-row">
+      <div class="column-one-third">
+        {%
+          with
+          url = url_for('.edit_brief_response', brief_id=brief['id'], brief_response_id=existing_draft_response.id),
+          label = "Continue application"
+        %}
+          {% include "toolkit/link-button.html" %}
+        {% endwith %}
+      </div>
+    </div>
+  {% endif %}
 {% endblock %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,6 @@ python-dateutil==2.4.2
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@21.11.0#egg=digitalmarketplace-utils==21.11.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@2.0.1#egg=digitalmarketplace-content-loader==2.0.1
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@7.9.0#egg=digitalmarketplace-apiclient==7.9.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@7.10.0#egg=digitalmarketplace-apiclient==7.10.0
 
 markdown==2.6.2

--- a/tests/app/helpers.py
+++ b/tests/app/helpers.py
@@ -287,6 +287,26 @@ class BaseApplicationTest(object):
             }
         }
 
+    @staticmethod
+    def brief_response(
+            id=5,
+            brief_id=1234,
+            supplier_id=1234,
+            data=None
+    ):
+        result = {
+            "briefResponses": {
+                "id": id,
+                "briefId": brief_id,
+                "supplierId": supplier_id
+            }
+        }
+
+        if data:
+            result['briefResponses'].update(data)
+
+        return result
+
     def teardown_login(self):
         if self.get_user_patch is not None:
             self.get_user_patch.stop()

--- a/tests/app/main/test_briefs.py
+++ b/tests/app/main/test_briefs.py
@@ -329,11 +329,245 @@ class TestSubmitClarificationQuestions(BaseApplicationTest):
         assert "must be no more than 100 words" in res.get_data(as_text=True)
 
 
-@mock.patch("app.main.views.briefs.data_api_client")
-class TestRespondToBrief(BaseApplicationTest):
+class TestApplyToBrief(BaseApplicationTest):
+    """Tests requests for the new multipage flow for applying for a brief"""
 
     def setup(self):
-        super(TestRespondToBrief, self).setup()
+        super(TestApplyToBrief, self).setup()
+
+        self.brief = api_stubs.brief(status='live', lot_slug='digital-specialists')
+        self.brief['briefs']['essentialRequirements'] = ['Essential one', 'Essential two', 'Essential three']
+        self.brief['briefs']['niceToHaveRequirements'] = ['Nice one', 'Top one', 'Get sorted']
+
+        lots = [api_stubs.lot(slug="digital-specialists", allows_brief=True)]
+        self.framework = api_stubs.framework(
+            status="live", slug="digital-outcomes-and-specialists", clarification_questions_open=False, lots=lots
+        )
+
+        self.data_api_client_patch = mock.patch('app.main.views.briefs.data_api_client')
+        self.data_api_client = self.data_api_client_patch.start()
+        self.data_api_client.get_brief.return_value = self.brief
+        self.data_api_client.get_framework.return_value = self.framework
+        self.data_api_client.get_brief_response.return_value = self.brief_response()
+
+        with self.app.test_client():
+            self.login()
+
+    def teardown(self):
+        super(TestApplyToBrief, self).teardown()
+        self.data_api_client_patch.stop()
+
+    @mock.patch("app.main.views.briefs.content_loader")
+    def test_will_redirect_from_generic_brief_response_url_to_first_section(self, content_loader):
+        content_loader.get_manifest.return_value.filter.return_value.get_next_editable_section_id.return_value = 'first'
+
+        res = self.client.get('/suppliers/opportunities/1234/responses/5')
+        assert res.status_code == 302
+        assert res.location == 'http://localhost/suppliers/opportunities/1234/responses/5/first'
+
+    def test_404_if_brief_response_does_not_exist(self):
+        for method in ('get', 'post'):
+
+            self.data_api_client.get_brief_response = mock.MagicMock(side_effect=HTTPError(mock.Mock(status_code=404)))
+
+            res = self.client.open('/suppliers/opportunities/1234/responses/250/section-name', method=method)
+
+            assert res.status_code == 404
+            self.data_api_client.get_brief_response.assert_called_once_with(250)
+
+    def test_404_if_brief_response_does_not_relate_to_brief(self):
+        for method in ('get', 'post'):
+            self.data_api_client.get_brief_response.return_value = {
+                "briefResponses": {
+                    "briefId": 234,
+                    "supplierId": 1234
+                }
+            }
+
+            res = self.client.open('/suppliers/opportunities/1234/responses/5/section-name', method=method)
+            assert res.status_code == 404
+
+    @mock.patch("app.main.views.briefs.current_user")
+    def test_404_if_brief_response_does_not_relate_to_current_user(self, current_user):
+        for method in ('get', 'post'):
+            current_user.supplier_id = 789
+
+            res = self.client.open('/suppliers/opportunities/1234/responses/5/section-name', method=method)
+            assert res.status_code == 404
+
+    def test_404_for_not_live_brief(self):
+        for method in ('get', 'post'):
+            self.data_api_client.get_brief.return_value = api_stubs.brief(
+                status='closed', lot_slug='digital-specialists'
+            )
+
+            res = self.client.open('/suppliers/opportunities/1234/responses/5/section-name', method=method)
+            assert res.status_code == 404
+
+    def test_404_for_not_live_framework(self):
+        for method in ('get', 'post'):
+            self.data_api_client.get_framework.return_value = api_stubs.framework(
+                status="expired", slug="digital-outcomes-and-specialists", clarification_questions_open=False
+            )
+
+            res = self.client.open('/suppliers/opportunities/1234/responses/5/section-name', method=method)
+            assert res.status_code == 404
+
+    @mock.patch("app.main.views.briefs.is_supplier_eligible_for_brief")
+    def test_show_not_eligible_page_if_supplier_not_eligible_to_apply_for_brief(self, is_supplier_eligible_for_brief):
+        for method in ('get', 'post'):
+            is_supplier_eligible_for_brief.return_value = False
+
+            res = self.client.open('/suppliers/opportunities/1234/responses/5/section-name', method=method)
+            assert res.status_code == 400
+
+            doc = html.fromstring(res.get_data(as_text=True))
+            assert doc.xpath('//title')[0].text == 'Not eligible for opportunity – Digital Marketplace'
+
+    @mock.patch("app.main.views.briefs.supplier_has_a_brief_response")
+    def test_redirect_to_show_brief_response_if_already_applied_for_brief(self, supplier_has_a_brief_response):
+        for method in ('get', 'post'):
+            supplier_has_a_brief_response.return_value = True
+
+            res = self.client.open('/suppliers/opportunities/1234/responses/5/section-name', method=method)
+            assert res.status_code == 302
+            assert res.location == 'http://localhost/suppliers/opportunities/1234/responses/result'
+            self.assert_flashes("already_applied", "error")
+
+    @mock.patch("app.main.views.briefs.content_loader")
+    def test_should_404_for_non_existent_content_section(self, content_loader):
+        for method in ('get', 'post'):
+            content_loader.get_manifest.return_value.filter.return_value.get_section.return_value = None
+
+            res = self.client.open('/suppliers/opportunities/1234/responses/5/section-name', method=method)
+            assert res.status_code == 404
+
+    @mock.patch("app.main.views.briefs.content_loader")
+    def test_should_404_for_non_editable_content_section(self, content_loader):
+        for method in ('get', 'post'):
+            content_loader.get_manifest.return_value.filter.return_value.get_section.return_value.editable = False
+
+            res = self.client.open('/suppliers/opportunities/1234/responses/5/section-name', method=method)
+            assert res.status_code == 404
+
+    @mock.patch("app.main.views.briefs.content_loader")
+    def test_non_final_editable_section_shows_continue_button(self, content_loader):
+        content_loader.get_manifest.return_value.filter.return_value.sections = [
+            {'id': 'section-one'},
+            {'id': 'section-two'},
+            {'id': 'section-three'}
+        ]
+
+        res = self.client.get('/suppliers/opportunities/1234/responses/5/section-two')
+        assert res.status_code == 200
+
+        doc = html.fromstring(res.get_data(as_text=True))
+        assert doc.xpath("//input[@class='button-save']/@value")[0] == 'Continue'
+
+    @mock.patch("app.main.views.briefs.content_loader")
+    def test_final_editable_section_shows_submit_application_button(self, content_loader):
+        content_loader.get_manifest.return_value.filter.return_value.sections = [
+            {'id': 'section-one'},
+            {'id': 'section-two'},
+            {'id': 'section-three'}
+        ]
+
+        res = self.client.get('/suppliers/opportunities/1234/responses/5/section-three')
+        assert res.status_code == 200
+
+        doc = html.fromstring(res.get_data(as_text=True))
+        assert doc.xpath("//input[@class='button-save']/@value")[0] == 'Submit application'
+
+    def test_content_from_manifest_is_shown(self):
+        res = self.client.get('/suppliers/opportunities/1234/responses/5/respond-to-email-address')
+        assert res.status_code == 200
+
+        doc = html.fromstring(res.get_data(as_text=True))
+        assert doc.xpath("//h1/text()")[0].strip() == 'Respond to email address'
+        assert (doc.xpath("//span[@class=\"question-heading-with-hint\"]/text()")[0].strip() ==
+                'Email address the buyer should use to contact you')
+        assert (doc.xpath("//span[@class=\"hint\"]/text()")[0].strip() ==
+                'All communication about your application will be sent to this address.')
+
+    def test_existing_brief_response_data_is_prefilled(self):
+        self.data_api_client.get_brief_response.return_value = self.brief_response(
+            data={'respondToEmailAddress': 'test@example.com'}
+        )
+
+        res = self.client.get('/suppliers/opportunities/1234/responses/5/respond-to-email-address')
+        assert res.status_code == 200
+
+        doc = html.fromstring(res.get_data(as_text=True))
+        assert doc.xpath("//input[@type='text']/@value")[0] == 'test@example.com'
+
+    def test_error_message_shown_if_invalid_input(self):
+        self.data_api_client.update_brief_response.side_effect = HTTPError(
+            mock.Mock(status_code=400),
+            {'respondToEmailAddress': 'answer_required'}
+        )
+
+        res = self.client.post(
+            '/suppliers/opportunities/1234/responses/5/respond-to-email-address',
+            data={
+                "respondToEmailAddress": ""
+            }
+        )
+
+        assert res.status_code == 400
+        doc = html.fromstring(res.get_data(as_text=True))
+        assert (doc.xpath("//h1[@class=\"validation-masthead-heading\"]/text()")[0].strip() ==
+                'There was a problem with your answer to:')
+        assert (doc.xpath("//a[@class=\"validation-masthead-link\"]/text()")[0].strip() ==
+                'Email address')
+        assert (doc.xpath("//span[@class=\"validation-message\"]/text()")[0].strip() ==
+                'You need to answer this question.')
+
+    def test_post_form_updates_api_and_redirects_to_next_section(self):
+        data = {'dayRate': '500'}
+        res = self.client.post(
+            '/suppliers/opportunities/1234/responses/5/day-rate',
+            data=data
+        )
+        assert res.status_code == 302
+
+        self.data_api_client.update_brief_response.assert_called_once_with(
+            5,
+            data,
+            'email@email.com',
+            page_questions=['dayRate']
+        )
+
+        assert res.location == 'http://localhost/suppliers/opportunities/1234/responses/5/essential-requirements'
+
+    def test_post_final_section_submits_response_redirects_to_results(self):
+        data = {'respondToEmailAddress': 'bob@example.com'}
+        res = self.client.post(
+            '/suppliers/opportunities/1234/responses/5/respond-to-email-address',
+            data=data
+        )
+        assert res.status_code == 302
+
+        self.data_api_client.update_brief_response.assert_called_once_with(
+            5,
+            data,
+            'email@email.com',
+            page_questions=['respondToEmailAddress']
+        )
+
+        self.data_api_client.submit_brief_response.assert_called_once_with(
+            5,
+            'email@email.com',
+        )
+
+        assert res.location == 'http://localhost/suppliers/opportunities/1234/responses/result'
+
+
+@mock.patch("app.main.views.briefs.data_api_client")
+class TestLegacyRespondToBrief(BaseApplicationTest):
+    """Tests for the old single page flow for applying for a brief which is being phased out"""
+
+    def setup(self):
+        super(TestLegacyRespondToBrief, self).setup()
 
         self.brief = api_stubs.brief(status='live', lot_slug='digital-specialists')
         self.brief['briefs']['essentialRequirements'] = ['Essential one', 'Essential two', 'Essential three']

--- a/tests/app/main/test_briefs.py
+++ b/tests/app/main/test_briefs.py
@@ -852,6 +852,7 @@ class TestStartBriefResponseApplication(BaseApplicationTest):
 
         doc = html.fromstring(res.get_data(as_text=True))
         assert doc.xpath('//h1')[0].text.strip() == "Apply for ‘I need a thing to do a thing’"
+        assert doc.xpath("//input[@class='button-save']/@value")[0] == 'Start application'
 
     def test_start_page_is_viewable_and_has_start_button_if_no_existing_brief_response(
         self, data_api_client
@@ -865,7 +866,7 @@ class TestStartBriefResponseApplication(BaseApplicationTest):
         doc = html.fromstring(res.get_data(as_text=True))
         assert doc.xpath("//input[@class='button-save']/@value")[0] == 'Start application'
 
-    def test_start_page_is_viewable_and_has_continue_button_if_draft_brief_response_exists(
+    def test_start_page_is_viewable_and_has_continue_link_if_draft_brief_response_exists(
         self, data_api_client
     ):
         data_api_client.get_brief.return_value = api_stubs.brief(status='live', lot_slug='digital-specialists')
@@ -880,7 +881,8 @@ class TestStartBriefResponseApplication(BaseApplicationTest):
         res = self.client.get('/suppliers/opportunities/1234/responses/start')
 
         doc = html.fromstring(res.get_data(as_text=True))
-        assert doc.xpath("//input[@class='button-save']/@value")[0] == 'Continue application'
+        assert doc.xpath("//a[@class='link-button']/text()")[0] == 'Continue application'
+        assert doc.xpath("//a[@class='link-button']/@href")[0] == '/suppliers/opportunities/1234/responses/2'
 
     def test_will_show_not_eligible_response_if_supplier_has_already_submitted_application(self, data_api_client):
         data_api_client.get_brief.return_value = api_stubs.brief(status='live', lot_slug='digital-specialists')
@@ -991,7 +993,7 @@ class TestPostStartBriefResponseApplication(BaseApplicationTest):
         res = self.client.post('/suppliers/opportunities/1234/responses/start')
         data_api_client.create_brief_response.assert_called_once_with(1234, 1234, {}, "email@email.com")
         assert res.status_code == 302
-        assert res.location == 'http://localhost/suppliers/opportunities/responses/10/edit'
+        assert res.location == 'http://localhost/suppliers/opportunities/1234/responses/10'
 
     def test_post_to_start_page_is_hidden_by_feature_flag(self, data_api_client):
         self.app.config['FEATURE_FLAGS_NEW_SUPPLIER_FLOW'] = False


### PR DESCRIPTION
For this story on Pivotal: [https://www.pivotaltracker.com/story/show/129843611](https://www.pivotaltracker.com/story/show/129843611)

The new supplier flow for responding to briefs displays each question on separate pages rather than all questions on one page. This new flow is driven by a manifest in the frameworks repo.

This PR will not be ready to be merged until the new manifest and new questions are created, and the old flow manifest and questions are changed to legacy versions. This work will be happening presently.

The work here was inspired by the patterns used previously for submitting supplier declarations and editing services.

The new view is entered into via the recently created start page. The content is loaded from the manifest, and the first section pulled from it and rendered. When submitted, and for each subsequent section submitted, the form data is stored and the next section retrieved and fed back into the same view. When there are no more sections to cycle through, the view calls the submit brief response route on the apiclient to mark the response as submitted, and then redirects to view the entire response.

See below for an example of the new flow.

![download_brief_responses_ods](https://cloud.githubusercontent.com/assets/13836290/20311316/368a607c-ab47-11e6-9cde-d6c7b939ff6e.gif)
