### PR TITLE
[#134680667] mark assurance hint as safe

### DIFF
--- a/app/templates/macros/assurance.html
+++ b/app/templates/macros/assurance.html
@@ -90,7 +90,7 @@
       question_content = {
         'question': 'You may have to provide evidence to back up your answer. Please confirm whether your response is assured by:',
         'id': name + '--assurance',
-        'hint': 'Read more about <a href="https://www.gov.uk/government/publications/implementing-the-cloud-security-principles/implementing-the-cloud-security-principles#common-approaches-to-implementing-cloud-security-principles">how you can assure your responses</a>.',
+        'hint': 'Read more about <a href="https://www.gov.uk/government/publications/implementing-the-cloud-security-principles/implementing-the-cloud-security-principles#common-approaches-to-implementing-cloud-security-principles">how you can assure your responses</a>.'|safe,
         'hint_underneath': 'True',
         'options': assurance_options[type]
       },


### PR DESCRIPTION
Missing "safe" filter on template string fixed for [#134680667].