### PR TITLE
Bootstrap G-Cloud 9

### DIFF
--- a/app/main/__init__.py
+++ b/app/main/__init__.py
@@ -32,6 +32,11 @@ content_loader.load_manifest('g-cloud-8', 'services', 'edit_submission')
 content_loader.load_manifest('g-cloud-8', 'declaration', 'declaration')
 content_loader.load_messages('g-cloud-8', ['dates', 'urls'])
 
+content_loader.load_manifest('g-cloud-9', 'services', 'edit_service')
+content_loader.load_manifest('g-cloud-9', 'services', 'edit_submission')
+content_loader.load_manifest('g-cloud-9', 'declaration', 'declaration')
+content_loader.load_messages('g-cloud-9', ['dates', 'urls'])
+
 
 @main.after_request
 def add_cache_control(response):

--- a/app/main/helpers/validation.py
+++ b/app/main/helpers/validation.py
@@ -238,4 +238,5 @@ VALIDATORS = {
     "g-cloud-8": G8Validator,
     "digital-outcomes-and-specialists": DOSValidator,
     "digital-outcomes-and-specialists-2": DOS2Validator,
+    "g-cloud-9": DOS2Validator,
 }

--- a/app/templates/emails/g-cloud-9_application_started.html
+++ b/app/templates/emails/g-cloud-9_application_started.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+<head lang="en">
+   <meta charset="UTF-8">
+</head>
+<body>
+    Dear supplier,
+    <br /><br />
+    You, or one of your team, started an application to become a G-Cloud&nbsp;9 supplier.
+    All contributors on your Digital Marketplace account will now receive email updates.
+    The deadline for completing your application is 11 April 2017.
+    <br /><br />
+    You must ask any clarification questions you have through your Digital Marketplace account before
+    5pm GMT, 28 March 2017.
+    <br /><br />
+    To complete your application, you must make the supplier declaration, provide information about the services
+    you offer, and mark each service as complete.
+    <br /><br />
+    To understand if your services are suitable for G-Cloud&nbsp;9, read this guidance:
+    <br />
+    <a href="https://www.gov.uk/guidance/g-cloud-suppliers-guide">
+        https://www.gov.uk/guidance/g-cloud-suppliers-guide
+    </a>
+    <br /><br />
+    The G-Cloud&nbsp;9 application area of your Digital Marketplace account lets you:
+    <ul>
+        <li>find all the legal and guidance documentation</li>
+        <li>ask clarification questions</li>
+        <li>read responses to all supplier questions</li>
+        <li>find additional information to help you complete your application</li>
+    </ul>
+
+    Thanks,
+    <br />
+    The Digital Marketplace team
+</body>
+</html>

--- a/app/templates/macros/toolkit_forms.html
+++ b/app/templates/macros/toolkit_forms.html
@@ -223,9 +223,11 @@
     </legend>
 
     <span class="question-heading{% if question_content.hint %}-with-hint{% endif %}">
+      {% if question_number is not none %}
         <span class="question-number">
           {{ question_number }}
         </span>
+      {% endif %}
         {{ question_content.question }}
     </span>
 

--- a/app/templates/macros/toolkit_forms.html
+++ b/app/templates/macros/toolkit_forms.html
@@ -242,10 +242,10 @@
     {% endif %}
 
     {% for child_question in question_content.questions %}
-      {% if errors and errors[child_question.id] %}
-        {{ text(child_question, service_data, errors) }}
+      {% if child_question.type == 'list' %}
+        {{ list(child_question, service_data, errors if errors and errors[child_question.id] else {}) }}
       {% else %}
-        {{ text(child_question, service_data, {}) }}
+        {{ text(child_question, service_data, errors if errors and errors[child_question.id] else {}) }}
       {% endif %}
     {% endfor %}
   </fieldset>

--- a/app/templates/services/_base_edit_section_page.html
+++ b/app/templates/services/_base_edit_section_page.html
@@ -37,7 +37,7 @@
         <div class="column-two-thirds">
 
             {% for question in section.questions %}
-              {% if errors and errors[question.id] %}
+              {% if errors and (errors[question.id] or question.type == 'multiquestion') %}
                 {{ forms[question.type](question, service_data, errors) }}
               {% else %}
                 {{ forms[question.type](question, service_data, {}) }}

--- a/bower.json
+++ b/bower.json
@@ -7,6 +7,6 @@
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
     "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v19.3.1",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.19.2/jinja_govuk_template-0.19.2.tgz",
-    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#5.9.1"
+    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#5.10.0"
   }
 }


### PR DESCRIPTION
This PR:
 - Pulls in the latest content including skeleton G-Cloud 9
 - Loads the G-Cloud 9 manifests on startup
 - Adds a welcome email template for G-Cloud 9
 - Fixes a few small multiquestion bugs:
    * showing "None" as a question number
    * only rendering textboxes as sub-questions
    * not passing validation errors properly to sub-questions

Tested locally and declaration and G9 service submissions work OK. 