### PR TITLE
Fix bug for previous page link when no nice to have requirements

### DIFF
--- a/app/main/views/briefs.py
+++ b/app/main/views/briefs.py
@@ -226,6 +226,10 @@ def edit_brief_response(brief_id, brief_response_id, question_id=None):
                 return redirect(url_for('.view_response_result', brief_id=brief_id))
 
     previous_question_id = section.get_previous_question_id(question_id)
+    # Skip previous question if the brief has no nice to have requirements
+    if previous_question_id in brief.keys() and not brief[previous_question_id]:
+        previous_question_id = section.get_previous_question_id(previous_question_id)
+
     previous_question_url = None
     if previous_question_id:
         previous_question_url = url_for(

--- a/tests/app/main/test_briefs.py
+++ b/tests/app/main/test_briefs.py
@@ -527,6 +527,17 @@ class TestApplyToBrief(BaseApplicationTest):
         assert (doc.xpath("//a[text()='Back to previous page']/@href")[0] ==
                 '/suppliers/opportunities/1234/responses/5/availability')
 
+    def test_respond_to_email_previous_page_link_skips_nice_to_have_requirements_if_no_nice_to_haves_for_brief(self):
+        self.brief['briefs']['niceToHaveRequirements'] = []
+        self.data_api_client.get_brief.return_value = self.brief
+
+        res = self.client.get('/suppliers/opportunities/1234/responses/5/respondToEmailAddress')
+        assert res.status_code == 200
+
+        doc = html.fromstring(res.get_data(as_text=True))
+        assert (doc.xpath("//a[text()='Back to previous page']/@href")[0] ==
+                '/suppliers/opportunities/1234/responses/5/essentialRequirements')
+
     def test_content_from_manifest_is_shown(self):
         res = self.client.get(
             '/suppliers/opportunities/1234/responses/5/respondToEmailAddress'


### PR DESCRIPTION
We should skip the nice to have requirements evidence and page and go straight to the essentialRequirements page if the brief has no nice to have requirements.

Bug fix for https://www.pivotaltracker.com/story/show/137359355