### PR TITLE
encrypt email tokens

### DIFF
--- a/app/main/views/login.py
+++ b/app/main/views/login.py
@@ -19,7 +19,7 @@ from ... import data_api_client
 def create_user(encoded_token):
     form = CreateUserForm()
 
-    token = decode_invitation_token(encoded_token, role='supplier')
+    token = decode_invitation_token(encoded_token)
 
     if token is None:
         current_app.logger.warning(
@@ -29,7 +29,7 @@ def create_user(encoded_token):
             "auth/create_user_error.html",
             token=None), 400
 
-    user_json = data_api_client.get_user(email_address=token.get("email_address"))
+    user_json = data_api_client.get_user(email_address=token["email_address"])
 
     if not user_json:
         return render_template(
@@ -50,7 +50,7 @@ def create_user(encoded_token):
 def submit_create_user(encoded_token):
     form = CreateUserForm()
 
-    token = decode_invitation_token(encoded_token, role='supplier')
+    token = decode_invitation_token(encoded_token)
     if token is None:
         current_app.logger.warning("createuser.token_invalid: {encoded_token}",
                                    extra={'encoded_token': encoded_token})
@@ -67,16 +67,16 @@ def submit_create_user(encoded_token):
                 "auth/create_user.html",
                 form=form,
                 token=encoded_token,
-                email_address=token.get('email_address'),
-                supplier_name=token.get('supplier_name')), 400
+                email_address=token['email_address'],
+                supplier_name=token['supplier_name']), 400
 
         try:
             user = data_api_client.create_user({
                 'name': form.name.data,
                 'password': form.password.data,
-                'emailAddress': token.get('email_address'),
+                'emailAddress': token['email_address'],
                 'role': 'supplier',
-                'supplierId': token.get('supplier_id')
+                'supplierId': token['supplier_id']
             })
 
             user = User.from_json(user)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ Flask-WTF==0.12
 werkzeug==0.10.4
 python-dateutil==2.4.2
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@22.0.0#egg=digitalmarketplace-utils==22.0.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@23.0.0#egg=digitalmarketplace-utils==23.0.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@2.0.1#egg=digitalmarketplace-content-loader==2.0.1
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@7.10.0#egg=digitalmarketplace-apiclient==7.10.0
 

--- a/tests/app/main/test_login.py
+++ b/tests/app/main/test_login.py
@@ -6,6 +6,7 @@ from dmapiclient.audit import AuditTypes
 from dmutils.email import generate_token, MandrillException
 from ..helpers import BaseApplicationTest
 import mock
+import pytest
 
 EMAIL_EMPTY_ERROR = "Email address must be provided"
 EMAIL_INVALID_ERROR = "Please enter a valid email address"
@@ -221,7 +222,7 @@ class TestCreateUser(BaseApplicationTest):
         assert res.location == 'http://localhost/suppliers/create-user'
 
     @mock.patch('app.main.views.login.data_api_client')
-    def test_should_be_an_error_for_invalid_token_contents(self, data_api_client):
+    def test_invalid_token_contents_500s(self, data_api_client):
         token = generate_token(
             {
                 'this_is_not_expected': 1234
@@ -230,12 +231,10 @@ class TestCreateUser(BaseApplicationTest):
             self.app.config['INVITE_EMAIL_SALT']
         )
 
-        res = self.client.get(
-            '/suppliers/create-user/{}'.format(token)
-        )
-        assert res.status_code == 400
-        assert data_api_client.get_user.called is False
-        assert data_api_client.get_supplier.called is False
+        with pytest.raises(KeyError):
+            self.client.get(
+                '/suppliers/create-user/{}'.format(token)
+            )
 
     def test_should_be_a_bad_request_if_token_expired(self):
         res = self.client.get(


### PR DESCRIPTION
stops personally identifiable information being committed to logs. also clean up file so we're not calling `.get` to get values out of dicts that we always need to be there. also don't pass in `role` to decode_token anymore

bump dmutils to 23.0.0 for this

- [x] https://github.com/alphagov/digitalmarketplace-utils/pull/288