### PR TITLE
Test content of availability question for all lots

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,6 +7,6 @@
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
     "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v19.3.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.19.2/jinja_govuk_template-0.19.2.tgz",
-    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#5.8.1"
+    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#5.8.2"
   }
 }


### PR DESCRIPTION
Part of this story on Pivotal [https://www.pivotaltracker.com/story/show/135599725](https://www.pivotaltracker.com/story/show/135599725)
See complimentary PR on the frameworks here: [https://github.com/alphagov/digitalmarketplace-frameworks/pull/354](https://github.com/alphagov/digitalmarketplace-frameworks/pull/354)
See complimentary PR no the api here [https://github.com/alphagov/digitalmarketplace-api/pull/513](https://github.com/alphagov/digitalmarketplace-api/pull/513)

The PR on the frameworks repo will need to be merged and tagged before tests go green.

The frameworks repo has been updated to include the availability question for responses to user research participants briefs. Previously different lots had separate availability questions with separate content. They've now been combined into one question with lot specific content. This PR adds a test to make sure that the correct content is being rendered.