### PR TITLE
update hard coded reference to DOS framework

### DIFF
--- a/app/main/views/briefs.py
+++ b/app/main/views/briefs.py
@@ -417,7 +417,7 @@ def _render_not_eligible_for_brief_error_page(brief, clarification_question=Fals
             reason = data_reason_slug = "supplier-not-on-lot"
     else:
         reason = "supplier-not-on-framework"
-        data_reason_slug = "supplier-not-on-{}".format(brief['frameworkFramework'])
+        data_reason_slug = "supplier-not-on-{}".format(brief['frameworkSlug'])
 
     return render_template(
         "briefs/not_is_supplier_eligible_for_brief_error.html",

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -405,7 +405,9 @@ def edit_service_submission(framework_slug, lot_slug, service_id, section_id, qu
     """
     framework, lot = get_framework_and_lot(data_api_client, framework_slug, lot_slug, allowed_statuses=['open'])
 
-    force_return_to_summary = request.args.get('return_to_summary') or framework['framework'] == "dos"
+    force_return_to_summary = (request.args.get('return_to_summary') or
+                               framework['framework'] == "dos" or
+                               framework['framework'] == "digital-outcomes-and-specialists")
 
     try:
         draft = data_api_client.get_draft_service(service_id)['services']

--- a/tests/app/main/test_briefs.py
+++ b/tests/app/main/test_briefs.py
@@ -270,7 +270,6 @@ class TestSubmitClarificationQuestions(BaseApplicationTest):
             self, send_email, data_api_client):
         self.login()
         data_api_client.get_brief.return_value = api_stubs.brief(status='live', lot_slug='digital-specialists')
-        data_api_client.get_brief.return_value['briefs']['frameworkFramework'] = 'dos'
         data_api_client.is_supplier_eligible_for_brief.return_value = False
         data_api_client.find_services.return_value = {"services": []}
 
@@ -1283,7 +1282,6 @@ class TestLegacyRespondToBrief(BaseApplicationTest, BriefResponseTestHelpers):
 
     def test_get_brief_response_returns_error_page_if_supplier_has_no_services_on_framework(self, data_api_client):
         data_api_client.get_brief.return_value = self.brief
-        data_api_client.get_brief.return_value['briefs']['frameworkFramework'] = 'dos'
         data_api_client.get_framework.return_value = self.framework
         data_api_client.is_supplier_eligible_for_brief.return_value = False
         data_api_client.find_services.return_value = {"services": []}
@@ -1298,12 +1296,11 @@ class TestLegacyRespondToBrief(BaseApplicationTest, BriefResponseTestHelpers):
                 ERROR_MESSAGE_NO_SERVICE_ON_FRAMEWORK_APPLICATION
             )
         )) == 1
-        assert len(doc.xpath('//*[@data-reason="supplier-not-on-dos"]')) == 1
+        assert len(doc.xpath('//*[@data-reason="supplier-not-on-digital-outcomes-and-specialists"]')) == 1
         assert data_api_client.create_audit_event.called is False
 
     def test_get_brief_response_returns_error_page_if_supplier_has_no_pub_services_on_framework(self, data_api_client):
         data_api_client.get_brief.return_value = self.brief
-        data_api_client.get_brief.return_value['briefs']['frameworkFramework'] = 'dos'
         data_api_client.get_framework.return_value = self.framework
         data_api_client.is_supplier_eligible_for_brief.return_value = False
         # simulating the case where we have non-"published", but on-framework, services
@@ -1323,7 +1320,7 @@ class TestLegacyRespondToBrief(BaseApplicationTest, BriefResponseTestHelpers):
                 ERROR_MESSAGE_NO_SERVICE_ON_FRAMEWORK_APPLICATION
             )
         )) == 1
-        assert len(doc.xpath('//*[@data-reason="supplier-not-on-dos"]')) == 1
+        assert len(doc.xpath('//*[@data-reason="supplier-not-on-digital-outcomes-and-specialists"]')) == 1
         assert data_api_client.create_audit_event.called is False
 
     def test_get_brief_response_returns_error_page_if_supplier_has_no_services_with_role(self, data_api_client):
@@ -1599,7 +1596,6 @@ class TestLegacyRespondToBrief(BaseApplicationTest, BriefResponseTestHelpers):
 
     def test_create_new_brief_returns_error_page_if_supplier_has_no_services_on_framework(self, data_api_client):
         data_api_client.get_brief.return_value = self.brief
-        data_api_client.get_brief.return_value['briefs']['frameworkFramework'] = 'dos'
         data_api_client.get_framework.return_value = self.framework
         data_api_client.is_supplier_eligible_for_brief.return_value = False
         data_api_client.find_services.return_value = {"services": []}


### PR DESCRIPTION
Backwards compatability as migration will soon land changing `framework.framework` from 'dos' to 'digital-outcomes-and-specialists' 