### PR TITLE
Turn off new supplier flow feature flag on staging

### DIFF
--- a/config.py
+++ b/config.py
@@ -157,7 +157,6 @@ class Production(Live):
 class Staging(Production):
     FEATURE_FLAGS_CONTRACT_VARIATION = enabled_since('2016-08-22')
     FEATURE_FLAGS_EDIT_SECTIONS = enabled_since('2016-09-14')
-    FEATURE_FLAGS_NEW_SUPPLIER_FLOW = enabled_since('2016-11-09')
 
 configs = {
     'development': Development,


### PR DESCRIPTION
This is by request of Andrew so staging is the same as production and we can use it for testing the existing supplier flow.