### PR TITLE
Old test framework purge: supplier frontend edition

### DIFF
--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -7,7 +7,6 @@ lxml==3.4.4
 cssselect==0.9.1
 freezegun==0.3.4
 watchdog==0.8.3
-nose==1.3.7
 coverage==3.7.1
 pytest-cov==2.2.0
 python-coveralls==2.5.0

--- a/tests/app/helpers.py
+++ b/tests/app/helpers.py
@@ -105,13 +105,13 @@ def empty_g7_draft_service():
 
 
 class BaseApplicationTest(object):
-    def setup(self):
+    def setup_method(self, method):
         self.app = create_app('test')
         self.app.register_blueprint(login_for_tests)
         self.client = self.app.test_client()
         self.get_user_patch = None
 
-    def teardown(self):
+    def teardown_method(self, method):
         self.teardown_login()
 
     @staticmethod

--- a/tests/app/helpers.py
+++ b/tests/app/helpers.py
@@ -7,7 +7,6 @@ from werkzeug.http import parse_cookie
 from app import data_api_client
 from datetime import datetime, timedelta
 from dmutils.formats import DATETIME_FORMAT
-from nose.tools import assert_in, assert_not_in
 import pytest
 
 
@@ -344,10 +343,10 @@ class BaseApplicationTest(object):
             assert response.status_code == 200
 
     def assert_in_strip_whitespace(self, needle, haystack):
-        return assert_in(self.strip_all_whitespace(needle), self.strip_all_whitespace(haystack))
+        assert self.strip_all_whitespace(needle) in self.strip_all_whitespace(haystack)
 
     def assert_not_in_strip_whitespace(self, needle, haystack):
-        return assert_not_in(self.strip_all_whitespace(needle), self.strip_all_whitespace(haystack))
+        assert self.strip_all_whitespace(needle) not in self.strip_all_whitespace(haystack)
 
     # Method to test flashes taken from http://blog.paulopoiati.com/2013/02/22/testing-flash-messages-in-flask/
     def assert_flashes(self, expected_message, expected_category='message'):

--- a/tests/app/main/helpers/test_frameworks.py
+++ b/tests/app/main/helpers/test_frameworks.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 import pytest
 import mock
-from nose.tools import assert_equal
 from werkzeug.exceptions import HTTPException
 
 from app.main.helpers.frameworks import (
@@ -298,14 +297,11 @@ def test_get_status_for_lot(parameters, expected_result):
     ]):
         print(label, parameters[index])
 
-    assert_equal(
-        expected_result,
-        get_statuses_for_lot(
-            *parameters,
-            lot_name='user research studios',
-            unit='lab',
-            unit_plural='labs'
-        )
+    assert expected_result == get_statuses_for_lot(
+        *parameters,
+        lot_name='user research studios',
+        unit='lab',
+        unit_plural='labs'
     )
 
 

--- a/tests/app/main/helpers/validation/test_g7_declaration.py
+++ b/tests/app/main/helpers/validation/test_g7_declaration.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from nose.tools import assert_equal
-
 from app.main.helpers.validation import G7Validator, get_validator
 from app.main import content_loader
 
@@ -88,7 +86,7 @@ def test_error_if_required_field_is_missing():
     del submission['SQ3-1i-i']
     validator = G7Validator(content, submission)
 
-    assert_equal(validator.errors(), {'SQ3-1i-i': 'answer_required'})
+    assert validator.errors() == {'SQ3-1i-i': 'answer_required'}
 
 
 def test_error_if_required_text_field_is_empty():
@@ -97,7 +95,7 @@ def test_error_if_required_text_field_is_empty():
     submission['SQ1-2b'] = ""
     validator = G7Validator(content, submission)
 
-    assert_equal(validator.errors(), {'SQ1-2b': 'answer_required'})
+    assert validator.errors() == {'SQ1-2b': 'answer_required'}
 
 
 def test_no_error_if_optional_field_is_missing():
@@ -106,7 +104,7 @@ def test_no_error_if_optional_field_is_missing():
     del submission['SQ1-1p-i']
     validator = G7Validator(content, submission)
 
-    assert_equal(validator.errors(), {})
+    assert validator.errors() == {}
 
 
 def test_trading_status_details_error_depends_on_trading_status():
@@ -117,11 +115,11 @@ def test_trading_status_details_error_depends_on_trading_status():
 
     submission['SQ1-1ci'] = "something"
     validator = G7Validator(content, submission)
-    assert_equal(validator.errors(), {})
+    assert validator.errors() == {}
 
     submission['SQ1-1ci'] = "other (please specify)"
     validator = G7Validator(content, submission)
-    assert_equal(validator.errors(), {'SQ1-1cii': 'answer_required'})
+    assert validator.errors() == {'SQ1-1cii': 'answer_required'}
 
 
 def test_trade_registers_details_error_depends_on_trade_registers():
@@ -131,11 +129,11 @@ def test_trade_registers_details_error_depends_on_trade_registers():
 
     submission['SQ1-1i-i'] = False
     validator = G7Validator(content, submission)
-    assert_equal(validator.errors(), {})
+    assert validator.errors() == {}
 
     submission['SQ1-1i-i'] = True
     validator = G7Validator(content, submission)
-    assert_equal(validator.errors(), {'SQ1-1i-ii': 'answer_required'})
+    assert validator.errors() == {'SQ1-1i-ii': 'answer_required'}
 
 
 def test_licenced_details_error_depends_on_licenced():
@@ -145,11 +143,11 @@ def test_licenced_details_error_depends_on_licenced():
 
     del submission['SQ1-1j-i']
     validator = G7Validator(content, submission)
-    assert_equal(validator.errors(), {})
+    assert validator.errors() == {}
 
     submission['SQ1-1j-i'] = ["licensed"]
     validator = G7Validator(content, submission)
-    assert_equal(validator.errors(), {'SQ1-1j-ii': 'answer_required'})
+    assert validator.errors() == {'SQ1-1j-ii': 'answer_required'}
 
 
 def test_no_error_if_no_tax_issues_and_no_details():
@@ -161,7 +159,7 @@ def test_no_error_if_no_tax_issues_and_no_details():
     del submission['SQ4-1c']
 
     validator = G7Validator(content, submission)
-    assert_equal(validator.errors(), {})
+    assert validator.errors() == {}
 
 
 def test_error_if_tax_issues_and_no_details():
@@ -173,12 +171,12 @@ def test_error_if_tax_issues_and_no_details():
     submission['SQ4-1a'] = True
     submission['SQ4-1b'] = False
     validator = G7Validator(content, submission)
-    assert_equal(validator.errors(), {'SQ4-1c': 'answer_required'})
+    assert validator.errors() == {'SQ4-1c': 'answer_required'}
 
     submission['SQ4-1a'] = False
     submission['SQ4-1b'] = True
     validator = G7Validator(content, submission)
-    assert_equal(validator.errors(), {'SQ4-1c': 'answer_required'})
+    assert validator.errors() == {'SQ4-1c': 'answer_required'}
 
 
 def test_error_if_mitigation_factors_not_provided_when_required():
@@ -198,7 +196,7 @@ def test_error_if_mitigation_factors_not_provided_when_required():
         submission[field] = True
 
         validator = G7Validator(content, submission)
-        assert_equal(validator.errors(), {'SQ3-1k': 'answer_required'})
+        assert validator.errors() == {'SQ3-1k': 'answer_required'}
 
 
 def test_mitigation_factors_not_required():
@@ -214,7 +212,7 @@ def test_mitigation_factors_not_required():
     for field in dependent_fields:
         submission[field] = False
     validator = G7Validator(content, submission)
-    assert_equal(validator.errors(), {})
+    assert validator.errors() == {}
 
 
 def test_fields_only_relevant_to_non_uk():
@@ -225,7 +223,7 @@ def test_fields_only_relevant_to_non_uk():
     del submission['SQ1-1i-i']
 
     validator = G7Validator(content, submission)
-    assert_equal(validator.errors(), {'SQ1-1i-i': 'answer_required'})
+    assert validator.errors() == {'SQ1-1i-i': 'answer_required'}
 
 
 def test_invalid_email_addresses_cause_errors():
@@ -236,10 +234,10 @@ def test_invalid_email_addresses_cause_errors():
     submission['SQ1-2b'] = 'some.user.missed.their.at.com'
 
     validator = G7Validator(content, submission)
-    assert_equal(validator.errors(),
-                 {'SQ1-1o': 'invalid_format',
-                  'SQ1-2b': 'invalid_format'}
-                 )
+    assert validator.errors() == {
+        'SQ1-1o': 'invalid_format',
+        'SQ1-2b': 'invalid_format',
+    }
 
 
 def test_character_limit_errors():
@@ -257,13 +255,13 @@ def test_character_limit_errors():
     for field, limit in cases:
         submission[field] = "a" * (limit + 1)
         validator = G7Validator(content, submission)
-        assert_equal(validator.errors(), {field: 'under_character_limit'})
+        assert validator.errors() == {field: 'under_character_limit'}
 
         submission[field] = "a" * limit
         validator = G7Validator(content, submission)
-        assert_equal(validator.errors(), {})
+        assert validator.errors() == {}
 
 
 def test_get_validator():
     validator = get_validator({"slug": "g-cloud-7"}, None, None)
-    assert_equal(type(validator), G7Validator)
+    assert type(validator) is G7Validator

--- a/tests/app/main/test_application.py
+++ b/tests/app/main/test_application.py
@@ -1,5 +1,4 @@
 import mock
-from nose.tools import assert_equal, assert_true
 from ..helpers import BaseApplicationTest
 
 
@@ -9,7 +8,5 @@ class TestApplication(BaseApplicationTest):
 
     def test_analytics_code_should_be_in_javascript(self):
         res = self.client.get('/suppliers/static/javascripts/application.js')
-        assert_equal(200, res.status_code)
-        assert_true(
-            'analytics.trackPageview'
-            in res.get_data(as_text=True))
+        assert res.status_code == 200
+        assert 'analytics.trackPageview' in res.get_data(as_text=True)

--- a/tests/app/main/test_application.py
+++ b/tests/app/main/test_application.py
@@ -4,8 +4,8 @@ from ..helpers import BaseApplicationTest
 
 
 class TestApplication(BaseApplicationTest):
-    def setup(self):
-        super(TestApplication, self).setup()
+    def setup_method(self, method):
+        super(TestApplication, self).setup_method(method)
 
     def test_analytics_code_should_be_in_javascript(self):
         res = self.client.get('/suppliers/static/javascripts/application.js')

--- a/tests/app/main/test_briefs.py
+++ b/tests/app/main/test_briefs.py
@@ -362,8 +362,8 @@ class TestSubmitClarificationQuestions(BaseApplicationTest):
 class TestApplyToBrief(BaseApplicationTest):
     """Tests requests for the new multipage flow for applying for a brief"""
 
-    def setup(self):
-        super(TestApplyToBrief, self).setup()
+    def setup_method(self, method):
+        super(TestApplyToBrief, self).setup_method(method)
 
         self.brief = api_stubs.brief(status='live', lot_slug='digital-specialists')
         self.brief['briefs']['essentialRequirements'] = ['Essential one', 'Essential two', 'Essential three']
@@ -387,8 +387,8 @@ class TestApplyToBrief(BaseApplicationTest):
         with self.app.test_client():
             self.login()
 
-    def teardown(self):
-        super(TestApplyToBrief, self).teardown()
+    def teardown_method(self, method):
+        super(TestApplyToBrief, self).teardown_method(method)
         self.data_api_client_patch.stop()
 
     @mock.patch("app.main.views.briefs.content_loader")
@@ -1101,8 +1101,8 @@ class TestApplyToBrief(BaseApplicationTest):
 class TestLegacyRespondToBrief(BaseApplicationTest):
     """Tests for the old single page flow for applying for a brief which is being phased out"""
 
-    def setup(self):
-        super(TestLegacyRespondToBrief, self).setup()
+    def setup_method(self, method):
+        super(TestLegacyRespondToBrief, self).setup_method(method)
 
         self.brief = api_stubs.brief(status='live', lot_slug='digital-specialists')
         self.brief['briefs']['essentialRequirements'] = ['Essential one', 'Essential two', 'Essential three']
@@ -1631,8 +1631,8 @@ class TestLegacyRespondToBrief(BaseApplicationTest):
 
 @mock.patch("app.main.views.briefs.data_api_client")
 class TestStartBriefResponseApplication(BaseApplicationTest):
-    def setup(self):
-        super(TestStartBriefResponseApplication, self).setup()
+    def setup_method(self, method):
+        super(TestStartBriefResponseApplication, self).setup_method(method)
         self.brief = api_stubs.brief(status='live', lot_slug='digital-specialists')
         self.brief['briefs']['publishedAt'] = '2016-12-25T12:00:00.000000Z'
 
@@ -1795,8 +1795,8 @@ class TestStartBriefResponseApplication(BaseApplicationTest):
 
 @mock.patch("app.main.views.briefs.data_api_client")
 class TestPostStartBriefResponseApplication(BaseApplicationTest):
-    def setup(self):
-        super(TestPostStartBriefResponseApplication, self).setup()
+    def setup_method(self, method):
+        super(TestPostStartBriefResponseApplication, self).setup_method(method)
         self.brief = api_stubs.brief(status='live', lot_slug='digital-specialists')
         self.brief['briefs']['publishedAt'] = '2016-12-25T12:00:00.000000Z'
 
@@ -1839,8 +1839,8 @@ class TestPostStartBriefResponseApplication(BaseApplicationTest):
 @mock.patch("app.main.views.briefs.data_api_client")
 class TestResponseResultPage(BaseApplicationTest):
 
-    def setup(self):
-        super(TestResponseResultPage, self).setup()
+    def setup_method(self, method):
+        super(TestResponseResultPage, self).setup_method(method)
         lots = [api_stubs.lot(slug="digital-specialists", allows_brief=True)]
         self.framework = api_stubs.framework(status="live", slug="digital-outcomes-and-specialists",
                                              clarification_questions_open=False, lots=lots)

--- a/tests/app/main/test_briefs.py
+++ b/tests/app/main/test_briefs.py
@@ -262,7 +262,7 @@ class TestSubmitClarificationQuestions(BaseApplicationTest):
                 ERROR_MESSAGE_NO_SERVICE_ON_LOT_CLARIFICATION
             )
         )) == 1
-        assert not data_api_client.create_audit_event.called
+        assert data_api_client.create_audit_event.called is False
 
     @mock.patch('app.main.helpers.briefs.send_email')
     def test_submit_clarification_question_returns_error_page_if_supplier_has_no_services_on_framework(
@@ -285,7 +285,7 @@ class TestSubmitClarificationQuestions(BaseApplicationTest):
                 ERROR_MESSAGE_NO_SERVICE_ON_FRAMEWORK_CLARIFICATION
             )
         )) == 1
-        assert not data_api_client.create_audit_event.called
+        assert data_api_client.create_audit_event.called is False
 
     @mock.patch('app.main.helpers.briefs.send_email')
     def test_submit_clarification_question_returns_error_page_if_supplier_has_no_services_with_role(
@@ -308,7 +308,7 @@ class TestSubmitClarificationQuestions(BaseApplicationTest):
                 ERROR_MESSAGE_NO_SERVICE_WITH_ROLE_CLARIFICATION
             )
         )) == 1
-        assert not data_api_client.create_audit_event.called
+        assert data_api_client.create_audit_event.called is False
 
     def test_submit_empty_clarification_question_returns_validation_error(self, data_api_client):
         self.login()
@@ -1203,7 +1203,7 @@ class TestLegacyRespondToBrief(BaseApplicationTest):
             )
         )) == 1
         assert len(doc.xpath('//*[@data-reason="supplier-not-on-lot"]')) == 1
-        assert not data_api_client.create_audit_event.called
+        assert data_api_client.create_audit_event.called is False
 
     def test_get_brief_response_returns_error_page_if_supplier_has_no_pub_services_on_lot(self, data_api_client):
         data_api_client.get_brief.return_value = self.brief
@@ -1228,7 +1228,7 @@ class TestLegacyRespondToBrief(BaseApplicationTest):
             )
         )) == 1
         assert len(doc.xpath('//*[@data-reason="supplier-not-on-lot"]')) == 1
-        assert not data_api_client.create_audit_event.called
+        assert data_api_client.create_audit_event.called is False
 
     def test_get_brief_response_returns_error_page_if_supplier_has_no_services_on_framework(self, data_api_client):
         data_api_client.get_brief.return_value = self.brief
@@ -1248,7 +1248,7 @@ class TestLegacyRespondToBrief(BaseApplicationTest):
             )
         )) == 1
         assert len(doc.xpath('//*[@data-reason="supplier-not-on-dos"]')) == 1
-        assert not data_api_client.create_audit_event.called
+        assert data_api_client.create_audit_event.called is False
 
     def test_get_brief_response_returns_error_page_if_supplier_has_no_pub_services_on_framework(self, data_api_client):
         data_api_client.get_brief.return_value = self.brief
@@ -1273,7 +1273,7 @@ class TestLegacyRespondToBrief(BaseApplicationTest):
             )
         )) == 1
         assert len(doc.xpath('//*[@data-reason="supplier-not-on-dos"]')) == 1
-        assert not data_api_client.create_audit_event.called
+        assert data_api_client.create_audit_event.called is False
 
     def test_get_brief_response_returns_error_page_if_supplier_has_no_services_with_role(self, data_api_client):
         data_api_client.get_brief.return_value = self.brief
@@ -1293,7 +1293,7 @@ class TestLegacyRespondToBrief(BaseApplicationTest):
             )
         )) == 1
         assert len(doc.xpath('//*[@data-reason="supplier-not-on-role"]')) == 1
-        assert not data_api_client.create_audit_event.called
+        assert data_api_client.create_audit_event.called is False
 
     def test_get_brief_response_does_not_contain_data_reason_if_supplier_is_eligible(self, data_api_client):
         data_api_client.get_brief.return_value = self.brief
@@ -1488,7 +1488,7 @@ class TestLegacyRespondToBrief(BaseApplicationTest):
             data=brief_form_submission
         )
         assert res.status_code == 404
-        assert not data_api_client.create_brief_response.called
+        assert data_api_client.create_brief_response.called is False
 
     def test_create_new_brief_response_404_if_not_live_framework(self, data_api_client):
         framework = self.framework.copy()
@@ -1501,7 +1501,7 @@ class TestLegacyRespondToBrief(BaseApplicationTest):
             data=brief_form_submission
         )
         assert res.status_code == 404
-        assert not data_api_client.create_brief_response.called
+        assert data_api_client.create_brief_response.called is False
 
     def test_create_new_brief_response_flashes_error_on_result_page_if_response_already_exists(self, data_api_client):
         data_api_client.get_brief.return_value = self.brief
@@ -1520,7 +1520,7 @@ class TestLegacyRespondToBrief(BaseApplicationTest):
         assert res.status_code == 302
         assert res.location == 'http://localhost/suppliers/opportunities/1234/responses/result'
         self.assert_flashes("already_applied", "error")
-        assert not data_api_client.create_brief_response.called
+        assert data_api_client.create_brief_response.called is False
 
     def test_create_new_brief_returns_error_page_if_supplier_has_no_services_on_lot(self, data_api_client):
         data_api_client.get_brief.return_value = self.brief
@@ -1544,7 +1544,7 @@ class TestLegacyRespondToBrief(BaseApplicationTest):
                 ERROR_MESSAGE_NO_SERVICE_ON_LOT_APPLICATION
             )
         )) == 1
-        assert not data_api_client.create_brief_response.called
+        assert data_api_client.create_brief_response.called is False
 
     def test_create_new_brief_returns_error_page_if_supplier_has_no_services_on_framework(self, data_api_client):
         data_api_client.get_brief.return_value = self.brief
@@ -1566,7 +1566,7 @@ class TestLegacyRespondToBrief(BaseApplicationTest):
                 ERROR_MESSAGE_NO_SERVICE_ON_FRAMEWORK_APPLICATION
             )
         )) == 1
-        assert not data_api_client.create_brief_response.called
+        assert data_api_client.create_brief_response.called is False
 
     def test_create_new_brief_returns_error_page_if_supplier_has_no_services_with_role(self, data_api_client):
         data_api_client.get_brief.return_value = self.brief
@@ -1588,7 +1588,7 @@ class TestLegacyRespondToBrief(BaseApplicationTest):
                 ERROR_MESSAGE_NO_SERVICE_WITH_ROLE_APPLICATION
             )
         )) == 1
-        assert not data_api_client.create_brief_response.called
+        assert data_api_client.create_brief_response.called is False
 
     def test_create_new_brief_response_with_api_error_fails(self, data_api_client):
         data_api_client.get_brief.return_value = self.brief
@@ -1626,7 +1626,7 @@ class TestLegacyRespondToBrief(BaseApplicationTest):
         assert res.status_code == 302
         assert res.location == "http://localhost/login"
         self.assert_flashes("supplier-role-required", "error")
-        assert not data_api_client.get_brief.called
+        assert data_api_client.get_brief.called is False
 
 
 @mock.patch("app.main.views.briefs.data_api_client")

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -3903,8 +3903,8 @@ class TestContractReviewPage(BaseApplicationTest):
 @mock.patch('app.main.views.frameworks.data_api_client', autospec=True)
 class TestContractVariation(BaseApplicationTest):
 
-    def setup(self):
-        super(TestContractVariation, self).setup()
+    def setup_method(self, method):
+        super(TestContractVariation, self).setup_method(method)
 
         self.good_supplier_framework = self.supplier_framework(
             declaration={'nameOfOrganisation': 'A.N. Supplier',

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -193,7 +193,7 @@ class TestFrameworksDashboard(BaseApplicationTest):
             res = self.client.get("/suppliers/frameworks/digital-outcomes-and-specialists")
 
             assert res.status_code == 200
-            assert not data_api_client.register_framework_interest.called
+            assert data_api_client.register_framework_interest.called is False
 
     def test_interest_set_but_no_declaration(self, data_api_client, s3):
         with self.app.test_client():
@@ -1828,10 +1828,10 @@ class TestFrameworkAgreementUpload(BaseApplicationTest):
                 download_filename='Supplier_Nme-1234-signed-framework-agreement.pdf'
             )
 
-            assert not data_api_client.create_framework_agreement.called
-            assert not data_api_client.update_framework_agreement.called
-            assert not data_api_client.sign_framework_agreement.called
-            assert not send_email.called
+            assert data_api_client.create_framework_agreement.called is False
+            assert data_api_client.update_framework_agreement.called is False
+            assert data_api_client.sign_framework_agreement.called is False
+            assert send_email.called is False
 
     @mock.patch('app.main.views.frameworks.generate_timestamped_document_upload_path')
     def test_email_is_not_sent_if_api_create_framework_agreement_fails(
@@ -1854,10 +1854,10 @@ class TestFrameworkAgreementUpload(BaseApplicationTest):
             )
 
             assert res.status_code == 500
-            assert data_api_client.create_framework_agreement.called
-            assert not data_api_client.update_framework_agreement.called
-            assert not data_api_client.sign_framework_agreement.called
-            assert not send_email.called
+            assert data_api_client.create_framework_agreement.called is True
+            assert data_api_client.update_framework_agreement.called is False
+            assert data_api_client.sign_framework_agreement.called is False
+            assert send_email.called is False
 
     @mock.patch('app.main.views.frameworks.generate_timestamped_document_upload_path')
     def test_email_is_not_sent_if_api_update_framework_agreement_fails(
@@ -1880,10 +1880,10 @@ class TestFrameworkAgreementUpload(BaseApplicationTest):
             )
 
             assert res.status_code == 500
-            assert data_api_client.create_framework_agreement.called
-            assert data_api_client.update_framework_agreement.called
-            assert not data_api_client.sign_framework_agreement.called
-            assert not send_email.called
+            assert data_api_client.create_framework_agreement.called is True
+            assert data_api_client.update_framework_agreement.called is True
+            assert data_api_client.sign_framework_agreement.called is False
+            assert send_email.called is False
 
     @mock.patch('app.main.views.frameworks.generate_timestamped_document_upload_path')
     def test_email_is_not_sent_if_api_sign_framework_agreement_fails(
@@ -1906,10 +1906,10 @@ class TestFrameworkAgreementUpload(BaseApplicationTest):
             )
 
             assert res.status_code == 500
-            assert data_api_client.create_framework_agreement.called
-            assert data_api_client.update_framework_agreement.called
-            assert data_api_client.sign_framework_agreement.called
-            assert not send_email.called
+            assert data_api_client.create_framework_agreement.called is True
+            assert data_api_client.update_framework_agreement.called is True
+            assert data_api_client.sign_framework_agreement.called is True
+            assert send_email.called is False
 
     @mock.patch('app.main.views.frameworks.generate_timestamped_document_upload_path')
     def test_email_failure(
@@ -1932,7 +1932,7 @@ class TestFrameworkAgreementUpload(BaseApplicationTest):
             )
 
             assert res.status_code == 503
-            assert send_email.called
+            assert send_email.called is True
 
     @mock.patch('app.main.views.frameworks.generate_timestamped_document_upload_path')
     def test_upload_agreement_document(
@@ -2146,7 +2146,7 @@ class TestSupplierDeclaration(BaseApplicationTest):
                 data=FULL_G7_SUBMISSION)
 
             assert res.status_code == 302
-            assert data_api_client.set_supplier_declaration.called
+            assert data_api_client.set_supplier_declaration.called is True
 
     def test_post_valid_data_to_complete_declaration(self, data_api_client):
         with self.app.test_client():
@@ -2162,7 +2162,7 @@ class TestSupplierDeclaration(BaseApplicationTest):
 
             assert res.status_code == 302
             assert res.location == 'http://localhost/suppliers/frameworks/g-cloud-7'
-            assert data_api_client.set_supplier_declaration.called
+            assert data_api_client.set_supplier_declaration.called is True
             assert data_api_client.set_supplier_declaration.call_args[0][2]['status'] == 'complete'
 
     def test_post_valid_data_with_api_failure(self, data_api_client):
@@ -2198,7 +2198,7 @@ class TestSupplierDeclaration(BaseApplicationTest):
                 data=FULL_G7_SUBMISSION)
 
             assert res.status_code == 400
-            assert not data_api_client.set_supplier_declaration.called
+            assert data_api_client.set_supplier_declaration.called is False
 
             doc = html.fromstring(res.get_data(as_text=True))
             elems = doc.cssselect('#input-PR1-yes')
@@ -2219,7 +2219,7 @@ class TestSupplierDeclaration(BaseApplicationTest):
                 data=FULL_G7_SUBMISSION)
 
             assert res.status_code == 404
-            assert not data_api_client.set_supplier_declaration.called
+            assert data_api_client.set_supplier_declaration.called is False
 
 
 @mock.patch('app.main.views.frameworks.data_api_client')
@@ -3516,7 +3516,7 @@ class TestContractReviewPage(BaseApplicationTest):
             )
             assert res.status_code == 400
             page = res.get_data(as_text=True)
-            assert not send_email.called
+            assert send_email.called is False
             assert "You must confirm you have the authority to return the agreement" in page
 
     @mock.patch('dmutils.s3.S3')
@@ -3686,9 +3686,9 @@ class TestContractReviewPage(BaseApplicationTest):
                 }
             )
 
-            assert data_api_client.sign_framework_agreement.called
+            assert data_api_client.sign_framework_agreement.called is True
             assert res.status_code == 500
-            assert not send_email.called
+            assert send_email.called is False
 
     @mock.patch('dmutils.s3.S3')
     @mock.patch('app.main.views.frameworks.send_email')
@@ -4074,8 +4074,8 @@ class TestContractVariation(BaseApplicationTest):
                                data={"accept_changes": "Yes"}
                                )
         assert res.status_code == 200
-        assert not data_api_client.agree_framework_variation.called
-        assert not send_email.called
+        assert data_api_client.agree_framework_variation.called is False
+        assert send_email.called is False
 
     def test_error_if_box_not_ticked(self, data_api_client):
         data_api_client.get_framework.return_value = self.g8_framework

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -5,7 +5,6 @@ try:
     from StringIO import StringIO
 except ImportError:
     from io import BytesIO as StringIO
-from nose.tools import assert_equal, assert_true, assert_in, assert_not_in
 import mock
 
 from flask import session
@@ -112,7 +111,7 @@ class TestFrameworksDashboard(BaseApplicationTest):
         data_api_client.get_supplier_framework_info.return_value = self.supplier_framework()
         res = self.client.get("/suppliers/frameworks/g-cloud-7")
 
-        assert_equal(res.status_code, 200)
+        assert res.status_code == 200
         doc = html.fromstring(res.get_data(as_text=True))
         assert len(doc.xpath(
             "//h1[normalize-space(string())=$b]",
@@ -127,7 +126,7 @@ class TestFrameworksDashboard(BaseApplicationTest):
         data_api_client.get_supplier_framework_info.return_value = self.supplier_framework()
         res = self.client.get("/suppliers/frameworks/g-cloud-7")
 
-        assert_equal(res.status_code, 200)
+        assert res.status_code == 200
         doc = html.fromstring(res.get_data(as_text=True))
         assert len(doc.xpath(
             "//h1[normalize-space(string())=$b]",
@@ -142,7 +141,7 @@ class TestFrameworksDashboard(BaseApplicationTest):
         data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(declaration=None)
         res = self.client.get("/suppliers/frameworks/g-cloud-7")
 
-        assert_equal(res.status_code, 404)
+        assert res.status_code == 404
 
     @mock.patch('app.main.views.frameworks.send_email')
     def test_interest_registered_in_framework_on_post(self, send_email, data_api_client, s3):
@@ -153,7 +152,7 @@ class TestFrameworksDashboard(BaseApplicationTest):
             data_api_client.get_supplier_framework_info.return_value = self.supplier_framework()
             res = self.client.post("/suppliers/frameworks/digital-outcomes-and-specialists")
 
-            assert_equal(res.status_code, 200)
+            assert res.status_code == 200
             data_api_client.register_framework_interest.assert_called_once_with(
                 1234,
                 "digital-outcomes-and-specialists",
@@ -174,7 +173,7 @@ class TestFrameworksDashboard(BaseApplicationTest):
             ]}
             res = self.client.post("/suppliers/frameworks/digital-outcomes-and-specialists")
 
-            assert_equal(res.status_code, 200)
+            assert res.status_code == 200
             send_email.assert_called_once_with(
                 ['email1', 'email2'],
                 mock.ANY,
@@ -193,7 +192,7 @@ class TestFrameworksDashboard(BaseApplicationTest):
             data_api_client.get_supplier_framework_info.return_value = self.supplier_framework()
             res = self.client.get("/suppliers/frameworks/digital-outcomes-and-specialists")
 
-            assert_equal(res.status_code, 200)
+            assert res.status_code == 200
             assert not data_api_client.register_framework_interest.called
 
     def test_interest_set_but_no_declaration(self, data_api_client, s3):
@@ -211,7 +210,7 @@ class TestFrameworksDashboard(BaseApplicationTest):
 
             res = self.client.get("/suppliers/frameworks/g-cloud-7")
 
-            assert_equal(res.status_code, 200)
+            assert res.status_code == 200
 
     def test_shows_gcloud_7_closed_message_if_pending_and_no_application_done(self, data_api_client, s3):
         with self.app.test_client():
@@ -232,11 +231,9 @@ class TestFrameworksDashboard(BaseApplicationTest):
             doc = html.fromstring(res.get_data(as_text=True))
 
             heading = doc.xpath('//div[@class="summary-item-lede"]//h2[@class="summary-item-heading"]')
-            assert_true(len(heading) > 0)
-            assert_in(u"G-Cloud 7 is closed for applications",
-                      heading[0].xpath('text()')[0])
-            assert_in(u"You didn't submit an application.",
-                      heading[0].xpath('../p[1]/text()')[0])
+            assert len(heading) > 0
+            assert u"G-Cloud 7 is closed for applications" in heading[0].xpath('text()')[0]
+            assert u"You didn't submit an application." in heading[0].xpath('../p[1]/text()')[0]
 
     def test_shows_gcloud_7_closed_message_if_pending_and_application(self, data_api_client, s3):
         with self.app.test_client():
@@ -256,14 +253,13 @@ class TestFrameworksDashboard(BaseApplicationTest):
 
             doc = html.fromstring(res.get_data(as_text=True))
             heading = doc.xpath('//div[@class="summary-item-lede"]//h2[@class="summary-item-heading"]')
-            assert_true(len(heading) > 0)
-            assert_in(u"G-Cloud 7 is closed for applications",
-                      heading[0].xpath('text()')[0])
+            assert len(heading) > 0
+            assert u"G-Cloud 7 is closed for applications" in heading[0].xpath('text()')[0]
             lede = doc.xpath('//div[@class="summary-item-lede"]')
-            assert_in(u"You made your supplier declaration and submitted 1 service for consideration.",
-                      lede[0].xpath('./p[1]/text()')[0])
-            assert_in(u"We’ll let you know the result of your application by ",  # noqa
-                      lede[0].xpath('./p[2]/text()')[0])  # noqa
+            assert u"You made your supplier declaration and submitted 1 service for consideration." in \
+                lede[0].xpath('./p[1]/text()')[0]
+            assert u"We’ll let you know the result of your application by " in \
+                lede[0].xpath('./p[2]/text()')[0]
 
     def test_declaration_status_when_complete(self, data_api_client, s3):
         with self.app.test_client():
@@ -276,9 +272,7 @@ class TestFrameworksDashboard(BaseApplicationTest):
             assert res.status_code == 200
 
             doc = html.fromstring(res.get_data(as_text=True))
-            assert_equal(
-                len(doc.xpath(u'//p/strong[contains(text(), "You’ve made the supplier declaration")]')),
-                1)
+            assert len(doc.xpath(u'//p/strong[contains(text(), "You’ve made the supplier declaration")]')) == 1
 
     def test_declaration_status_when_started(self, data_api_client, s3):
         with self.app.test_client():
@@ -299,9 +293,7 @@ class TestFrameworksDashboard(BaseApplicationTest):
             assert res.status_code == 200
 
             doc = html.fromstring(res.get_data(as_text=True))
-            assert_equal(
-                len(doc.xpath('//p[contains(text(), "You need to finish making the supplier declaration")]')),  # noqa
-                1)
+            assert len(doc.xpath('//p[contains(text(), "You need to finish making the supplier declaration")]')) == 1
 
     def test_declaration_status_when_not_complete(self, data_api_client, s3):
         with self.app.test_client():
@@ -314,9 +306,7 @@ class TestFrameworksDashboard(BaseApplicationTest):
             assert res.status_code == 200
 
             doc = html.fromstring(res.get_data(as_text=True))
-            assert_equal(
-                len(doc.xpath('//p[contains(text(), "You need to make the supplier declaration")]')),
-                1)
+            assert len(doc.xpath('//p[contains(text(), "You need to make the supplier declaration")]')) == 1
 
     def test_downloads_shown_open_framework(self, data_api_client, s3):
         files = [
@@ -710,7 +700,7 @@ class TestFrameworksDashboard(BaseApplicationTest):
 
             res = self.client.get('/suppliers/frameworks/does-not-exist')
 
-            assert_equal(res.status_code, 404)
+            assert res.status_code == 404
 
     def test_result_letter_is_shown_when_is_in_standstill(self, data_api_client, s3):
         with self.app.test_client():
@@ -728,7 +718,7 @@ class TestFrameworksDashboard(BaseApplicationTest):
 
             data = res.get_data(as_text=True)
 
-            assert_in(u'Download your application result letter', data)
+            assert u'Download your application result letter' in data
 
     def test_result_letter_is_not_shown_when_not_in_standstill(self, data_api_client, s3):
         with self.app.test_client():
@@ -746,7 +736,7 @@ class TestFrameworksDashboard(BaseApplicationTest):
 
             data = res.get_data(as_text=True)
 
-            assert_not_in(u'Download your application result letter', data)
+            assert u'Download your application result letter' not in data
 
     def test_result_letter_is_not_shown_when_no_application(self, data_api_client, s3):
         with self.app.test_client():
@@ -763,7 +753,7 @@ class TestFrameworksDashboard(BaseApplicationTest):
 
             data = res.get_data(as_text=True)
 
-            assert_not_in(u'Download your application result letter', data)
+            assert u'Download your application result letter' not in data
 
     def test_link_to_unsigned_framework_agreement_is_shown_if_supplier_is_on_framework(self, data_api_client, s3):
         with self.app.test_client():
@@ -781,8 +771,8 @@ class TestFrameworksDashboard(BaseApplicationTest):
 
             data = res.get_data(as_text=True)
 
-            assert_in(u'Sign and return your framework agreement', data)
-            assert_not_in(u'Download your countersigned framework agreement', data)
+            assert u'Sign and return your framework agreement' in data
+            assert u'Download your countersigned framework agreement' not in data
 
     def test_pending_success_message_is_explicit_if_supplier_is_on_framework(self, data_api_client, s3):
         with self.app.test_client():
@@ -796,7 +786,7 @@ class TestFrameworksDashboard(BaseApplicationTest):
         }
         data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(on_framework=True)
         res = self.client.get("/suppliers/frameworks/g-cloud-7")
-        assert_equal(res.status_code, 200)
+        assert res.status_code == 200
 
         data = res.get_data(as_text=True)
 
@@ -807,14 +797,14 @@ class TestFrameworksDashboard(BaseApplicationTest):
             u'Download your application award letter (.pdf)',
             u'This letter is a record of your successful G-Cloud 7 application.'
         ]:
-            assert_in(success_message, data)
+            assert success_message in data
 
         for equivocal_message in [
             u'You made your supplier declaration and submitted 1 service.',
             u'Download your application result letter (.pdf)',
             u'This letter informs you if your G-Cloud 7 application has been successful.'
         ]:
-            assert_not_in(equivocal_message, data)
+            assert equivocal_message not in data
 
     def test_link_to_framework_agreement_is_not_shown_if_supplier_is_not_on_framework(self, data_api_client, s3):
         with self.app.test_client():
@@ -832,7 +822,7 @@ class TestFrameworksDashboard(BaseApplicationTest):
 
             data = res.get_data(as_text=True)
 
-            assert_not_in(u'Sign and return your framework agreement', data)
+            assert u'Sign and return your framework agreement' not in data
 
     def test_pending_success_message_is_equivocal_if_supplier_is_on_framework(self, data_api_client, s3):
         with self.app.test_client():
@@ -846,7 +836,7 @@ class TestFrameworksDashboard(BaseApplicationTest):
         }
         data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(on_framework=False)
         res = self.client.get("/suppliers/frameworks/g-cloud-7")
-        assert_equal(res.status_code, 200)
+        assert res.status_code == 200
 
         data = res.get_data(as_text=True)
 
@@ -855,14 +845,14 @@ class TestFrameworksDashboard(BaseApplicationTest):
             u'Download your application award letter (.pdf)',
             u'This letter is a record of your successful G-Cloud 7 application.'
         ]:
-            assert_not_in(success_message, data)
+            assert success_message not in data
 
         for equivocal_message in [
             u'You made your supplier declaration and submitted 1 service.',
             u'Download your application result letter (.pdf)',
             u'This letter informs you if your G-Cloud 7 application has been successful.'
         ]:
-            assert_in(equivocal_message, data)
+            assert equivocal_message in data
 
     def test_countersigned_framework_agreement_non_fav_framework(self, data_api_client, s3):
         # "fav" being "frameworkAgreementVersion"
@@ -1617,9 +1607,9 @@ class TestFrameworkAgreement(BaseApplicationTest):
             res = self.client.get("/suppliers/frameworks/g-cloud-7/agreement")
             data = res.get_data(as_text=True)
 
-            assert_equal(res.status_code, 200)
-            assert_in(u'Send document to CCS', data)
-            assert_not_in(u'Return your signed signature page', data)
+            assert res.status_code == 200
+            assert u'Send document to CCS' in data
+            assert u'Return your signed signature page' not in data
 
     def test_page_returns_404_if_framework_in_wrong_state(self, data_api_client):
         with self.app.test_client():
@@ -1631,7 +1621,7 @@ class TestFrameworkAgreement(BaseApplicationTest):
 
             res = self.client.get("/suppliers/frameworks/g-cloud-7/agreement")
 
-            assert_equal(res.status_code, 404)
+            assert res.status_code == 404
 
     def test_page_returns_404_if_supplier_not_on_framework(self, data_api_client):
         with self.app.test_client():
@@ -1643,7 +1633,7 @@ class TestFrameworkAgreement(BaseApplicationTest):
 
             res = self.client.get("/suppliers/frameworks/g-cloud-7/agreement")
 
-            assert_equal(res.status_code, 404)
+            assert res.status_code == 404
 
     @mock.patch('dmutils.s3.S3')
     def test_upload_message_if_agreement_is_returned(self, s3, data_api_client):
@@ -1659,13 +1649,10 @@ class TestFrameworkAgreement(BaseApplicationTest):
             data = res.get_data(as_text=True)
             doc = html.fromstring(data)
 
-            assert_equal(res.status_code, 200)
-            assert_equal(
-                u'/suppliers/frameworks/g-cloud-7/agreement',
-                doc.xpath('//form')[0].action
-            )
-            assert_in(u'Document uploaded Monday 2 November 2015 at 15:25', data)
-            assert_in(u'Your document has been uploaded', data)
+            assert res.status_code == 200
+            assert u'/suppliers/frameworks/g-cloud-7/agreement' == doc.xpath('//form')[0].action
+            assert u'Document uploaded Monday 2 November 2015 at 15:25' in data
+            assert u'Your document has been uploaded' in data
 
     def test_upload_message_if_agreement_is_not_returned(self, data_api_client):
         with self.app.test_client():
@@ -1679,13 +1666,10 @@ class TestFrameworkAgreement(BaseApplicationTest):
             data = res.get_data(as_text=True)
             doc = html.fromstring(data)
 
-            assert_equal(res.status_code, 200)
-            assert_equal(
-                u'/suppliers/frameworks/g-cloud-7/agreement',
-                doc.xpath('//form')[0].action
-            )
-            assert_not_in(u'Document uploaded', data)
-            assert_not_in(u'Your document has been uploaded', data)
+            assert res.status_code == 200
+            assert u'/suppliers/frameworks/g-cloud-7/agreement' == doc.xpath('//form')[0].action
+            assert u'Document uploaded' not in data
+            assert u'Your document has been uploaded' not in data
 
     def test_loads_contract_start_page_if_framework_agreement_version_exists(self, data_api_client):
         with self.app.test_client():
@@ -1757,7 +1741,7 @@ class TestFrameworkAgreementUpload(BaseApplicationTest):
                 }
             )
 
-            assert_equal(res.status_code, 404)
+            assert res.status_code == 404
 
     def test_page_returns_404_if_supplier_not_on_framework(self, data_api_client, send_email, s3):
         with self.app.test_client():
@@ -1774,7 +1758,7 @@ class TestFrameworkAgreementUpload(BaseApplicationTest):
                 }
             )
 
-            assert_equal(res.status_code, 404)
+            assert res.status_code == 404
 
     @mock.patch('app.main.views.frameworks.file_is_less_than_5mb')
     def test_page_returns_400_if_file_is_too_large(self, file_is_less_than_5mb, data_api_client, send_email, s3):
@@ -1813,8 +1797,8 @@ class TestFrameworkAgreementUpload(BaseApplicationTest):
                 }
             )
 
-            assert_equal(res.status_code, 400)
-            assert_in(u'Document must not be empty', res.get_data(as_text=True))
+            assert res.status_code == 400
+            assert u'Document must not be empty' in res.get_data(as_text=True)
 
     @mock.patch('app.main.views.frameworks.generate_timestamped_document_upload_path')
     def test_api_is_not_updated_and_email_not_sent_if_upload_fails(
@@ -1836,7 +1820,7 @@ class TestFrameworkAgreementUpload(BaseApplicationTest):
                 }
             )
 
-            assert_equal(res.status_code, 503)
+            assert res.status_code == 503
             s3.return_value.save.assert_called_with(
                 'my/path.pdf',
                 mock.ANY,
@@ -2024,8 +2008,8 @@ class TestFrameworkAgreementUpload(BaseApplicationTest):
                 acl='private',
                 download_filename='Supplier_Nme-1234-signed-framework-agreement.jpg'
             )
-            assert_equal(res.status_code, 302)
-            assert_equal(res.location, 'http://localhost/suppliers/frameworks/g-cloud-7/agreement')
+            assert res.status_code == 302
+            assert res.location == 'http://localhost/suppliers/frameworks/g-cloud-7/agreement'
 
 
 @mock.patch('app.main.views.frameworks.data_api_client', autospec=True)
@@ -2039,7 +2023,7 @@ class TestFrameworkAgreementDocumentDownload(BaseApplicationTest):
 
             res = self.client.get('/suppliers/frameworks/g-cloud-7/agreements/example.pdf')
 
-            assert_equal(res.status_code, 404)
+            assert res.status_code == 404
 
     def test_download_document_fails_if_no_supplier_declaration(self, S3, data_api_client):
         data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(declaration=None)
@@ -2049,7 +2033,7 @@ class TestFrameworkAgreementDocumentDownload(BaseApplicationTest):
 
             res = self.client.get('/suppliers/frameworks/g-cloud-7/agreements/example.pdf')
 
-            assert_equal(res.status_code, 404)
+            assert res.status_code == 404
 
     def test_download_document(self, S3, data_api_client):
         data_api_client.get_supplier_framework_info.return_value = self.supplier_framework()
@@ -2063,8 +2047,8 @@ class TestFrameworkAgreementDocumentDownload(BaseApplicationTest):
 
             res = self.client.get('/suppliers/frameworks/g-cloud-7/agreements/example.pdf')
 
-            assert_equal(res.status_code, 302)
-            assert_equal(res.location, 'http://asset-host/path?param=value')
+            assert res.status_code == 302
+            assert res.location == 'http://asset-host/path?param=value'
             uploader.get_signed_url.assert_called_with(
                 'g-cloud-7/agreements/1234/1234-example.pdf')
 
@@ -2081,8 +2065,8 @@ class TestFrameworkAgreementDocumentDownload(BaseApplicationTest):
 
             res = self.client.get('/suppliers/frameworks/g-cloud-7/agreements/example.pdf')
 
-            assert_equal(res.status_code, 302)
-            assert_equal(res.location, 'https://example/path?param=value')
+            assert res.status_code == 302
+            assert res.location == 'https://example/path?param=value'
             uploader.get_signed_url.assert_called_with(
                 'g-cloud-7/agreements/1234/1234-example.pdf')
 
@@ -2099,8 +2083,8 @@ class TestFrameworkDocumentDownload(BaseApplicationTest):
 
             res = self.client.get('/suppliers/frameworks/g-cloud-7/files/example.pdf')
 
-            assert_equal(res.status_code, 302)
-            assert_equal(res.location, 'http://asset-host/path?param=value')
+            assert res.status_code == 302
+            assert res.location == 'http://asset-host/path?param=value'
             uploader.get_signed_url.assert_called_with('g-cloud-7/communications/example.pdf')
 
     def test_download_document_returns_404_if_url_is_None(self, S3):
@@ -2113,7 +2097,7 @@ class TestFrameworkDocumentDownload(BaseApplicationTest):
 
             res = self.client.get('/suppliers/frameworks/g-cloud-7/files/example.pdf')
 
-            assert_equal(res.status_code, 404)
+            assert res.status_code == 404
 
 
 @mock.patch('app.main.views.frameworks.data_api_client', autospec=True)
@@ -2128,12 +2112,10 @@ class TestSupplierDeclaration(BaseApplicationTest):
             res = self.client.get(
                 '/suppliers/frameworks/g-cloud-7/declaration/g-cloud-7-essentials')
 
-            assert_equal(res.status_code, 200)
+            assert res.status_code == 200
             doc = html.fromstring(res.get_data(as_text=True))
-            assert_equal(
-                doc.xpath('//input[@id="PR-1-yes"]/@checked'), [])
-            assert_equal(
-                doc.xpath('//input[@id="PR-1-no"]/@checked'), [])
+            assert doc.xpath('//input[@id="PR-1-yes"]/@checked') == []
+            assert doc.xpath('//input[@id="PR-1-no"]/@checked') == []
 
     def test_get_with_with_previous_answers(self, data_api_client):
         with self.app.test_client():
@@ -2147,10 +2129,9 @@ class TestSupplierDeclaration(BaseApplicationTest):
             res = self.client.get(
                 '/suppliers/frameworks/g-cloud-7/declaration/g-cloud-7-essentials')
 
-            assert_equal(res.status_code, 200)
+            assert res.status_code == 200
             doc = html.fromstring(res.get_data(as_text=True))
-            assert_equal(
-                len(doc.xpath('//input[@id="input-PR1-no"]/@checked')), 1)
+            assert len(doc.xpath('//input[@id="input-PR1-no"]/@checked')) == 1
 
     def test_post_valid_data(self, data_api_client):
         with self.app.test_client():
@@ -2164,7 +2145,7 @@ class TestSupplierDeclaration(BaseApplicationTest):
                 '/suppliers/frameworks/g-cloud-7/declaration/g-cloud-7-essentials',
                 data=FULL_G7_SUBMISSION)
 
-            assert_equal(res.status_code, 302)
+            assert res.status_code == 302
             assert data_api_client.set_supplier_declaration.called
 
     def test_post_valid_data_to_complete_declaration(self, data_api_client):
@@ -2179,8 +2160,8 @@ class TestSupplierDeclaration(BaseApplicationTest):
                 '/suppliers/frameworks/g-cloud-7/declaration/grounds-for-discretionary-exclusion',
                 data=FULL_G7_SUBMISSION)
 
-            assert_equal(res.status_code, 302)
-            assert_equal(res.location, 'http://localhost/suppliers/frameworks/g-cloud-7')
+            assert res.status_code == 302
+            assert res.location == 'http://localhost/suppliers/frameworks/g-cloud-7'
             assert data_api_client.set_supplier_declaration.called
             assert data_api_client.set_supplier_declaration.call_args[0][2]['status'] == 'complete'
 
@@ -2198,7 +2179,7 @@ class TestSupplierDeclaration(BaseApplicationTest):
                 '/suppliers/frameworks/g-cloud-7/declaration/g-cloud-7-essentials',
                 data=FULL_G7_SUBMISSION)
 
-            assert_equal(res.status_code, 400)
+            assert res.status_code == 400
 
     @mock.patch('app.main.helpers.validation.G7Validator.get_error_messages_for_page')
     def test_post_with_validation_errors(self, get_error_messages_for_page, data_api_client):
@@ -2216,7 +2197,7 @@ class TestSupplierDeclaration(BaseApplicationTest):
                 '/suppliers/frameworks/g-cloud-7/declaration/g-cloud-7-essentials',
                 data=FULL_G7_SUBMISSION)
 
-            assert_equal(res.status_code, 400)
+            assert res.status_code == 400
             assert not data_api_client.set_supplier_declaration.called
 
             doc = html.fromstring(res.get_data(as_text=True))
@@ -2237,7 +2218,7 @@ class TestSupplierDeclaration(BaseApplicationTest):
                 '/suppliers/frameworks/g-cloud-7/declaration/g-cloud-7-essentials',
                 data=FULL_G7_SUBMISSION)
 
-            assert_equal(res.status_code, 404)
+            assert res.status_code == 404
             assert not data_api_client.set_supplier_declaration.called
 
 
@@ -2247,10 +2228,7 @@ class TestFrameworkUpdatesPage(BaseApplicationTest):
 
     def _assert_page_title_and_table_headings(self, doc, tables_exist=True):
 
-        assert_true(
-            self.strip_all_whitespace('G-Cloud 7 updates')
-            in self.strip_all_whitespace(doc.xpath('//h1')[0].text)
-        )
+        assert self.strip_all_whitespace('G-Cloud 7 updates') in self.strip_all_whitespace(doc.xpath('//h1')[0].text)
 
         section_names = [
             'Communications',
@@ -2258,21 +2236,15 @@ class TestFrameworkUpdatesPage(BaseApplicationTest):
         ]
 
         headers = doc.xpath('//div[contains(@class, "updates-document-tables")]/h2[@class="summary-item-heading"]')
-        assert_equal(len(headers), 2)
+        assert len(headers) == 2
         for index, section_name in enumerate(section_names):
-            assert_true(
-                self.strip_all_whitespace(section_name)
-                in self.strip_all_whitespace(headers[index].text)
-            )
+            assert self.strip_all_whitespace(section_name) in self.strip_all_whitespace(headers[index].text)
 
         if tables_exist:
             table_captions = doc.xpath('//div[contains(@class, "updates-document-tables")]/table/caption')
-            assert_equal(len(table_captions), 2)
+            assert len(table_captions) == 2
             for index, section_name in enumerate(section_names):
-                assert_true(
-                    self.strip_all_whitespace(section_name)
-                    in self.strip_all_whitespace(table_captions[index].text)
-                )
+                assert self.strip_all_whitespace(section_name) in self.strip_all_whitespace(table_captions[index].text)
 
     def test_should_be_a_503_if_connecting_to_amazon_fails(self, s3, data_api_client):
         data_api_client.get_framework.return_value = self.framework('open')
@@ -2286,11 +2258,9 @@ class TestFrameworkUpdatesPage(BaseApplicationTest):
                 '/suppliers/frameworks/g-cloud-7/updates'
             )
 
-            assert_equal(response.status_code, 503)
-            assert_true(
-                self.strip_all_whitespace(u"<h1>Sorry, we’re experiencing technical difficulties</h1>")
-                in self.strip_all_whitespace(response.get_data(as_text=True))
-            )
+            assert response.status_code == 503
+            assert self.strip_all_whitespace(u"<h1>Sorry, we’re experiencing technical difficulties</h1>") in \
+                self.strip_all_whitespace(response.get_data(as_text=True))
 
     def test_empty_messages_exist_if_no_files_returned(self, s3, data_api_client):
         data_api_client.get_framework.return_value = self.framework('open')
@@ -2302,7 +2272,7 @@ class TestFrameworkUpdatesPage(BaseApplicationTest):
                 '/suppliers/frameworks/g-cloud-7/updates'
             )
 
-            assert_equal(response.status_code, 200)
+            assert response.status_code == 200
             doc = html.fromstring(response.get_data(as_text=True))
             self._assert_page_title_and_table_headings(doc, tables_exist=False)
 
@@ -2310,10 +2280,8 @@ class TestFrameworkUpdatesPage(BaseApplicationTest):
                 '<p class="summary-item-no-content">No communications have been sent out.</p>',
                 '<p class="summary-item-no-content">No clarification questions and answers have been posted yet.</p>',
             ]:
-                assert_true(
-                    self.strip_all_whitespace(empty_message)
-                    in self.strip_all_whitespace(response.get_data(as_text=True))
-                )
+                assert self.strip_all_whitespace(empty_message) in \
+                    self.strip_all_whitespace(response.get_data(as_text=True))
 
     def test_dates_for_open_framework_closed_for_questions(self, s3, data_api_client):
         data_api_client.get_framework.return_value = self.framework('open', clarification_questions_open=False)
@@ -2373,19 +2341,18 @@ class TestFrameworkUpdatesPage(BaseApplicationTest):
             # test that for each table, we have the right number of rows
             for table in tables:
                 item_rows = table.findall('.//tr[@class="summary-item-row"]')
-                assert_equal(len(item_rows), 2)
+                assert len(item_rows) == 2
 
                 # test that the file names and urls are right
                 for row in item_rows:
                     section, filename, ext = files.pop(0)
                     filename_link = row.find('.//a[@class="document-link-with-icon"]')
 
-                    assert_true(filename in filename_link.text_content())
-                    assert_equal(
-                        filename_link.get('href'),
-                        '/suppliers/frameworks/g-cloud-7/files/{}{}.{}'.format(
-                            section, filename.replace(' ', '%20'), ext
-                        )
+                    assert filename in filename_link.text_content()
+                    assert filename_link.get('href') == '/suppliers/frameworks/g-cloud-7/files/{}{}.{}'.format(
+                        section,
+                        filename.replace(' ', '%20'),
+                        ext,
                     )
 
     def test_names_with_the_section_name_in_them_will_display_correctly(self, s3, data_api_client):
@@ -2417,19 +2384,18 @@ class TestFrameworkUpdatesPage(BaseApplicationTest):
             # test that for each table, we have the right number of rows
             for table in tables:
                 item_rows = table.findall('.//tr[@class="summary-item-row"]')
-                assert_equal(len(item_rows), 1)
+                assert len(item_rows) == 1
 
                 # test that the file names and urls are right
                 for row in item_rows:
                     section, filename, ext = files.pop(0)
                     filename_link = row.find('.//a[@class="document-link-with-icon"]')
 
-                    assert_true(filename in filename_link.text_content())
-                    assert_equal(
-                        filename_link.get('href'),
-                        '/suppliers/frameworks/g-cloud-7/files/{}{}.{}'.format(
-                            section, filename.replace(' ', '%20'), ext
-                        )
+                    assert filename in filename_link.text_content()
+                    assert filename_link.get('href') == '/suppliers/frameworks/g-cloud-7/files/{}{}.{}'.format(
+                        section,
+                        filename.replace(' ', '%20'),
+                        ext,
                     )
 
     def test_question_box_is_shown_if_countersigned_agreement_is_not_yet_returned(self, s3, data_api_client):
@@ -2443,7 +2409,7 @@ class TestFrameworkUpdatesPage(BaseApplicationTest):
             data = response.get_data(as_text=True)
 
             assert response.status_code == 200
-            assert_in(u'Ask a question about your G-Cloud 7 application', data)
+            assert u'Ask a question about your G-Cloud 7 application' in data
 
     def test_no_question_box_shown_if_countersigned_agreement_is_returned(self, s3, data_api_client):
         data_api_client.get_framework.return_value = self.framework('live', clarification_questions_open=False)
@@ -2456,7 +2422,7 @@ class TestFrameworkUpdatesPage(BaseApplicationTest):
             data = response.get_data(as_text=True)
 
             assert response.status_code == 200
-            assert_not_in(u'Ask a question about your G-Cloud 7 application', data)
+            assert u'Ask a question about your G-Cloud 7 application' not in data
 
 
 class TestSendClarificationQuestionEmail(BaseApplicationTest):
@@ -2475,11 +2441,11 @@ class TestSendClarificationQuestionEmail(BaseApplicationTest):
     def _assert_clarification_email(self, send_email, is_called=True, succeeds=True):
 
         if succeeds:
-            assert_equal(2, send_email.call_count)
+            assert send_email.call_count == 2
         elif is_called:
-            assert_equal(1, send_email.call_count)
+            assert send_email.call_count == 1
         else:
-            assert_equal(0, send_email.call_count)
+            assert send_email.call_count == 0
 
         if is_called:
             send_email.assert_any_call(
@@ -2506,9 +2472,9 @@ class TestSendClarificationQuestionEmail(BaseApplicationTest):
     def _assert_application_email(self, send_email, succeeds=True):
 
         if succeeds:
-            assert_equal(1, send_email.call_count)
+            assert send_email.call_count == 1
         else:
-            assert_equal(0, send_email.call_count)
+            assert send_email.call_count == 0
 
         if succeeds:
             send_email.assert_called_with(
@@ -2546,15 +2512,11 @@ class TestSendClarificationQuestionEmail(BaseApplicationTest):
             response = self._send_email(invalid_clarification_question['question'])
             self._assert_clarification_email(send_email, is_called=False, succeeds=False)
 
-            assert_equal(response.status_code, 400)
-            assert_true(
-                self.strip_all_whitespace('There was a problem with your submitted question')
-                in self.strip_all_whitespace(response.get_data(as_text=True))
-            )
-            assert_true(
-                self.strip_all_whitespace(invalid_clarification_question['error_message'])
-                in self.strip_all_whitespace(response.get_data(as_text=True))
-            )
+            assert response.status_code == 400
+            assert self.strip_all_whitespace('There was a problem with your submitted question') in \
+                self.strip_all_whitespace(response.get_data(as_text=True))
+            assert self.strip_all_whitespace(invalid_clarification_question['error_message']) in \
+                self.strip_all_whitespace(response.get_data(as_text=True))
 
     @mock.patch('dmutils.s3.S3')
     @mock.patch('app.main.views.frameworks.data_api_client')
@@ -2567,11 +2529,11 @@ class TestSendClarificationQuestionEmail(BaseApplicationTest):
 
         self._assert_clarification_email(send_email)
 
-        assert_equal(response.status_code, 200)
-        assert_true(
-            self.strip_all_whitespace('<p class="banner-message">Your clarification question has been sent. Answers to all clarification questions will be published on this page.</p>')  # noqa
-            in self.strip_all_whitespace(response.get_data(as_text=True))
-        )
+        assert response.status_code == 200
+        assert self.strip_all_whitespace(
+            '<p class="banner-message">Your clarification question has been sent. Answers to all ' +
+            'clarification questions will be published on this page.</p>'
+        ) in self.strip_all_whitespace(response.get_data(as_text=True))
 
     @mock.patch('dmutils.s3.S3')
     @mock.patch('app.main.views.frameworks.data_api_client')
@@ -2584,11 +2546,11 @@ class TestSendClarificationQuestionEmail(BaseApplicationTest):
 
         self._assert_application_email(send_email)
 
-        assert_equal(response.status_code, 200)
-        assert_in(
-            self.strip_all_whitespace('<p class="banner-message">Your question has been sent. You&#39;ll get a reply from the Crown Commercial Service soon.</p>'),  # noqa
-            self.strip_all_whitespace(response.get_data(as_text=True))
-        )
+        assert response.status_code == 200
+        assert self.strip_all_whitespace(
+            '<p class="banner-message">Your question has been sent. You&#39;ll get a reply from ' +
+            'the Crown Commercial Service soon.</p>'
+        ) in self.strip_all_whitespace(response.get_data(as_text=True))
 
     @mock.patch('dmutils.s3.S3')
     @mock.patch('app.main.views.frameworks.data_api_client')
@@ -2600,7 +2562,7 @@ class TestSendClarificationQuestionEmail(BaseApplicationTest):
 
         self._assert_clarification_email(send_email)
 
-        assert_equal(response.status_code, 200)
+        assert response.status_code == 200
         data_api_client.create_audit_event.assert_called_with(
             audit_type=AuditTypes.send_clarification_question,
             user="email@email.com",
@@ -2619,7 +2581,7 @@ class TestSendClarificationQuestionEmail(BaseApplicationTest):
 
         self._assert_application_email(send_email)
 
-        assert_equal(response.status_code, 200)
+        assert response.status_code == 200
         data_api_client.create_audit_event.assert_called_with(
             audit_type=AuditTypes.send_application_question,
             user="email@email.com",
@@ -2637,7 +2599,7 @@ class TestSendClarificationQuestionEmail(BaseApplicationTest):
         response = self._send_email(clarification_question)
         self._assert_clarification_email(send_email, succeeds=False)
 
-        assert_equal(response.status_code, 503)
+        assert response.status_code == 503
 
 
 @mock.patch('app.main.views.frameworks.data_api_client', autospec=True)
@@ -2651,7 +2613,7 @@ class TestG7ServicesList(BaseApplicationTest):
         data_api_client.find_draft_services.return_value = {'services': []}
         count_unanswered.return_value = 0
         response = self.client.get('/suppliers/frameworks/g-cloud-7/submissions/iaas')
-        assert_equal(response.status_code, 404)
+        assert response.status_code == 404
 
     def test_404_when_g7_pending_and_no_declaration(self, count_unanswered, data_api_client):
         with self.app.test_client():
@@ -2661,7 +2623,7 @@ class TestG7ServicesList(BaseApplicationTest):
             "declaration": {"status": "started"}
         }
         response = self.client.get('/suppliers/frameworks/g-cloud-7/submissions/iaas')
-        assert_equal(response.status_code, 404)
+        assert response.status_code == 404
 
     def test_no_404_when_g7_open_and_no_complete_services(self, count_unanswered, data_api_client):
         with self.app.test_client():
@@ -2670,7 +2632,7 @@ class TestG7ServicesList(BaseApplicationTest):
         data_api_client.find_draft_services.return_value = {'services': []}
         count_unanswered.return_value = 0
         response = self.client.get('/suppliers/frameworks/g-cloud-7/submissions/iaas')
-        assert_equal(response.status_code, 200)
+        assert response.status_code == 200
 
     def test_no_404_when_g7_open_and_no_declaration(self, count_unanswered, data_api_client):
         with self.app.test_client():
@@ -2681,7 +2643,7 @@ class TestG7ServicesList(BaseApplicationTest):
             "declaration": {"status": "started"}
         }
         response = self.client.get('/suppliers/frameworks/g-cloud-7/submissions/iaas')
-        assert_equal(response.status_code, 200)
+        assert response.status_code == 200
 
     def test_shows_g7_message_if_pending_and_application_made(self, count_unanswered, data_api_client):
         with self.app.test_client():
@@ -2698,13 +2660,12 @@ class TestG7ServicesList(BaseApplicationTest):
         response = self.client.get('/suppliers/frameworks/g-cloud-7/submissions/scs')
         doc = html.fromstring(response.get_data(as_text=True))
 
-        assert_equal(response.status_code, 200)
+        assert response.status_code == 200
         heading = doc.xpath('//div[@class="summary-item-lede"]//h2[@class="summary-item-heading"]')
-        assert_true(len(heading) > 0)
-        assert_in(u"G-Cloud 7 is closed for applications",
-                  heading[0].xpath('text()')[0])
-        assert_in(u"You made your supplier declaration and submitted 1 complete service.",
-                  heading[0].xpath('../p[1]/text()')[0])
+        assert len(heading) > 0
+        assert u"G-Cloud 7 is closed for applications" in heading[0].xpath('text()')[0]
+        assert u"You made your supplier declaration and submitted 1 complete service." in \
+            heading[0].xpath('../p[1]/text()')[0]
 
     def test_drafts_list_progress_count(self, count_unanswered, data_api_client):
         with self.app.test_client():
@@ -2721,11 +2682,11 @@ class TestG7ServicesList(BaseApplicationTest):
         submissions = self.client.get('/suppliers/frameworks/g-cloud-7/submissions')
         lot_page = self.client.get('/suppliers/frameworks/g-cloud-7/submissions/scs')
 
-        assert_true(u'Service can be moved to complete' not in lot_page.get_data(as_text=True))
-        assert_in(u'4 unanswered questions', lot_page.get_data(as_text=True))
+        assert u'Service can be moved to complete' not in lot_page.get_data(as_text=True)
+        assert u'4 unanswered questions' in lot_page.get_data(as_text=True)
 
-        assert_in(u'1 draft service', submissions.get_data(as_text=True))
-        assert_true(u'complete service' not in submissions.get_data(as_text=True))
+        assert u'1 draft service' in submissions.get_data(as_text=True)
+        assert u'complete service' not in submissions.get_data(as_text=True)
 
     def test_drafts_list_can_be_completed(self, count_unanswered, data_api_client):
         with self.app.test_client():
@@ -2742,8 +2703,8 @@ class TestG7ServicesList(BaseApplicationTest):
 
         res = self.client.get('/suppliers/frameworks/g-cloud-7/submissions/scs')
 
-        assert_in(u'Service can be marked as complete', res.get_data(as_text=True))
-        assert_in(u'1 optional question unanswered', res.get_data(as_text=True))
+        assert u'Service can be marked as complete' in res.get_data(as_text=True)
+        assert u'1 optional question unanswered' in res.get_data(as_text=True)
 
     def test_drafts_list_completed(self, count_unanswered, data_api_client):
         with self.app.test_client():
@@ -2761,12 +2722,12 @@ class TestG7ServicesList(BaseApplicationTest):
         submissions = self.client.get('/suppliers/frameworks/g-cloud-7/submissions')
         lot_page = self.client.get('/suppliers/frameworks/g-cloud-7/submissions/scs')
 
-        assert_true(u'Service can be moved to complete' not in lot_page.get_data(as_text=True))
-        assert_in(u'1 optional question unanswered', lot_page.get_data(as_text=True))
-        assert_in(u'make the supplier&nbsp;declaration', lot_page.get_data(as_text=True))
+        assert u'Service can be moved to complete' not in lot_page.get_data(as_text=True)
+        assert u'1 optional question unanswered' in lot_page.get_data(as_text=True)
+        assert u'make the supplier&nbsp;declaration' in lot_page.get_data(as_text=True)
 
-        assert_in(u'1 service marked as complete', submissions.get_data(as_text=True))
-        assert_true(u'draft service' not in submissions.get_data(as_text=True))
+        assert u'1 service marked as complete' in submissions.get_data(as_text=True)
+        assert u'draft service' not in submissions.get_data(as_text=True)
 
     def test_drafts_list_completed_with_declaration_status(self, count_unanswered, data_api_client):
         with self.app.test_client():
@@ -2786,9 +2747,9 @@ class TestG7ServicesList(BaseApplicationTest):
 
         submissions = self.client.get('/suppliers/frameworks/g-cloud-7/submissions')
 
-        assert_in(u'1 service will be submitted', submissions.get_data(as_text=True))
-        assert_not_in(u'1 complete service was submitted', submissions.get_data(as_text=True))
-        assert_in(u'browse-list-item-status-happy', submissions.get_data(as_text=True))
+        assert u'1 service will be submitted' in submissions.get_data(as_text=True)
+        assert u'1 complete service was submitted' not in submissions.get_data(as_text=True)
+        assert u'browse-list-item-status-happy' in submissions.get_data(as_text=True)
 
     def test_drafts_list_services_were_submitted(self, count_unanswered, data_api_client):
         with self.app.test_client():
@@ -2809,7 +2770,7 @@ class TestG7ServicesList(BaseApplicationTest):
 
         submissions = self.client.get('/suppliers/frameworks/g-cloud-7/submissions')
 
-        assert_in(u'1 complete service was submitted', submissions.get_data(as_text=True))
+        assert u'1 complete service was submitted' in submissions.get_data(as_text=True)
 
     def test_dos_drafts_list_with_open_framework(self, count_unanswered, data_api_client):
         with self.app.test_client():
@@ -2830,9 +2791,9 @@ class TestG7ServicesList(BaseApplicationTest):
 
         submissions = self.client.get('/suppliers/frameworks/digital-outcomes-and-specialists/submissions')
 
-        assert_in(u'This will be submitted', submissions.get_data(as_text=True))
-        assert_in(u'browse-list-item-status-happy', submissions.get_data(as_text=True))
-        assert_in(u'Apply to provide', submissions.get_data(as_text=True))
+        assert u'This will be submitted' in submissions.get_data(as_text=True)
+        assert u'browse-list-item-status-happy' in submissions.get_data(as_text=True)
+        assert u'Apply to provide' in submissions.get_data(as_text=True)
 
     def test_dos_drafts_list_with_closed_framework(self, count_unanswered, data_api_client):
         with self.app.test_client():
@@ -2855,8 +2816,8 @@ class TestG7ServicesList(BaseApplicationTest):
         submissions = self.client.get('/suppliers/frameworks/digital-outcomes-and-specialists/submissions')
 
         assert submissions.status_code == 200
-        assert_in(u'Submitted', submissions.get_data(as_text=True))
-        assert_not_in(u'Apply to provide', submissions.get_data(as_text=True))
+        assert u'Submitted' in submissions.get_data(as_text=True)
+        assert u'Apply to provide' not in submissions.get_data(as_text=True)
 
 
 @mock.patch('app.main.views.frameworks.data_api_client', autospec=True)

--- a/tests/app/main/test_login.py
+++ b/tests/app/main/test_login.py
@@ -127,8 +127,8 @@ class TestInviteUser(BaseApplicationTest):
                     'email_address': 'total rubbish'
                 })
             assert res.status_code == 400
-            assert not send_email.called
-            assert not generate_token.called
+            assert send_email.called is False
+            assert generate_token.called is False
 
     @mock.patch('app.main.views.login.send_email')
     def test_should_be_an_error_if_send_invitation_email_fails(self, send_email):

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -534,8 +534,8 @@ class TestSupplierEditUpdateServiceSection(BaseApplicationTest):
         }
     }
 
-    def setup(self):
-        super(TestSupplierEditUpdateServiceSection, self).setup()
+    def setup_method(self, method):
+        super(TestSupplierEditUpdateServiceSection, self).setup_method(method)
         with self.app.test_client():
             self.login()
 
@@ -662,8 +662,8 @@ class TestSupplierEditUpdateServiceSection(BaseApplicationTest):
 
 @mock.patch('app.main.views.services.data_api_client', autospec=True)
 class TestCreateDraftService(BaseApplicationTest):
-    def setup(self):
-        super(TestCreateDraftService, self).setup()
+    def setup_method(self, method):
+        super(TestCreateDraftService, self).setup_method(method)
         self._answer_required = 'Answer is required'
         self._validation_error = 'There was a problem with your answer to:'
 
@@ -736,8 +736,8 @@ class TestCreateDraftService(BaseApplicationTest):
 @mock.patch('app.main.views.services.data_api_client')
 class TestCopyDraft(BaseApplicationTest):
 
-    def setup(self):
-        super(TestCopyDraft, self).setup()
+    def setup_method(self, method):
+        super(TestCopyDraft, self).setup_method(method)
 
         with self.app.test_client():
             self.login()
@@ -768,8 +768,8 @@ class TestCopyDraft(BaseApplicationTest):
 @mock.patch('app.main.views.services.data_api_client')
 class TestCompleteDraft(BaseApplicationTest):
 
-    def setup(self):
-        super(TestCompleteDraft, self).setup()
+    def setup_method(self, method):
+        super(TestCompleteDraft, self).setup_method(method)
 
         with self.app.test_client():
             self.login()
@@ -802,8 +802,8 @@ class TestCompleteDraft(BaseApplicationTest):
 @mock.patch('app.main.views.services.data_api_client')
 class TestEditDraftService(BaseApplicationTest):
 
-    def setup(self):
-        super(TestEditDraftService, self).setup()
+    def setup_method(self, method):
+        super(TestEditDraftService, self).setup_method(method)
         with self.app.test_client():
             self.login()
 
@@ -1426,8 +1426,8 @@ class TestShowDraftService(BaseApplicationTest):
     complete_service['services']['status'] = 'submitted'
     complete_service['services']['id'] = 2
 
-    def setup(self):
-        super(TestShowDraftService, self).setup()
+    def setup_method(self, method):
+        super(TestShowDraftService, self).setup_method(method)
         with self.app.test_client():
             self.login()
 
@@ -1539,8 +1539,8 @@ class TestDeleteDraftService(BaseApplicationTest):
         'validationErrors': {}
     }
 
-    def setup(self):
-        super(TestDeleteDraftService, self).setup()
+    def setup_method(self, method):
+        super(TestDeleteDraftService, self).setup_method(method)
         with self.app.test_client():
             self.login()
 
@@ -1592,8 +1592,8 @@ class TestDeleteDraftService(BaseApplicationTest):
 
 @mock.patch('dmutils.s3.S3')
 class TestSubmissionDocuments(BaseApplicationTest):
-    def setup(self):
-        super(TestSubmissionDocuments, self).setup()
+    def setup_method(self, method):
+        super(TestSubmissionDocuments, self).setup_method(method)
         with self.app.test_client():
             self.login()
 

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -11,7 +11,6 @@ import pytest
 from lxml import html
 from freezegun import freeze_time
 
-from nose.tools import assert_equal, assert_true, assert_false, assert_in, assert_not_in, assert_is
 from tests.app.helpers import BaseApplicationTest, empty_g7_draft_service
 
 
@@ -57,13 +56,10 @@ class TestListServices(BaseApplicationTest):
                 }
 
             res = self.client.get('/suppliers/services')
-            assert_equal(res.status_code, 200)
+            assert res.status_code == 200
             data_api_client.find_services.assert_called_once_with(
                 supplier_id=1234)
-            assert_in(
-                "You don&#39;t have any services on the Digital Marketplace",
-                res.get_data(as_text=True)
-            )
+            assert "You don&#39;t have any services on the Digital Marketplace" in res.get_data(as_text=True)
 
     @mock.patch('app.main.views.services.data_api_client')
     def test_shows_services_list(self, data_api_client):
@@ -83,12 +79,12 @@ class TestListServices(BaseApplicationTest):
             }
 
             res = self.client.get('/suppliers/services')
-            assert_equal(res.status_code, 200)
+            assert res.status_code == 200
             data_api_client.find_services.assert_called_once_with(
                 supplier_id=1234)
-            assert_true("Service name 123" in res.get_data(as_text=True))
-            assert_true("Software as a Service" in res.get_data(as_text=True))
-            assert_true("G-Cloud 1" in res.get_data(as_text=True))
+            assert "Service name 123" in res.get_data(as_text=True)
+            assert "Software as a Service" in res.get_data(as_text=True)
+            assert "G-Cloud 1" in res.get_data(as_text=True)
 
     @mock.patch('app.data_api_client')
     def test_should_not_be_able_to_see_page_if_made_inactive(self, services_data_api_client):
@@ -105,8 +101,8 @@ class TestListServices(BaseApplicationTest):
             )
 
             res = self.client.get('/suppliers/services')
-            assert_equal(res.status_code, 302)
-            assert_equal(res.location, 'http://localhost/login?next=%2Fsuppliers%2Fservices')
+            assert res.status_code == 302
+            assert res.location == 'http://localhost/login?next=%2Fsuppliers%2Fservices'
 
     @mock.patch('app.main.views.services.data_api_client')
     def test_shows_service_edit_link_with_id(self, data_api_client):
@@ -123,11 +119,10 @@ class TestListServices(BaseApplicationTest):
             }
 
             res = self.client.get('/suppliers/services')
-            assert_equal(res.status_code, 200)
+            assert res.status_code == 200
             data_api_client.find_services.assert_called_once_with(
                 supplier_id=1234)
-            assert_true(
-                "/suppliers/services/123" in res.get_data(as_text=True))
+            assert "/suppliers/services/123" in res.get_data(as_text=True)
 
     @mock.patch('app.main.views.services.data_api_client')
     def test_services_without_service_name_show_lot_instead(self, data_api_client):
@@ -144,7 +139,7 @@ class TestListServices(BaseApplicationTest):
             }
 
             res = self.client.get('/suppliers/services')
-            assert_equal(res.status_code, 200)
+            assert res.status_code == 200
             data_api_client.find_services.assert_called_once_with(supplier_id=1234)
 
             assert "Special Lot Name" in res.get_data(as_text=True)
@@ -165,7 +160,7 @@ class TestListServices(BaseApplicationTest):
             }
 
             res = self.client.get('/suppliers/services')
-            assert_equal(res.status_code, 200)
+            assert res.status_code == 200
             data_api_client.find_services.assert_called_once_with(supplier_id=1234)
 
             assert "Service name 123" in res.get_data(as_text=True)
@@ -186,18 +181,15 @@ class TestListServicesLogin(BaseApplicationTest):
 
             res = self.client.get('/suppliers/services')
 
-            assert_equal(res.status_code, 200)
+            assert res.status_code == 200
 
-            assert_true(
-                self.strip_all_whitespace('<h1>Current services</h1>')
-                in self.strip_all_whitespace(res.get_data(as_text=True))
-            )
+            assert self.strip_all_whitespace('<h1>Current services</h1>') in \
+                self.strip_all_whitespace(res.get_data(as_text=True))
 
     def test_should_redirect_to_login_if_not_logged_in(self):
         res = self.client.get("/suppliers/services")
-        assert_equal(res.status_code, 302)
-        assert_equal(res.location,
-                     'http://localhost/login?next=%2Fsuppliers%2Fservices')
+        assert res.status_code == 302
+        assert res.location == 'http://localhost/login?next=%2Fsuppliers%2Fservices'
 
 
 class _BaseTestSupplierEditRemoveService(BaseApplicationTest):
@@ -247,14 +239,12 @@ class TestSupplierEditService(_BaseTestSupplierEditRemoveService):
 
         res = self.client.get('/suppliers/services/123')
         if not framework_editable_services:
-            assert_equal(res.status_code, 404)
+            assert res.status_code == 404
             return
 
-        assert_equal(res.status_code, 200)
+        assert res.status_code == 200
 
-        assert_true(
-            'Service name 123' in res.get_data(as_text=True)
-        )
+        assert 'Service name 123' in res.get_data(as_text=True)
 
         # first message should be there
         self.assert_in_strip_whitespace(
@@ -301,14 +291,12 @@ class TestSupplierEditService(_BaseTestSupplierEditRemoveService):
 
         res = self.client.get('/suppliers/services/123')
         if not framework_editable_services:
-            assert_equal(res.status_code, 404)
+            assert res.status_code == 404
             return
 
-        assert_equal(res.status_code, 200)
+        assert res.status_code == 200
 
-        assert_true(
-            'Service name 123' in res.get_data(as_text=True)
-        )
+        assert 'Service name 123' in res.get_data(as_text=True)
 
         # first message should be there
         self.assert_in_strip_whitespace(
@@ -349,13 +337,11 @@ class TestSupplierEditService(_BaseTestSupplierEditRemoveService):
 
         res = self.client.get('/suppliers/services/123')
         if not framework_editable_services:
-            assert_equal(res.status_code, 404)
+            assert res.status_code == 404
             return
 
-        assert_equal(res.status_code, 200)
-        assert_true(
-            'Service name 123' in res.get_data(as_text=True)
-        )
+        assert res.status_code == 200
+        assert 'Service name 123' in res.get_data(as_text=True)
 
         self.assert_in_strip_whitespace(
             '<h2>This service was removed on Monday 23 March 2015</h2>',
@@ -376,10 +362,10 @@ class TestSupplierEditService(_BaseTestSupplierEditRemoveService):
 
         res = self.client.get('/suppliers/services/123')
         if not framework_editable_services:
-            assert_equal(res.status_code, 404)
+            assert res.status_code == 404
             return
 
-        assert_equal(res.status_code, 200)
+        assert res.status_code == 200
         self.assert_in_strip_whitespace(
             'Service name 123',
             res.get_data(as_text=True)
@@ -400,13 +386,12 @@ class TestSupplierEditService(_BaseTestSupplierEditRemoveService):
 
         res = self.client.get('/suppliers/services/123')
 
-        assert_equal(res.status_code, 404)
+        assert res.status_code == 404
 
     def test_should_redirect_to_login_if_not_logged_in(self, data_api_client):
         res = self.client.get("/suppliers/services/123")
-        assert_equal(res.status_code, 302)
-        assert_equal(res.location,
-                     'http://localhost/login?next=%2Fsuppliers%2Fservices%2F123')
+        assert res.status_code == 302
+        assert res.location == 'http://localhost/login?next=%2Fsuppliers%2Fservices%2F123'
 
 
 @mock.patch('app.main.views.services.data_api_client')
@@ -426,11 +411,11 @@ class TestSupplierRemoveServiceEditInterplay(_BaseTestSupplierEditRemoveService)
         # NOTE two http requests performed here
         res = self.client.post('/suppliers/services/123/remove', follow_redirects=True)
         if not framework_editable_services:
-            assert_equal(res.status_code, 404)
-            assert_is(data_api_client.update_service_status.called, False)
+            assert res.status_code == 404
+            assert data_api_client.update_service_status.called is False
             return
 
-        assert_equal(res.status_code, 200)
+        assert res.status_code == 200
 
         # first message should be gone
         self.assert_not_in_strip_whitespace(
@@ -463,11 +448,11 @@ class TestSupplierRemoveServiceEditInterplay(_BaseTestSupplierEditRemoveService)
             data={'remove_confirmed': True},
             follow_redirects=True)
         if not framework_editable_services:
-            assert_equal(res.status_code, 404)
-            assert_is(data_api_client.update_service_status.called, False)
+            assert res.status_code == 404
+            assert data_api_client.update_service_status.called is False
             return
 
-        assert_equal(res.status_code, 200)
+        assert res.status_code == 200
         self.assert_in_strip_whitespace(
             'Service name 123 has been removed.',
             res.get_data(as_text=True)
@@ -508,12 +493,12 @@ class TestSupplierRemoveService(_BaseTestSupplierEditRemoveService):
             data={'remove_confirmed': True} if post_data else {},
         )
         if not framework_editable_services:
-            assert_equal(response.status_code, 404)
-            assert_is(data_api_client.update_service_status.called, False)
+            assert response.status_code == 404
+            assert data_api_client.update_service_status.called is False
             return
 
-        assert_is(data_api_client.update_service_status.called, expect_api_call_if_data and post_data)
-        assert_equal(response.status_code, expected_status_code)
+        assert data_api_client.update_service_status.called is (expect_api_call_if_data and post_data)
+        assert response.status_code == expected_status_code
 
 
 @mock.patch('app.main.views.services.data_api_client')
@@ -542,11 +527,9 @@ class TestSupplierEditUpdateServiceSection(BaseApplicationTest):
     def test_return_to_service_summary_link_present(self, data_api_client):
         data_api_client.get_service.return_value = self.empty_service
         res = self.client.get('/suppliers/services/1/edit/description')
-        assert_equal(res.status_code, 200)
-        assert_in(
-            self.strip_all_whitespace('<a href="/suppliers/services/1">Return to service summary</a>'),
+        assert res.status_code == 200
+        assert self.strip_all_whitespace('<a href="/suppliers/services/1">Return to service summary</a>') in \
             self.strip_all_whitespace(res.get_data(as_text=True))
-        )
 
     def test_questions_for_this_service_section_can_be_changed(self, data_api_client):
         data_api_client.get_service.return_value = self.empty_service
@@ -557,7 +540,7 @@ class TestSupplierEditUpdateServiceSection(BaseApplicationTest):
                 'serviceSummary': 'This is the service',
             })
 
-        assert_equal(res.status_code, 302)
+        assert res.status_code == 302
         data_api_client.update_service.assert_called_once_with(
             '1', {'serviceName': 'The service', 'serviceSummary': 'This is the service'},
             'email@email.com')
@@ -571,7 +554,7 @@ class TestSupplierEditUpdateServiceSection(BaseApplicationTest):
         data_api_client.get_service.return_value = self.empty_service
 
         res = self.client.get('/suppliers/services/1/edit/service-attributes')
-        assert_equal(res.status_code, 404)
+        assert res.status_code == 404
 
         data_api_client.get_draft_service.return_value = self.empty_service
         res = self.client.post(
@@ -579,7 +562,8 @@ class TestSupplierEditUpdateServiceSection(BaseApplicationTest):
             data={
                 'lotSlug': 'scs',
             })
-        assert_equal(res.status_code, 404)
+
+        assert res.status_code == 404
         self.assert_no_flashes()
 
     def test_only_questions_for_this_service_section_can_be_changed(self, data_api_client):
@@ -590,7 +574,7 @@ class TestSupplierEditUpdateServiceSection(BaseApplicationTest):
                 'serviceFeatures': '',
             })
 
-        assert_equal(res.status_code, 302)
+        assert res.status_code == 302
         data_api_client.update_service.assert_called_once_with(
             '1', dict(), 'email@email.com')
 
@@ -603,14 +587,14 @@ class TestSupplierEditUpdateServiceSection(BaseApplicationTest):
         data_api_client.get_service.return_value = None
         res = self.client.get('/suppliers/services/1/edit/description')
 
-        assert_equal(res.status_code, 404)
+        assert res.status_code == 404
 
     def test_edit_non_existent_section_returns_404(self, data_api_client):
         data_api_client.get_service.return_value = self.empty_service
         res = self.client.get(
             '/suppliers/services/1/edit/invalid-section'
         )
-        assert_equal(404, res.status_code)
+        assert res.status_code == 404
 
     def test_update_with_answer_required_error(self, data_api_client):
         data_api_client.get_service.return_value = self.empty_service
@@ -621,11 +605,11 @@ class TestSupplierEditUpdateServiceSection(BaseApplicationTest):
             '/suppliers/services/1/edit/description',
             data={})
 
-        assert_equal(res.status_code, 200)
+        assert res.status_code == 200
         document = html.fromstring(res.get_data(as_text=True))
-        assert_equal(
-            "You need to answer this question.",
-            document.xpath('//span[@class="validation-message"]/text()')[0].strip())
+        assert document.xpath(
+            '//span[@class="validation-message"]/text()'
+        )[0].strip() == "You need to answer this question."
         self.assert_no_flashes()
 
     def test_update_with_under_50_words_error(self, data_api_client):
@@ -637,18 +621,18 @@ class TestSupplierEditUpdateServiceSection(BaseApplicationTest):
             '/suppliers/services/1/edit/description',
             data={})
 
-        assert_equal(res.status_code, 200)
+        assert res.status_code == 200
         document = html.fromstring(res.get_data(as_text=True))
-        assert_equal(
-            "Your description must be no more than 50 words.",
-            document.xpath('//span[@class="validation-message"]/text()')[0].strip())
+        assert document.xpath(
+            '//span[@class="validation-message"]/text()'
+        )[0].strip() == "Your description must be no more than 50 words."
         self.assert_no_flashes()
 
     def test_update_non_existent_service_returns_404(self, data_api_client):
         data_api_client.get_service.return_value = None
         res = self.client.post('/suppliers/services/1/edit/description')
 
-        assert_equal(res.status_code, 404)
+        assert res.status_code == 404
         self.assert_no_flashes()
 
     def test_update_non_existent_section_returns_404(self, data_api_client):
@@ -656,7 +640,7 @@ class TestSupplierEditUpdateServiceSection(BaseApplicationTest):
         res = self.client.post(
             '/suppliers/services/1/edit/invalid_section'
         )
-        assert_equal(404, res.status_code)
+        assert res.status_code == 404
         self.assert_no_flashes()
 
 
@@ -674,16 +658,16 @@ class TestCreateDraftService(BaseApplicationTest):
         data_api_client.get_framework.return_value = self.framework(status='open')
 
         res = self.client.get('/suppliers/frameworks/g-cloud-7/submissions/scs/create')
-        assert_equal(res.status_code, 200)
-        assert_in(u'Service name', res.get_data(as_text=True))
+        assert res.status_code == 200
+        assert u'Service name' in res.get_data(as_text=True)
 
-        assert_not_in(self._validation_error, res.get_data(as_text=True))
+        assert self._validation_error not in res.get_data(as_text=True)
 
     def test_can_not_get_create_draft_service_page_if_not_open(self, data_api_client):
         data_api_client.get_framework.return_value = self.framework(status='other')
 
         res = self.client.get('/suppliers/frameworks/g-cloud-7/submissions/scs/create')
-        assert_equal(res.status_code, 404)
+        assert res.status_code == 404
 
     def _test_post_create_draft_service(self, data, if_error_expected, data_api_client):
         data_api_client.get_framework.return_value = self.framework(status='open')
@@ -695,10 +679,10 @@ class TestCreateDraftService(BaseApplicationTest):
         )
 
         if if_error_expected:
-            assert_equal(res.status_code, 400)
-            assert_in(self._validation_error, res.get_data(as_text=True))
+            assert res.status_code == 400
+            assert self._validation_error in res.get_data(as_text=True)
         else:
-            assert_equal(res.status_code, 302)
+            assert res.status_code == 302
 
     def test_post_create_draft_service_succeeds(self, data_api_client):
         self._test_post_create_draft_service(
@@ -722,15 +706,15 @@ class TestCreateDraftService(BaseApplicationTest):
             data={}
         )
 
-        assert_equal(res.status_code, 400)
-        assert_in(self._validation_error, res.get_data(as_text=True))
+        assert res.status_code == 400
+        assert self._validation_error in res.get_data(as_text=True)
 
     def test_cannot_post_if_not_open(self, data_api_client):
         data_api_client.get_framework.return_value = self.framework(status='other')
         res = self.client.post(
             '/suppliers/submission/g-cloud-7/submissions/scs/create'
         )
-        assert_equal(res.status_code, 404)
+        assert res.status_code == 404
 
 
 @mock.patch('app.main.views.services.data_api_client')
@@ -749,20 +733,20 @@ class TestCopyDraft(BaseApplicationTest):
         data_api_client.get_draft_service.return_value = {'services': self.draft}
 
         res = self.client.post('/suppliers/frameworks/g-cloud-7/submissions/scs/1/copy')
-        assert_equal(res.status_code, 302)
+        assert res.status_code == 302
 
     def test_copy_draft_checks_supplier_id(self, data_api_client):
         self.draft['supplierId'] = 2
         data_api_client.get_draft_service.return_value = {'services': self.draft}
 
         res = self.client.post('/suppliers/frameworks/g-cloud-7/submissions/scs/1/copy')
-        assert_equal(res.status_code, 404)
+        assert res.status_code == 404
 
     def test_cannot_copy_draft_if_not_open(self, data_api_client):
         data_api_client.get_framework.return_value = self.framework(status='other')
 
         res = self.client.post('/suppliers/frameworks/g-cloud-7/submissions/scs/1/copy')
-        assert_equal(res.status_code, 404)
+        assert res.status_code == 404
 
 
 @mock.patch('app.main.views.services.data_api_client')
@@ -780,22 +764,22 @@ class TestCompleteDraft(BaseApplicationTest):
         data_api_client.get_framework.return_value = self.framework(status='open')
         data_api_client.get_draft_service.return_value = {'services': self.draft}
         res = self.client.post('/suppliers/frameworks/g-cloud-7/submissions/scs/1/complete')
-        assert_equal(res.status_code, 302)
-        assert_true('lot=scs' in res.location)
-        assert_in('/suppliers/frameworks/g-cloud-7/submissions', res.location)
+        assert res.status_code == 302
+        assert 'lot=scs' in res.location
+        assert '/suppliers/frameworks/g-cloud-7/submissions' in res.location
 
     def test_complete_draft_checks_supplier_id(self, data_api_client):
         self.draft['supplierId'] = 2
         data_api_client.get_draft_service.return_value = {'services': self.draft}
 
         res = self.client.post('/suppliers/frameworks/g-cloud-7/submissions/scs/1/complete')
-        assert_equal(res.status_code, 404)
+        assert res.status_code == 404
 
     def test_cannot_complete_draft_if_not_open(self, data_api_client):
         data_api_client.get_framework.return_value = self.framework(status='other')
 
         res = self.client.post('/suppliers/frameworks/g-cloud-7/submissions/scs/1/complete')
-        assert_equal(res.status_code, 404)
+        assert res.status_code == 404
 
 
 @mock.patch('dmutils.s3.S3')
@@ -843,7 +827,7 @@ class TestEditDraftService(BaseApplicationTest):
                 'serviceSummary': 'This is the service',
             })
 
-        assert_equal(res.status_code, 302)
+        assert res.status_code == 302
         data_api_client.update_draft_service.assert_called_once_with(
             '1',
             {'serviceSummary': 'This is the service'},
@@ -864,8 +848,8 @@ class TestEditDraftService(BaseApplicationTest):
                 'serviceSummary': u"summary",
             })
 
-        assert_equal(res.status_code, 302)
-        assert_false(data_api_client.update_draft_service.called)
+        assert res.status_code == 302
+        assert data_api_client.update_draft_service.called is False
 
     def test_S3_should_not_be_called_if_there_are_no_files(self, data_api_client, s3):
         uploader = mock.Mock()
@@ -879,14 +863,14 @@ class TestEditDraftService(BaseApplicationTest):
                 'serviceSummary': 'This is the service',
             })
 
-        assert_equal(res.status_code, 302)
+        assert res.status_code == 302
         assert not uploader.save.called
 
     def test_editing_readonly_section_is_not_allowed(self, data_api_client, s3):
         data_api_client.get_draft_service.return_value = self.empty_draft
 
         res = self.client.get('/suppliers/frameworks/g-cloud-7/submissions/scs/1/edit/service-attributes')
-        assert_equal(res.status_code, 404)
+        assert res.status_code == 404
 
         data_api_client.get_draft_service.return_value = self.empty_draft
         res = self.client.post(
@@ -894,7 +878,7 @@ class TestEditDraftService(BaseApplicationTest):
             data={
                 'lotSlug': 'scs',
             })
-        assert_equal(res.status_code, 404)
+        assert res.status_code == 404
 
     def test_draft_section_cannot_be_edited_if_not_open(self, data_api_client, s3):
         data_api_client.get_framework.return_value = self.framework(status='other')
@@ -904,7 +888,7 @@ class TestEditDraftService(BaseApplicationTest):
             data={
                 'serviceSummary': 'This is the service',
             })
-        assert_equal(res.status_code, 404)
+        assert res.status_code == 404
 
     def test_only_questions_for_this_draft_section_can_be_changed(self, data_api_client, s3):
         s3.return_value.bucket_short_name = 'submissions'
@@ -916,7 +900,7 @@ class TestEditDraftService(BaseApplicationTest):
                 'serviceFeatures': '',
             })
 
-        assert_equal(res.status_code, 302)
+        assert res.status_code == 302
         data_api_client.update_draft_service.assert_called_once_with(
             '1', {}, 'email@email.com',
             page_questions=['serviceSummary']
@@ -932,8 +916,8 @@ class TestEditDraftService(BaseApplicationTest):
         )
         document = html.fromstring(response.get_data(as_text=True))
 
-        assert_equal(response.status_code, 200)
-        assert_equal(len(document.cssselect('p.file-upload-existing-value')), 1)
+        assert response.status_code == 200
+        assert len(document.cssselect('p.file-upload-existing-value')) == 1
 
     def test_display_file_upload_with_no_existing_file(self, data_api_client, s3):
         data_api_client.get_framework.return_value = self.framework(status='open')
@@ -943,8 +927,8 @@ class TestEditDraftService(BaseApplicationTest):
         )
         document = html.fromstring(response.get_data(as_text=True))
 
-        assert_equal(response.status_code, 200)
-        assert_equal(len(document.cssselect('p.file-upload-existing-value')), 0)
+        assert response.status_code == 200
+        assert len(document.cssselect('p.file-upload-existing-value')) == 0
 
     def test_file_upload(self, data_api_client, s3):
         s3.return_value.bucket_short_name = 'submissions'
@@ -958,7 +942,7 @@ class TestEditDraftService(BaseApplicationTest):
                 }
             )
 
-        assert_equal(res.status_code, 302)
+        assert res.status_code == 302
         data_api_client.update_draft_service.assert_called_once_with(
             '1', {
                 'serviceDefinitionDocumentURL': 'http://localhost/suppliers/assets/g-cloud-7/submissions/1234/1-service-definition-document-2015-01-02-0304.pdf'  # noqa
@@ -983,13 +967,13 @@ class TestEditDraftService(BaseApplicationTest):
                 'pricingDocumentURL': (StringIO(b'doc'), 'document.pdf'),
             })
 
-        assert_equal(res.status_code, 302)
+        assert res.status_code == 302
         data_api_client.update_draft_service.assert_called_once_with(
             '1', {}, 'email@email.com',
             page_questions=['serviceDefinitionDocumentURL']
         )
 
-        assert_false(s3.return_value.save.called)
+        assert s3.return_value.save.called is False
 
     def test_upload_question_not_accepted_as_form_data(self, data_api_client, s3):
         s3.return_value.bucket_short_name = 'submissions'
@@ -1001,7 +985,7 @@ class TestEditDraftService(BaseApplicationTest):
                 'serviceDefinitionDocumentURL': 'http://example.com/document.pdf',
             })
 
-        assert_equal(res.status_code, 302)
+        assert res.status_code == 302
         data_api_client.update_draft_service.assert_called_once_with(
             '1', {}, 'email@email.com',
             page_questions=['serviceDefinitionDocumentURL']
@@ -1020,7 +1004,7 @@ class TestEditDraftService(BaseApplicationTest):
                 'priceInterval': "Second",
             })
 
-        assert_equal(res.status_code, 302)
+        assert res.status_code == 302
         data_api_client.update_draft_service.assert_called_once_with(
             '1',
             {
@@ -1036,14 +1020,14 @@ class TestEditDraftService(BaseApplicationTest):
         data_api_client.get_draft_service.side_effect = HTTPError(mock.Mock(status_code=404))
         res = self.client.get('/suppliers/frameworks/g-cloud-7/submissions/scs/1/edit/service-description')
 
-        assert_equal(res.status_code, 404)
+        assert res.status_code == 404
 
     def test_edit_non_existent_draft_section_returns_404(self, data_api_client, s3):
         data_api_client.get_draft_service.return_value = self.empty_draft
         res = self.client.get(
             '/suppliers/frameworks/g-cloud-7/submissions/scs/1/edit/invalid_section'
         )
-        assert_equal(404, res.status_code)
+        assert res.status_code == 404
 
     def test_update_redirects_to_next_editable_section(self, data_api_client, s3):
         s3.return_value.bucket_short_name = 'submissions'
@@ -1057,9 +1041,9 @@ class TestEditDraftService(BaseApplicationTest):
                 'continue_to_next_section': 'Save and continue'
             })
 
-        assert_equal(302, res.status_code)
-        assert_equal('http://localhost/suppliers/frameworks/g-cloud-7/submissions/scs/1/edit/service-type',
-                     res.headers['Location'])
+        assert res.status_code == 302
+        assert 'http://localhost/suppliers/frameworks/g-cloud-7/submissions/scs/1/edit/service-type' == \
+            res.headers['Location']
 
     def test_page_offers_continue_to_next_editable_section(self, data_api_client, s3):
         s3.return_value.bucket_short_name = 'submissions'
@@ -1070,7 +1054,7 @@ class TestEditDraftService(BaseApplicationTest):
             '/suppliers/frameworks/g-cloud-7/submissions/scs/1/edit/service-description',
         )
 
-        assert_equal(200, res.status_code)
+        assert res.status_code == 200
         document = html.fromstring(res.get_data(as_text=True))
         assert len(document.xpath("//input[@type='submit'][@name='continue_to_next_section']")) > 0
 
@@ -1091,12 +1075,9 @@ class TestEditDraftService(BaseApplicationTest):
                 'continue_to_next_section': 'Save and continue'
             })
 
-        assert_equal(302, res.status_code)
-        assert_equal(
-            'http://localhost/suppliers/frameworks/digital-outcomes-and-specialists/submissions/'
-            'digital-specialists/1#individual-specialist-roles',
-            res.headers['Location']
-        )
+        assert res.status_code == 302
+        assert 'http://localhost/suppliers/frameworks/digital-outcomes-and-specialists/submissions/' \
+            'digital-specialists/1#individual-specialist-roles' == res.headers['Location']
 
     def test_page_doesnt_offer_continue_to_next_editable_section_if_dos(self, data_api_client, s3):
         s3.return_value.bucket_short_name = 'submissions'
@@ -1112,7 +1093,7 @@ class TestEditDraftService(BaseApplicationTest):
             'edit/individual-specialist-roles/product-manager',
         )
 
-        assert_equal(200, res.status_code)
+        assert res.status_code == 200
         document = html.fromstring(res.get_data(as_text=True))
         assert len(document.xpath("//input[@type='submit'][@name='continue_to_next_section']")) == 0
 
@@ -1126,11 +1107,9 @@ class TestEditDraftService(BaseApplicationTest):
             '/suppliers/frameworks/g-cloud-7/submissions/scs/1/edit/sfia-rate-card',
             data={})
 
-        assert_equal(302, res.status_code)
-        assert_equal(
-            'http://localhost/suppliers/frameworks/g-cloud-7/submissions/scs/1#sfia-rate-card',
+        assert res.status_code == 302
+        assert 'http://localhost/suppliers/frameworks/g-cloud-7/submissions/scs/1#sfia-rate-card' == \
             res.headers['Location']
-        )
 
     def test_update_doesnt_offer_continue_to_next_editable_section_if_no_next_editable_section(self,
                                                                                                data_api_client,
@@ -1143,7 +1122,7 @@ class TestEditDraftService(BaseApplicationTest):
             '/suppliers/frameworks/g-cloud-7/submissions/scs/1/edit/sfia-rate-card',
         )
 
-        assert_equal(200, res.status_code)
+        assert res.status_code == 200
         document = html.fromstring(res.get_data(as_text=True))
         assert len(document.xpath("//input[@type='submit'][@name='continue_to_next_section']")) == 0
 
@@ -1157,11 +1136,9 @@ class TestEditDraftService(BaseApplicationTest):
             '/suppliers/frameworks/g-cloud-7/submissions/scs/1/edit/service-description?return_to_summary=1',
             data={})
 
-        assert_equal(302, res.status_code)
-        assert_equal(
-            'http://localhost/suppliers/frameworks/g-cloud-7/submissions/scs/1#service-description',
+        assert res.status_code == 302
+        assert 'http://localhost/suppliers/frameworks/g-cloud-7/submissions/scs/1#service-description' == \
             res.headers['Location']
-        )
 
     def test_update_doesnt_offer_continue_to_next_editable_section_if_return_to_summary(self, data_api_client, s3):
         s3.return_value.bucket_short_name = 'submissions'
@@ -1172,7 +1149,7 @@ class TestEditDraftService(BaseApplicationTest):
             '/suppliers/frameworks/g-cloud-7/submissions/scs/1/edit/service-description?return_to_summary=1',
         )
 
-        assert_equal(200, res.status_code)
+        assert res.status_code == 200
         document = html.fromstring(res.get_data(as_text=True))
         assert len(document.xpath("//input[@type='submit'][@name='continue_to_next_section']")) == 0
 
@@ -1186,11 +1163,9 @@ class TestEditDraftService(BaseApplicationTest):
             '/suppliers/frameworks/g-cloud-7/submissions/scs/1/edit/service-description',
             data={})
 
-        assert_equal(302, res.status_code)
-        assert_equal(
-            'http://localhost/suppliers/frameworks/g-cloud-7/submissions/scs/1#service-description',
+        assert res.status_code == 302
+        assert 'http://localhost/suppliers/frameworks/g-cloud-7/submissions/scs/1#service-description' == \
             res.headers['Location']
-        )
 
     def test_update_with_answer_required_error(self, data_api_client, s3):
         s3.return_value.bucket_short_name = 'submissions'
@@ -1203,11 +1178,11 @@ class TestEditDraftService(BaseApplicationTest):
             '/suppliers/frameworks/g-cloud-7/submissions/scs/1/edit/service-description',
             data={})
 
-        assert_equal(res.status_code, 200)
+        assert res.status_code == 200
         document = html.fromstring(res.get_data(as_text=True))
-        assert_equal(
-            "You need to answer this question.",
-            document.xpath('//span[@class="validation-message"]/text()')[0].strip())
+        assert "You need to answer this question." == document.xpath(
+            '//span[@class="validation-message"]/text()'
+        )[0].strip()
 
     def test_update_with_under_50_words_error(self, data_api_client, s3):
         s3.return_value.bucket_short_name = 'submissions'
@@ -1220,11 +1195,11 @@ class TestEditDraftService(BaseApplicationTest):
             '/suppliers/frameworks/g-cloud-7/submissions/scs/1/edit/service-description',
             data={})
 
-        assert_equal(res.status_code, 200)
+        assert res.status_code == 200
         document = html.fromstring(res.get_data(as_text=True))
-        assert_equal(
-            "Your description must be no more than 50 words.",
-            document.xpath('//span[@class="validation-message"]/text()')[0].strip())
+        assert "Your description must be no more than 50 words." == document.xpath(
+            '//span[@class="validation-message"]/text()'
+        )[0].strip()
 
     def test_update_with_pricing_errors(self, data_api_client, s3):
         s3.return_value.bucket_short_name = 'submissions'
@@ -1246,23 +1221,22 @@ class TestEditDraftService(BaseApplicationTest):
                 '/suppliers/frameworks/g-cloud-7/submissions/scs/1/edit/pricing',
                 data={})
 
-            assert_equal(res.status_code, 200)
+            assert res.status_code == 200
             document = html.fromstring(res.get_data(as_text=True))
-            assert_equal(
-                message, document.xpath('//span[@class="validation-message"]/text()')[0].strip())
+            assert message == document.xpath('//span[@class="validation-message"]/text()')[0].strip()
 
     def test_update_non_existent_draft_service_returns_404(self, data_api_client, s3):
         data_api_client.get_draft_service.side_effect = HTTPError(mock.Mock(status_code=404))
         res = self.client.post('/suppliers/frameworks/g-cloud-7/submissions/scs/1/edit/service-description')
 
-        assert_equal(res.status_code, 404)
+        assert res.status_code == 404
 
     def test_update_non_existent_draft_section_returns_404(self, data_api_client, s3):
         data_api_client.get_draft_service.return_value = self.empty_draft
         res = self.client.post(
             '/suppliers/frameworks/g-cloud-7/submissions/scs/1/edit/invalid-section'
         )
-        assert_equal(404, res.status_code)
+        assert res.status_code == 404
 
     def test_update_multiquestion(self, data_api_client, s3):
         s3.return_value.bucket_short_name = 'submissions'
@@ -1280,7 +1254,7 @@ class TestEditDraftService(BaseApplicationTest):
             'digital-specialists/1/edit/individual-specialist-roles/agile-coach'
         )
 
-        assert_equal(res.status_code, 200)
+        assert res.status_code == 200
 
         res = self.client.post(
             '/suppliers/frameworks/digital-outcomes-and-specialists/submissions/' +
@@ -1289,7 +1263,7 @@ class TestEditDraftService(BaseApplicationTest):
                 'agileCoachLocations': ['Scotland'],
             })
 
-        assert_equal(res.status_code, 302)
+        assert res.status_code == 302
         data_api_client.update_draft_service.assert_called_once_with(
             '1',
             {'agileCoachLocations': ['Scotland']},
@@ -1310,7 +1284,7 @@ class TestEditDraftService(BaseApplicationTest):
             'digital-specialists/1/remove/individual-specialist-roles/agile-coach'
         )
 
-        assert_equal(res.status_code, 302)
+        assert res.status_code == 302
         assert(
             '/suppliers/frameworks/digital-outcomes-and-specialists/submissions/digital-specialists/1?' in res.location
         )
@@ -1321,14 +1295,14 @@ class TestEditDraftService(BaseApplicationTest):
             '/suppliers/frameworks/digital-outcomes-and-specialists/submissions/' +
             'digital-specialists/1?section_id=specialists&confirm_remove=agile-coach'
         )
-        assert_equal(res2.status_code, 200)
-        assert_in(u'Are you sure you want to remove agile coach?', res2.get_data(as_text=True))
+        assert res2.status_code == 200
+        assert u'Are you sure you want to remove agile coach?' in res2.get_data(as_text=True)
 
         res3 = self.client.post(
             '/suppliers/frameworks/digital-outcomes-and-specialists/submissions/' +
             'digital-specialists/1/remove/individual-specialist-roles/agile-coach?confirm=True')
 
-        assert_equal(res3.status_code, 302)
+        assert res3.status_code == 302
         assert(res3.location.endswith(
             '/suppliers/frameworks/digital-outcomes-and-specialists/submissions/digital-specialists/1')
         )
@@ -1361,19 +1335,18 @@ class TestEditDraftService(BaseApplicationTest):
             'digital-specialists/1/remove/individual-specialist-roles/agile-coach'
         )
 
-        assert_equal(res.status_code, 302)
-        assert(res.location.endswith(
-            '/suppliers/frameworks/digital-outcomes-and-specialists/submissions/digital-specialists/1')
+        assert res.status_code == 302
+        assert res.location.endswith(
+            '/suppliers/frameworks/digital-outcomes-and-specialists/submissions/digital-specialists/1'
         )
 
         res2 = self.client.get(
             '/suppliers/frameworks/digital-outcomes-and-specialists/submissions/digital-specialists/1'
         )
-        assert_equal(res2.status_code, 200)
-        assert_in("You must offer one of the individual specialist roles to be eligible.",
-                  res2.get_data(as_text=True))
+        assert res2.status_code == 200
+        assert "You must offer one of the individual specialist roles to be eligible." in res2.get_data(as_text=True)
 
-        data_api_client.update_draft_service.assert_not_called()
+        assert data_api_client.update_draft_service.called is False
 
     def test_can_not_remove_other_suppliers_subsection(self, data_api_client, s3):
         draft_service = copy.deepcopy(self.multiquestion_draft)
@@ -1383,15 +1356,15 @@ class TestEditDraftService(BaseApplicationTest):
             '/suppliers/frameworks/digital-outcomes-and-specialists/submissions/' +
             'digital-specialists/1/remove/individual-specialist-roles/agile-coach?confirm=True')
 
-        assert_equal(res.status_code, 404)
-        data_api_client.update_draft_service.assert_not_called()
+        assert res.status_code == 404
+        assert data_api_client.update_draft_service.called is False
 
     def test_fails_if_api_get_fails(self, data_api_client, s3):
         data_api_client.get_draft_service.side_effect = HTTPError(mock.Mock(status_code=504))
         res = self.client.post(
             '/suppliers/frameworks/digital-outcomes-and-specialists/submissions/' +
             'digital-specialists/1/remove/individual-specialist-roles/agile-coach?confirm=True')
-        assert_equal(res.status_code, 504)
+        assert res.status_code == 504
 
     def test_fails_if_api_update_fails(self, data_api_client, s3):
         data_api_client.get_draft_service.return_value = self.multiquestion_draft
@@ -1399,7 +1372,7 @@ class TestEditDraftService(BaseApplicationTest):
         res = self.client.post(
             '/suppliers/frameworks/digital-outcomes-and-specialists/submissions/' +
             'digital-specialists/1/remove/individual-specialist-roles/agile-coach?confirm=True')
-        assert_equal(res.status_code, 504)
+        assert res.status_code == 504
 
 
 @mock.patch('app.main.views.services.data_api_client')
@@ -1437,12 +1410,10 @@ class TestShowDraftService(BaseApplicationTest):
         res = self.client.get('/suppliers/frameworks/g-cloud-7/submissions/scs/1')
         document = html.fromstring(res.get_data(as_text=True))
 
-        assert_equal(res.status_code, 200)
+        assert res.status_code == 200
         service_price_row_xpath = '//tr[contains(.//span/text(), "Service price")]'
         service_price_xpath = service_price_row_xpath + '/td[@class="summary-item-field"]/span/text()'
-        assert_equal(
-            document.xpath(service_price_xpath)[0].strip(),
-            u"£12.50 to £15 per person per second")
+        assert document.xpath(service_price_xpath)[0].strip() == u"£12.50 to £15 per person per second"
 
     @mock.patch('app.main.views.services.count_unanswered_questions')
     def test_unanswered_questions_count(self, count_unanswered, data_api_client):
@@ -1451,8 +1422,8 @@ class TestShowDraftService(BaseApplicationTest):
         count_unanswered.return_value = 1, 2
         res = self.client.get('/suppliers/frameworks/g-cloud-7/submissions/scs/1')
 
-        assert_true(u'3 unanswered questions' in res.get_data(as_text=True),
-                    "'3 unanswered questions' not found in html")
+        assert u'3 unanswered questions' in res.get_data(as_text=True), \
+            "'3 unanswered questions' not found in html"
 
     @mock.patch('app.main.views.services.count_unanswered_questions')
     def test_move_to_complete_button(self, count_unanswered, data_api_client):
@@ -1461,9 +1432,8 @@ class TestShowDraftService(BaseApplicationTest):
         count_unanswered.return_value = 0, 1
         res = self.client.get('/suppliers/frameworks/g-cloud-7/submissions/scs/1')
 
-        assert_in(u'1 optional question unanswered', res.get_data(as_text=True))
-        assert_in(u'<input type="submit" class="button-save"  value="Mark as complete" />',
-                  res.get_data(as_text=True))
+        assert u'1 optional question unanswered' in res.get_data(as_text=True)
+        assert u'<input type="submit" class="button-save"  value="Mark as complete" />' in res.get_data(as_text=True)
 
     @mock.patch('app.main.views.services.count_unanswered_questions')
     def test_no_move_to_complete_button_if_not_open(self, count_unanswered, data_api_client):
@@ -1472,8 +1442,8 @@ class TestShowDraftService(BaseApplicationTest):
         count_unanswered.return_value = 0, 1
         res = self.client.get('/suppliers/frameworks/g-cloud-7/submissions/scs/1')
 
-        assert_not_in(u'<input type="submit" class="button-save"  value="Mark as complete" />',
-                      res.get_data(as_text=True))
+        assert u'<input type="submit" class="button-save"  value="Mark as complete" />' not in \
+            res.get_data(as_text=True)
 
     @mock.patch('app.main.views.services.count_unanswered_questions')
     def test_no_move_to_complete_button_if_validation_errors(self, count_unanswered, data_api_client):
@@ -1486,8 +1456,8 @@ class TestShowDraftService(BaseApplicationTest):
 
         res = self.client.get('/suppliers/frameworks/g-cloud-7/submissions/scs/1')
 
-        assert_not_in(u'<input type="submit" class="button-save"  value="Mark as complete" />',
-                      res.get_data(as_text=True))
+        assert u'<input type="submit" class="button-save"  value="Mark as complete" />' not in \
+            res.get_data(as_text=True)
 
     @mock.patch('app.main.views.services.count_unanswered_questions')
     def test_shows_g7_message_if_pending_and_service_is_in_draft(self, count_unanswered, data_api_client):
@@ -1499,11 +1469,13 @@ class TestShowDraftService(BaseApplicationTest):
         doc = html.fromstring(res.get_data(as_text=True))
         message = doc.xpath('//aside[@class="temporary-message"]')
 
-        assert_true(len(message) > 0)
-        assert_in(u"This service was not submitted",
-                  message[0].xpath('h2[@class="temporary-message-heading"]/text()')[0])
-        assert_in(u"It wasn't marked as complete at the deadline.",
-                  message[0].xpath('p[@class="temporary-message-message"]/text()')[0])
+        assert len(message) > 0
+        assert u"This service was not submitted" in message[0].xpath(
+            'h2[@class="temporary-message-heading"]/text()'
+        )[0]
+        assert u"It wasn't marked as complete at the deadline." in message[0].xpath(
+            'p[@class="temporary-message-message"]/text()'
+        )[0]
 
     @mock.patch('app.main.views.services.count_unanswered_questions')
     def test_shows_g7_message_if_pending_and_service_is_complete(self, count_unanswered, data_api_client):
@@ -1515,11 +1487,10 @@ class TestShowDraftService(BaseApplicationTest):
         doc = html.fromstring(res.get_data(as_text=True))
         message = doc.xpath('//aside[@class="temporary-message"]')
 
-        assert_true(len(message) > 0)
-        assert_in(u"This service was submitted",
-                  message[0].xpath('h2[@class="temporary-message-heading"]/text()')[0])
-        assert_in(u"If your application is successful, it will be available on the Digital Marketplace when G-Cloud 7 goes live.",  # noqa
-                  message[0].xpath('p[@class="temporary-message-message"]/text()')[0])
+        assert len(message) > 0
+        assert u"This service was submitted" in message[0].xpath('h2[@class="temporary-message-heading"]/text()')[0]
+        assert u"If your application is successful, it will be available on the Digital Marketplace when " \
+            u"G-Cloud 7 goes live." in message[0].xpath('p[@class="temporary-message-message"]/text()')[0]
 
 
 @mock.patch('app.main.views.services.data_api_client')
@@ -1550,12 +1521,10 @@ class TestDeleteDraftService(BaseApplicationTest):
         res = self.client.post(
             '/suppliers/frameworks/g-cloud-7/submissions/scs/1/delete',
             data={})
-        assert_equal(res.status_code, 302)
-        assert_in('/frameworks/g-cloud-7/submissions/scs/1?delete_requested=True', res.location)
+        assert res.status_code == 302
+        assert '/frameworks/g-cloud-7/submissions/scs/1?delete_requested=True' in res.location
         res2 = self.client.get('/suppliers/frameworks/g-cloud-7/submissions/scs/1?delete_requested=True')
-        assert_in(
-            b"Are you sure you want to delete this service?", res2.get_data()
-        )
+        assert b"Are you sure you want to delete this service?" in res2.get_data()
 
     def test_cannot_delete_if_not_open(self, data_api_client):
         data_api_client.get_framework.return_value = self.framework(status='other')
@@ -1563,7 +1532,7 @@ class TestDeleteDraftService(BaseApplicationTest):
         res = self.client.post(
             '/suppliers/frameworks/g-cloud-7/submissions/scs/1/delete',
             data={})
-        assert_equal(res.status_code, 404)
+        assert res.status_code == 404
 
     def test_confirm_delete_button_deletes_and_redirects_to_dashboard(self, data_api_client):
         data_api_client.get_framework.return_value = self.framework(status='open')
@@ -1573,11 +1542,8 @@ class TestDeleteDraftService(BaseApplicationTest):
             data={'delete_confirmed': 'true'})
 
         data_api_client.delete_draft_service.assert_called_with('1', 'email@email.com')
-        assert_equal(res.status_code, 302)
-        assert_equal(
-            res.location,
-            'http://localhost/suppliers/frameworks/g-cloud-7/submissions/scs'
-        )
+        assert res.status_code == 302
+        assert res.location == 'http://localhost/suppliers/frameworks/g-cloud-7/submissions/scs'
 
     def test_cannot_delete_other_suppliers_draft(self, data_api_client):
         other_draft = copy.deepcopy(self.draft_to_delete)
@@ -1587,7 +1553,7 @@ class TestDeleteDraftService(BaseApplicationTest):
             '/suppliers/frameworks/g-cloud-7/submissions/scs/1/delete',
             data={'delete_confirmed': 'true'})
 
-        assert_equal(res.status_code, 404)
+        assert res.status_code == 404
 
 
 @mock.patch('dmutils.s3.S3')
@@ -1605,11 +1571,8 @@ class TestSubmissionDocuments(BaseApplicationTest):
             '/suppliers/assets/g-cloud-7/submissions/1234/document.pdf'
         )
 
-        assert_equal(res.status_code, 302)
-        assert_equal(
-            res.headers['Location'],
-            'http://asset-host/document.pdf'
-        )
+        assert res.status_code == 302
+        assert res.headers['Location'] == 'http://asset-host/document.pdf'
 
     def test_missing_document_url(self, s3):
         s3.return_value.bucket_short_name = 'submissions'
@@ -1619,11 +1582,11 @@ class TestSubmissionDocuments(BaseApplicationTest):
             '/suppliers/frameworks/g-cloud-7/submissions/documents/1234/document.pdf'
         )
 
-        assert_equal(res.status_code, 404)
+        assert res.status_code == 404
 
     def test_document_url_not_matching_user_supplier(self, s3):
         res = self.client.get(
             '/suppliers/frameworks/g-cloud-7/submissions/documents/999/document.pdf'
         )
 
-        assert_equal(res.status_code, 404)
+        assert res.status_code == 404

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -864,7 +864,7 @@ class TestEditDraftService(BaseApplicationTest):
             })
 
         assert res.status_code == 302
-        assert not uploader.save.called
+        assert uploader.save.called is False
 
     def test_editing_readonly_section_is_not_allowed(self, data_api_client, s3):
         data_api_client.get_draft_service.return_value = self.empty_draft

--- a/tests/app/main/test_suppliers.py
+++ b/tests/app/main/test_suppliers.py
@@ -4,7 +4,6 @@ from dmapiclient import HTTPError
 from dmutils.email import MandrillException
 import mock
 from flask import session
-from nose.tools import assert_equal, assert_true, assert_in, assert_false, assert_not_in
 from tests.app.helpers import BaseApplicationTest
 from lxml import html
 
@@ -73,39 +72,30 @@ class TestSuppliersDashboard(BaseApplicationTest):
             self.login()
 
             res = self.client.get("/suppliers")
-            assert_equal(res.status_code, 200)
+            assert res.status_code == 200
 
             data_api_client.get_supplier.assert_called_once_with(1234)
 
             resp_data = res.get_data(as_text=True)
 
-            assert_in("Supplier Description", resp_data)
-            assert_in("Client One", resp_data)
-            assert_in("Client Two", resp_data)
+            assert "Supplier Description" in resp_data
+            assert "Client One" in resp_data
+            assert "Client Two" in resp_data
 
-            assert_in("1 Street", resp_data)
-            assert_in("2 Building", resp_data)
-            assert_in("supplier.dmdev", resp_data)
-            assert_in("supplier@user.dmdev", resp_data)
-            assert_in("Supplier Person", resp_data)
-            assert_in("0800123123", resp_data)
-            assert_in("Supplierville", resp_data)
-            assert_in("Supplierland", resp_data)
-            assert_in("11 AB", resp_data)
+            assert "1 Street" in resp_data
+            assert "2 Building" in resp_data
+            assert "supplier.dmdev" in resp_data
+            assert "supplier@user.dmdev" in resp_data
+            assert "Supplier Person" in resp_data
+            assert "0800123123" in resp_data
+            assert "Supplierville" in resp_data
+            assert "Supplierland" in resp_data
+            assert "11 AB" in resp_data
 
             # Check contributors table exists
-            assert_in(
-                self.strip_all_whitespace('Contributors</h2>'),
-                self.strip_all_whitespace(resp_data)
-            )
-            assert_in(
-                self.strip_all_whitespace('User Name</span></td>'),
-                self.strip_all_whitespace(resp_data)
-            )
-            assert_in(
-                self.strip_all_whitespace('email@email.com</span></td>'),
-                self.strip_all_whitespace(resp_data)
-            )
+            assert self.strip_all_whitespace('Contributors</h2>') in self.strip_all_whitespace(resp_data)
+            assert self.strip_all_whitespace('User Name</span></td>') in self.strip_all_whitespace(resp_data)
+            assert self.strip_all_whitespace('email@email.com</span></td>') in self.strip_all_whitespace(resp_data)
 
     @mock.patch("app.main.views.suppliers.data_api_client")
     @mock.patch("app.main.views.suppliers.get_current_suppliers_users")
@@ -179,10 +169,10 @@ class TestSuppliersDashboard(BaseApplicationTest):
             self.login()
 
             res = self.client.get("/suppliers")
-            assert_equal(res.status_code, 200)
+            assert res.status_code == 200
 
-            assert_in('<a href="/suppliers/edit" class="summary-change-link">Edit</a>', res.get_data(as_text=True))
-            assert_in('<a href="/suppliers/services" class="summary-change-link">View</a>', res.get_data(as_text=True))
+            assert '<a href="/suppliers/edit" class="summary-change-link">Edit</a>' in res.get_data(as_text=True)
+            assert '<a href="/suppliers/services" class="summary-change-link">View</a>' in res.get_data(as_text=True)
 
     @mock.patch("app.main.views.suppliers.data_api_client")
     @mock.patch("app.main.views.suppliers.get_current_suppliers_users")
@@ -214,11 +204,11 @@ class TestSuppliersDashboard(BaseApplicationTest):
             doc = html.fromstring(res.get_data(as_text=True))
 
             message = doc.xpath('//div[@class="temporary-message"]')
-            assert_equal(len(message), 1)
-            assert_in(u"Digital Outcomes and Specialists will be open for applications soon",
-                      message[0].xpath('h3/text()')[0])
-            assert_in(u"We’ll email you when you can apply to Digital Outcomes and Specialists",
-                      message[0].xpath('p/text()')[0])
+            assert len(message) == 1
+            assert u"Digital Outcomes and Specialists will be open for applications soon" in \
+                message[0].xpath('h3/text()')[0]
+            assert u"We’ll email you when you can apply to Digital Outcomes and Specialists" in \
+                message[0].xpath('p/text()')[0]
             assert u"Find out if your services are suitable" in message[0].xpath('p/a/text()')[0]
 
     @mock.patch("app.main.views.suppliers.data_api_client")
@@ -247,17 +237,9 @@ class TestSuppliersDashboard(BaseApplicationTest):
             res = self.client.get("/suppliers")
             doc = html.fromstring(res.get_data(as_text=True))
 
-            assert_equal(res.status_code, 200)
-
-            assert_in(
-                'Apply to G-Cloud 7',
-                doc.xpath('//h2[@class="summary-item-heading"]/text()')[0]
-            )
-
-            assert_equal(
-                'Start application',
-                doc.xpath('//input[@class="button-save"]/@value')[0]
-            )
+            assert res.status_code == 200
+            assert 'Apply to G-Cloud 7' in doc.xpath('//h2[@class="summary-item-heading"]/text()')[0]
+            assert doc.xpath('//input[@class="button-save"]/@value')[0] == 'Start application'
 
     @mock.patch("app.main.views.suppliers.data_api_client")
     @mock.patch("app.main.views.suppliers.get_current_suppliers_users")
@@ -276,9 +258,9 @@ class TestSuppliersDashboard(BaseApplicationTest):
             res = self.client.get("/suppliers")
             doc = html.fromstring(res.get_data(as_text=True))
 
-            assert_equal(res.status_code, 200)
-            assert_equal(doc.xpath('//a[@href="/suppliers/frameworks/g-cloud-7"]/text()')[0],
-                         "Continue your G-Cloud 7 application")
+            assert res.status_code == 200
+            assert doc.xpath('//a[@href="/suppliers/frameworks/g-cloud-7"]/text()')[0] == \
+                "Continue your G-Cloud 7 application"
 
     @mock.patch("app.main.views.suppliers.data_api_client")
     @mock.patch("app.main.views.suppliers.get_current_suppliers_users")
@@ -303,10 +285,9 @@ class TestSuppliersDashboard(BaseApplicationTest):
             doc = html.fromstring(res.get_data(as_text=True))
 
             message = doc.xpath('//aside[@class="temporary-message"]')
-            assert_true(len(message) > 0)
-            assert_in(u"G-Cloud 7 is closed for applications",
-                      message[0].xpath('h2/text()')[0])
-            assert_true(len(message[0].xpath('p[1]/a[@href="https://digitalmarketplace.blog.gov.uk/"]')) > 0)
+            assert len(message) > 0
+            assert u"G-Cloud 7 is closed for applications" in message[0].xpath('h2/text()')[0]
+            assert len(message[0].xpath('p[1]/a[@href="https://digitalmarketplace.blog.gov.uk/"]')) > 0
 
     @mock.patch("app.main.views.suppliers.data_api_client")
     @mock.patch("app.main.views.suppliers.get_current_suppliers_users")
@@ -340,12 +321,10 @@ class TestSuppliersDashboard(BaseApplicationTest):
             doc = html.fromstring(res.get_data(as_text=True))
 
             message = doc.xpath('//aside[@class="temporary-message"]')
-            assert_true(len(message) > 0)
-            assert_in(u"G-Cloud 7 is closed for applications",
-                      message[0].xpath('h2/text()')[0])
-            assert_in(u"You didn’t submit an application",
-                      message[0].xpath('p[1]/text()')[0])
-            assert_true(len(message[0].xpath('p[2]/a[contains(@href, "suppliers/frameworks/g-cloud-7")]')) > 0)
+            assert len(message) > 0
+            assert u"G-Cloud 7 is closed for applications" in message[0].xpath('h2/text()')[0]
+            assert u"You didn’t submit an application" in message[0].xpath('p[1]/text()')[0]
+            assert len(message[0].xpath('p[2]/a[contains(@href, "suppliers/frameworks/g-cloud-7")]')) > 0
 
     @mock.patch("app.main.views.suppliers.data_api_client")
     @mock.patch("app.main.views.suppliers.get_current_suppliers_users")
@@ -378,14 +357,11 @@ class TestSuppliersDashboard(BaseApplicationTest):
             res = self.client.get("/suppliers")
             doc = html.fromstring(res.get_data(as_text=True))
             headings = doc.xpath('//h2[@class="summary-item-heading"]')
-            assert_true(len(headings) > 0)
-            assert_in(u"G-Cloud 7 is closed for applications",
-                      headings[0].xpath('text()')[0])
-            assert_in(u"You submitted 99 services for consideration",
-                      headings[0].xpath('../p[1]/text()')[0])
-            assert_true(len(headings[0].xpath('../p[1]/a[contains(@href, "suppliers/frameworks/g-cloud-7")]')) > 0)
-            assert_in(u"View your submitted application",
-                      headings[0].xpath('../p[1]/a/text()')[0])
+            assert len(headings) > 0
+            assert u"G-Cloud 7 is closed for applications" in headings[0].xpath('text()')[0]
+            assert u"You submitted 99 services for consideration" in headings[0].xpath('../p[1]/text()')[0]
+            assert len(headings[0].xpath('../p[1]/a[contains(@href, "suppliers/frameworks/g-cloud-7")]')) > 0
+            assert u"View your submitted application" in headings[0].xpath('../p[1]/a/text()')[0]
 
     @mock.patch("app.main.views.suppliers.data_api_client")
     @mock.patch("app.main.views.suppliers.get_current_suppliers_users")
@@ -423,27 +399,20 @@ class TestSuppliersDashboard(BaseApplicationTest):
             doc = html.fromstring(res.get_data(as_text=True))
             headings = doc.xpath('//h2[@class="summary-item-heading"]')
 
-            assert_in(u"Pending services",
-                      headings[0].xpath('text()')[0])
+            assert u"Pending services" in headings[0].xpath('text()')[0]
 
             first_table = doc.xpath(
                 '//table[@class="summary-item-body"]'
             )
 
-            assert_in(u"Pending services",
-                      first_table[0].xpath('caption/text()')[0])
+            assert u"Pending services" in first_table[0].xpath('caption/text()')[0]
 
             first_row = "".join(first_table[0].xpath('tbody/descendant::*/text()'))
-            assert_in(u"G-Cloud 7",
-                      first_row)
-            assert_in(u"Live from 23 November 2015",
-                      first_row)
-            assert_in(u"99 services",
-                      first_row)
-            assert_in(u"99 services",
-                      first_row)
-            assert_in(u"You must sign the framework agreement to sell these services",
-                      first_row)
+            assert u"G-Cloud 7" in first_row
+            assert u"Live from 23 November 2015" in first_row
+            assert u"99 services" in first_row
+            assert u"99 services" in first_row
+            assert u"You must sign the framework agreement to sell these services" in first_row
 
     @mock.patch("app.main.views.suppliers.data_api_client")
     @mock.patch("app.main.views.suppliers.get_current_suppliers_users")
@@ -485,15 +454,11 @@ class TestSuppliersDashboard(BaseApplicationTest):
                 '//table[@class="summary-item-body"]'
             )
 
-            assert_in(u"Pending services",
-                      first_table[0].xpath('caption/text()')[0])
+            assert u"Pending services" in first_table[0].xpath('caption/text()')[0]
 
             first_row = "".join(first_table[0].xpath('tbody/descendant::*/text()'))
-            assert_in(u"G-Cloud 7",
-                      first_row)
-            assert_not_in(
-                u"Live from",
-                first_row)
+            assert u"G-Cloud 7" in first_row
+            assert u"Live from" not in first_row
 
     @mock.patch("app.main.views.suppliers.data_api_client")
     @mock.patch("app.main.views.suppliers.get_current_suppliers_users")
@@ -529,25 +494,19 @@ class TestSuppliersDashboard(BaseApplicationTest):
             doc = html.fromstring(res.get_data(as_text=True))
             headings = doc.xpath('//h2[@class="summary-item-heading"]')
 
-            assert_in(u"Pending services",
-                      headings[0].xpath('text()')[0])
+            assert u"Pending services" in headings[0].xpath('text()')[0]
 
             first_table = doc.xpath(
                 '//table[@class="summary-item-body"]'
             )
 
-            assert_in(u"Pending services",
-                      first_table[0].xpath('caption/text()')[0])
+            assert u"Pending services" in first_table[0].xpath('caption/text()')[0]
 
             first_row = "".join(first_table[0].xpath('tbody/descendant::*/text()'))
-            assert_in(u"G-Cloud 7",
-                      first_row)
-            assert_in(u"Live from 23 November 2015",
-                      first_row)
-            assert_in(u"99 services",
-                      first_row)
-            assert_not_in(u"You must sign the framework agreement to sell these services",
-                          first_row)
+            assert u"G-Cloud 7" in first_row
+            assert u"Live from 23 November 2015" in first_row
+            assert u"99 services" in first_row
+            assert u"You must sign the framework agreement to sell these services" not in first_row
 
     @mock.patch("app.main.views.suppliers.data_api_client")
     @mock.patch("app.main.views.suppliers.get_current_suppliers_users")
@@ -574,8 +533,7 @@ class TestSuppliersDashboard(BaseApplicationTest):
             doc = html.fromstring(res.get_data(as_text=True))
             headings = doc.xpath('//h2[@class="summary-item-heading"]')
 
-            assert_not_in(u"Pending services",
-                          headings[0].xpath('text()')[0])
+            assert u"Pending services" not in headings[0].xpath('text()')[0]
 
     @mock.patch("app.main.views.suppliers.data_api_client")
     @mock.patch("app.main.views.suppliers.get_current_suppliers_users")
@@ -611,27 +569,20 @@ class TestSuppliersDashboard(BaseApplicationTest):
             doc = html.fromstring(res.get_data(as_text=True))
             headings = doc.xpath('//h2[@class="summary-item-heading"]')
 
-            assert_in(u"Pending services",
-                      headings[0].xpath('text()')[0])
+            assert u"Pending services" in headings[0].xpath('text()')[0]
 
             first_table = doc.xpath(
                 '//table[@class="summary-item-body"]'
             )
 
-            assert_in(u"Pending services",
-                      first_table[0].xpath('caption/text()')[0])
+            assert u"Pending services" in first_table[0].xpath('caption/text()')[0]
 
             first_row = "".join(first_table[0].xpath('tbody/descendant::*/text()'))
-            assert_in(u"G-Cloud 7",
-                      first_row)
-            assert_not_in(u"Live from 23 November 2015",
-                          first_row)
-            assert_in(u"99 services submitted",
-                      first_row)
-            assert_not_in(u"You must sign the framework agreement to sell these services",
-                          first_row)
-            assert_in(u"View your documents",
-                      first_row)
+            assert u"G-Cloud 7" in first_row
+            assert u"Live from 23 November 2015" not in first_row
+            assert u"99 services submitted" in first_row
+            assert u"You must sign the framework agreement to sell these services" not in first_row
+            assert u"View your documents" in first_row
 
     @mock.patch("app.main.views.suppliers.data_api_client")
     @mock.patch("app.main.views.suppliers.get_current_suppliers_users")
@@ -667,27 +618,19 @@ class TestSuppliersDashboard(BaseApplicationTest):
             doc = html.fromstring(res.get_data(as_text=True))
             headings = doc.xpath('//h2[@class="summary-item-heading"]')
 
-            assert_in(u"Pending services",
-                      headings[0].xpath('text()')[0])
+            assert u"Pending services" in headings[0].xpath('text()')[0]
 
             first_table = doc.xpath(
                 '//table[@class="summary-item-body"]'
             )
 
-            assert_in(u"Pending services",
-                      first_table[0].xpath('caption/text()')[0])
+            assert u"Pending services" in first_table[0].xpath('caption/text()')[0]
 
             first_row = "".join(first_table[0].xpath('tbody/descendant::*/text()'))
-            assert_in(u"G-Cloud 7",
-                      first_row)
-            assert_in(u"Live from 23 November 2015",
-                      first_row)
-            assert_in(u"99 services",
-                      first_row)
-            assert_in(u"99 services",
-                      first_row)
-            assert_not_in(u"You must sign the framework agreement to sell these services",
-                          first_row)
+            assert u"G-Cloud 7" in first_row
+            assert u"Live from 23 November 2015" in first_row
+            assert u"99 services" in first_row
+            assert u"You must sign the framework agreement to sell these services" not in first_row
 
     @mock.patch("app.main.views.suppliers.data_api_client")
     @mock.patch("app.main.views.suppliers.get_current_suppliers_users")
@@ -715,11 +658,12 @@ class TestSuppliersDashboard(BaseApplicationTest):
             res = self.client.get("/suppliers")
             doc = html.fromstring(res.get_data(as_text=True))
 
-            assert_equal(res.status_code, 200)
+            assert res.status_code == 200
 
-            assert_in("Apply to Digital Outcomes and Specialists",
-                      doc.xpath('//div[@class="summary-item-lede"]//h2[@class="summary-item-heading"]/text()')[0])
-            assert_equal("Start application", doc.xpath('//div[@class="summary-item-lede"]//input/@value')[0])
+            assert "Apply to Digital Outcomes and Specialists" in doc.xpath(
+                '//div[@class="summary-item-lede"]//h2[@class="summary-item-heading"]/text()'
+            )[0]
+            assert doc.xpath('//div[@class="summary-item-lede"]//input/@value')[0] == "Start application"
 
     @mock.patch("app.main.views.suppliers.data_api_client")
     @mock.patch("app.main.views.suppliers.get_current_suppliers_users")
@@ -751,9 +695,10 @@ class TestSuppliersDashboard(BaseApplicationTest):
             res = self.client.get("/suppliers")
             doc = html.fromstring(res.get_data(as_text=True))
 
-            assert_equal(res.status_code, 200)
-            assert_in("Continue your Digital Outcomes and Specialists application",
-                      doc.xpath('//a[@class="browse-list-item-link"]/text()')[0])
+            assert res.status_code == 200
+            assert "Continue your Digital Outcomes and Specialists application" in doc.xpath(
+                '//a[@class="browse-list-item-link"]/text()'
+            )[0]
 
 
 class TestSupplierDashboardLogin(BaseApplicationTest):
@@ -777,22 +722,17 @@ class TestSupplierDashboardLogin(BaseApplicationTest):
 
             res = self.client.get("/suppliers")
 
-            assert_equal(res.status_code, 200)
+            assert res.status_code == 200
 
-            assert_in(
-                self.strip_all_whitespace(u"<h1>Supplier NĀme</h1>"),
+            assert self.strip_all_whitespace(u"<h1>Supplier NĀme</h1>") in \
                 self.strip_all_whitespace(res.get_data(as_text=True))
-            )
-            assert_in(
-                self.strip_all_whitespace("email@email.com"),
+            assert self.strip_all_whitespace("email@email.com") in \
                 self.strip_all_whitespace(res.get_data(as_text=True))
-            )
 
     def test_should_redirect_to_login_if_not_logged_in(self):
         res = self.client.get("/suppliers")
-        assert_equal(res.status_code, 302)
-        assert_equal(res.location,
-                     "http://localhost/login?next=%2Fsuppliers")
+        assert res.status_code == 302
+        assert res.location == "http://localhost/login?next=%2Fsuppliers"
 
 
 @mock.patch("app.main.views.suppliers.data_api_client")
@@ -840,14 +780,14 @@ class TestSupplierUpdate(BaseApplicationTest):
         data_api_client.get_supplier.side_effect = limited_supplier
 
         response = self.client.get("/suppliers/edit")
-        assert_equal(response.status_code, 200)
+        assert response.status_code == 200
 
     def test_update_all_supplier_fields(self, data_api_client):
         self.login()
 
         status, _ = self.post_supplier_edit()
 
-        assert_equal(status, 302)
+        assert status == 302
 
         data_api_client.update_supplier.assert_called_once_with(
             1234,
@@ -894,7 +834,7 @@ class TestSupplierUpdate(BaseApplicationTest):
 
         status, _ = self.post_supplier_edit(data=data)
 
-        assert_equal(status, 302)
+        assert status == 302
 
         data_api_client.update_supplier.assert_called_once_with(
             1234,
@@ -938,26 +878,24 @@ class TestSupplierUpdate(BaseApplicationTest):
             "contact_postcode": "11 AB",
         })
 
-        assert_equal(status, 200)
-        assert_in('You must provide an email address', resp)
+        assert status == 200
+        assert 'You must provide an email address' in resp
 
-        assert_false(data_api_client.update_supplier.called)
-        assert_false(
-            data_api_client.update_contact_information.called
-        )
+        assert data_api_client.update_supplier.called is False
+        assert data_api_client.update_contact_information.called is False
 
-        assert_in("New Description", resp)
-        assert_in('value="ClientA"', resp)
-        assert_in('value="ClientB"', resp)
-        assert_in('value="2"', resp)
-        assert_in('value="supplier.dmdev"', resp)
-        assert_in('value="Supplier Person"', resp)
-        assert_in('value="0800123123"', resp)
-        assert_in('value="1 Street"', resp)
-        assert_in('value="2 Building"', resp)
-        assert_in('value="Supplierville"', resp)
-        assert_in('value="Supplierland"', resp)
-        assert_in('value="11 AB"', resp)
+        assert "New Description" in resp
+        assert 'value="ClientA"' in resp
+        assert 'value="ClientB"' in resp
+        assert 'value="2"' in resp
+        assert 'value="supplier.dmdev"' in resp
+        assert 'value="Supplier Person"' in resp
+        assert 'value="0800123123"' in resp
+        assert 'value="1 Street"' in resp
+        assert 'value="2 Building"' in resp
+        assert 'value="Supplierville"' in resp
+        assert 'value="Supplierland"' in resp
+        assert 'value="11 AB"' in resp
 
     def test_description_below_word_length(self, data_api_client):
         self.login()
@@ -966,10 +904,10 @@ class TestSupplierUpdate(BaseApplicationTest):
             description="DESCR " * 49
         )
 
-        assert_equal(status, 302)
+        assert status == 302
 
-        assert_true(data_api_client.update_supplier.called)
-        assert_true(data_api_client.update_contact_information.called)
+        assert data_api_client.update_supplier.called is True
+        assert data_api_client.update_contact_information.called is True
 
     def test_description_above_word_length(self, data_api_client):
         self.login()
@@ -978,11 +916,11 @@ class TestSupplierUpdate(BaseApplicationTest):
             description="DESCR " * 51
         )
 
-        assert_equal(status, 200)
-        assert_in('must not be more than 50', resp)
+        assert status == 200
+        assert 'must not be more than 50' in resp
 
-        assert_false(data_api_client.update_supplier.called)
-        assert_false(data_api_client.update_contact_information.called)
+        assert data_api_client.update_supplier.called is False
+        assert data_api_client.update_contact_information.called is False
 
     def test_clients_above_limit(self, data_api_client):
         self.login()
@@ -991,16 +929,13 @@ class TestSupplierUpdate(BaseApplicationTest):
             clients=["", "A Client"] * 11
         )
 
-        assert_equal(status, 200)
-        assert_in('You must have 10 or fewer clients', resp)
+        assert status == 200
+        assert 'You must have 10 or fewer clients' in resp
 
     def test_should_redirect_to_login_if_not_logged_in(self, data_api_client):
         res = self.client.get("/suppliers/edit")
-        assert_equal(res.status_code, 302)
-        assert_equal(
-            res.location,
-            "http://localhost/login?next=%2Fsuppliers%2Fedit"
-        )
+        assert res.status_code == 302
+        assert res.location == "http://localhost/login?next=%2Fsuppliers%2Fedit"
 
 
 class TestCreateSupplier(BaseApplicationTest):
@@ -1009,8 +944,8 @@ class TestCreateSupplier(BaseApplicationTest):
             "/suppliers/duns-number",
             data={}
         )
-        assert_equal(res.status_code, 400)
-        assert_in("You must enter a DUNS number with 9 digits.", res.get_data(as_text=True))
+        assert res.status_code == 400
+        assert "You must enter a DUNS number with 9 digits." in res.get_data(as_text=True)
 
     def test_should_be_an_error_if_no_duns_number_is_letters(self):
         res = self.client.post(
@@ -1019,8 +954,8 @@ class TestCreateSupplier(BaseApplicationTest):
                 'duns_number': "invalid"
             }
         )
-        assert_equal(res.status_code, 400)
-        assert_in("You must enter a DUNS number with 9 digits.", res.get_data(as_text=True))
+        assert res.status_code == 400
+        assert "You must enter a DUNS number with 9 digits." in res.get_data(as_text=True)
 
     def test_should_be_an_error_if_no_duns_number_is_less_than_nine_digits(self):
         res = self.client.post(
@@ -1029,8 +964,8 @@ class TestCreateSupplier(BaseApplicationTest):
                 'duns_number': "12345678"
             }
         )
-        assert_equal(res.status_code, 400)
-        assert_in("You must enter a DUNS number with 9 digits.", res.get_data(as_text=True))
+        assert res.status_code == 400
+        assert "You must enter a DUNS number with 9 digits." in res.get_data(as_text=True)
 
     def test_should_be_an_error_if_no_duns_number_is_more_than_nine_digits(self):
         res = self.client.post(
@@ -1039,8 +974,8 @@ class TestCreateSupplier(BaseApplicationTest):
                 'duns_number': "1234567890"
             }
         )
-        assert_equal(res.status_code, 400)
-        assert_in("You must enter a DUNS number with 9 digits.", res.get_data(as_text=True))
+        assert res.status_code == 400
+        assert "You must enter a DUNS number with 9 digits." in res.get_data(as_text=True)
 
     @mock.patch("app.main.suppliers.data_api_client")
     def test_should_be_an_error_if_duns_number_in_use(self, data_api_client):
@@ -1055,10 +990,10 @@ class TestCreateSupplier(BaseApplicationTest):
                 'duns_number': "123456789"
             }
         )
-        assert_equal(res.status_code, 400)
+        assert res.status_code == 400
         page = res.get_data(as_text=True)
-        assert_in("A supplier account already exists with that DUNS number", page)
-        assert_in("DUNS number already used", page)
+        assert "A supplier account already exists with that DUNS number" in page
+        assert "DUNS number already used" in page
 
     @mock.patch("app.main.suppliers.data_api_client")
     def test_should_allow_nine_digit_duns_number(self, data_api_client):
@@ -1069,8 +1004,8 @@ class TestCreateSupplier(BaseApplicationTest):
                 'duns_number': "123456789"
             }
         )
-        assert_equal(res.status_code, 302)
-        assert_equal(res.location, 'http://localhost/suppliers/companies-house-number')
+        assert res.status_code == 302
+        assert res.location == 'http://localhost/suppliers/companies-house-number'
 
     @mock.patch("app.main.suppliers.data_api_client")
     def test_should_allow_duns_numbers_that_start_with_zero(self, data_api_client):
@@ -1081,8 +1016,8 @@ class TestCreateSupplier(BaseApplicationTest):
                 'duns_number': "012345678"
             }
         )
-        assert_equal(res.status_code, 302)
-        assert_equal(res.location, 'http://localhost/suppliers/companies-house-number')
+        assert res.status_code == 302
+        assert res.location == 'http://localhost/suppliers/companies-house-number'
 
     @mock.patch("app.main.suppliers.data_api_client")
     def test_should_strip_whitespace_surrounding_duns_number_field(self, data_api_client):
@@ -1094,16 +1029,16 @@ class TestCreateSupplier(BaseApplicationTest):
                     'duns_number': "  012345678  "
                 }
             )
-            assert_true("duns_number" in session)
-            assert_equal(session.get("duns_number"), "012345678")
+            assert "duns_number" in session
+            assert session.get("duns_number") == "012345678"
 
     def test_should_not_be_an_error_if_no_companies_house_number(self):
         res = self.client.post(
             "/suppliers/companies-house-number",
             data={}
         )
-        assert_equal(res.status_code, 302)
-        assert_equal(res.location, 'http://localhost/suppliers/company-name')
+        assert res.status_code == 302
+        assert res.location == 'http://localhost/suppliers/company-name'
 
     def test_should_be_an_error_if_companies_house_number_is_not_8_characters_short(self):
         res = self.client.post(
@@ -1112,8 +1047,8 @@ class TestCreateSupplier(BaseApplicationTest):
                 'companies_house_number': "short"
             }
         )
-        assert_equal(res.status_code, 400)
-        assert_in("Companies House numbers must have 8 characters.", res.get_data(as_text=True))
+        assert res.status_code == 400
+        assert "Companies House numbers must have 8 characters." in res.get_data(as_text=True)
 
     def test_should_be_an_error_if_companies_house_number_is_not_8_characters_long(self):
         res = self.client.post(
@@ -1122,8 +1057,8 @@ class TestCreateSupplier(BaseApplicationTest):
                 'companies_house_number': "muchtoolongtobecompanieshouse"
             }
         )
-        assert_equal(res.status_code, 400)
-        assert_in("Companies House numbers must have 8 characters.", res.get_data(as_text=True))
+        assert res.status_code == 400
+        assert "Companies House numbers must have 8 characters." in res.get_data(as_text=True)
 
     def test_should_allow_valid_companies_house_number(self):
         with self.client as c:
@@ -1133,8 +1068,8 @@ class TestCreateSupplier(BaseApplicationTest):
                     'companies_house_number': "SC001122"
                 }
             )
-            assert_equal(res.status_code, 302)
-            assert_equal(res.location, 'http://localhost/suppliers/company-name')
+            assert res.status_code == 302
+            assert res.location == 'http://localhost/suppliers/company-name'
 
     def test_should_strip_whitespace_surrounding_companies_house_number_field(self):
         with self.client as c:
@@ -1144,8 +1079,8 @@ class TestCreateSupplier(BaseApplicationTest):
                     'companies_house_number': "  SC001122  "
                 }
             )
-            assert_true("companies_house_number" in session)
-            assert_equal(session.get("companies_house_number"), "SC001122")
+            assert "companies_house_number" in session
+            assert session.get("companies_house_number") == "SC001122"
 
     def test_should_wipe_companies_house_number_if_not_supplied(self):
         with self.client as c:
@@ -1155,9 +1090,9 @@ class TestCreateSupplier(BaseApplicationTest):
                     'companies_house_number': ""
                 }
             )
-            assert_equal(res.status_code, 302)
-            assert_equal(res.location, 'http://localhost/suppliers/company-name')
-            assert_false("companies_house_number" in session)
+            assert res.status_code == 302
+            assert res.location == 'http://localhost/suppliers/company-name'
+            assert "companies_house_number" not in session
 
     def test_should_allow_valid_company_name(self):
         res = self.client.post(
@@ -1166,8 +1101,8 @@ class TestCreateSupplier(BaseApplicationTest):
                 'company_name': "My Company"
             }
         )
-        assert_equal(res.status_code, 302)
-        assert_equal(res.location, 'http://localhost/suppliers/company-contact-details')
+        assert res.status_code == 302
+        assert res.location == 'http://localhost/suppliers/company-contact-details'
 
     def test_should_strip_whitespace_surrounding_company_name_field(self):
         with self.client as c:
@@ -1177,16 +1112,16 @@ class TestCreateSupplier(BaseApplicationTest):
                     'company_name': "  My Company  "
                 }
             )
-            assert_true("company_name" in session)
-            assert_equal(session.get("company_name"), "My Company")
+            assert "company_name" in session
+            assert session.get("company_name") == "My Company"
 
     def test_should_be_an_error_if_no_company_name(self):
         res = self.client.post(
             "/suppliers/company-name",
             data={}
         )
-        assert_equal(res.status_code, 400)
-        assert_in("You must provide a company name.", res.get_data(as_text=True))
+        assert res.status_code == 400
+        assert "You must provide a company name." in res.get_data(as_text=True)
 
     def test_should_be_an_error_if_company_name_too_long(self):
         twofiftysix = "a" * 256
@@ -1196,8 +1131,8 @@ class TestCreateSupplier(BaseApplicationTest):
                 'company_name': twofiftysix
             }
         )
-        assert_equal(res.status_code, 400)
-        assert_in("You must provide a company name under 256 characters.", res.get_data(as_text=True))
+        assert res.status_code == 400
+        assert "You must provide a company name under 256 characters." in res.get_data(as_text=True)
 
     def test_should_allow_valid_company_contact_details(self):
         res = self.client.post(
@@ -1208,8 +1143,8 @@ class TestCreateSupplier(BaseApplicationTest):
                 'phone_number': "999"
             }
         )
-        assert_equal(res.status_code, 302)
-        assert_equal(res.location, 'http://localhost/suppliers/create-your-account')
+        assert res.status_code == 302
+        assert res.location == 'http://localhost/suppliers/create-your-account'
 
     def test_should_strip_whitespace_surrounding_contact_details_fields(self):
         contact_details = {
@@ -1225,8 +1160,8 @@ class TestCreateSupplier(BaseApplicationTest):
             )
 
             for key, value in contact_details.items():
-                assert_true(key in session)
-                assert_equal(session.get(key), value.strip())
+                assert key in session
+                assert session.get(key) == value.strip()
 
     def test_should_not_allow_contact_details_without_name(self):
         res = self.client.post(
@@ -1236,8 +1171,8 @@ class TestCreateSupplier(BaseApplicationTest):
                 'phone_number': "999"
             }
         )
-        assert_equal(res.status_code, 400)
-        assert_true("You must provide a contact name." in res.get_data(as_text=True))
+        assert res.status_code == 400
+        assert "You must provide a contact name." in res.get_data(as_text=True)
 
     def test_should_not_allow_contact_details_with_too_long_name(self):
         twofiftysix = "a" * 256
@@ -1249,8 +1184,8 @@ class TestCreateSupplier(BaseApplicationTest):
                 'phone_number': "999"
             }
         )
-        assert_equal(res.status_code, 400)
-        assert_true("You must provide a contact name under 256 characters." in res.get_data(as_text=True))
+        assert res.status_code == 400
+        assert "You must provide a contact name under 256 characters." in res.get_data(as_text=True)
 
     def test_should_not_allow_contact_details_without_email(self):
         res = self.client.post(
@@ -1260,8 +1195,8 @@ class TestCreateSupplier(BaseApplicationTest):
                 'phone_number': "999"
             }
         )
-        assert_equal(res.status_code, 400)
-        assert_true("You must provide a email address." in res.get_data(as_text=True))
+        assert res.status_code == 400
+        assert "You must provide a email address." in res.get_data(as_text=True)
 
     def test_should_not_allow_contact_details_with_invalid_email(self):
         res = self.client.post(
@@ -1272,8 +1207,8 @@ class TestCreateSupplier(BaseApplicationTest):
                 'phone_number': "999"
             }
         )
-        assert_equal(res.status_code, 400)
-        assert_true("You must provide a valid email address." in res.get_data(as_text=True))
+        assert res.status_code == 400
+        assert "You must provide a valid email address." in res.get_data(as_text=True)
 
     def test_should_not_allow_contact_details_without_phone_number(self):
         res = self.client.post(
@@ -1283,8 +1218,8 @@ class TestCreateSupplier(BaseApplicationTest):
                 'email_address': "name@email.com"
             }
         )
-        assert_equal(res.status_code, 400)
-        assert_true("You must provide a phone number." in res.get_data(as_text=True))
+        assert res.status_code == 400
+        assert "You must provide a phone number." in res.get_data(as_text=True)
 
     def test_should_not_allow_contact_details_with_invalid_phone_number(self):
         twentyone = "a" * 21
@@ -1296,18 +1231,18 @@ class TestCreateSupplier(BaseApplicationTest):
                 'phone_number': twentyone
             }
         )
-        assert_equal(res.status_code, 400)
-        assert_true("You must provide a phone number under 20 characters." in res.get_data(as_text=True))
+        assert res.status_code == 400
+        assert "You must provide a phone number under 20 characters." in res.get_data(as_text=True)
 
     def test_should_show_multiple_errors(self):
         res = self.client.post(
             "/suppliers/company-contact-details",
             data={}
         )
-        assert_equal(res.status_code, 400)
-        assert_true("You must provide a phone number." in res.get_data(as_text=True))
-        assert_true("You must provide a email address." in res.get_data(as_text=True))
-        assert_true("You must provide a contact name." in res.get_data(as_text=True))
+        assert res.status_code == 400
+        assert "You must provide a phone number." in res.get_data(as_text=True)
+        assert "You must provide a email address." in res.get_data(as_text=True)
+        assert "You must provide a contact name." in res.get_data(as_text=True)
 
     def test_should_populate_duns_from_session(self):
         with self.client.session_transaction() as sess:
@@ -1371,8 +1306,8 @@ class TestCreateSupplier(BaseApplicationTest):
 
             data_api_client.create_supplier.return_value = self.supplier()
             res = c.post("/suppliers/company-summary")
-            assert_equal(res.status_code, 302)
-            assert_equal(res.location, "http://localhost/suppliers/create-your-account-complete")
+            assert res.status_code == 302
+            assert res.location == "http://localhost/suppliers/create-your-account-complete"
             data_api_client.create_supplier.assert_called_once_with({
                 "contactInformation": [{
                     "email": "email_address",
@@ -1383,14 +1318,14 @@ class TestCreateSupplier(BaseApplicationTest):
                 "name": "company_name",
                 "companiesHouseNumber": "companies_house_number",
             })
-            assert_false('email_address' in session)
-            assert_false('phone_number' in session)
-            assert_false('contact_name' in session)
-            assert_false('duns_number' in session)
-            assert_false('company_name' in session)
-            assert_false('companies_house_number' in session)
-            assert_equal(session['email_supplier_id'], 12345)
-            assert_equal(session['email_company_name'], 'Supplier Name')
+            assert 'email_address' not in session
+            assert 'phone_number' not in session
+            assert 'contact_name' not in session
+            assert 'duns_number' not in session
+            assert 'company_name' not in session
+            assert 'companies_house_number' not in session
+            assert session['email_supplier_id'] == 12345
+            assert session['email_company_name'] == 'Supplier Name'
 
     @mock.patch("app.main.suppliers.data_api_client")
     @mock.patch("app.main.suppliers.send_email")
@@ -1411,8 +1346,8 @@ class TestCreateSupplier(BaseApplicationTest):
                 'email_address': 'valid@email.com'
             }
         )
-        assert_equal(res.status_code, 302)
-        assert_equal(res.location, "http://localhost/suppliers/create-your-account-complete")
+        assert res.status_code == 302
+        assert res.location == "http://localhost/suppliers/create-your-account-complete"
         data_api_client.create_supplier.assert_called_once_with({
             "contactInformation": [{
                 "email": "email_address",
@@ -1433,11 +1368,9 @@ class TestCreateSupplier(BaseApplicationTest):
 
         data_api_client.create_supplier.return_value = True
         res = self.client.post("/suppliers/company-summary")
-        assert_equal(res.status_code, 400)
-        assert_equal(data_api_client.create_supplier.called, False)
-        assert_equal(
-            'You must answer all the questions' in res.get_data(as_text=True),
-            True)
+        assert res.status_code == 400
+        assert data_api_client.create_supplier.called is False
+        assert 'You must answer all the questions' in res.get_data(as_text=True)
 
     @mock.patch("app.main.suppliers.data_api_client")
     def test_should_return_503_if_api_error(self, data_api_client):
@@ -1451,7 +1384,7 @@ class TestCreateSupplier(BaseApplicationTest):
 
         data_api_client.create_supplier.side_effect = HTTPError("gone bad")
         res = self.client.post("/suppliers/company-summary")
-        assert_equal(res.status_code, 503)
+        assert res.status_code == 503
 
     def test_should_require_an_email_address(self):
         with self.client.session_transaction() as sess:
@@ -1461,8 +1394,8 @@ class TestCreateSupplier(BaseApplicationTest):
             "/suppliers/create-your-account",
             data={}
         )
-        assert_equal(res.status_code, 400)
-        assert_true("You must provide a email address." in res.get_data(as_text=True))
+        assert res.status_code == 400
+        assert "You must provide a email address." in res.get_data(as_text=True)
 
     def test_should_not_allow_incorrect_email_address(self):
         with self.client.session_transaction() as sess:
@@ -1474,8 +1407,8 @@ class TestCreateSupplier(BaseApplicationTest):
                 'email_address': "bademail"
             }
         )
-        assert_equal(res.status_code, 400)
-        assert_true("You must provide a valid email address." in res.get_data(as_text=True))
+        assert res.status_code == 400
+        assert "You must provide a valid email address." in res.get_data(as_text=True)
 
     @mock.patch("app.main.suppliers.data_api_client")
     @mock.patch("app.main.suppliers.send_email")
@@ -1514,9 +1447,9 @@ class TestCreateSupplier(BaseApplicationTest):
                 ["user-creation"]
             )
 
-            assert_equal(res.status_code, 302)
-            assert_equal(res.location, 'http://localhost/suppliers/create-your-account-complete')
-            assert_equal(session['email_sent_to'], 'valid@email.com')
+            assert res.status_code == 302
+            assert res.location == 'http://localhost/suppliers/create-your-account-complete'
+            assert session['email_sent_to'] == 'valid@email.com'
 
     @mock.patch("app.main.suppliers.send_email")
     @mock.patch("app.main.suppliers.generate_token")
@@ -1525,9 +1458,9 @@ class TestCreateSupplier(BaseApplicationTest):
             "/suppliers/company-summary"
         )
 
-        assert_false(generate_token.called)
-        assert_false(send_email.called)
-        assert_equal(res.status_code, 400)
+        assert generate_token.called is False
+        assert send_email.called is False
+        assert res.status_code == 400
 
     @mock.patch("app.main.suppliers.data_api_client")
     @mock.patch("app.main.suppliers.send_email")
@@ -1568,7 +1501,7 @@ class TestCreateSupplier(BaseApplicationTest):
             ["user-creation"]
         )
 
-        assert_equal(res.status_code, 503)
+        assert res.status_code == 503
 
     def test_should_show_email_address_on_create_account_complete(self):
         with self.client as c:
@@ -1578,9 +1511,9 @@ class TestCreateSupplier(BaseApplicationTest):
 
             res = c.get("/suppliers/create-your-account-complete")
 
-            assert_equal(res.status_code, 200)
-            assert_true('An email has been sent to my@email.com' in res.get_data(as_text=True))
-            assert_false('other_stuff' in session)
+            assert res.status_code == 200
+            assert 'An email has been sent to my@email.com' in res.get_data(as_text=True)
+            assert 'other_stuff' not in session
 
     def test_should_show_email_address_even_when_refreshed(self):
         with self.client as c:
@@ -1589,10 +1522,10 @@ class TestCreateSupplier(BaseApplicationTest):
 
             res = c.get('/suppliers/create-your-account-complete')
 
-            assert_equal(res.status_code, 200)
-            assert_true('An email has been sent to my-email@example.com' in res.get_data(as_text=True))
+            assert res.status_code == 200
+            assert 'An email has been sent to my-email@example.com' in res.get_data(as_text=True)
 
             res = c.get('/suppliers/create-your-account-complete')
 
-            assert_equal(res.status_code, 200)
-            assert_true('An email has been sent to my-email@example.com' in res.get_data(as_text=True))
+            assert res.status_code == 200
+            assert 'An email has been sent to my-email@example.com' in res.get_data(as_text=True)

--- a/tests/app/main/test_users.py
+++ b/tests/app/main/test_users.py
@@ -1,5 +1,4 @@
 import mock
-from nose.tools import assert_equal, assert_in, assert_not_in
 from tests.app.helpers import BaseApplicationTest
 
 
@@ -64,7 +63,7 @@ class TestListUsers(BaseApplicationTest):
             data_api_client.find_users.return_value = get_users()
 
             res = self.client.get('/suppliers/users')
-            assert_equal(res.status_code, 200)
+            assert res.status_code == 200
             data_api_client.find_users.assert_called_once_with(supplier_id=1234)
 
             # strings we would expect to find in the output
@@ -76,12 +75,8 @@ class TestListUsers(BaseApplicationTest):
                 # deactivate button for Don
                 "<form method=\"post\" action=\"/suppliers/users/1/deactivate\">"
             ]:
-                assert_in(
-                    self.strip_all_whitespace(
-                        '{}'.format(string)
-                    ),
+                assert self.strip_all_whitespace('{}'.format(string)) in \
                     self.strip_all_whitespace(res.get_data(as_text=True))
-                )
 
             # strings we would hope not to find in the output
             for string in [
@@ -90,12 +85,8 @@ class TestListUsers(BaseApplicationTest):
                 # deactivate button for logged-in user
                 "<form method=\"post\" action=\"/suppliers/users/123/deactivate\">"
             ]:
-                assert_not_in(
-                    self.strip_all_whitespace(
-                        '{}'.format(string)
-                    ),
+                assert self.strip_all_whitespace('{}'.format(string)) not in \
                     self.strip_all_whitespace(res.get_data(as_text=True))
-                )
 
 
 class TestPostUsers(BaseApplicationTest):
@@ -104,15 +95,15 @@ class TestPostUsers(BaseApplicationTest):
         res = self.client.post(
             '/suppliers/users/123/deactivate'
         )
-        assert_equal(res.status_code, 302)
-        assert_equal(res.location, 'http://localhost/login')
+        assert res.status_code == 302
+        assert res.location == 'http://localhost/login'
 
     def test_cannot_deactivate_self(self):
         with self.app.test_client():
             self.login()
 
             res = self.client.post('/suppliers/users/123/deactivate')
-            assert_equal(res.status_code, 404)
+            assert res.status_code == 404
 
     @mock.patch('app.main.views.users.data_api_client')
     def test_cannot_deactivate_nonexistent_id(self, data_api_client):
@@ -122,7 +113,7 @@ class TestPostUsers(BaseApplicationTest):
             data_api_client.find_users.return_value = get_users()
 
             res = self.client.post('/suppliers/users/1231231231231/deactivate')
-            assert_equal(res.status_code, 404)
+            assert res.status_code == 404
 
     @mock.patch('app.main.views.users.data_api_client')
     def test_cannot_deactivate_a_user_without_supplier_role(self, data_api_client):
@@ -144,7 +135,7 @@ class TestPostUsers(BaseApplicationTest):
             data_api_client.get_user.return_value = get_users(additional_users, index=3)
 
             res = self.client.post('/suppliers/users/3/deactivate')
-            assert_equal(res.status_code, 404)
+            assert res.status_code == 404
 
     @mock.patch('app.main.views.users.data_api_client')
     def test_cannot_deactivate_another_suppliers_user(self, data_api_client):
@@ -170,7 +161,7 @@ class TestPostUsers(BaseApplicationTest):
             data_api_client.get_user.return_value = get_users(additional_users, index=3)
 
             res = self.client.post('/suppliers/users/4/deactivate')
-            assert_equal(res.status_code, 404)
+            assert res.status_code == 404
 
     @mock.patch('app.main.views.users.data_api_client')
     def can_deactivate_a_user(self, data_api_client):
@@ -183,8 +174,6 @@ class TestPostUsers(BaseApplicationTest):
 
             res = self.client.post(
                 '/suppliers/users/1/deactivate', follow_redirects=True)
-            assert_equal(res.status_code, 200)
-            assert_in(
-                self.strip_all_whitespace('Don Draper (don@scdp.com) has been removed as a contributor'),
+            assert res.status_code == 200
+            assert self.strip_all_whitespace('Don Draper (don@scdp.com) has been removed as a contributor') in \
                 self.strip_all_whitespace(res.get_data(as_text=True))
-            )

--- a/tests/app/status/test_status.py
+++ b/tests/app/status/test_status.py
@@ -2,7 +2,6 @@ import json
 from ..helpers import BaseApplicationTest
 
 import mock
-from nose.tools import assert_equal, assert_in, assert_false
 
 
 class TestStatus(BaseApplicationTest):
@@ -10,8 +9,8 @@ class TestStatus(BaseApplicationTest):
     @mock.patch('app.status.views.data_api_client')
     def test_should_return_200_from_elb_status_check(self, data_api_client):
         status_response = self.client.get('/suppliers/_status?ignore-dependencies')
-        assert_equal(200, status_response.status_code)
-        assert_false(data_api_client.called)
+        assert status_response.status_code == 200
+        assert data_api_client.called is False
 
     @mock.patch('app.status.views.data_api_client')
     def test_status_ok(self, data_api_client):
@@ -20,13 +19,11 @@ class TestStatus(BaseApplicationTest):
         }
 
         status_response = self.client.get('/suppliers/_status')
-        assert_equal(200, status_response.status_code)
+        assert status_response.status_code == 200
 
         json_data = json.loads(status_response.get_data().decode('utf-8'))
-        assert_equal(
-            "ok", "{}".format(json_data['status']))
-        assert_equal(
-            "ok", "{}".format(json_data['api_status']['status']))
+        assert "{}".format(json_data['status']) == "ok"
+        assert "{}".format(json_data['api_status']['status']) == "ok"
 
     @mock.patch('app.status.views.data_api_client')
     def test_status_error(self, data_api_client):
@@ -38,12 +35,9 @@ class TestStatus(BaseApplicationTest):
         }
 
         status_response = self.client.get('/suppliers/_status')
-        assert_equal(500, status_response.status_code)
+        assert status_response.status_code == 500
 
         json_data = json.loads(status_response.get_data().decode('utf-8'))
-        assert_equal(
-            "error", "{}".format(json_data['status']))
-        assert_equal(
-            "error", "{}".format(json_data['api_status']['status']))
-        assert_in(
-            "Error connecting to", "{}".format(json_data['message']))
+        assert "{}".format(json_data['status']) == "error"
+        assert "{}".format(json_data['api_status']['status']) == "error"
+        assert "Error connecting to" in "{}".format(json_data['message'])

--- a/tests/app/test_application.py
+++ b/tests/app/test_application.py
@@ -1,7 +1,6 @@
 # coding=utf-8
 
 import mock
-from nose.tools import assert_equal, assert_true
 from .helpers import BaseApplicationTest
 from dmapiclient.errors import HTTPError
 from app.main.helpers.frameworks import question_references
@@ -14,7 +13,7 @@ class TestApplication(BaseApplicationTest):
     def test_response_headers(self):
         response = self.client.get('/suppliers/create')
 
-        assert 200 == response.status_code
+        assert response.status_code == 200
         assert (
             response.headers['cache-control'] ==
             "no-cache"
@@ -22,23 +21,19 @@ class TestApplication(BaseApplicationTest):
 
     def test_url_with_non_canonical_trailing_slash(self):
         response = self.client.get('/suppliers/')
-        assert 301 == response.status_code
+        assert response.status_code == 301
         assert "http://localhost/suppliers" == response.location
 
     def test_404(self):
         res = self.client.get('/service/1234')
-        assert_equal(404, res.status_code)
-        assert_true(
-            u"Check you’ve entered the correct web "
-            u"address or start again on the Digital Marketplace homepage."
-            in res.get_data(as_text=True))
-        assert_true(
-            u"If you can’t find what you’re looking for, contact us at "
-            u"<a href=\"mailto:enquiries@digitalmarketplace.service.gov.uk?"
-            u"subject=Digital%20Marketplace%20feedback\" title=\"Please "
-            u"send feedback to enquiries@digitalmarketplace.service.gov.uk\">"
-            u"enquiries@digitalmarketplace.service.gov.uk</a>"
-            in res.get_data(as_text=True))
+        assert res.status_code == 404
+        assert u"Check you’ve entered the correct web " \
+            u"address or start again on the Digital Marketplace homepage." in res.get_data(as_text=True)
+        assert u"If you can’t find what you’re looking for, contact us at " \
+            u"<a href=\"mailto:enquiries@digitalmarketplace.service.gov.uk?" \
+            u"subject=Digital%20Marketplace%20feedback\" title=\"Please " \
+            u"send feedback to enquiries@digitalmarketplace.service.gov.uk\">" \
+            u"enquiries@digitalmarketplace.service.gov.uk</a>" in res.get_data(as_text=True)
 
     @mock.patch('app.main.views.suppliers.data_api_client')
     def test_503(self, data_api_client):
@@ -49,26 +44,20 @@ class TestApplication(BaseApplicationTest):
             self.app.config['DEBUG'] = False
 
             res = self.client.get('/suppliers')
-            assert_equal(503, res.status_code)
-            assert_true(
-                u"Sorry, we’re experiencing technical difficulties"
-                in res.get_data(as_text=True))
-            assert_true(
-                "Try again later."
-                in res.get_data(as_text=True))
+            assert res.status_code == 503
+            assert u"Sorry, we’re experiencing technical difficulties" in res.get_data(as_text=True)
+            assert "Try again later." in res.get_data(as_text=True)
 
     def test_header_xframeoptions_set_to_deny(self):
         res = self.client.get('/suppliers/create')
-        assert 200 == res.status_code
+        assert res.status_code == 200
         assert 'DENY', res.headers['X-Frame-Options']
 
     def test_should_use_local_cookie_page_on_cookie_message(self):
         res = self.client.get('/suppliers/create')
-        assert_equal(200, res.status_code)
-        assert_true(
-            '<p>GOV.UK uses cookies to make the site simpler. <a href="/cookies">Find out more about cookies</a></p>'
-            in res.get_data(as_text=True)
-        )
+        assert res.status_code == 200
+        assert '<p>GOV.UK uses cookies to make the site simpler. <a href="/cookies">Find ' \
+            'out more about cookies</a></p>' in res.get_data(as_text=True)
 
 
 class TestQuestionReferences(object):

--- a/tests/app/test_application.py
+++ b/tests/app/test_application.py
@@ -8,8 +8,8 @@ from app.main.helpers.frameworks import question_references
 
 
 class TestApplication(BaseApplicationTest):
-    def setup(self):
-        super(TestApplication, self).setup()
+    def setup_method(self, method):
+        super(TestApplication, self).setup_method(method)
 
     def test_response_headers(self):
         response = self.client.get('/suppliers/create')


### PR DESCRIPTION
~~This sits on top of https://github.com/alphagov/digitalmarketplace-supplier-frontend/pull/589 because the alternative would have caused muchos merge conflicts with it, so will have to wait till that's in.~~

Most significant thing here is the removal of nose, but some uses of mock's `.*called*` assertions have been converted to less error-prone forms.