### PR TITLE
[#133024283]frontend toolkit: bump dependency to version 19.2.1 to fix service summary table action link padding

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "jquery": "1.11.2",
     "hogan": "3.0.2",
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
-    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v19.2.0",
+    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v19.2.1",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.17.3/jinja_govuk_template-0.17.3.tgz",
     "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#5.1.0"
   }


### PR DESCRIPTION
Story https://www.pivotaltracker.com/story/show/133024283

Before:
![20161128_services_table_missing_padding](https://cloud.githubusercontent.com/assets/807447/20674748/ed3af036-b581-11e6-93f2-912c6f7a3dd1.png)

After:
![20161128_services_table_with_padding](https://cloud.githubusercontent.com/assets/807447/20674749/ed432800-b581-11e6-8805-8742697b84dd.png)

