### PR TITLE
Remove reference to old `framework.framework` value

### DIFF
--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -406,7 +406,6 @@ def edit_service_submission(framework_slug, lot_slug, service_id, section_id, qu
     framework, lot = get_framework_and_lot(data_api_client, framework_slug, lot_slug, allowed_statuses=['open'])
 
     force_return_to_summary = (request.args.get('return_to_summary') or
-                               framework['framework'] == "dos" or
                                framework['framework'] == "digital-outcomes-and-specialists")
 
     try:


### PR DESCRIPTION
`framework.framework` has now been migrated to be 'digital-outcomes-and-specialists' rather than 'dos'. The line removed was to maintain backwards compatibility whilst that migration was rolled out.