### PR TITLE
Keep DOS1 functional when it's expired

### DIFF
--- a/app/main/views/briefs.py
+++ b/app/main/views/briefs.py
@@ -376,7 +376,7 @@ def view_response_result(brief_id):
 
     brief_response = brief_response[0]
     framework, lot = get_framework_and_lot(
-        data_api_client, brief['frameworkSlug'], brief['lotSlug'], allowed_statuses=['live'])
+        data_api_client, brief['frameworkSlug'], brief['lotSlug'], allowed_statuses=['live', 'expired'])
 
     if brief_response.get('essentialRequirementsMet'):
         brief_response_display_manifest = 'display_brief_response'

--- a/app/main/views/briefs.py
+++ b/app/main/views/briefs.py
@@ -145,7 +145,7 @@ def edit_brief_response(brief_id, brief_response_id, question_id=None):
         return redirect(url_for(".view_response_result", brief_id=brief_id))
 
     framework, lot = get_framework_and_lot(
-        data_api_client, brief['frameworkSlug'], brief['lotSlug'], allowed_statuses=['live'])
+        data_api_client, brief['frameworkSlug'], brief['lotSlug'], allowed_statuses=['live', 'expired'])
 
     max_day_rate = None
     role = brief.get('specialistRole')

--- a/tests/app/main/test_briefs.py
+++ b/tests/app/main/test_briefs.py
@@ -483,13 +483,17 @@ class TestApplyToBrief(BaseApplicationTest):
 
     @mock.patch("app.main.views.briefs.supplier_has_a_brief_response")
     def test_redirect_to_show_brief_response_if_already_applied_for_brief(self, supplier_has_a_brief_response):
-        for method in ('get', 'post'):
-            supplier_has_a_brief_response.return_value = True
+        framework = self.framework.copy()
+        for framework_status in ['live', 'expired']:
+            framework.update({'status': framework_status})
+            self.data_api_client.get_framework.return_value = framework
+            for method in ('get', 'post'):
+                supplier_has_a_brief_response.return_value = True
 
-            res = self.client.open('/suppliers/opportunities/1234/responses/5/question-id', method=method)
-            assert res.status_code == 302
-            assert res.location == 'http://localhost/suppliers/opportunities/1234/responses/result'
-            self.assert_flashes("already_applied", "error")
+                res = self.client.open('/suppliers/opportunities/1234/responses/5/question-id', method=method)
+                assert res.status_code == 302
+                assert res.location == 'http://localhost/suppliers/opportunities/1234/responses/result'
+                self.assert_flashes("already_applied", "error")
 
     @mock.patch("app.main.views.briefs.content_loader")
     def test_should_404_for_non_existent_content_section(self, content_loader):


### PR DESCRIPTION
Part of this story: [https://www.pivotaltracker.com/story/show/139283847](https://www.pivotaltracker.com/story/show/139283847)

When we expire DOS1, suppliers will still need to be able to apply to live DOS1 briefs and view their previous responses.

This does that.

Also see this PR on the API: [https://github.com/alphagov/digitalmarketplace-api/pull/543](https://github.com/alphagov/digitalmarketplace-api/pull/543)