### PR TITLE
Use renamed brief response manifest

### DIFF
--- a/app/main/__init__.py
+++ b/app/main/__init__.py
@@ -15,7 +15,7 @@ content_loader.load_messages('g-cloud-7', ['dates', 'urls'])
 content_loader.load_manifest('digital-outcomes-and-specialists', 'declaration', 'declaration')
 content_loader.load_manifest('digital-outcomes-and-specialists', 'services', 'edit_submission')
 content_loader.load_manifest('digital-outcomes-and-specialists', 'briefs', 'edit_brief')
-content_loader.load_manifest('digital-outcomes-and-specialists', 'brief-responses', 'edit_brief_response')
+content_loader.load_manifest('digital-outcomes-and-specialists', 'brief-responses', 'legacy_edit_brief_response')
 content_loader.load_manifest('digital-outcomes-and-specialists', 'brief-responses', 'display_brief_response')
 content_loader.load_messages('digital-outcomes-and-specialists', ['dates', 'urls'])
 

--- a/app/main/views/briefs.py
+++ b/app/main/views/briefs.py
@@ -138,7 +138,7 @@ def brief_response(brief_id):
     framework, lot = get_framework_and_lot(
         data_api_client, brief['frameworkSlug'], brief['lotSlug'], allowed_statuses=['live'])
 
-    content = content_loader.get_manifest(framework['slug'], 'edit_brief_response').filter({'lot': lot['slug']})
+    content = content_loader.get_manifest(framework['slug'], 'legacy_edit_brief_response').filter({'lot': lot['slug']})
     section = content.get_section(content.get_next_editable_section_id())
 
     # replace generic 'Apply for opportunity' title with title including the name of the brief
@@ -172,7 +172,7 @@ def create_brief_response(brief_id):
     framework, lot = get_framework_and_lot(
         data_api_client, brief['frameworkSlug'], brief['lotSlug'], allowed_statuses=['live'])
 
-    content = content_loader.get_manifest(framework['slug'], 'edit_brief_response').filter({'lot': lot['slug']})
+    content = content_loader.get_manifest(framework['slug'], 'legacy_edit_brief_response').filter({'lot': lot['slug']})
     section = content.get_section(content.get_next_editable_section_id())
     response_data = section.get_data(request.form)
 

--- a/bower.json
+++ b/bower.json
@@ -7,6 +7,6 @@
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
     "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v19.0.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.17.3/jinja_govuk_template-0.17.3.tgz",
-    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#v4.0.2"
+    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#v5.0.0"
   }
 }


### PR DESCRIPTION
Brings in the renamed brief response manifests from https://github.com/alphagov/digitalmarketplace-frameworks/pull/330.

Tests will fail until https://github.com/alphagov/digitalmarketplace-frameworks/pull/330 is merged.