### PR TITLE
[#136029251]service editing: add "service updated" flash message & tests

### DIFF
--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -167,6 +167,8 @@ def update_section(service_id, section_id):
             errors=errors
         )
 
+    flash(u"You\u2019ve edited your service. The changes are now live on the Digital Marketplace.", 'message')
+
     return redirect(url_for(".edit_service", service_id=service_id))
 
 

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -167,7 +167,7 @@ def update_section(service_id, section_id):
             errors=errors
         )
 
-    flash(u"You\u2019ve edited your service. The changes are now live on the Digital Marketplace.", 'message')
+    flash({"service_name": posted_data.get("serviceName") or service.get("serviceName")}, 'service_updated')
 
     return redirect(url_for(".edit_service", service_id=service_id))
 

--- a/app/templates/services/_base_service_page.html
+++ b/app/templates/services/_base_service_page.html
@@ -20,6 +20,8 @@
                 <span data-analytics="trackPageView" data-url="{{message.virtual_pageview_url}}"></span>
             {% elif category == 'service_deleted' %}
                 <strong>{{message.service_name}}</strong> was deleted
+            {% elif category == 'service_updated' %}
+                You&#x2019;ve edited your service. The changes are now live on the Digital Marketplace.
             {% else %}
                 {{ message }}
             {% endif %}

--- a/tests/app/helpers.py
+++ b/tests/app/helpers.py
@@ -8,6 +8,7 @@ from app import data_api_client
 from datetime import datetime, timedelta
 from dmutils.formats import DATETIME_FORMAT
 from nose.tools import assert_in, assert_not_in
+import pytest
 
 
 FULL_G7_SUBMISSION = {
@@ -355,7 +356,12 @@ class BaseApplicationTest(object):
                 category, message = session['_flashes'][0]
             except KeyError:
                 raise AssertionError('nothing flashed')
-            assert expected_message in message
+            try:
+                assert expected_message == message or expected_message in message
+            except TypeError:
+                # presumably this was raised from the "in" test being reached and fed types which don't support "in".
+                # either way, a failure.
+                pytest.fail("Flash message contents not found in _flashes")
             assert expected_category == category
 
     def assert_no_flashes(self):

--- a/tests/app/helpers.py
+++ b/tests/app/helpers.py
@@ -358,6 +358,10 @@ class BaseApplicationTest(object):
             assert expected_message in message
             assert expected_category == category
 
+    def assert_no_flashes(self):
+        with self.client.session_transaction() as session:
+            assert not session.get("_flashes")
+
 
 class FakeMail(object):
     """An object that equals strings containing all of the given substrings

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -276,7 +276,7 @@ class TestSupplierEditService(_BaseTestSupplierEditRemoveService):
 
         # service removed notification banner shouldn't be there
         self.assert_not_in_strip_whitespace(
-            '<h2>This service was removed on Monday 23 March 2015</h2>',
+            'This service was removed',
             res.get_data(as_text=True)
         )
 
@@ -330,7 +330,7 @@ class TestSupplierEditService(_BaseTestSupplierEditRemoveService):
 
         # service removed notification banner shouldn't be there
         self.assert_not_in_strip_whitespace(
-            '<h2>This service was removed on Monday 23 March 2015</h2>',
+            'This service was removed',
             res.get_data(as_text=True)
         )
 

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -563,8 +563,8 @@ class TestSupplierEditUpdateServiceSection(BaseApplicationTest):
             'email@email.com')
 
         self.assert_flashes(
-            u"You\u2019ve edited your service. The changes are now live on the Digital Marketplace.",
-            "message",
+            {"service_name": "The service"},
+            "service_updated",
         )
 
     def test_editing_readonly_section_is_not_allowed(self, data_api_client):
@@ -595,8 +595,8 @@ class TestSupplierEditUpdateServiceSection(BaseApplicationTest):
             '1', dict(), 'email@email.com')
 
         self.assert_flashes(
-            u"You\u2019ve edited your service. The changes are now live on the Digital Marketplace.",
-            "message",
+            {"service_name": "Service name 123"},
+            "service_updated",
         )
 
     def test_edit_non_existent_service_returns_404(self, data_api_client):


### PR DESCRIPTION
Story https://www.pivotaltracker.com/story/show/136029251

(tl;dr we're adding a flash message that says "You’ve edited your service. The changes are now live on the Digital Marketplace.")

![20170110_service_editing_flash_message](https://cloud.githubusercontent.com/assets/807447/22063417/9991e616-dd76-11e6-9411-abffa356cb03.png)