### PR TITLE
Add breadcrumbs to brief response start page

### DIFF
--- a/app/templates/briefs/start_brief_response.html
+++ b/app/templates/briefs/start_brief_response.html
@@ -2,6 +2,27 @@
 
 {% block page_title %}Apply for {{ brief.title }} – Digital Marketplace{% endblock %}
 
+{% block breadcrumb %}
+  {%
+    with items = [
+      {
+        "link": "/",
+        "label": "Digital Marketplace"
+      },
+      {
+        "link": "/{}/opportunities".format(brief.frameworkSlug),
+        "label": "Supplier opportunities"
+      },
+      {
+        "link": "/{}/opportunities/{}".format(brief.frameworkSlug, brief.id),
+        "label": brief.title
+      },
+    ]
+  %}
+    {% include "toolkit/breadcrumb.html" %}
+  {% endwith %}
+{% endblock %}
+
 {% block main_content %}
 
   {%


### PR DESCRIPTION
For this story - https://www.pivotaltracker.com/story/show/138429463

Question for reviewer. Is this the best way to do the tests, by creating a test helper class and then the main test classes inheriting from both `BaseApplicationTest` and `BriefResponseTestHelpers` or instead should we create `BriefResponseTest` that inherits from `BaseApplicationTest` and then our main test classes just inherit from `BriefResponseTest`?

<img width="866" alt="screen shot 2017-01-30 at 10 57 56" src="https://cloud.githubusercontent.com/assets/7228605/22420634/39b8bc2e-e6db-11e6-82a6-1aedd1008a2e.png">
