### PR TITLE
Essential requirements evidence

### DIFF
--- a/app/main/helpers/frameworks.py
+++ b/app/main/helpers/frameworks.py
@@ -119,11 +119,13 @@ def return_supplier_framework_info_if_on_framework_or_abort(data_api_client, fra
 def question_references(data, get_question):
     if not data:
         return data
-    return re.sub(
+    references = re.sub(
         r"\[\[([^\]]+)\]\]",  # anything that looks like [[nameOfQuestion]]
         lambda question_id: str(get_question(question_id.group(1))['number']),
         data
     )
+
+    return data.__class__(references)
 
 
 def get_frameworks_by_status(frameworks, status, extra_condition=False):

--- a/app/main/views/briefs.py
+++ b/app/main/views/briefs.py
@@ -200,7 +200,7 @@ def edit_brief_response(brief_id, brief_response_id, question_id=None):
         except HTTPError as e:
             errors = question.get_error_messages(e.message)
             status_code = 400
-            brief_response.update(question.get_data(request.form))
+            brief_response.update(question.unformat_data(question.get_data(request.form)))
 
         else:
             if next_question_id:
@@ -226,7 +226,7 @@ def edit_brief_response(brief_id, brief_response_id, question_id=None):
         errors=errors,
         is_last_page=False if next_question_id else True,
         question=question,
-        service_data=brief_response,
+        service_data=question.unformat_data(brief_response),
         **dict(main.config['BASE_TEMPLATE_DATA'])
     ), status_code
 

--- a/app/main/views/briefs.py
+++ b/app/main/views/briefs.py
@@ -182,6 +182,9 @@ def edit_brief_response(brief_id, brief_response_id, question_id=None):
     if question is None:
         abort(404)
 
+    # Unformat brief response into data for form
+    service_data = question.unformat_data(brief_response)
+
     # This line can soon be removed when we no longer show boolean list questions as part of the new flow
     section.inject_brief_questions_into_boolean_list_question(brief)
 
@@ -200,7 +203,7 @@ def edit_brief_response(brief_id, brief_response_id, question_id=None):
         except HTTPError as e:
             errors = question.get_error_messages(e.message)
             status_code = 400
-            brief_response.update(question.unformat_data(question.get_data(request.form)))
+            service_data.update(question.unformat_data(question.get_data(request.form)))
 
         else:
             if next_question_id:
@@ -226,7 +229,7 @@ def edit_brief_response(brief_id, brief_response_id, question_id=None):
         errors=errors,
         is_last_page=False if next_question_id else True,
         question=question,
-        service_data=question.unformat_data(brief_response),
+        service_data=service_data,
         **dict(main.config['BASE_TEMPLATE_DATA'])
     ), status_code
 

--- a/bower.json
+++ b/bower.json
@@ -7,6 +7,6 @@
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
     "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v19.2.1",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.17.3/jinja_govuk_template-0.17.3.tgz",
-    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#5.1.9"
+    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#5.2.0"
   }
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ werkzeug==0.10.4
 python-dateutil==2.4.2
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@23.0.0#egg=digitalmarketplace-utils==23.0.0
-git+https://github.com/alphagov/digitalmarketplace-content-loader.git@2.4.0#egg=digitalmarketplace-content-loader==2.4.0
+git+https://github.com/alphagov/digitalmarketplace-content-loader.git@2.4.1#egg=digitalmarketplace-content-loader==2.4.1
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@7.10.0#egg=digitalmarketplace-apiclient==7.10.0
 
 # For Cloud Foundry

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ werkzeug==0.10.4
 python-dateutil==2.4.2
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@23.0.0#egg=digitalmarketplace-utils==23.0.0
-git+https://github.com/alphagov/digitalmarketplace-content-loader.git@2.3.0#egg=digitalmarketplace-content-loader==2.3.0
+git+https://github.com/alphagov/digitalmarketplace-content-loader.git@2.4.0#egg=digitalmarketplace-content-loader==2.4.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@7.10.0#egg=digitalmarketplace-apiclient==7.10.0
 
 # For Cloud Foundry

--- a/tests/app/main/test_briefs.py
+++ b/tests/app/main/test_briefs.py
@@ -585,12 +585,9 @@ class TestApplyToBrief(BaseApplicationTest):
         )
         assert res.status_code == 200
 
-        doc = html.fromstring(res.get_data(as_text=True))
-        buyers_max_day_rate = doc.xpath(
-            "//*[@id='input-dayRate-question-advice']/descendant::h2[1]/following::p[1]")
-        # if item is excaped correctly it will appear as text rather than an element
-        assert buyers_max_day_rate[0].find('strong') is None
-        assert buyers_max_day_rate[0].text == '**markdown**'
+        data = res.get_data(as_text=True)
+
+        assert '**markdown**' in data
 
     def test_day_rate_question_escapes_brief_day_rate_html(self):
         self.brief['briefs']['budgetRange'] = '<h1>xss</h1>'
@@ -600,12 +597,9 @@ class TestApplyToBrief(BaseApplicationTest):
         )
         assert res.status_code == 200
 
-        doc = html.fromstring(res.get_data(as_text=True))
-        buyers_max_day_rate = doc.xpath(
-            "//*[@id='input-dayRate-question-advice']/descendant::h2[1]/following::p[1]")
-        # if item is excaped correctly it will appear as text rather than an element
-        assert buyers_max_day_rate[0].find('h1') is None
-        assert buyers_max_day_rate[0].text == '<h1>xss</h1>'
+        data = res.get_data(as_text=True)
+
+        assert '&lt;h1&gt;xss&lt;/h1&gt;' in data
 
     def test_day_rate_question_does_not_replay_buyers_budget_range_if_not_provided(self):
         self.brief['briefs']['specialistRole'] = 'deliveryManager'
@@ -626,12 +620,9 @@ class TestApplyToBrief(BaseApplicationTest):
         )
         assert res.status_code == 200
 
-        doc = html.fromstring(res.get_data(as_text=True))
-        start_date = doc.xpath(
-            "//*[@id='input-availability-question-advice']")[0]
-        # if item is excaped correctly it will appear as text rather than an element
-        assert start_date.find('strong') is None
-        assert start_date.text.strip() == "The buyer needs the specialist to start by **markdown**."
+        data = res.get_data(as_text=True)
+
+        assert "The buyer needs the specialist to start by **markdown**." in data
 
     def test_start_date_question_escapes_brief_start_date_html(self):
         self.brief['briefs']['startDate'] = '<h1>xss</h1>'
@@ -641,12 +632,9 @@ class TestApplyToBrief(BaseApplicationTest):
         )
         assert res.status_code == 200
 
-        doc = html.fromstring(res.get_data(as_text=True))
-        start_date = doc.xpath(
-            "//*[@id='input-availability-question-advice']")[0]
-        # if item is excaped correctly it will appear as text rather than an element
-        assert start_date.find('h1') is None
-        assert start_date.text.strip() == "The buyer needs the specialist to start by <h1>xss</h1>."
+        data = res.get_data(as_text=True)
+
+        assert "The buyer needs the specialist to start by &lt;h1&gt;xss&lt;/h1&gt;." in data
 
     def test_essential_requirements_evidence_has_question_for_every_requirement(self):
         res = self.client.get(
@@ -656,7 +644,7 @@ class TestApplyToBrief(BaseApplicationTest):
         doc = html.fromstring(res.get_data(as_text=True))
         questions = doc.xpath(
             "//*[@class='question-heading']/text()")
-        questions = map(str.strip, questions)
+        questions = list(map(str.strip, questions))
         assert questions[0] == 'Essential one'
         assert questions[1] == 'Essential two'
         assert questions[2] == 'Essential three'
@@ -673,14 +661,10 @@ class TestApplyToBrief(BaseApplicationTest):
         )
         assert res.status_code == 200
 
-        doc = html.fromstring(res.get_data(as_text=True))
-        questions = doc.xpath(
-            "//*[@class='question-heading']")
-        # if item is excaped correctly it will appear as text rather than an element
-        assert questions[0].find("h1") is None
-        assert questions[0].text.strip() == '<h1>Essential one with xss</h1>'
-        assert questions[1].find("strong") is None
-        assert questions[1].text.strip() == '**Essential two with markdown**'
+        data = res.get_data(as_text=True)
+
+        assert '&lt;h1&gt;Essential one with xss&lt;/h1&gt;' in data
+        assert '**Essential two with markdown**' in data
 
     def test_specialist_brief_essential_requirements_evidence_shows_specialist_content(self):
         res = self.client.get(


### PR DESCRIPTION
[Pivotal story](https://www.pivotaltracker.com/story/show/129841565)

- Pulls in latest frameworks repo giving us a new page for the new `essentialRequirements` dynamic list question
- Corresponding tests for the new page
- Uses the content loader `unformat_data` to transform brief response data into form data (see nice example of unformatting [here](https://github.com/alphagov/digitalmarketplace-content-loader/blob/master/dmcontent/questions.py#L315) in the content loader)

<img width="1440" alt="screen shot 2017-01-04 at 12 26 14" src="https://cloud.githubusercontent.com/assets/13836290/21642269/0d107e76-d279-11e6-8433-d024b83b6741.png">
