### PR TITLE
Update utils version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ Flask-WTF==0.12
 werkzeug==0.10.4
 python-dateutil==2.4.2
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@21.11.0#egg=digitalmarketplace-utils==21.11.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@22.0.0#egg=digitalmarketplace-utils==22.0.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@2.0.1#egg=digitalmarketplace-content-loader==2.0.1
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@7.9.0#egg=digitalmarketplace-apiclient==7.9.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,3 @@ git+https://github.com/alphagov/digitalmarketplace-utils.git@22.0.0#egg=digitalm
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@2.0.1#egg=digitalmarketplace-content-loader==2.0.1
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@7.9.0#egg=digitalmarketplace-apiclient==7.9.0
 
-markdown==2.6.2


### PR DESCRIPTION
This is technically a breaking change because it removes the `|markdown` filter from jinja, which means we can't use it in our templates in this app anymore.

Fortunately, we've removed all uses of `|markdown` in this app, so there aren't any changes needed.