### PR TITLE
Use frameworkFramework when rendering service name

### DIFF
--- a/app/templates/services/list_services.html
+++ b/app/templates/services/list_services.html
@@ -61,7 +61,7 @@
      {# TODO this should be removed once we have a manifests for DOS services
         and a public DOS service page on the buyer frontend (or a way to hide
         the "View service" link from the supplier service page) #}
-      {% if item.frameworkSlug == 'digital-outcomes-and-specialists' %}
+      {% if item.frameworkFramework == 'digital-outcomes-and-specialists' %}
         {% call summary.field(first=True, wide=wide) -%}
           {{ item.serviceName or item.lotName }}
         {%- endcall %}

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -155,7 +155,8 @@ class TestListServices(BaseApplicationTest):
                     'lotName': 'Special Lot Name',
                     'status': 'published',
                     'id': '123',
-                    'frameworkSlug': 'digital-outcomes-and-specialists'
+                    'frameworkSlug': 'digital-outcomes-and-specialists-2',
+                    'frameworkFramework': 'digital-outcomes-and-specialists',
                 }]
             }
 


### PR DESCRIPTION
For [this chore on Pivotal](https://www.pivotaltracker.com/story/show/139269583).

In the list view of services, if a service is a DOS service we don't
provide a link to edit that service. This was achieved by comparing the
services `frameworkName` to the string
`digital-outcomes-and-specialists`. This wouldn't work for DOS2.

We now compare using the recently update `frameworkFramework` which will
be `digital-outcomes-and-specialists` for all DOS services, regardless
of the framework iteration.