### PR TITLE
Use framework URL from content

### DIFF
--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -535,6 +535,7 @@ def framework_agreement(framework_slug):
             'frameworks/contract_start.html',
             signature_page_filename=SIGNATURE_PAGE_FILENAME,
             framework=framework,
+            framework_urls=content_loader.get_message(framework_slug, 'urls'),
             lots=[{
                 'name': lot['name'],
                 'has_completed_draft': (lot in lots_with_completed_drafts)

--- a/app/templates/frameworks/contract_start.html
+++ b/app/templates/frameworks/contract_start.html
@@ -89,7 +89,7 @@
                           "download": True
                       }
                   ],
-                  "bottom": "You can review the rest of the <a href='https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/537952/g-cloud-8-framework-agreement.pdf'>framework agreement</a> on GOV.UK."|safe
+                  "bottom": "You can review the rest of the <a href='{}'>framework agreement</a> on GOV.UK.".format(framework_urls.framework_agreement_url)|safe
               }, 
               {
                   "body": "Return your signed signature page and give the details of the person who signed it.",


### PR DESCRIPTION
The template here had a G-Cloud 8 URL hard coded.  I've changed it to instead use the `framwork_url` from the content of the relevant framework.