### PR TITLE
[194] One question per page

### DIFF
--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -227,7 +227,6 @@ def start_new_draft_service(framework_slug, lot_slug):
         "services/edit_submission_section.html",
         framework=framework,
         lot=lot,
-        one_service_limit=lot['oneServiceLimit'],
         service_data={},
         section=section,
         force_continue_button=True,
@@ -375,7 +374,6 @@ def view_service_submission(framework_slug, lot_slug, service_id):
         "services/service_submission.html",
         framework=framework,
         lot=lot,
-        one_service_limit=lot['oneServiceLimit'],
         confirm_remove=request.args.get("confirm_remove", None),
         service_id=service_id,
         service_data=draft,
@@ -486,7 +484,6 @@ def edit_service_submission(framework_slug, lot_slug, service_id, section_id, qu
         service_data=service_data,
         service_id=service_id,
         force_return_to_summary=force_return_to_summary,
-        one_service_limit=lot['oneServiceLimit'],
         errors=errors,
     )
 

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -407,6 +407,7 @@ def edit_service_submission(framework_slug, lot_slug, service_id, section_id, qu
 
     force_return_to_summary = (request.args.get('return_to_summary') or
                                framework['framework'] == "digital-outcomes-and-specialists")
+    next_question = None
 
     try:
         draft = data_api_client.get_draft_service(service_id)['services']
@@ -422,6 +423,7 @@ def edit_service_submission(framework_slug, lot_slug, service_id, section_id, qu
     content = content_loader.get_manifest(framework_slug, 'edit_submission').filter(draft)
     section = content.get_section(section_id)
     if section and (question_slug is not None):
+        next_question = section.get_question_by_slug(section.get_next_question_slug(question_slug))
         section = section.get_question_as_section(question_slug)
 
     if section is None or not section.editable:
@@ -456,14 +458,13 @@ def edit_service_submission(framework_slug, lot_slug, service_id, section_id, qu
                 errors = section.get_error_messages(e.message)
 
         if not errors:
-            next_section = content.get_next_editable_section_id(section_id)
-
-            if next_section and request.form.get('continue_to_next_section') and not force_return_to_summary:
+            if next_question and not force_return_to_summary:
                 return redirect(url_for(".edit_service_submission",
                                         framework_slug=framework['slug'],
                                         lot_slug=draft['lotSlug'],
                                         service_id=service_id,
-                                        section_id=next_section))
+                                        section_id=section_id,
+                                        question_slug=next_question.slug))
             else:
                 return redirect(url_for(".view_service_submission",
                                         framework_slug=framework['slug'],
@@ -483,7 +484,7 @@ def edit_service_submission(framework_slug, lot_slug, service_id, section_id, qu
         "services/edit_submission_section.html",
         section=section,
         framework=framework,
-        next_section_name=get_next_section_name(content, section.id),
+        next_question=next_question,
         service_data=service_data,
         service_id=service_id,
         force_return_to_summary=force_return_to_summary,

--- a/app/templates/macros/toolkit_forms.html
+++ b/app/templates/macros/toolkit_forms.html
@@ -241,12 +241,10 @@
     <span class="hint">{{ question_content.hint }}</span>
     {% endif %}
 
+    {% import "macros/toolkit_forms.html" as forms %}
+
     {% for child_question in question_content.questions %}
-      {% if child_question.type == 'list' %}
-        {{ list(child_question, service_data, errors if errors and errors[child_question.id] else {}) }}
-      {% else %}
-        {{ text(child_question, service_data, errors if errors and errors[child_question.id] else {}) }}
-      {% endif %}
+      {{ forms[child_question.type](child_question, service_data, errors if errors and errors[child_question.id] else {}) }}
     {% endfor %}
   </fieldset>
 {%- endmacro %}

--- a/app/templates/services/_base_service_page.html
+++ b/app/templates/services/_base_service_page.html
@@ -82,7 +82,7 @@
             {{ summary.field_name(question.label) }}
             {% if question.is_empty %}
               {% if framework and framework.status == 'open' and section.edit_questions %}
-                {% if one_service_limit %}
+                {% if lot['oneServiceLimit'] %}
                   {% if question.empty_message %}
                     {% call summary.field() %}
                       <span class="summary-item-field-answer-required">{{ question.empty_message }}</span>
@@ -97,12 +97,12 @@
             {% endif %}
             {% if framework.status == 'open' %}
               {% if section.edit_questions and not question.is_empty %}
-                {% if one_service_limit %}
+                {% if lot['oneServiceLimit'] %}
                   {{ summary.remove_link('Remove', url_for(".remove_subsection", framework_slug=framework.slug, lot_slug=service_data.lot, service_id=service_id, section_id=section.id, question_slug=question.slug)) }}
                 {% endif %}
                 {{ summary.edit_link('Edit', url_for(".edit_service_submission", framework_slug=framework.slug, lot_slug=service_data.lot, service_id=service_id, section_id=section.id, question_slug=question.slug)) }}
-              {% elif section.edit_questions and one_service_limit %}
-                {% if one_service_limit %}
+              {% elif section.edit_questions and lot['oneServiceLimit'] %}
+                {% if lot['oneServiceLimit'] %}
                   {% call summary.field() %}
                   {% endcall %}
                 {% endif %}

--- a/app/templates/services/_base_service_page.html
+++ b/app/templates/services/_base_service_page.html
@@ -59,9 +59,6 @@
       {% import "toolkit/summary-table.html" as summary %}
       {% for section in sections %}
         {{ summary.heading(section.name, id=section.slug) }}
-        {% if section.editable %}
-          {% block edit_link scoped %}{% endblock %}
-        {% endif %}
         {% if section.summary_page_description %}
           {{ summary.description(section.summary_page_description) }}
         {% endif %}
@@ -78,30 +75,27 @@
           ],
           field_headings_visible=False
         ) %}
-          {% call summary.row(complete=not question.answer_required) %}
+          {% call summary.row() %}
             {{ summary.field_name(question.label) }}
-            {% if question.answer_required %}
-              {% call summary.field() %}
-                {% if framework and framework.status == 'open' %}
-                    <a href="{{ url_for(".edit_service_submission", framework_slug=framework.slug, lot_slug=service_data.lot, service_id=service_id, section_id=section.id, _anchor=question.id) }}">Answer required</a>
+            {% if question.is_empty %}
+              {% if framework and framework.status == 'open' and section.edit_questions %}
+                {% if question.is_empty %}
+                  {{ summary.link('Answer question', url_for(".edit_service_submission", framework_slug=framework.slug, lot_slug=service_data.lot, service_id=service_id, section_id=section.id, question_slug=question.slug)) }}
                 {% else %}
-                  Not answered
+                  {{ summary.field("Not answered") }}
                 {% endif %}
-              {% endcall %}
-            {% elif question.is_empty %}
-              {% call summary.field() %}
-                <span class="summary-item-field-answer-required">{{ question.empty_message }}</span>
-              {% endcall %}
+              {% endif %}
             {% else %}
               {{ summary[question.type](question.value, question.assurance) }}
             {% endif %}
-            {% if section.edit_questions and framework.status == 'open' %}
-              {% if not question.is_empty %}
-                {{ summary.remove_link('Remove', url_for(".remove_subsection", framework_slug=framework.slug, lot_slug=service_data.lot, service_id=service_id, section_id=section.id, question_slug=question.slug)) }}
+            {% if framework.status == 'open' %}
+              {% if not question.is_empty and section.edit_questions %}
+                {{ summary.edit_link('Edit', url_for(".edit_service_submission", framework_slug=framework.slug, lot_slug=service_data.lot, service_id=service_id, section_id=section.id, question_slug=question.slug)) }}
               {% else %}
-                {{ summary.text("") }}
+                {% call summary.field(action=True) %}
+                  {{ 'Optional' if question.get('optional') else '' }}
+                {% endcall %}
               {% endif %}
-              {{ summary.edit_link('Add' if question.is_empty else 'Edit', url_for(".edit_service_submission", framework_slug=framework.slug, lot_slug=service_data.lot, service_id=service_id, section_id=section.id, question_slug=question.slug)) }}
             {% endif %}
           {% endcall %}
         {% endcall %}

--- a/app/templates/services/_base_service_page.html
+++ b/app/templates/services/_base_service_page.html
@@ -59,6 +59,9 @@
       {% import "toolkit/summary-table.html" as summary %}
       {% for section in sections %}
         {{ summary.heading(section.name, id=section.slug) }}
+        {% if section.editable %}
+          {% block edit_link scoped %}{% endblock %}
+        {% endif %}
         {% if section.summary_page_description %}
           {{ summary.description(section.summary_page_description) }}
         {% endif %}
@@ -79,18 +82,31 @@
             {{ summary.field_name(question.label) }}
             {% if question.is_empty %}
               {% if framework and framework.status == 'open' and section.edit_questions %}
-                {% if question.is_empty %}
-                  {{ summary.link('Answer question', url_for(".edit_service_submission", framework_slug=framework.slug, lot_slug=service_data.lot, service_id=service_id, section_id=section.id, question_slug=question.slug)) }}
+                {% if one_service_limit %}
+                  {% if question.empty_message %}
+                    {% call summary.field() %}
+                      <span class="summary-item-field-answer-required">{{ question.empty_message }}</span>
+                    {% endcall %}
+                  {% endif %}
                 {% else %}
-                  {{ summary.field("Not answered") }}
+                  {{ summary.link('Answer question', url_for(".edit_service_submission", framework_slug=framework.slug, lot_slug=service_data.lot, service_id=service_id, section_id=section.id, question_slug=question.slug)) }}
                 {% endif %}
               {% endif %}
             {% else %}
               {{ summary[question.type](question.value, question.assurance) }}
             {% endif %}
             {% if framework.status == 'open' %}
-              {% if not question.is_empty and section.edit_questions %}
+              {% if section.edit_questions and not question.is_empty %}
+                {% if one_service_limit %}
+                  {{ summary.remove_link('Remove', url_for(".remove_subsection", framework_slug=framework.slug, lot_slug=service_data.lot, service_id=service_id, section_id=section.id, question_slug=question.slug)) }}
+                {% endif %}
                 {{ summary.edit_link('Edit', url_for(".edit_service_submission", framework_slug=framework.slug, lot_slug=service_data.lot, service_id=service_id, section_id=section.id, question_slug=question.slug)) }}
+              {% elif section.edit_questions and one_service_limit %}
+                {% if one_service_limit %}
+                  {% call summary.field() %}
+                  {% endcall %}
+                {% endif %}
+                {{ summary.edit_link('Add', url_for(".edit_service_submission", framework_slug=framework.slug, lot_slug=service_data.lot, service_id=service_id, section_id=section.id, question_slug=question.slug)) }}
               {% else %}
                 {% call summary.field(action=True) %}
                   {{ 'Optional' if question.get('optional') else '' }}

--- a/app/templates/services/_base_service_page.html
+++ b/app/templates/services/_base_service_page.html
@@ -82,7 +82,7 @@
             {{ summary.field_name(question.label) }}
             {% if question.is_empty %}
               {% if framework and framework.status == 'open' and section.edit_questions %}
-                {% if lot['oneServiceLimit'] %}
+                {% if lot.oneServiceLimit %}
                   {% if question.empty_message %}
                     {% call summary.field() %}
                       <span class="summary-item-field-answer-required">{{ question.empty_message }}</span>
@@ -97,12 +97,12 @@
             {% endif %}
             {% if framework.status == 'open' %}
               {% if section.edit_questions and not question.is_empty %}
-                {% if lot['oneServiceLimit'] %}
+                {% if lot.oneServiceLimit %}
                   {{ summary.remove_link('Remove', url_for(".remove_subsection", framework_slug=framework.slug, lot_slug=service_data.lot, service_id=service_id, section_id=section.id, question_slug=question.slug)) }}
                 {% endif %}
                 {{ summary.edit_link('Edit', url_for(".edit_service_submission", framework_slug=framework.slug, lot_slug=service_data.lot, service_id=service_id, section_id=section.id, question_slug=question.slug)) }}
-              {% elif section.edit_questions and lot['oneServiceLimit'] %}
-                {% if lot['oneServiceLimit'] %}
+              {% elif section.edit_questions and lot.oneServiceLimit %}
+                {% if lot.oneServiceLimit %}
                   {% call summary.field() %}
                   {% endcall %}
                 {% endif %}

--- a/app/templates/services/edit_submission_section.html
+++ b/app/templates/services/edit_submission_section.html
@@ -35,16 +35,7 @@
 
 {% block save_button %}
 
-  {% if not next_question or force_return_to_summary %}
-    {%
-      with
-      label="Save and return to service overview",
-      name="save_and_return",
-      type="save"
-    %}
-      {% include "toolkit/button.html" %}
-    {% endwith %}
-  {% else %}
+  {% if force_continue_button or (next_question and not force_return_to_summary) %}
     {%
       with
       label="Save and continue",
@@ -54,9 +45,20 @@
       {% include "toolkit/button.html" %}
     {% endwith %}
 
-    <p class="next-page-message">
-      Next: {{ next_question.name }}
-    </p>
+    {% if next_question %}
+      <p class="next-page-message">
+        Next: {{ next_question.name }}
+      </p>
+    {% endif %}
+  {% else %}
+    {%
+      with
+      label=("Save and return to " + lot.unitSingular + " summary") if lot else "Save and return to summary",
+      name="save_and_return",
+      type="save"
+    %}
+      {% include "toolkit/button.html" %}
+    {% endwith %}
   {% endif %}
 
 {% endblock %}

--- a/app/templates/services/edit_submission_section.html
+++ b/app/templates/services/edit_submission_section.html
@@ -35,36 +35,28 @@
 
 {% block save_button %}
 
-  {% if next_section_name and not force_return_to_summary %}
+  {% if not next_question or force_return_to_summary %}
+    {%
+      with
+      label="Save and return to service overview",
+      name="save_and_return",
+      type="save"
+    %}
+      {% include "toolkit/button.html" %}
+    {% endwith %}
+  {% else %}
     {%
       with
       label="Save and continue",
-      name = "continue_to_next_section",
+      name="save_and_continue",
       type="save"
     %}
       {% include "toolkit/button.html" %}
     {% endwith %}
 
     <p class="next-page-message">
-      Next: {{ next_section_name }}
+      Next: {{ next_question.name }}
     </p>
-
-    {%
-    with
-      type = "secondary",
-      label = "Save and return to service overview"
-    %}
-      {% include "toolkit/button.html" %}
-    {% endwith %}
-
-  {% else %}
-    {%
-      with
-      label="Save and continue",
-      type="save"
-    %}
-      {% include "toolkit/button.html" %}
-    {% endwith %}
   {% endif %}
 
 {% endblock %}

--- a/bower.json
+++ b/bower.json
@@ -7,6 +7,6 @@
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
     "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v19.3.1",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.19.2/jinja_govuk_template-0.19.2.tgz",
-    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#5.12.0"
+    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#5.15.2"
   }
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ werkzeug==0.10.4
 python-dateutil==2.4.2
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@24.0.4#egg=digitalmarketplace-utils==24.0.4
-git+https://github.com/alphagov/digitalmarketplace-content-loader.git@2.5.0#egg=digitalmarketplace-content-loader==2.5.0
+git+https://github.com/alphagov/digitalmarketplace-content-loader.git@2.6.0#egg=digitalmarketplace-content-loader==2.9.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@7.10.0#egg=digitalmarketplace-apiclient==7.10.0
 
 # For Cloud Foundry

--- a/tests/app/helpers.py
+++ b/tests/app/helpers.py
@@ -103,6 +103,22 @@ def empty_g7_draft_service():
     }
 
 
+def empty_g9_draft_service():
+    return {
+        'id': 1,
+        'supplierId': 1234,
+        'supplierName': 'supplierName',
+        'frameworkName': 'G-Cloud 9',
+        'frameworkSlug': 'g-cloud-9',
+        'lot': 'cloud-hosting',
+        'lotSlug': 'cloud-hosting',
+        'lotName': 'Cloud hosting',
+        'status': 'not-submitted',
+        'links': {},
+        'updatedAt': '2017-02-01T15:26:07.650368Z',
+    }
+
+
 class BaseApplicationTest(object):
     def setup_method(self, method):
         self.app = create_app('test')
@@ -198,16 +214,26 @@ class BaseApplicationTest(object):
             framework_agreement_version=None
     ):
         if 'g-cloud-' in slug:
-            lots = [
-                {'id': 1, 'slug': 'iaas', 'name': 'Infrastructure as a Service', 'oneServiceLimit': False,
-                 'unitSingular': 'service', 'unitPlural': 'service'},
-                {'id': 2, 'slug': 'scs', 'name': 'Specialist Cloud Services', 'oneServiceLimit': False,
-                 'unitSingular': 'service', 'unitPlural': 'service'},
-                {'id': 3, 'slug': 'paas', 'name': 'Platform as a Service', 'oneServiceLimit': False,
-                 'unitSingular': 'service', 'unitPlural': 'service'},
-                {'id': 4, 'slug': 'saas', 'name': 'Software as a Service', 'oneServiceLimit': False,
-                 'unitSingular': 'service', 'unitPlural': 'service'},
-            ]
+            if slug == 'g-cloud-9':
+                lots = [
+                    {'id': 1, 'slug': 'cloud-hosting', 'name': 'Cloud hosting', 'oneServiceLimit': False,
+                     'unitSingular': 'service', 'unitPlural': 'service'},
+                    {'id': 2, 'slug': 'cloud-software', 'name': 'Cloud software', 'oneServiceLimit': False,
+                     'unitSingular': 'service', 'unitPlural': 'service'},
+                    {'id': 3, 'slug': 'cloud-support', 'name': 'Cloud support', 'oneServiceLimit': False,
+                     'unitSingular': 'service', 'unitPlural': 'service'},
+                ]
+            else:
+                lots = [
+                    {'id': 1, 'slug': 'iaas', 'name': 'Infrastructure as a Service', 'oneServiceLimit': False,
+                     'unitSingular': 'service', 'unitPlural': 'service'},
+                    {'id': 2, 'slug': 'scs', 'name': 'Specialist Cloud Services', 'oneServiceLimit': False,
+                     'unitSingular': 'service', 'unitPlural': 'service'},
+                    {'id': 3, 'slug': 'paas', 'name': 'Platform as a Service', 'oneServiceLimit': False,
+                     'unitSingular': 'service', 'unitPlural': 'service'},
+                    {'id': 4, 'slug': 'saas', 'name': 'Software as a Service', 'oneServiceLimit': False,
+                     'unitSingular': 'service', 'unitPlural': 'service'},
+                ]
             metaframework = "g-cloud"
         elif slug == 'digital-outcomes-and-specialists':
             lots = [

--- a/tests/app/helpers.py
+++ b/tests/app/helpers.py
@@ -240,7 +240,7 @@ class BaseApplicationTest(object):
                 {'id': 1, 'slug': 'digital-specialists', 'name': 'Digital specialists', 'oneServiceLimit': True,
                  'unitSingular': 'service', 'unitPlural': 'service'},
             ]
-            metaframework = "dos"
+            metaframework = "digital-outcomes-and-specialists"
 
         return {
             'frameworks': {


### PR DESCRIPTION
One question per page flow for supplier services.

This changes the service specification flow for suppliers and moves towards a 'one question per page' standard. On the summary page, per-section editing is disabled and a link to add/edit answers is shown next to each question. As you work through the service spec, each question will follow on to the next question in the same section; when you reach the end of the section you will be returned to the service summary.

Included in this PR is a bugfix for multiquestions that will allow them to display any question type as children without individually specifying/checking the type each time.