### PR TITLE
service update_section view: use `updated_service_name` dict key for flash message which makes more sense and is more consistent with remove_service…

### DIFF
--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -167,7 +167,7 @@ def update_section(service_id, section_id):
             errors=errors
         )
 
-    flash({"service_name": posted_data.get("serviceName") or service.get("serviceName")}, 'service_updated')
+    flash({"updated_service_name": posted_data.get("serviceName") or service.get("serviceName")}, 'service_updated')
 
     return redirect(url_for(".edit_service", service_id=service_id))
 

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -563,7 +563,7 @@ class TestSupplierEditUpdateServiceSection(BaseApplicationTest):
             'email@email.com')
 
         self.assert_flashes(
-            {"service_name": "The service"},
+            {"updated_service_name": "The service"},
             "service_updated",
         )
 
@@ -595,7 +595,7 @@ class TestSupplierEditUpdateServiceSection(BaseApplicationTest):
             '1', dict(), 'email@email.com')
 
         self.assert_flashes(
-            {"service_name": "Service name 123"},
+            {"updated_service_name": "Service name 123"},
             "service_updated",
         )
 


### PR DESCRIPTION
this has no real effect of course because the key is not consumed by the template - it's just a tiny sanity change

tiniest most insignificant change ever.