### PR TITLE
[Proposal] Upgrade pip every time to kill the cryptography bug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,10 +16,13 @@ run_app: show_environment virtualenv
 virtualenv:
 	[ -z $$VIRTUAL_ENV ] && [ ! -d venv ] && virtualenv venv || true
 
-requirements: virtualenv requirements.txt
+upgrade_pip: virtualenv
+	${VIRTUALENV_ROOT}/bin/pip install --upgrade pip
+
+requirements: virtualenv upgrade_pip requirements.txt
 	${VIRTUALENV_ROOT}/bin/pip install -r requirements.txt
 
-requirements_for_test: virtualenv requirements_for_test.txt
+requirements_for_test: virtualenv upgrade_pip requirements_for_test.txt
 	${VIRTUALENV_ROOT}/bin/pip install -r requirements_for_test.txt
 
 npm_install: package.json


### PR DESCRIPTION
We've had a problem installing cryptography on local machines,
one solution to which is to make sure your is updated.

This pull request would add a step to the Makefile to always
upgrade pip before installing the rest of the requirements.

If we want to do this, I can port it to the other apps.

[Issue discussion on github](https://github.com/pyca/cryptography/issues/2350#issuecomment-179321979)

We could also just put something into the README, if that was a lower-overhead thing people would me more comfortable with.
