### PR TITLE
Don't call filter() unnecessarily

### DIFF
--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -265,7 +265,7 @@ def framework_submission_services(framework_slug, lot_slug):
 def framework_supplier_declaration(framework_slug, section_id=None):
     framework = get_framework(data_api_client, framework_slug, allowed_statuses=['open'])
 
-    content = content_loader.get_manifest(framework_slug, 'declaration').filter({})
+    content = content_loader.get_manifest(framework_slug, 'declaration')
     status_code = 200
 
     if section_id is None:


### PR DESCRIPTION
Supplier declarations don't have any `depends` dependencies in content, so the call to filter here doesn't achieve anything.