### PR TITLE
Add nice to have question to new supplier flow

### DIFF
--- a/app/assets/javascripts/_selection-buttons.js
+++ b/app/assets/javascripts/_selection-buttons.js
@@ -1,4 +1,4 @@
-(function(GOVUK, GDM) {
+;(function(GOVUK, GDM) {
 
   GDM.selectionButtons = function() {
 
@@ -8,6 +8,8 @@
       'focusedClass' : 'selection-button-focused',
       'selectedClass' : 'selection-button-selected'
     });
+
+    new GOVUK.ShowHideContent().init();
 
   };
 

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -13,6 +13,7 @@
 //= include ../../../bower_components/digitalmarketplace-frontend-toolkit/toolkit/javascripts/word-counter.js
 //= include ../../../bower_components/digitalmarketplace-frontend-toolkit/toolkit/javascripts/validation.js
 //= include ../../../node_modules/govuk_frontend_toolkit/javascripts/govuk/selection-buttons.js
+//= include ../../../node_modules/govuk_frontend_toolkit/javascripts/govuk/show-hide-content.js
 //= include _selection-buttons.js
 //= include _analytics.js
 

--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -52,6 +52,7 @@ $path: "/suppliers/static/images/";
 @import "toolkit/forms/_textboxes.scss";
 @import "toolkit/forms/_upload.scss";
 @import "toolkit/forms/_validation.scss";
+@import "toolkit/forms/_combinations.scss";
 @import "toolkit/search/_search-result.scss";
 
 

--- a/app/main/views/briefs.py
+++ b/app/main/views/briefs.py
@@ -203,7 +203,7 @@ def edit_brief_response(brief_id, brief_response_id, question_id=None):
         except HTTPError as e:
             errors = question.get_error_messages(e.message)
             status_code = 400
-            service_data.update(question.unformat_data(question.get_data(request.form)))
+            service_data = question.unformat_data(question.get_data(request.form))
 
         else:
             if next_question_id:

--- a/app/main/views/briefs.py
+++ b/app/main/views/briefs.py
@@ -170,12 +170,12 @@ def edit_brief_response(brief_id, brief_response_id, question_id=None):
     # data. The question will be skipped in the brief response flow (see below). If a user attempts to access the
     # question by directly visiting the url, this check will return a 404. It has been created specifically for nice to
     # have requirements, and works because briefs and responses share the same key for this question/response.
-    if question_id in list(brief.keys()) and not brief[question_id]:
+    if question_id in brief.keys() and not brief[question_id]:
         abort(404)
 
     # If a question is to be skipped in the normal flow (due to the reason above), we update the next_question_id.
     next_question_id = section.get_next_question_id(question_id)
-    if next_question_id in list(brief.keys()) and not brief[next_question_id]:
+    if next_question_id in brief.keys() and not brief[next_question_id]:
         next_question_id = section.get_next_question_id(next_question_id)
 
     def redirect_to_next_page():

--- a/app/main/views/briefs.py
+++ b/app/main/views/briefs.py
@@ -166,10 +166,19 @@ def edit_brief_response(brief_id, brief_response_id, question_id=None):
     if section is None or not section.editable:
         abort(404)
 
-    next_question_id = section.get_next_question_id(question_id)
+    # If a question in a brief is optional and is unanswered by the buyer, the brief will have the key but will have no
+    # data. The question will be skipped in the brief response flow (see below). If a user attempts to access the
+    # question by directly visiting the url, this check will return a 404. It has been created specifically for nice to
+    # have requirements, and works because briefs and responses share the same key for this question/response.
+    if question_id in list(brief.keys()) and not brief[question_id]:
+        abort(404)
 
-    # If no question_id in url then redirect to first question
-    if question_id is None:
+    # If a question is to be skipped in the normal flow (due to the reason above), we update the next_question_id.
+    next_question_id = section.get_next_question_id(question_id)
+    if next_question_id in list(brief.keys()) and not brief[next_question_id]:
+        next_question_id = section.get_next_question_id(next_question_id)
+
+    def redirect_to_next_page():
         return redirect(url_for(
             '.edit_brief_response',
             brief_id=brief_id,
@@ -177,6 +186,10 @@ def edit_brief_response(brief_id, brief_response_id, question_id=None):
             question_id=next_question_id
             )
         )
+
+    # If no question_id in url then redirect to first question
+    if question_id is None:
+        return redirect_to_next_page()
 
     question = section.get_question(question_id)
     if question is None:
@@ -207,14 +220,7 @@ def edit_brief_response(brief_id, brief_response_id, question_id=None):
 
         else:
             if next_question_id:
-                return redirect(
-                    url_for(
-                        '.edit_brief_response',
-                        brief_id=brief_id,
-                        brief_response_id=brief_response_id,
-                        question_id=next_question_id
-                    )
-                )
+                return redirect_to_next_page()
             else:
                 data_api_client.submit_brief_response(
                     brief_response_id,

--- a/app/templates/macros/toolkit_forms.html
+++ b/app/templates/macros/toolkit_forms.html
@@ -11,6 +11,7 @@
     unit_position=question_content.unit_position,
     unit=question_content.unit,
     smaller=question_content.smaller,
+    hidden=question_content.hidden,
     error=errors.get(question_content.id)['message']|question_references(get_question)
   %}
     {% include "toolkit/forms/textbox.html" %}
@@ -28,6 +29,7 @@
     value=service_data[question_content.id],
     large=True,
     max_length_in_words=question_content.max_length_in_words,
+    hidden=question_content.hidden,
     error=errors.get(question_content.id)['message']|question_references(get_question)
   %}
     {% include "toolkit/forms/textbox.html" %}
@@ -101,6 +103,7 @@
     value=service_data[question_content.id],
     id=question_content.id,
     type='boolean',
+    followup=question_content.followup,
     error=errors.get(question_content.id)['message']|question_references(get_question),
     question_number=question_number
   %}

--- a/bower.json
+++ b/bower.json
@@ -7,6 +7,6 @@
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
     "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v19.3.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.19.2/jinja_govuk_template-0.19.2.tgz",
-    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#5.2.0"
+    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#5.5.0"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "jquery": "1.11.2",
     "hogan": "3.0.2",
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
-    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v19.2.1",
+    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v19.2.2",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.19.2/jinja_govuk_template-0.19.2.tgz",
     "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#5.2.0"
   }

--- a/bower.json
+++ b/bower.json
@@ -7,6 +7,6 @@
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
     "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v19.3.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.19.2/jinja_govuk_template-0.19.2.tgz",
-    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#5.5.0"
+    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#5.6.0"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "jquery": "1.11.2",
     "hogan": "3.0.2",
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
-    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v19.2.2",
+    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v19.3.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.19.2/jinja_govuk_template-0.19.2.tgz",
     "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#5.2.0"
   }

--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,7 @@
     "hogan": "3.0.2",
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
     "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v19.2.1",
-    "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.17.3/jinja_govuk_template-0.17.3.tgz",
+    "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.19.2/jinja_govuk_template-0.19.2.tgz",
     "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#5.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "bower": "1.5.2",
     "del": "1.1.1",
-    "govuk_frontend_toolkit": "4.12.0",
+    "govuk_frontend_toolkit": "4.18.0",
     "gulp": "3.8.7",
     "gulp-filelog": "0.4.1",
     "gulp-include": "1.1.1",

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ werkzeug==0.10.4
 python-dateutil==2.4.2
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@23.0.0#egg=digitalmarketplace-utils==23.0.0
-git+https://github.com/alphagov/digitalmarketplace-content-loader.git@2.4.2#egg=digitalmarketplace-content-loader==2.4.2
+git+https://github.com/alphagov/digitalmarketplace-content-loader.git@2.4.3#egg=digitalmarketplace-content-loader==2.4.3
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@7.10.0#egg=digitalmarketplace-apiclient==7.10.0
 
 # For Cloud Foundry

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ werkzeug==0.10.4
 python-dateutil==2.4.2
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@23.0.0#egg=digitalmarketplace-utils==23.0.0
-git+https://github.com/alphagov/digitalmarketplace-content-loader.git@2.4.1#egg=digitalmarketplace-content-loader==2.4.1
+git+https://github.com/alphagov/digitalmarketplace-content-loader.git@2.4.2#egg=digitalmarketplace-content-loader==2.4.2
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@7.10.0#egg=digitalmarketplace-apiclient==7.10.0
 
 # For Cloud Foundry

--- a/tests/app/main/test_briefs.py
+++ b/tests/app/main/test_briefs.py
@@ -815,7 +815,7 @@ class TestApplyToBrief(BaseApplicationTest):
         questions = list(map(str.strip, questions))
 
         assert questions == [
-            'Nice one', 'Nice one evidence', 'Top one', 'Top one evidence', 'Get sorted', 'Get sorted evidence'
+            'Nice one', 'Evidence of Nice one', 'Top one', 'Evidence of Top one', 'Get sorted', 'Evidence of Get sorted'
         ]
 
     def test_existing_nice_to_have_requirements_evidence_prefills_existing_data(self):
@@ -901,14 +901,14 @@ class TestApplyToBrief(BaseApplicationTest):
                 'There was a problem with your answer to:')
         masthead_errors = doc.xpath("//a[@class=\"validation-masthead-link\"]/text()")
         masthead_errors = list(map(str.strip, masthead_errors))
-        assert masthead_errors == ['Nice one', 'Top one evidence', 'Get sorted evidence']
+        assert masthead_errors == ['Nice one', 'Evidence of Top one', 'Evidence of Get sorted']
 
         # Test individual questions errors and prefilled content
         assert (doc.xpath("//span[@class=\"validation-message\"]/text()")[0].strip() ==
-                'You need to answer this question.')
+                'You must answer ‘yes’ or ‘no’ to this question.')
 
         assert (doc.xpath("//span[@class=\"validation-message\"]/text()")[1].strip() ==
-                'You need to answer this question.')
+                'You must provide evidence if you answer ‘yes’ to this question.')
         assert len(doc.xpath("//*[@id='input-yesNo-1-yes' and @checked]")) == 1
 
         assert (doc.xpath("//span[@class=\"validation-message\"]/text()")[2].strip() ==

--- a/tests/app/main/test_briefs.py
+++ b/tests/app/main/test_briefs.py
@@ -850,8 +850,8 @@ class TestApplyToBrief(BaseApplicationTest):
                 "evidence-0": 'first evidence',
                 "yesNo-1": False,
                 "evidence-1": "",
-                "yesNo-2": True,
-                "evidence-2": 'third evidence'
+                "yesNo-2": False,
+                "evidence-2": 'evidence we expect not to be sent'
             }
         )
 
@@ -863,7 +863,7 @@ class TestApplyToBrief(BaseApplicationTest):
                 "niceToHaveRequirements": [
                     {'yesNo': True, 'evidence': 'first evidence'},
                     {'yesNo': False},
-                    {'yesNo': True, 'evidence': 'third evidence'}
+                    {'yesNo': False}
                 ]
             },
             'email@email.com',

--- a/tests/app/main/test_briefs.py
+++ b/tests/app/main/test_briefs.py
@@ -804,6 +804,31 @@ class TestApplyToBrief(BaseApplicationTest):
         assert doc.xpath("//*[@id='input-evidence-1']/text()")[0] == "valid evidence"
         assert not doc.xpath("//*[@id='input-evidence-2']/text()")
 
+    def test_essential_requirements_evidence_does_not_redirect_to_nice_to_haves_if_brief_has_no_nice_to_haves(self):
+        self.brief['briefs']['niceToHaveRequirements'] = []
+        self.data_api_client.get_brief.return_value = self.brief
+
+        res = self.client.post(
+            '/suppliers/opportunities/1234/responses/5/essentialRequirements',
+            data={
+                "evidence-0": "valid evidence",
+                "evidence-1": "valid evidence",
+                "evidence-2": "valid evidence"
+            }
+        )
+
+        assert res.status_code == 302
+        assert res.location == 'http://localhost/suppliers/opportunities/1234/responses/5/respondToEmailAddress'
+
+    def test_nice_to_have_requirements_url_404s_if_no_nice_to_have_requirements(self):
+        self.brief['briefs']['niceToHaveRequirements'] = []
+        self.data_api_client.get_brief.return_value = self.brief
+
+        res = self.client.get(
+            '/suppliers/opportunities/1234/responses/5/niceToHaveRequirements'
+        )
+        assert res.status_code == 404
+
     def test_nice_to_have_requirements_evidence_has_question_for_every_requirement(self):
         res = self.client.get(
             '/suppliers/opportunities/1234/responses/5/niceToHaveRequirements'


### PR DESCRIPTION
Part of this story on Pivotal [https://www.pivotaltracker.com/story/show/129841633](https://www.pivotaltracker.com/story/show/129841633).

This PR updates the supplier frontend to deal with the new nice-to-have-requirements question

The nice-to-have-requirements question uses the progressive disclosure pattern to collect the suppliers evidence. This requires an updated version of the govuk frontend toolkit.

The new version of the content loader fixes a bug with the unpacking of brief_response data for dynamic lists questions.

Finally, a small update to the `update_brief_response` view to only replay the form data from a POST request if the request fails validation. Previously the form date was being merged with the service data already pulled from the api, and this was causing issues with data being displayed when it shouldn't have been.

Also tests.