### PR TITLE
Remove full stops from brief-response availability question

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,6 +7,6 @@
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
     "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v19.3.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.19.2/jinja_govuk_template-0.19.2.tgz",
-    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#5.8.2"
+    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#5.9.1"
   }
 }

--- a/tests/app/main/test_briefs.py
+++ b/tests/app/main/test_briefs.py
@@ -635,7 +635,7 @@ class TestApplyToBrief(BaseApplicationTest):
             assert len(page_heading) == 1
             assert page_heading[0].strip() == 'When is the earliest {}'.format(question)
             assert len(page_hint) == 1
-            assert page_hint[0] == 'The buyer needs {} 17/01/2017.'.format(hint)
+            assert page_hint[0] == 'The buyer needs {} 17/01/2017'.format(hint)
 
     def test_availability_question_escapes_brief_start_date_markdown(self):
         self.brief['briefs']['startDate'] = '**markdown**'
@@ -647,7 +647,7 @@ class TestApplyToBrief(BaseApplicationTest):
 
         data = res.get_data(as_text=True)
 
-        assert "The buyer needs the specialist to start: **markdown**." in data
+        assert "The buyer needs the specialist to start: **markdown**" in data
 
     def test_availability_question_escapes_brief_start_date_html(self):
         self.brief['briefs']['startDate'] = '<h1>xss</h1>'
@@ -660,7 +660,7 @@ class TestApplyToBrief(BaseApplicationTest):
 
         data = res.get_data(as_text=True)
 
-        assert "The buyer needs the specialist to start: &lt;h1&gt;xss&lt;/h1&gt;." in data
+        assert "The buyer needs the specialist to start: &lt;h1&gt;xss&lt;/h1&gt;" in data
 
     def test_essential_requirements_evidence_has_question_for_every_requirement(self):
         res = self.client.get(


### PR DESCRIPTION
For this story on Pivotal: [https://www.pivotaltracker.com/story/show/135599725](https://www.pivotaltracker.com/story/show/135599725)

Needs this PR on the frameworks to be merged before tests will pass. [https://github.com/alphagov/digitalmarketplace-frameworks/pull/360](https://github.com/alphagov/digitalmarketplace-frameworks/pull/360)

This version of the frameworks repo removes a trailing full stop in the availability question for brief-responses. If a buyer includes a full stop at the end of their requirements, you get two full stops on the page and it looks weird. See the pivotal story for an example.