### PR TITLE
Allow end to end flow for new brief responses

### DIFF
--- a/app/main/views/briefs.py
+++ b/app/main/views/briefs.py
@@ -86,7 +86,7 @@ def start_brief_response(brief_id):
 
     if not (datetime.strptime(current_app.config['FEATURE_FLAGS_NEW_SUPPLIER_FLOW'], "%Y-%m-%d")
             <= datetime.strptime(brief['publishedAt'], DATETIME_FORMAT)):
-        return redirect(url_for('.brief_response', brief_id=brief['id']))
+        abort(404)
 
     if not is_supplier_eligible_for_brief(data_api_client, current_user.supplier_id, brief):
         return _render_not_eligible_for_brief_error_page(brief)
@@ -233,7 +233,7 @@ def brief_response(brief_id):
 
     if (datetime.strptime(current_app.config['FEATURE_FLAGS_NEW_SUPPLIER_FLOW'], "%Y-%m-%d")
             <= datetime.strptime(brief['publishedAt'], DATETIME_FORMAT)):
-        return redirect(url_for('.start_brief_response', brief_id=brief['id']))
+        abort(404)
 
     if not is_supplier_eligible_for_brief(data_api_client, current_user.supplier_id, brief):
         return _render_not_eligible_for_brief_error_page(brief)

--- a/app/main/views/briefs.py
+++ b/app/main/views/briefs.py
@@ -10,6 +10,7 @@ from flask_login import current_user
 import flask_featureflags as feature
 
 from dmapiclient import HTTPError
+from dmutils.formats import DATETIME_FORMAT
 
 from ..helpers import login_required
 from ..helpers.briefs import (
@@ -84,7 +85,7 @@ def start_brief_response(brief_id):
     brief = get_brief(data_api_client, brief_id, allowed_statuses=['live'])
 
     if not (datetime.strptime(current_app.config['FEATURE_FLAGS_NEW_SUPPLIER_FLOW'], "%Y-%m-%d")
-            <= datetime.strptime(brief['publishedAt'][0:10], "%Y-%m-%d")):
+            <= datetime.strptime(brief['publishedAt'], DATETIME_FORMAT)):
         return redirect(url_for('.brief_response', brief_id=brief['id']))
 
     if not is_supplier_eligible_for_brief(data_api_client, current_user.supplier_id, brief):
@@ -231,7 +232,7 @@ def brief_response(brief_id):
     brief = get_brief(data_api_client, brief_id, allowed_statuses=['live'])
 
     if (datetime.strptime(current_app.config['FEATURE_FLAGS_NEW_SUPPLIER_FLOW'], "%Y-%m-%d")
-            <= datetime.strptime(brief['publishedAt'][0:10], "%Y-%m-%d")):
+            <= datetime.strptime(brief['publishedAt'], DATETIME_FORMAT)):
         return redirect(url_for('.start_brief_response', brief_id=brief['id']))
 
     if not is_supplier_eligible_for_brief(data_api_client, current_user.supplier_id, brief):

--- a/app/main/views/briefs.py
+++ b/app/main/views/briefs.py
@@ -231,7 +231,8 @@ def edit_brief_response(brief_id, brief_response_id, section_id=None):
 def brief_response(brief_id):
     brief = get_brief(data_api_client, brief_id, allowed_statuses=['live'])
 
-    if (datetime.strptime(current_app.config['FEATURE_FLAGS_NEW_SUPPLIER_FLOW'], "%Y-%m-%d")
+    if current_app.config['FEATURE_FLAGS_NEW_SUPPLIER_FLOW'] and \
+        (datetime.strptime(current_app.config['FEATURE_FLAGS_NEW_SUPPLIER_FLOW'], "%Y-%m-%d")
             <= datetime.strptime(brief['publishedAt'], DATETIME_FORMAT)):
         abort(404)
 

--- a/app/main/views/briefs.py
+++ b/app/main/views/briefs.py
@@ -322,7 +322,7 @@ def view_response_result(brief_id):
 
     if len(brief_response) == 0:
         return redirect(url_for(".brief_response", brief_id=brief_id))
-    elif all(brief_response[0]['essentialRequirements']):
+    elif brief_response[0].get('essentialRequirementsMet') or all(brief_response[0]['essentialRequirements']):
         result_state = 'submitted_ok'
     else:
         result_state = 'submitted_unsuccessful'

--- a/config.py
+++ b/config.py
@@ -147,7 +147,7 @@ class Live(Config):
 class Preview(Live):
     FEATURE_FLAGS_CONTRACT_VARIATION = enabled_since('2016-08-22')
     FEATURE_FLAGS_EDIT_SECTIONS = enabled_since('2016-09-14')
-    FEATURE_FLAGS_NEW_SUPPLIER_FLOW = enabled_since('2016-11-29')
+    FEATURE_FLAGS_NEW_SUPPLIER_FLOW = enabled_since('2017-02-01')
 
 
 class Production(Live):

--- a/config.py
+++ b/config.py
@@ -100,7 +100,7 @@ class Test(Config):
 
     FEATURE_FLAGS_EDIT_SECTIONS = enabled_since('2015-06-03')
     FEATURE_FLAGS_CONTRACT_VARIATION = enabled_since('2016-08-11')
-    FEATURE_FLAGS_NEW_SUPPLIER_FLOW = enabled_since('2016-11-09')
+    FEATURE_FLAGS_NEW_SUPPLIER_FLOW = enabled_since('2016-11-29')
 
     DM_DATA_API_AUTH_TOKEN = 'myToken'
 
@@ -118,7 +118,7 @@ class Development(Config):
     # Dates not formatted like YYYY-(0)M-(0)D will fail
     FEATURE_FLAGS_EDIT_SECTIONS = enabled_since('2015-06-03')
     FEATURE_FLAGS_CONTRACT_VARIATION = enabled_since('2016-08-11')
-    FEATURE_FLAGS_NEW_SUPPLIER_FLOW = enabled_since('2016-11-09')
+    FEATURE_FLAGS_NEW_SUPPLIER_FLOW = enabled_since('2016-11-29')
 
     DM_DATA_API_URL = "http://localhost:5000"
     DM_DATA_API_AUTH_TOKEN = "myToken"
@@ -147,7 +147,7 @@ class Live(Config):
 class Preview(Live):
     FEATURE_FLAGS_CONTRACT_VARIATION = enabled_since('2016-08-22')
     FEATURE_FLAGS_EDIT_SECTIONS = enabled_since('2016-09-14')
-    FEATURE_FLAGS_NEW_SUPPLIER_FLOW = enabled_since('2016-11-09')
+    FEATURE_FLAGS_NEW_SUPPLIER_FLOW = enabled_since('2016-11-29')
 
 
 class Production(Live):

--- a/tests/app/main/test_briefs.py
+++ b/tests/app/main/test_briefs.py
@@ -758,17 +758,13 @@ class TestLegacyRespondToBrief(BaseApplicationTest):
             assert breadcrumbs[index].find('a').text_content().strip() == link[0]
             assert breadcrumbs[index].find('a').get('href').strip() == link[1]
 
-    @mock.patch("app.main.views.briefs.is_supplier_eligible_for_brief")
-    def test_will_redirect_to_start_route_if_brief_is_not_a_legacy_brief(
-        self, is_supplier_eligible_for_brief, data_api_client
-    ):
+    def test_will_404_if_brief_is_not_a_legacy_brief(self, data_api_client):
         self.brief['briefs']['publishedAt'] = '2016-12-25T12:00:00.000000Z'
         data_api_client.get_brief.return_value = self.brief
 
         res = self.client.get('/suppliers/opportunities/1234/responses/create')
 
-        assert res.status_code == 302
-        assert res.location == 'http://localhost/suppliers/opportunities/1234/responses/start'
+        assert res.status_code == 404
 
     def test_get_brief_response_page(self, data_api_client):
         data_api_client.get_brief.return_value = self.brief
@@ -1258,17 +1254,13 @@ class TestStartBriefResponseApplication(BaseApplicationTest):
         with self.app.test_client():
             self.login()
 
-    @mock.patch("app.main.views.briefs.is_supplier_eligible_for_brief")
-    def test_will_redirect_to_create_route_if_brief_is_a_legacy_brief(
-        self, is_supplier_eligible_for_brief, data_api_client
-    ):
+    def test_will_return_404_if_brief_is_a_legacy_brief(self, data_api_client):
         self.brief['briefs']['publishedAt'] = '2016-10-25T12:00:00.000000Z'
         data_api_client.get_brief.return_value = self.brief
 
         res = self.client.get('/suppliers/opportunities/1234/responses/start')
 
-        assert res.status_code == 302
-        assert res.location == 'http://localhost/suppliers/opportunities/1234/responses/create'
+        assert res.status_code == 404
 
     @mock.patch("app.main.views.briefs.is_supplier_eligible_for_brief")
     def test_will_show_not_eligible_response_if_supplier_is_not_eligible_for_brief(

--- a/tests/app/main/test_briefs.py
+++ b/tests/app/main/test_briefs.py
@@ -780,6 +780,15 @@ class TestLegacyRespondToBrief(BaseApplicationTest):
             '//h2[contains(text(), "Do you have any of the nice-to-have skills and experience?")]')) == 1
         self._test_breadcrumbs_on_brief_response_page(res)
 
+    def test_will_not_404_if_new_supplier_flow_flag_set_to_false(self, data_api_client):
+        self.app.config['FEATURE_FLAGS_NEW_SUPPLIER_FLOW'] = False
+
+        data_api_client.get_brief.return_value = self.brief
+        data_api_client.get_framework.return_value = self.framework
+        res = self.client.get('/suppliers/opportunities/1234/responses/create')
+
+        assert res.status_code == 200
+
     def test_get_brief_response_returns_404_for_not_live_brief(self, data_api_client):
         brief = self.brief.copy()
         brief['briefs']['status'] = 'draft'
@@ -1256,6 +1265,14 @@ class TestStartBriefResponseApplication(BaseApplicationTest):
 
     def test_will_return_404_if_brief_is_a_legacy_brief(self, data_api_client):
         self.brief['briefs']['publishedAt'] = '2016-10-25T12:00:00.000000Z'
+        data_api_client.get_brief.return_value = self.brief
+
+        res = self.client.get('/suppliers/opportunities/1234/responses/start')
+
+        assert res.status_code == 404
+
+    def test_will_return_404_if_new_supplier_flow_flag_set_to_false(self, data_api_client):
+        self.app.config['FEATURE_FLAGS_NEW_SUPPLIER_FLOW'] = False
         data_api_client.get_brief.return_value = self.brief
 
         res = self.client.get('/suppliers/opportunities/1234/responses/start')

--- a/tests/app/main/test_briefs.py
+++ b/tests/app/main/test_briefs.py
@@ -731,7 +731,7 @@ class TestLegacyRespondToBrief(BaseApplicationTest):
         self.brief = api_stubs.brief(status='live', lot_slug='digital-specialists')
         self.brief['briefs']['essentialRequirements'] = ['Essential one', 'Essential two', 'Essential three']
         self.brief['briefs']['niceToHaveRequirements'] = ['Nice one', 'Top one', 'Get sorted']
-        self.brief['briefs']['publishedAt'] = '2016-10-25T12:00:00.000000Z'
+        self.brief['briefs']['publishedAt'] = '2016-10-25T12:00:00.000000Z'  # Date is before the new flow feature flag
 
         lots = [api_stubs.lot(slug="digital-specialists", allows_brief=True)]
         self.framework = api_stubs.framework(status="live", slug="digital-outcomes-and-specialists",


### PR DESCRIPTION
Part of this story on Pivotal [https://www.pivotaltracker.com/story/show/129843611](https://www.pivotaltracker.com/story/show/129843611).

This PR is a small update to the supplier frontend which allows the new style brief-responses to work end to end. Without it, new style brief responses would cause the app to fall over after submission.

There is a check made when viewing the response result that all of the `essentialRequirements` are True. The new style brief responses do not have this key, instead it they have `essentialRequirementsMet` which is just a boolean. This PR makes the app check if this new key exists and if it's True, before checking the original `essentialRequirements` key.