### PR TITLE
Supplier frontend on PaaS

### DIFF
--- a/.cfignore
+++ b/.cfignore
@@ -1,0 +1,5 @@
+node_modules/
+bower_components/
+
+*.pyc
+venv/

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,5 @@ git+https://github.com/alphagov/digitalmarketplace-utils.git@22.0.0#egg=digitalm
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@2.0.1#egg=digitalmarketplace-content-loader==2.0.1
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@7.9.0#egg=digitalmarketplace-apiclient==7.9.0
 
+# For Cloud Foundry
+gunicorn==19.4.5


### PR DESCRIPTION
### Add gunicorn to the requirements.txt

We're running gunicorn when deploying apps to PaaS, so it has to be listed in the requirements file.

### Add .cfignore file for PaaS
Lists folders ignored by `cf push`. Significantly speeds up PaaS deployments. Contents copied from the buyer frontend.