### PR TITLE
Make brief response results page work for new flow

### DIFF
--- a/app/main/__init__.py
+++ b/app/main/__init__.py
@@ -18,6 +18,7 @@ content_loader.load_manifest('digital-outcomes-and-specialists', 'briefs', 'edit
 content_loader.load_manifest('digital-outcomes-and-specialists', 'brief-responses', 'legacy_edit_brief_response')
 content_loader.load_manifest('digital-outcomes-and-specialists', 'brief-responses', 'edit_brief_response')
 content_loader.load_manifest('digital-outcomes-and-specialists', 'brief-responses', 'legacy_display_brief_response')
+content_loader.load_manifest('digital-outcomes-and-specialists', 'brief-responses', 'display_brief_response')
 content_loader.load_messages('digital-outcomes-and-specialists', ['dates', 'urls'])
 
 content_loader.load_manifest('digital-outcomes-and-specialists-2', 'declaration', 'declaration')

--- a/app/main/views/briefs.py
+++ b/app/main/views/briefs.py
@@ -358,7 +358,12 @@ def view_response_result(brief_id):
 
     if len(brief_response) == 0:
         return redirect(url_for(".brief_response", brief_id=brief_id))
-    elif brief_response[0].get('essentialRequirementsMet') or all(brief_response[0]['essentialRequirements']):
+
+    # The legacy brief response data format has a booleans for each essential requirement
+    # rather than a single flag
+    if ('essentialRequirementsMet' not in brief_response[0]
+        and all(brief_response[0]['essentialRequirements'])
+            or brief_response[0].get('essentialRequirementsMet')):
         result_state = 'submitted_ok'
     else:
         result_state = 'submitted_unsuccessful'

--- a/app/main/views/briefs.py
+++ b/app/main/views/briefs.py
@@ -358,12 +358,7 @@ def view_response_result(brief_id):
 
     if len(brief_response) == 0:
         return redirect(url_for(".brief_response", brief_id=brief_id))
-
-    # The legacy brief response data format has a booleans for each essential requirement
-    # rather than a single flag
-    if ('essentialRequirementsMet' not in brief_response[0]
-        and all(brief_response[0]['essentialRequirements'])
-            or brief_response[0].get('essentialRequirementsMet')):
+    elif brief_response[0].get('essentialRequirementsMet') or all(brief_response[0]['essentialRequirements']):
         result_state = 'submitted_ok'
     else:
         result_state = 'submitted_unsuccessful'

--- a/app/main/views/briefs.py
+++ b/app/main/views/briefs.py
@@ -356,8 +356,17 @@ def view_response_result(brief_id):
         supplier_id=current_user.supplier_id
     )['briefResponses']
 
+    legacy_brief = True
+    if current_app.config['FEATURE_FLAGS_NEW_SUPPLIER_FLOW']:
+        legacy_brief = (
+            datetime.strptime(current_app.config['FEATURE_FLAGS_NEW_SUPPLIER_FLOW'], "%Y-%m-%d")
+            > datetime.strptime(brief['publishedAt'], DATETIME_FORMAT))
+
     if len(brief_response) == 0:
-        return redirect(url_for(".brief_response", brief_id=brief_id))
+        if legacy_brief:
+            return redirect(url_for(".brief_response", brief_id=brief_id))
+        else:
+            return redirect(url_for(".start_brief_response", brief_id=brief_id))
     elif brief_response[0].get('essentialRequirementsMet') or all(brief_response[0]['essentialRequirements']):
         result_state = 'submitted_ok'
         flash('submitted_ok', 'success')

--- a/app/main/views/briefs.py
+++ b/app/main/views/briefs.py
@@ -367,8 +367,13 @@ def view_response_result(brief_id):
     framework, lot = get_framework_and_lot(
         data_api_client, brief['frameworkSlug'], brief['lotSlug'], allowed_statuses=['live'])
 
+    if brief_response.get('essentialRequirementsMet'):
+        brief_response_display_manifest = 'display_brief_response'
+    else:
+        brief_response_display_manifest = 'legacy_display_brief_response'
+
     response_content = content_loader.get_manifest(
-        framework['slug'], 'legacy_display_brief_response').filter({'lot': lot['slug'], 'brief': brief})
+        framework['slug'], brief_response_display_manifest).filter({'lot': lot['slug'], 'brief': brief})
     for section in response_content:
         section.inject_brief_questions_into_boolean_list_question(brief)
 

--- a/app/main/views/briefs.py
+++ b/app/main/views/briefs.py
@@ -372,6 +372,7 @@ def view_response_result(brief_id):
         flash('submitted_ok', 'success')
     else:
         result_state = 'submitted_unsuccessful'
+        flash('submitted_unsuccessful', 'error')
 
     brief_response = brief_response[0]
     framework, lot = get_framework_and_lot(

--- a/app/main/views/briefs.py
+++ b/app/main/views/briefs.py
@@ -368,7 +368,7 @@ def view_response_result(brief_id):
         data_api_client, brief['frameworkSlug'], brief['lotSlug'], allowed_statuses=['live'])
 
     response_content = content_loader.get_manifest(
-        framework['slug'], 'legacy_display_brief_response').filter({'lot': lot['slug']})
+        framework['slug'], 'legacy_display_brief_response').filter({'lot': lot['slug'], 'brief': brief})
     for section in response_content:
         section.inject_brief_questions_into_boolean_list_question(brief)
 

--- a/app/main/views/briefs.py
+++ b/app/main/views/briefs.py
@@ -360,6 +360,7 @@ def view_response_result(brief_id):
         return redirect(url_for(".brief_response", brief_id=brief_id))
     elif brief_response[0].get('essentialRequirementsMet') or all(brief_response[0]['essentialRequirements']):
         result_state = 'submitted_ok'
+        flash('submitted_ok', 'success')
     else:
         result_state = 'submitted_unsuccessful'
 

--- a/app/templates/briefs/_brief_response_data.html
+++ b/app/templates/briefs/_brief_response_data.html
@@ -26,12 +26,22 @@
               {% endfor %}
             {% elif item.type == "dynamic_list" %}
               {% for question in item.questions %}
-                {% call summary.row() %}
-                  {% if question.type != "boolean" %}
-                    {{ summary.field_name(question.question) }}
-                    {{ summary.text(item.unformat_data(brief_response)[question.id]) }}
+                  {% if question.type == "boolean" %}
+                    {% if question._data['followup'] %}
+                      {% call summary.row() %}
+                        {{ summary.field_name(question.question) }}
+                        {{ summary.text(item.unformat_data(brief_response)[question._data['followup']]) }}
+                      {% endcall %}
+                    {% endif %}
+                  {% else %}
+                    {% set followup = item.questions[loop.index0 - 1]._data['followup'] %}
+                    {% if not followup or followup != question.id %}
+                      {% call summary.row() %}
+                        {{ summary.field_name(question.question) }}
+                        {{ summary.text(item.unformat_data(brief_response)[question.id]) }}
+                      {% endcall %}
+                    {% endif %}
                   {% endif %}
-                {% endcall %}
               {% endfor %}
             {% else %}
             {% call summary.row() %}

--- a/app/templates/briefs/_brief_response_data.html
+++ b/app/templates/briefs/_brief_response_data.html
@@ -1,21 +1,33 @@
 {% import "toolkit/summary-table.html" as summary %}
 {% for section in response_content.summary(brief_response) %}
+    {% if section.id in ("your-nice-to-have-skills-and-experience", "your-essential-skills-and-experience") and ('essentialRequirementsMet' in brief_response) %}
+      {% set field_headings = ["Requirement", "Evidence"] %}
+      {% set field_headings_visible = True %}
+    {% else %}
+      {% set field_headings = ["Opportunity attribute name", "Opportunity attribute value"] %}
+      {% set field_headings_visible = False %}
+    {% endif %}
+
+    {# Don't have a table for nice-to-have requirements if none have been given #}
     {% if not (section.id == 'your-nice-to-have-skills-and-experience' and not section.get_question('niceToHaveRequirements').boolean_list_questions) %}
         {{ summary.heading(section.name, id="opportunity-attributes-{}".format(loop.index)) }}
         {% call(item) summary.list_table(
           section.questions,
           caption=section.name,
-          field_headings=[
-            "Opportunity attribute name",
-            "Opportunity attribute value"
-          ],
-          field_headings_visible=False
+          field_headings=field_headings,
+          field_headings_visible=field_headings_visible
         ) %}
             {% if item.type == "boolean_list" %}
               {% for question in item.boolean_list_questions %}
                 {% call summary.row() %}
                   {{ summary.field_name(question, two_thirds=True) }}
-                  {{ summary['boolean'](item.value[loop.index0]) }}
+                  {% set answer = item.value[loop.index0] -%}
+                  {# Legacy boolean_list response answers are just a list of booleans #}
+                  {% if answer is not mapping -%}
+                    {{ summary['boolean'](answer) }}
+                  {% else -%} 
+                    {{ summary.text(answer.evidence or '') }}
+                  {% endif -%}
                 {% endcall %}
               {% endfor %}
             {% else %}

--- a/app/templates/briefs/_brief_response_data.html
+++ b/app/templates/briefs/_brief_response_data.html
@@ -27,8 +27,10 @@
             {% elif item.type == "dynamic_list" %}
               {% for question in item.questions %}
                 {% call summary.row() %}
-                  {{ summary.field_name(question.question, two_thirds=True) }}
-                  {{ summary.text(item.unformat_data(brief_response)[question.id]) }}
+                  {% if question.type != "boolean" %}
+                    {{ summary.field_name(question.question, two_thirds=True) }}
+                    {{ summary.text(item.unformat_data(brief_response)[question.id]) }}
+                  {% endif %}
                 {% endcall %}
               {% endfor %}
             {% else %}

--- a/app/templates/briefs/_brief_response_data.html
+++ b/app/templates/briefs/_brief_response_data.html
@@ -28,7 +28,7 @@
               {% for question in item.questions %}
                 {% call summary.row() %}
                   {% if question.type != "boolean" %}
-                    {{ summary.field_name(question.question, two_thirds=True) }}
+                    {{ summary.field_name(question.question) }}
                     {{ summary.text(item.unformat_data(brief_response)[question.id]) }}
                   {% endif %}
                 {% endcall %}

--- a/app/templates/briefs/_brief_response_data.html
+++ b/app/templates/briefs/_brief_response_data.html
@@ -9,7 +9,7 @@
     {% endif %}
 
     {# Don't have a table for nice-to-have requirements if none have been given #}
-    {% if not (section.id == 'your-nice-to-have-skills-and-experience' and not section.get_question('niceToHaveRequirements').boolean_list_questions) %}
+    {% if not (section.id == 'your-nice-to-have-skills-and-experience' and not brief['niceToHaveRequirements']|length) %}
         {{ summary.heading(section.name, id="opportunity-attributes-{}".format(loop.index)) }}
         {% call(item) summary.list_table(
           section.questions,
@@ -21,13 +21,14 @@
               {% for question in item.boolean_list_questions %}
                 {% call summary.row() %}
                   {{ summary.field_name(question, two_thirds=True) }}
-                  {% set answer = item.value[loop.index0] -%}
-                  {# Legacy boolean_list response answers are just a list of booleans #}
-                  {% if answer is not mapping -%}
-                    {{ summary['boolean'](answer) }}
-                  {% else -%} 
-                    {{ summary.text(answer.evidence or '') }}
-                  {% endif -%}
+                  {{ summary['boolean'](item.value[loop.index0]) }}
+                {% endcall %}
+              {% endfor %}
+            {% elif item.type == "dynamic_list" %}
+              {% for question in item.questions %}
+                {% call summary.row() %}
+                  {{ summary.field_name(question.question, two_thirds=True) }}
+                  {{ summary.text(item.unformat_data(brief_response)[question.id]) }}
                 {% endcall %}
               {% endfor %}
             {% else %}

--- a/app/templates/briefs/_legacy_view_response_result_content.html
+++ b/app/templates/briefs/_legacy_view_response_result_content.html
@@ -2,7 +2,7 @@
       
       <ol class="list-number">
         <li>
-          <div class="explanation-list padding-bottom-small">
+          <div class="explanation-list">
             <p class="lead"> When the opportunity closes, the buyer will create a shortlist. They can exclude you if:</p>
             <ul class="list-bullet">
               <li>you can’t start when they need you to</li>
@@ -26,7 +26,7 @@
 
       <ol class="list-number" start="3">
         <li>
-          <div class="explanation-list padding-bottom-small">
+          <div class="explanation-list">
             <p class="lead"> At the evaluation stage, the buyer will ask you to provide:</p>
             <ul class="list-bullet">
               <li>
@@ -53,7 +53,7 @@
             </ul>
           </div>
           
-          <div class="explanation-list padding-bottom-small">
+          <div class="explanation-list">
             <p class="lead">The buyer will use the assessment methods listed in their requirements to evaluate your evidence. They’ll use:</p>
                 <ul class="list-bullet">
                 {% for eval_type in brief_summary.get_question('evaluationType').value %}

--- a/app/templates/briefs/_legacy_view_response_result_content.html
+++ b/app/templates/briefs/_legacy_view_response_result_content.html
@@ -1,0 +1,77 @@
+      <h3>Shortlist</h3>
+      
+      <ol class="list-number">
+        <li>
+          <div class="explanation-list padding-bottom-small">
+            <p class="lead"> When the opportunity closes, the buyer will create a shortlist. They can exclude you if:</p>
+            <ul class="list-bullet">
+              <li>you can’t start when they need you to</li>
+              <li>you have fewer nice‑to‑have skills and experience than other suppliers</li>
+              {% if brief.lotSlug == "digital-specialists" and brief.get('budgetRange') %}
+              <li>your day rate exceeds their budget</li>
+              {% endif %}
+            </ul>
+          </div>
+          <p>The buyer will tell you if you’ve been excluded.</p>
+        </li>
+        
+        <li>
+          <p>If the buyer can’t reduce the number of suppliers to {{ brief.get('numberOfSuppliers') }} or less, they
+             may ask for written evidence of your essential and nice-to-have skills and experience.</p>
+          <p>The buyer will evaluate your evidence and let you know if you made it through to the evaluation stage.</p>
+        </li>
+      </ol>
+
+      <h3>Evaluation</h3>
+
+      <ol class="list-number" start="3">
+        <li>
+          <div class="explanation-list padding-bottom-small">
+            <p class="lead"> At the evaluation stage, the buyer will ask you to provide:</p>
+            <ul class="list-bullet">
+              <li>
+              {% if brief.lotSlug == "digital-specialists" %}
+                evidence of the specialist’s skills and experience
+              {% else %} 
+                evidence of your skills and experience
+              {% endif %}
+              </li>
+              
+              {% if brief.lotSlug != "digital-specialists" %}
+                <li>your proposal</li>
+              {% endif %}
+              
+              <li>
+              {% if brief.lotSlug == "user-research-participants" %}
+                evidence showing how you meet their availability criteria
+              {% elif brief.lotSlug == "digital-specialists" %}
+                evidence showing how the specialist meets their cultural fit criteria
+              {% else %}
+                evidence showing how you meet their cultural fit criteria
+              {% endif %}
+              </li>
+            </ul>
+          </div>
+          
+          <div class="explanation-list padding-bottom-small">
+            <p class="lead">The buyer will use the assessment methods listed in their requirements to evaluate your evidence. They’ll use:</p>
+                <ul class="list-bullet">
+                {% for eval_type in brief_summary.get_question('evaluationType').value %}
+                  <li>{{ 'an' if eval_type == 'Interview' else 'a' }} {{ eval_type|lower }}</li>
+                {% endfor %}
+                </ul>
+          </div>
+          
+          <p>
+            Your evidence must describe the skills and experience of the 
+            {{ 'person' if brief.lotSlug == "digital-specialists" else 'people' }} 
+            who’ll be working on the project.
+          </p>
+        </li>
+
+        <li>
+          <p>The buyer will score all suppliers who reached the evaluation stage using the weightings they published 
+            with their requirements. They’ll provide feedback if you’re unsuccessful.</p>
+        </li>
+      </ol>
+      

--- a/app/templates/briefs/view_response_result.html
+++ b/app/templates/briefs/view_response_result.html
@@ -32,7 +32,8 @@
     with
     message = {
       "already_applied": "You’ve already applied for ‘{}’ so you can’t apply again".format(brief.title) if result_state == "submitted_ok"
-                    else "You already applied for ‘{}’ but you didn’t meet the essential requirements".format(brief.title)
+                    else "You already applied for ‘{}’ but you didn’t meet the essential requirements".format(brief.title),
+      "submitted_ok": "Your application for ‘{}’ has been submitted.".format(brief.title)
     }[message] or message,
     type = "destructive" if category == "error" else "success"
     %}
@@ -44,10 +45,7 @@
 <div class="grid-row">
   <div class="column-two-thirds">
     {% with
-      heading = {
-                  "submitted_ok": "Your response to ‘{}’ has been sent".format(brief.title),
-                  "submitted_unsuccessful": "You don’t meet all the essential requirements"
-                }[result_state],
+      heading = "You don’t meet all the essential requirements" if result_state == "submitted_unsuccessful" else "Your application",
       smaller = true
       %}
         {% include 'toolkit/page-heading.html' %}

--- a/app/templates/briefs/view_response_result.html
+++ b/app/templates/briefs/view_response_result.html
@@ -36,83 +36,46 @@
     {% if result_state == "submitted_ok" %}
       <h2 class="summary-item-heading">What happens next</h2>
 
-      <h3>Shortlist</h3>
-      
-      <ol class="list-number">
-        <li>
-          <div class="explanation-list padding-bottom-small">
-            <p class="lead"> When the opportunity closes, the buyer will create a shortlist. They can exclude you if:</p>
-            <ul class="list-bullet">
-              <li>you can’t start when they need you to</li>
-              <li>you have fewer nice‑to‑have skills and experience than other suppliers</li>
-              {% if brief.lotSlug == "digital-specialists" and brief.get('budgetRange') %}
-              <li>your day rate exceeds their budget</li>
-              {% endif %}
-            </ul>
-          </div>
-          <p>The buyer will tell you if you’ve been excluded.</p>
-        </li>
+      {% if 'essentialRequirementsMet' in brief_response %}
+        <h3>Shortlist</h3>
         
-        <li>
-          <p>If the buyer can’t reduce the number of suppliers to {{ brief.get('numberOfSuppliers') }} or less, they
-             may ask for written evidence of your essential and nice-to-have skills and experience.</p>
-          <p>The buyer will evaluate your evidence and let you know if you made it through to the evaluation stage.</p>
-        </li>
-      </ol>
+        <p>When the opportunity closes, the buyer will score your evidence. If you’re one of the top {{ brief.get('numberOfSuppliers') }} suppliers, you'll go through to the evaluation stage.</p>
+        <p>If you’re not successful, the buyer will give you feedback on the evidence you provided.</p>
 
-      <h3>Evaluation</h3>
+        <h3>Evaluation</h3>
 
-      <ol class="list-number" start="3">
-        <li>
-          <div class="explanation-list padding-bottom-small">
-            <p class="lead"> At the evaluation stage, the buyer will ask you to provide:</p>
-            <ul class="list-bullet">
-              <li>
-              {% if brief.lotSlug == "digital-specialists" %}
-                evidence of the specialist’s skills and experience
-              {% else %} 
-                evidence of your skills and experience
-              {% endif %}
-              </li>
-              
-              {% if brief.lotSlug != "digital-specialists" %}
-                <li>your proposal</li>
-              {% endif %}
-              
-              <li>
-              {% if brief.lotSlug == "user-research-participants" %}
-                evidence showing how you meet their availability criteria
-              {% elif brief.lotSlug == "digital-specialists" %}
-                evidence showing how the specialist meets their cultural fit criteria
-              {% else %}
-                evidence showing how you meet their cultural fit criteria
-              {% endif %}
-              </li>
-            </ul>
-          </div>
-          
-          <div class="explanation-list padding-bottom-small">
-            <p class="lead">The buyer will use the assessment methods listed in their requirements to evaluate your evidence. They’ll use:</p>
-                <ul class="list-bullet">
-                {% for eval_type in brief_summary.get_question('evaluationType').value %}
-                  <li>{{ 'an' if eval_type == 'Interview' else 'a' }} {{ eval_type|lower }}</li>
-                {% endfor %}
-                </ul>
-          </div>
-          
-          <p>
-            Your evidence must describe the skills and experience of the 
-            {{ 'person' if brief.lotSlug == "digital-specialists" else 'people' }} 
-            who’ll be working on the project.
-          </p>
-        </li>
-
-        <li>
-          <p>The buyer will score all suppliers who reached the evaluation stage using the weightings they published 
-            with their requirements. They’ll provide feedback if you’re unsuccessful.</p>
-        </li>
-      </ol>
-      
+        <div class="explanation-list">
+          <p class="lead">At the evaluation stage, the buyer will ask you to provide:</p>
+          <ul class="list-bullet">
+            <li>
+            {% if brief.lotSlug == "digital-specialists" %}
+              evidence of the specialist’s skills and experience
+            {% else %}
+              evidence of your skills and experience
+            {% endif %}
+            </li>
+            {% if brief.lotSlug != "digital-specialists" %}
+            <li>your proposal</li>
+            {% endif %}
+          </ul>
+        </div>
+        <div class="explanation-list">
+          <p class="lead">The buyer will use the assessment methods listed in their requirements to evaluate your evidence. They’ll use:</p>
+          <ul class="list-bullet">
+            {% for eval_type in brief_summary.get_question('evaluationType').value %}
+              <li>{{ 'an' if eval_type == 'Interview' else 'a' }} {{ eval_type|lower }}</li>
+            {% endfor %}
+          </ul>
+        </div>
+        <p>
+          Your evidence must describe the skills and experience of the {{ 'person' if brief.lotSlug == "digital-specialists" else 'people' }} who’ll be working on the project.
+        </p>
+        <p>
+          The buyer will score all suppliers who reached the evaluation stage using the weightings they published with their requirements. They’ll provide feedback if you’re unsuccessful.
+        </p>
+      {% else %}
+        {% include 'briefs/_legacy_view_response_result_content.html' %}
+      {% endif %}
     {% elif result_state == "submitted_unsuccessful" %}
       <p>
         You don’t have all the essential skills and experience so you can’t go through to the shortlisting stage.

--- a/app/templates/briefs/view_response_result.html
+++ b/app/templates/briefs/view_response_result.html
@@ -30,8 +30,8 @@
   {% if ("error", "already_applied") in messages %}
     {%
     with
-    message = "You’ve already applied so you can’t apply again".format(brief.title) if result_state == "submitted_ok"
-                    else "You already applied but you didn’t meet the essential requirements".format(brief.title),
+    message = "You’ve already applied so you can’t apply again.".format(brief.title) if result_state == "submitted_ok"
+                    else "You already applied but you didn’t meet the essential requirements.".format(brief.title),
     type = "destructive"
     %}
     {% include "toolkit/notification-banner.html" %}
@@ -41,7 +41,8 @@
       {%
       with
       message = {
-        "submitted_ok": "Your application has been submitted.".format(brief.title)
+        "submitted_ok": "Your application has been submitted.".format(brief.title),
+        "submitted_unsuccessful": "You don’t meet all the essential requirements.".format(brief.title)
       }[message] or message,
       type = "destructive" if category == "error" else "success"
       %}

--- a/app/templates/briefs/view_response_result.html
+++ b/app/templates/briefs/view_response_result.html
@@ -27,25 +27,34 @@
 {% block main_content %}
 
 {% with messages = get_flashed_messages(with_categories=True) %}
-  {% for category, message in messages %}
+  {% if ("error", "already_applied") in messages %}
     {%
     with
-    message = {
-      "already_applied": "You’ve already applied for ‘{}’ so you can’t apply again".format(brief.title) if result_state == "submitted_ok"
-                    else "You already applied for ‘{}’ but you didn’t meet the essential requirements".format(brief.title),
-      "submitted_ok": "Your application for ‘{}’ has been submitted.".format(brief.title)
-    }[message] or message,
-    type = "destructive" if category == "error" else "success"
+    message = "You’ve already applied so you can’t apply again".format(brief.title) if result_state == "submitted_ok"
+                    else "You already applied but you didn’t meet the essential requirements".format(brief.title),
+    type = "destructive"
     %}
-      {% include "toolkit/notification-banner.html" %}
+    {% include "toolkit/notification-banner.html" %}
     {% endwith %}
-  {% endfor %}
+  {% else %}
+    {% for category, message in messages %}
+      {%
+      with
+      message = {
+        "submitted_ok": "Your application has been submitted.".format(brief.title)
+      }[message] or message,
+      type = "destructive" if category == "error" else "success"
+      %}
+        {% include "toolkit/notification-banner.html" %}
+      {% endwith %}
+    {% endfor %}
+  {% endif %}
 {% endwith %}
 
 <div class="grid-row">
   <div class="column-two-thirds">
     {% with
-      heading = "You don’t meet all the essential requirements" if result_state == "submitted_unsuccessful" else "Your application",
+      heading = "Your application for ‘{}’".format(brief.title),
       smaller = true
       %}
         {% include 'toolkit/page-heading.html' %}

--- a/app/templates/briefs/view_response_result.html
+++ b/app/templates/briefs/view_response_result.html
@@ -2,6 +2,28 @@
 
 {% block page_title %}Your response to ‘{{ brief.title }}’ - Digital Marketplace{% endblock %}
 
+{% block breadcrumb %}
+
+  {%
+    with items = [
+      {
+        "link": "/",
+        "label": "Digital Marketplace"
+      },
+      {
+        "link": "/{}/opportunities".format(brief.frameworkSlug),
+        "label": "Supplier opportunities"
+      },
+      {
+        "link": "/{}/opportunities/{}".format(brief.frameworkSlug, brief.id),
+        "label": brief.title
+      },
+    ]
+  %}
+    {% include "toolkit/breadcrumb.html" %}
+  {% endwith %}
+{% endblock %}
+
 {% block main_content %}
 
 {% with messages = get_flashed_messages(with_categories=True) %}

--- a/tests/app/main/test_briefs.py
+++ b/tests/app/main/test_briefs.py
@@ -1906,6 +1906,30 @@ class ResponseResultPageBothFlows(BaseApplicationTest, BriefResponseTestHelpers)
         data_api_client.get_framework.return_value = self.framework
         data_api_client.is_supplier_eligible_for_brief.return_value = True
 
+    def test_evaluation_methods_load_default_value(self, data_api_client):
+        no_extra_eval_brief = self.brief.copy()
+        no_extra_eval_brief['briefs'].pop('evaluationType')
+
+        self.set_framework_and_eligibility_for_api_client(data_api_client)
+        data_api_client.get_brief.return_value = no_extra_eval_brief
+        data_api_client.find_brief_responses.return_value = self.brief_responses
+        res = self.client.get('/suppliers/opportunities/1234/responses/result')
+
+        assert res.status_code == 200
+        doc = html.fromstring(res.get_data(as_text=True))
+        assert len(doc.xpath('//li[contains(normalize-space(text()), "a work history")]')) == 1
+
+    def test_evaluation_methods_shown_with_a_or_an(self, data_api_client):
+        self.set_framework_and_eligibility_for_api_client(data_api_client)
+        data_api_client.get_brief.return_value = self.brief
+        data_api_client.find_brief_responses.return_value = self.brief_responses
+        res = self.client.get('/suppliers/opportunities/1234/responses/result')
+
+        assert res.status_code == 200
+        doc = html.fromstring(res.get_data(as_text=True))
+        assert len(doc.xpath('//li[contains(normalize-space(text()), "a work history")]')) == 1
+        assert len(doc.xpath('//li[contains(normalize-space(text()), "an interview")]')) == 1
+
 
 @mock.patch("app.main.views.briefs.data_api_client")
 class TestResponseResultPageLegacyFlow(ResponseResultPageBothFlows):
@@ -1984,6 +2008,8 @@ class TestResponseResultPageLegacyFlow(ResponseResultPageBothFlows):
         assert res.status_code == 200
         doc = html.fromstring(res.get_data(as_text=True))
         assert doc.xpath('//h1')[0].text.strip() == "Your application for ‘I need a thing to do a thing’"
+        assert doc.xpath('//p[contains(@class, "banner-message")]')[0].text.strip() == \
+            "You don’t meet all the essential requirements."
 
     def test_essential_skills_shown_with_response(self, data_api_client):
         self.set_framework_and_eligibility_for_api_client(data_api_client)
@@ -2074,30 +2100,6 @@ class TestResponseResultPageLegacyFlow(ResponseResultPageBothFlows):
         assert res.status_code == 200
         doc = html.fromstring(res.get_data(as_text=True))
         assert len(doc.xpath('//li[contains(normalize-space(text()), "your day rate exceeds their budget")]')) == 0
-
-    def test_evaluation_methods_load_default_value(self, data_api_client):
-        no_extra_eval_brief = self.brief.copy()
-        no_extra_eval_brief['briefs'].pop('evaluationType')
-
-        self.set_framework_and_eligibility_for_api_client(data_api_client)
-        data_api_client.get_brief.return_value = no_extra_eval_brief
-        data_api_client.find_brief_responses.return_value = self.brief_responses
-        res = self.client.get('/suppliers/opportunities/1234/responses/result')
-
-        assert res.status_code == 200
-        doc = html.fromstring(res.get_data(as_text=True))
-        assert len(doc.xpath('//li[contains(normalize-space(text()), "a work history")]')) == 1
-
-    def test_evaluation_methods_shown_with_a_or_an(self, data_api_client):
-        self.set_framework_and_eligibility_for_api_client(data_api_client)
-        data_api_client.get_brief.return_value = self.brief
-        data_api_client.find_brief_responses.return_value = self.brief_responses
-        res = self.client.get('/suppliers/opportunities/1234/responses/result')
-
-        assert res.status_code == 200
-        doc = html.fromstring(res.get_data(as_text=True))
-        assert len(doc.xpath('//li[contains(normalize-space(text()), "a work history")]')) == 1
-        assert len(doc.xpath('//li[contains(normalize-space(text()), "an interview")]')) == 1
 
 
 @mock.patch("app.main.views.briefs.data_api_client")
@@ -2295,27 +2297,3 @@ class TestResponseResultPage(ResponseResultPageBothFlows, BriefResponseTestHelpe
         assert requirements_data.row(1).cell(1) == "02/02/2017"
         assert requirements_data.row(2).cell(0) == "Email address"
         assert requirements_data.row(2).cell(1) == "contact@big.com"
-
-    def test_evaluation_methods_load_default_value(self, data_api_client):
-        no_extra_eval_brief = self.brief.copy()
-        no_extra_eval_brief['briefs'].pop('evaluationType')
-
-        self.set_framework_and_eligibility_for_api_client(data_api_client)
-        data_api_client.get_brief.return_value = no_extra_eval_brief
-        data_api_client.find_brief_responses.return_value = self.brief_responses
-        res = self.client.get('/suppliers/opportunities/1234/responses/result')
-
-        assert res.status_code == 200
-        doc = html.fromstring(res.get_data(as_text=True))
-        assert len(doc.xpath('//li[contains(normalize-space(text()), "a work history")]')) == 1
-
-    def test_evaluation_methods_shown_with_a_or_an(self, data_api_client):
-        self.set_framework_and_eligibility_for_api_client(data_api_client)
-        data_api_client.get_brief.return_value = self.brief
-        data_api_client.find_brief_responses.return_value = self.brief_responses
-        res = self.client.get('/suppliers/opportunities/1234/responses/result')
-
-        assert res.status_code == 200
-        doc = html.fromstring(res.get_data(as_text=True))
-        assert len(doc.xpath('//li[contains(normalize-space(text()), "a work history")]')) == 1
-        assert len(doc.xpath('//li[contains(normalize-space(text()), "an interview")]')) == 1

--- a/tests/app/main/test_briefs.py
+++ b/tests/app/main/test_briefs.py
@@ -1974,7 +1974,7 @@ class TestResponseResultPageLegacyFlow(ResponseResultPageBothFlows):
             assert res.status_code == 200
             doc = html.fromstring(res.get_data(as_text=True))
             assert doc.xpath('//p[contains(@class, "banner-message")]')[0].text.strip() == \
-                "Your application for ‘I need a thing to do a thing’ has been submitted."
+                "Your application has been submitted."
 
     def test_view_response_result_submitted_unsuccessful(self, data_api_client):
         self.set_framework_and_eligibility_for_api_client(data_api_client)
@@ -1988,7 +1988,7 @@ class TestResponseResultPageLegacyFlow(ResponseResultPageBothFlows):
 
         assert res.status_code == 200
         doc = html.fromstring(res.get_data(as_text=True))
-        assert doc.xpath('//h1')[0].text.strip() == "You don’t meet all the essential requirements"
+        assert doc.xpath('//h1')[0].text.strip() == "Your application for ‘I need a thing to do a thing’"
 
     def test_essential_skills_shown_with_response(self, data_api_client):
         self.set_framework_and_eligibility_for_api_client(data_api_client)
@@ -2209,7 +2209,7 @@ class TestResponseResultPage(ResponseResultPageBothFlows, BriefResponseTestHelpe
             assert res.status_code == 200
             doc = html.fromstring(res.get_data(as_text=True))
             assert doc.xpath('//p[contains(@class, "banner-message")]')[0].text.strip() == \
-                "Your application for ‘I need a thing to do a thing’ has been submitted."
+                "Your application has been submitted."
 
     def test_essential_skills_shown_with_response(self, data_api_client):
         self.set_framework_and_eligibility_for_api_client(data_api_client)

--- a/tests/app/main/test_briefs.py
+++ b/tests/app/main/test_briefs.py
@@ -1928,8 +1928,8 @@ class TestResponseResultPageLegacyFlow(ResponseResultPageBothFlows):
 
         assert res.status_code == 200
         doc = html.fromstring(res.get_data(as_text=True))
-        assert doc.xpath('//h1')[0].text.strip() == \
-            "Your response to ‘I need a thing to do a thing’ has been sent"
+        assert doc.xpath('//p[contains(@class, "banner-message")]')[0].text.strip() == \
+            "Your application for ‘I need a thing to do a thing’ has been submitted."
 
     def test_view_response_result_submitted_ok_for_closed_brief(self, data_api_client):
         closed_brief = self.brief.copy()
@@ -1946,8 +1946,8 @@ class TestResponseResultPageLegacyFlow(ResponseResultPageBothFlows):
 
         assert res.status_code == 200
         doc = html.fromstring(res.get_data(as_text=True))
-        assert doc.xpath('//h1')[0].text.strip() == \
-            "Your response to ‘I need a thing to do a thing’ has been sent"
+        assert doc.xpath('//p[contains(@class, "banner-message")]')[0].text.strip() == \
+            "Your application for ‘I need a thing to do a thing’ has been submitted."
 
     def test_view_response_result_submitted_unsuccessful(self, data_api_client):
         data_api_client.get_brief.return_value = self.brief
@@ -2164,8 +2164,8 @@ class TestResponseResultPage(ResponseResultPageBothFlows):
 
         assert res.status_code == 200
         doc = html.fromstring(res.get_data(as_text=True))
-        assert doc.xpath('//h1')[0].text.strip() == \
-            "Your response to ‘I need a thing to do a thing’ has been sent"
+        assert doc.xpath('//p[contains(@class, "banner-message")]')[0].text.strip() == \
+            "Your application for ‘I need a thing to do a thing’ has been submitted."
 
     def test_view_response_result_submitted_ok_for_closed_brief(self, data_api_client):
         closed_brief = self.brief.copy()
@@ -2178,21 +2178,8 @@ class TestResponseResultPage(ResponseResultPageBothFlows):
 
         assert res.status_code == 200
         doc = html.fromstring(res.get_data(as_text=True))
-        assert doc.xpath('//h1')[0].text.strip() == \
-            "Your response to ‘I need a thing to do a thing’ has been sent"
-
-    def test_view_response_result_submitted_unsuccessful(self, data_api_client):
-        self.brief_responses['briefResponses'][0]['essentialRequirementsMet'] = False
-
-        data_api_client.get_brief.return_value = self.brief
-        data_api_client.get_framework.return_value = self.framework
-        data_api_client.is_supplier_eligible_for_brief.return_value = True
-        data_api_client.find_brief_responses.return_value = self.brief_responses
-        res = self.client.get('/suppliers/opportunities/1234/responses/result')
-
-        assert res.status_code == 200
-        doc = html.fromstring(res.get_data(as_text=True))
-        assert doc.xpath('//h1')[0].text.strip() == "You don’t meet all the essential requirements"
+        assert doc.xpath('//p[contains(@class, "banner-message")]')[0].text.strip() == \
+            "Your application for ‘I need a thing to do a thing’ has been submitted."
 
     def test_essential_skills_shown_with_response(self, data_api_client):
         data_api_client.get_brief.return_value = self.brief


### PR DESCRIPTION
More specifically, makes the brief response results page work for both formats of data. The tests will not pass until [#363](https://github.com/alphagov/digitalmarketplace-frameworks/pull/363) on the content loader is merged.

![new_flow_results_page](https://cloud.githubusercontent.com/assets/87140/22478795/4d67b51e-e7e3-11e6-984f-9473dd773083.png)

This almost doubles the amount of tests for the page so is best read commit-by-commit. 