### PR TITLE
Make it clear that this is the MIT licence

### DIFF
--- a/LICENCE
+++ b/LICENCE
@@ -1,3 +1,4 @@
+The MIT License (MIT)
 Copyright (C) 2015 Crown Copyright (Government Digital Service)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy


### PR DESCRIPTION
I was looking for a licence to send someone as an example and noticed that this one doesn't make it clear it's the MIT licence. This PR changes that, to make it easier for people to understand what licence is being used.