### PR TITLE
138323285-declaration_reuse_view

### DIFF
--- a/app/main/helpers/frameworks.py
+++ b/app/main/helpers/frameworks.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 import re
+from datetime import datetime
 
+from dmutils.formats import DATETIME_FORMAT
 from flask import abort
 from flask_login import current_user
 from dmapiclient import APIError
@@ -36,6 +38,18 @@ def get_framework_lot(framework, lot_slug):
         return next(lot for lot in framework['lots'] if lot['slug'] == lot_slug)
     except StopIteration:
         abort(404)
+
+
+def order_frameworks_for_reuse(frameworks):
+    """Sort frameworks by reuse suitability.
+
+    If a declaration has the reuse flag set and is the most recently closed framework then that's our framework.
+    """
+    return sorted(
+        filter(lambda i: i['allow_declaration_reuse'] and i['application_close_date'], frameworks),
+        key=lambda i: datetime.strptime(i['application_close_date'], DATETIME_FORMAT),
+        reverse=True
+    )
 
 
 def register_interest_in_framework(client, framework_slug):
@@ -79,6 +93,24 @@ def get_declaration_status(data_api_client, framework_slug):
         return 'unstarted'
     else:
         return declaration.get('status', 'unstarted')
+
+
+def get_reusable_declaration(supplier_id, client, exclude_framework_slugs=None):
+    """Given a list of declarations find the most suitable for reuse.
+
+     :param supplier_id: supplier whose declarations we are inspecting
+     :param client: data client if not frameworks
+     :param exclude_framework_slugs: list of framework slugs to exclude from results
+     :return: (declaration, framework)
+     """
+    exclude_framework_slugs = exclude_framework_slugs or []
+    declarations = {i['frameworkSlug']: i for i in client.find_supplier_declarations(supplier_id)['frameworkInterest']}
+    frameworks = client.find_frameworks()['frameworks']
+
+    for framework in order_frameworks_for_reuse(frameworks):
+        if framework['slug'] in declarations and framework['slug'] not in exclude_framework_slugs:
+            return framework, declarations[framework['slug']]
+    return None, None
 
 
 def get_supplier_framework_info(data_api_client, framework_slug):

--- a/app/templates/frameworks/reuse_declaration.html
+++ b/app/templates/frameworks/reuse_declaration.html
@@ -1,0 +1,73 @@
+{% extends "_base_page.html" %}
+
+{% block page_title %}
+  {% block page_title_inner %}
+    Reusing answers from an earlier declaration
+  {% endblock %} – Digital Marketplace
+{% endblock %}
+
+{% block breadcrumb %}
+  {%
+    with items = [
+      {
+        "link": "/",
+        "label": "Digital Marketplace",
+      },
+      {
+        "link": url_for(".dashboard"),
+        "label": "Your account",
+      },
+      {
+        "link": url_for(".framework_dashboard", framework_slug=current_framework.slug),
+        "label": "Apply to " + current_framework.name,
+      }
+    ]
+  %}
+    {% include "toolkit/breadcrumb.html" %}
+  {% endwith %}
+{% endblock %}
+
+{% block main_content %}
+  <div class="grid-row framework-dashboard">
+    <div class="column-two-thirds">
+      {% with
+         heading = self.page_title_inner(),
+         smaller = True
+      %}
+        {% include "toolkit/page-heading.html" %}
+      {% endwith %}
+      <p>In {{ old_framework_application_close_date }}, your organisation completed a declaration for {{ old_framework.name }}.</p>
+      <p>You can reuse some of the answers from that declaration.</p>
+      <br>
+      <p>You’ll need to:</p>
+      <ul class="list-bullet">
+          <li>review the answers you gave before and make sure they’re still correct</li>
+          <li>provide some new answers for this declaration</li>
+      </ul>
+      <br>
+      <br>
+
+      <form method="POST" action="{{ url_for(".reuse_framework_supplier_declaration_post", framework_slug=current_framework.slug, old_framework_slug=old_framework.slug) }}">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+        {%
+          with
+          name = "reuse",
+          question = "Do you want to reuse the answers from your earlier declaration?",
+          inline = true,
+          type = "radio",
+          options = [
+            {"label": "Yes", "value": old_framework.slug},
+            {"label": "No", "value": 0}
+          ]
+        %}
+          {% include "toolkit/forms/selection-buttons.html" %}
+        {% endwith %}
+        {% with type = "save", label = "Continue" %}
+          {% include "toolkit/button.html" %}
+        {% endwith %}
+      </form>
+
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/templates/frameworks/start_declaration.html
+++ b/app/templates/frameworks/start_declaration.html
@@ -43,7 +43,7 @@
       <br>
       <p>You can come back and change your answers at any time before the framework application deadline, {{ framework_close_date }}.</p>
       <br><br>
-      <a href="{{ url_for('.framework_supplier_declaration_overview', framework_slug=framework.slug) }}" class="button-save" role="button">Start your declaration</a>
+      <a href='{{ url_for(".reuse_framework_supplier_declaration", framework_slug=framework.slug) }}' class="button-save" role="button">Start your declaration</a>
 
     </div>
   </div>


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/138323285

* Helper function for framework ordering
* Helper function to get a reusable declaration given a supplier
* New view reuse_framework_supplier_declaration to determine whether to ask if we should reuse
* New view reuse_framework_supplier_declaration_post to set prefill preference based on form
* New template app/templates/frameworks/reuse_declaration.html for reuse page
    (as per http://dm-prototype.herokuapp.com/structure/declaration-start-page/declaration?thisPage=declaration-reuse)
* Change start declaration 'next page' to new reuse page
* Bump apiclient dependency version
* Tests

Requires: https://github.com/alphagov/digitalmarketplace-api/pull/539