### PR TITLE
Fix bug with POST to 'responses/start' if brief response exists

### DIFF
--- a/app/main/views/briefs.py
+++ b/app/main/views/briefs.py
@@ -91,21 +91,30 @@ def start_brief_response(brief_id):
     if not is_supplier_eligible_for_brief(data_api_client, current_user.supplier_id, brief):
         return _render_not_eligible_for_brief_error_page(brief)
 
-    if request.method == 'POST':
-        brief_response = data_api_client.create_brief_response(
-            brief_id,
-            current_user.supplier_id,
-            {},
-            current_user.email_address,
-        )['briefResponses']
-        brief_response_id = brief_response['id']
-        return redirect(url_for('.edit_brief_response', brief_id=brief_id, brief_response_id=brief_response_id))
-
     brief_response = data_api_client.find_brief_responses(
         brief_id=brief_id,
         supplier_id=current_user.supplier_id,
         status='draft,submitted'
     )['briefResponses']
+
+    if request.method == 'POST':
+        if brief_response:
+            if brief_response[0].get('status') == 'submitted':
+                flash('already_applied', 'error')
+                return redirect(url_for(".view_response_result", brief_id=brief_id))
+            if brief_response[0].get('status') == 'draft':
+                return redirect(
+                    url_for('.edit_brief_response', brief_id=brief_id, brief_response_id=brief_response[0]['id'])
+                )
+        else:
+            brief_response = data_api_client.create_brief_response(
+                brief_id,
+                current_user.supplier_id,
+                {},
+                current_user.email_address,
+            )['briefResponses']
+            brief_response_id = brief_response['id']
+            return redirect(url_for('.edit_brief_response', brief_id=brief_id, brief_response_id=brief_response_id))
 
     if brief_response:
         if brief_response[0].get('status') == 'submitted':

--- a/app/main/views/briefs.py
+++ b/app/main/views/briefs.py
@@ -97,15 +97,15 @@ def start_brief_response(brief_id):
         status='draft,submitted'
     )['briefResponses']
 
+    if brief_response and brief_response[0]['status'] == 'submitted':
+        flash('already_applied', 'error')
+        return redirect(url_for(".view_response_result", brief_id=brief_id))
+
     if request.method == 'POST':
-        if brief_response:
-            if brief_response[0]['status'] == 'submitted':
-                flash('already_applied', 'error')
-                return redirect(url_for(".view_response_result", brief_id=brief_id))
-            if brief_response[0]['status'] == 'draft':
-                return redirect(
-                    url_for('.edit_brief_response', brief_id=brief_id, brief_response_id=brief_response[0]['id'])
-                )
+        if brief_response and brief_response[0]['status'] == 'draft':
+            return redirect(
+                url_for('.edit_brief_response', brief_id=brief_id, brief_response_id=brief_response[0]['id'])
+            )
         else:
             brief_response = data_api_client.create_brief_response(
                 brief_id,
@@ -116,14 +116,9 @@ def start_brief_response(brief_id):
             brief_response_id = brief_response['id']
             return redirect(url_for('.edit_brief_response', brief_id=brief_id, brief_response_id=brief_response_id))
 
-    if brief_response:
-        if brief_response[0]['status'] == 'submitted':
-            flash('already_applied', 'error')
-            return redirect(url_for(".view_response_result", brief_id=brief_id))
-        if brief_response[0]['status'] == 'draft':
-            existing_draft_response = brief_response[0]
-    else:
-        existing_draft_response = False
+    existing_draft_response = False
+    if brief_response and brief_response[0]['status'] == 'draft':
+        existing_draft_response = brief_response[0]
 
     return render_template(
         "briefs/start_brief_response.html",

--- a/app/main/views/briefs.py
+++ b/app/main/views/briefs.py
@@ -99,10 +99,10 @@ def start_brief_response(brief_id):
 
     if request.method == 'POST':
         if brief_response:
-            if brief_response[0].get('status') == 'submitted':
+            if brief_response[0]['status'] == 'submitted':
                 flash('already_applied', 'error')
                 return redirect(url_for(".view_response_result", brief_id=brief_id))
-            if brief_response[0].get('status') == 'draft':
+            if brief_response[0]['status'] == 'draft':
                 return redirect(
                     url_for('.edit_brief_response', brief_id=brief_id, brief_response_id=brief_response[0]['id'])
                 )
@@ -117,10 +117,10 @@ def start_brief_response(brief_id):
             return redirect(url_for('.edit_brief_response', brief_id=brief_id, brief_response_id=brief_response_id))
 
     if brief_response:
-        if brief_response[0].get('status') == 'submitted':
+        if brief_response[0]['status'] == 'submitted':
             flash('already_applied', 'error')
             return redirect(url_for(".view_response_result", brief_id=brief_id))
-        if brief_response[0].get('status') == 'draft':
+        if brief_response[0]['status'] == 'draft':
             existing_draft_response = brief_response[0]
     else:
         existing_draft_response = False

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -2,7 +2,7 @@
 pytest==2.8.2
 pep8==1.5.7
 requests-mock==0.6.0
-mock==1.0.1
+mock==2.0.0
 lxml==3.4.4
 cssselect==0.9.1
 freezegun==0.3.4


### PR DESCRIPTION
Reviewers, please read the pivotal story with comments first - https://www.pivotaltracker.com/story/show/139468419

POST route now handles three cases
- no existing brief response
- existing draft brief response
- existing submitted brief response

If you click the 'Start application' button and you have an ongoing application that has not been submitted you should be redirected to the application flow at the start for your existing application which is prefilled (similar to the continue application button).

If you click the 'Start application' button and you have already applied and completed an application you should be redirected to your response page with a error message saying 'you have already applied' or to that effect, again the same as the continue application button.

I wanted to bring in `assert_not_called` from mock 1.3.0 for tests but decided we might as well upgrade all the way to 2.0.0. (http://mock.readthedocs.io/en/latest/changelog.html)