### PR TITLE
Always show legal docs

### DIFF
--- a/app/templates/frameworks/_framework_actions.html
+++ b/app/templates/frameworks/_framework_actions.html
@@ -1,5 +1,5 @@
 {% if framework.status in ['standstill', 'live'] and application_made and not countersigned_agreement_file %}
-  {% if not framework.frameworkAgreementVersion %}
+  {% if not (framework.frameworkAgreementVersion and supplier_is_on_framework) %}
   <li class="browse-list-item">
     <a class="browse-list-item-link" href="{{ url_for('.download_agreement_file', framework_slug=framework.slug, document_name='result-letter.pdf') }}" download>
       <span>Download your application {% if supplier_is_on_framework %}award{% else %}result{% endif %} letter (.pdf)</span>

--- a/app/templates/frameworks/_guidance_links.html
+++ b/app/templates/frameworks/_guidance_links.html
@@ -21,7 +21,13 @@
       </a>
     </p>
   </div>
-{% if framework.status not in ['standstill', 'live'] and not supplier_framework.agreementReturned %}
+{#
+  For framework states prior to 'pending' 'supplier_is_on_framework' will be false for everyone so links will be shown.
+  Passes and fails are set some time during 'pending' but we want to continue to show the links to *all* suppliers
+  up until the start of standstill.
+  After that they are hidden from successful suppliers and replaced by '_agreement_returned_legal.html' content.
+#}
+{% if framework.status == 'pending' or not supplier_is_on_framework %}
   <div>
     <h2 class="heading-xmedium">Legal documents</h2>
 


### PR DESCRIPTION
Fixes this bug: https://www.pivotaltracker.com/story/show/134350957

(I also picked up another issue that the "result letter" link wasn't appearing for FAILed G-Cloud 8 suppliers.  All failed suppliers get a letter, even on the "new" style frameworks.)