### PR TITLE
framework_dashboard: heed framework.clarificationQuestionsOpen

### DIFF
--- a/app/templates/frameworks/_guidance_links.html
+++ b/app/templates/frameworks/_guidance_links.html
@@ -99,7 +99,7 @@
   <div>
     <h2 class="heading-xmedium" class="heading-xmedium">Communications</h2>
 
-    {% if framework.status == "open" %}
+    {% if framework.status == "open" and framework.clarificationQuestionsOpen %}
     <p>
       You can review and ask clarification questions about this
       framework until {{ framework_dates.clarifications_close_date }}.
@@ -109,7 +109,7 @@
     <p>
       <a href="{{ url_for('.framework_updates', framework_slug=framework.slug) }}">
         View communications and
-        {% if framework.status == "open" %}ask{% endif %}
+        {% if framework.status == "open" and framework.clarificationQuestionsOpen %}ask{% endif %}
         clarification questions
       </a>
       {% if communications_files.supplier_updates.last_modified %}


### PR DESCRIPTION
to determine whether to show prompts for clarification questions instead of just framework.state being "open".

Add a test that covers this.

Would be quite good to get this out quickly as it's currently showing misleading text on production.