### PR TITLE
Consistent content for essential requirements

### DIFF
--- a/app/templates/briefs/start_brief_response.html
+++ b/app/templates/briefs/start_brief_response.html
@@ -37,7 +37,7 @@
 
       <h2 class="heading-xmedium">How to give evidence</h2>
       <p>The buyer will assess and score your evidence to shortlist the best {% if brief.lotSlug == 'digital-specialists' %}specialists{% else %}suppliers{% endif %}.</p>
-      <p>You’ll need to meet or exceed their essential criteria to get through to the next stage.</p>
+      <p>You’ll need to meet or exceed their essential requirements to get through to the next stage.</p>
 
       <h3 class="heading-small">Evidence structure</h3>
       <div class="explanation-list padding-bottom-small">
@@ -48,9 +48,9 @@
           <li>what the results were</li>
         </ul>
       </div>
-      <p>There’s a 100-word maximum for each essential or nice-to-have criteria.</p>
-      <p>You should only provide one example for each essential or nice-to-have criteria (unless the buyer specifies otherwise).</p>
-      <p>You can reuse examples across different essential or nice-to-have criteria if you need to.</p>
+      <p>There’s a 100-word maximum for each essential or nice-to-have requirement.</p>
+      <p>You should only provide one example for each essential or nice-to-have requirement (unless the buyer specifies otherwise).</p>
+      <p>You can reuse examples across different essential or nice-to-have requirements if you need to.</p>
 
       {% if not existing_draft_response %}
         <form action="{{ url_for('.start_brief_response', brief_id=brief['id']) }}" method="post">

--- a/bower.json
+++ b/bower.json
@@ -7,6 +7,6 @@
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
     "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v19.2.1",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.17.3/jinja_govuk_template-0.17.3.tgz",
-    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#5.1.7"
+    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#5.1.8"
   }
 }


### PR DESCRIPTION
A content tweak for the following pivotal story - https://www.pivotaltracker.com/story/show/129839965

Content changes outlined in [this google doc](https://docs.google.com/document/d/1TDZhOjV9ykfPA0tMoWbxS8oZzyGXG8B7lOF51SRRaO4/edit?ts=5852b310)

Tests will fail until the related [frameworks pull request](https://github.com/alphagov/digitalmarketplace-frameworks/pull/346) is merged.

For the start page we were using the word "criteria". We now use "requirements"
![image](https://cloud.githubusercontent.com/assets/7228605/21260626/c838c492-c37e-11e6-866b-abc6064582b3.png)

For the essential requirements met page we use "essential skills and experience" instead of "essential requirements.
![image](https://cloud.githubusercontent.com/assets/7228605/21260614/b9f55f62-c37e-11e6-88d0-66468f546688.png)


