### PR TITLE
[#131267691]supplier declaration question css: don't out-dent question numbers in non-wide mode

### DIFF
--- a/app/assets/scss/_supplier-declaration.scss
+++ b/app/assets/scss/_supplier-declaration.scss
@@ -48,16 +48,6 @@
 
   }
 
-  .validation-wrapper {
-
-    overflow: visible;
-
-    .question-number {
-      margin-left: -20px;
-    }
-
-  }
-
 }
 
 .section-description {


### PR DESCRIPTION
Because it causes overlap of validation side borders.

Story https://www.pivotaltracker.com/story/show/131267691