### PR TITLE
Fix crash if framework's "lot question" is inconsistent with lots in DB.

### DIFF
--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -181,15 +181,16 @@ def framework_submission_lots(framework_slug):
     if framework['status'] == 'pending' and not application_made:
         abort(404)
 
-    lots = [
-        dict(lot,
-             draft_count=count_drafts_by_lot(drafts, lot['slug']),
-             complete_count=count_drafts_by_lot(complete_drafts, lot['slug']))
-        for lot in framework['lots']]
     lot_question = {
         option["value"]: option
         for option in content_loader.get_question(framework_slug, 'services', 'lot')['options']
     }
+    lots = [
+        dict(lot,
+             draft_count=count_drafts_by_lot(drafts, lot['slug']),
+             complete_count=count_drafts_by_lot(complete_drafts, lot['slug']))
+        for lot in framework['lots'] if lot['slug'] in lot_question.keys()]
+
     lots = [{
         "title": lot_question[lot['slug']]['label'] if framework["status"] == "open" else lot["name"],
         'body': lot_question[lot['slug']]['description'],


### PR DESCRIPTION
Probably only causes issues when we are prototyping a new framework, but we'll definitely need to do this again in future, and obscure crashes aren't good.

Possibly a better version of this fix would assume the database to be correct, i.e. provide defaults for values (like 'lot description') that come from the framework/yaml question. Getting this committed for now so that we can support the PaaS testing ASAP.