### PR TITLE
Bring in new toolkit with new input fields

### DIFF
--- a/app/assets/javascripts/_analytics.js
+++ b/app/assets/javascripts/_analytics.js
@@ -1,3 +1,8 @@
+//= include ../../../node_modules/govuk_frontend_toolkit/javascripts/govuk/analytics/google-analytics-universal-tracker.js
+//= include ../../../node_modules/govuk_frontend_toolkit/javascripts/govuk/analytics/analytics.js
+
+; // JavaScript in the govuk_frontend_toolkit doesn't have trailing semicolons
+
 //= include analytics/_register.js
 //= include analytics/_pageViews.js
 //= include analytics/_events.js

--- a/app/assets/javascripts/_selection-buttons.js
+++ b/app/assets/javascripts/_selection-buttons.js
@@ -1,13 +1,10 @@
-;(function(GOVUK, GDM) {
+(function(GOVUK, GDM) {
 
   GDM.selectionButtons = function() {
 
     if (!GOVUK.SelectionButtons) return;
 
-    new GOVUK.SelectionButtons('.selection-button input', {
-      'focusedClass' : 'selection-button-focused',
-      'selectedClass' : 'selection-button-selected'
-    });
+    new GOVUK.SelectionButtons('.selection-button input');
 
     new GOVUK.ShowHideContent().init();
 

--- a/app/assets/javascripts/_shim-links-with-button-role.js
+++ b/app/assets/javascripts/_shim-links-with-button-role.js
@@ -1,0 +1,15 @@
+(function(GOVUK, GDM) {
+
+  GDM.shimLinksWithButtonRole = function() {
+
+    if (!GOVUK.shimLinksWithButtonRole) return;
+
+    GOVUK.shimLinksWithButtonRole.init({
+      selector: '[class^=link-button]'
+    });
+
+  };
+
+  GOVUK.GDM = GDM;
+
+}).apply(this, [GOVUK||{}, GOVUK.GDM||{}]);

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -11,9 +11,11 @@
 //= include ../../../bower_components/digitalmarketplace-frontend-toolkit/toolkit/javascripts/word-counter.js
 //= include ../../../bower_components/digitalmarketplace-frontend-toolkit/toolkit/javascripts/validation.js
 //= include ../../../node_modules/govuk_frontend_toolkit/javascripts/govuk/selection-buttons.js
+//= include ../../../node_modules/govuk_frontend_toolkit/javascripts/govuk/shim-links-with-button-role.js
 //= include ../../../node_modules/govuk_frontend_toolkit/javascripts/govuk/show-hide-content.js
 //= include _analytics.js
 //= include _selection-buttons.js
+//= include _shim-links-with-button-role.js
 
 (function(GOVUK, GDM) {
 

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -4,8 +4,6 @@
   Sprockets-style (https://github.com/sstephenson/sprockets)
   directives to concatenate multiple Javascript files into one.
 */
-//= include ../../../node_modules/govuk_frontend_toolkit/javascripts/govuk/analytics/analytics.js
-//= include ../../../node_modules/govuk_frontend_toolkit/javascripts/govuk/analytics/google-analytics-universal-tracker.js
 //= include ../../../node_modules/govuk_frontend_toolkit/javascripts/vendor/polyfills/bind.js
 //= include ../../../bower_components/jquery/dist/jquery.js
 //= include ../../../bower_components/hogan/web/builds/3.0.2/hogan-3.0.2.js
@@ -14,8 +12,8 @@
 //= include ../../../bower_components/digitalmarketplace-frontend-toolkit/toolkit/javascripts/validation.js
 //= include ../../../node_modules/govuk_frontend_toolkit/javascripts/govuk/selection-buttons.js
 //= include ../../../node_modules/govuk_frontend_toolkit/javascripts/govuk/show-hide-content.js
-//= include _selection-buttons.js
 //= include _analytics.js
+//= include _selection-buttons.js
 
 (function(GOVUK, GDM) {
 

--- a/app/assets/scss/_footer.scss
+++ b/app/assets/scss/_footer.scss
@@ -102,25 +102,4 @@
       font-size: 16px;
     }
   }
-
-  .footer-categories a[rel="external"],
-  .footer-meta .footer-meta-inner a[rel="external"] {
-    /* There is no mixin for a 16px black link with a font weight of normal in the govuk toolkit hence the variant below */
-    &:after {
-      content: "\A0\A0\A0\A0\A0";
-      background-position: right 3px;
-      background-image: file-url("external-links/external-link-black-12x12.png");
-      background-repeat: no-repeat;
-
-      @include device-pixel-ratio() {
-        background-image: file-url("external-links/external-link-black-24x24.png");
-        background-size: 12px 12px;
-      }
-    }
-
-    &:hover:after {
-      background-position: right 3px;
-    }
-  }
-
 }

--- a/app/assets/scss/_supplier-declaration.scss
+++ b/app/assets/scss/_supplier-declaration.scss
@@ -2,13 +2,11 @@
 
 .supplier-declaration {
 
-  .question-heading,
-  .question-heading-with-hint {
+  .question-heading {
     font-size: 19px;
     font-weight: normal;
   }
   .question-heading li,
-  .question-heading-with-hint li,
   .hint li {
 
     margin: 10px 0 10px 20px;

--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -16,8 +16,9 @@ $path: "/suppliers/static/images/";
 @import "shared_scss/_dmspeak.scss";
 
 /* Blocks shared between multiple selectors */
-@import "shared_placeholders/_temporary-messages.scss";
-@import "shared_placeholders/_dm-typography.scss";
+@import "toolkit/shared_placeholders/_temporary-messages.scss";
+@import "toolkit/shared_placeholders/_placeholders.scss";
+@import "toolkit/shared_placeholders/_dm-typography.scss";
 
 #wrapper, .wrapper {
   @extend %site-width-container;

--- a/app/templates/auth/create_user.html
+++ b/app/templates/auth/create_user.html
@@ -24,7 +24,7 @@
                 <div class="validation-wrapper">
                     {% endif %}
                     <div class="question">
-                        {{ form.name.label(class="question-heading-with-hint") }}
+                        {{ form.name.label(class="question-heading") }}
                         <p class="hint">
                             Enter the name to be referred to on the Digital Marketplace
                         </p>
@@ -43,7 +43,7 @@
                 <div class="validation-wrapper">
             {% endif %}
                 <div class="question">
-                    {{ form.password.label(class="question-heading-with-hint") }}
+                    {{ form.password.label(class="question-heading") }}
                     <p class="hint">
                       Must be between 10 and 50 characters
                     </p>

--- a/app/templates/macros/toolkit_forms.html
+++ b/app/templates/macros/toolkit_forms.html
@@ -222,7 +222,7 @@
       <span class="visually-hidden">{{ question_content.name }}</span>
     </legend>
 
-    <span class="question-heading{% if question_content.hint %}-with-hint{% endif %}">
+    <span class="question-heading">
       {% if question_number is not none %}
         <span class="question-number">
           {{ question_number }}

--- a/app/templates/suppliers/edit_supplier.html
+++ b/app/templates/suppliers/edit_supplier.html
@@ -82,7 +82,7 @@
       {{ forms.question_input('contact_phoneNumber', 'Phone number', contact_form.phoneNumber.data, errors=contact_form.phoneNumber.errors) }}
 
       <div class="question">
-        <label class="question-heading-with-hint">
+        <label class="question-heading">
           Business address
         </label>
         {{ forms.input('contact_id', contact_form.id.data, type='hidden') }}

--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "jquery": "1.11.2",
     "hogan": "3.0.2",
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
-    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v19.3.1",
+    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v20.0.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.19.2/jinja_govuk_template-0.19.2.tgz",
     "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#5.15.2"
   }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "bower": "1.5.2",
     "del": "1.1.1",
-    "govuk_frontend_toolkit": "4.18.0",
+    "govuk_frontend_toolkit": "5.0.3",
     "gulp": "3.8.7",
     "gulp-filelog": "0.4.1",
     "gulp-include": "1.1.1",

--- a/tests/app/main/test_briefs.py
+++ b/tests/app/main/test_briefs.py
@@ -571,7 +571,7 @@ class TestApplyToBrief(BaseApplicationTest):
 
         doc = html.fromstring(res.get_data(as_text=True))
         assert doc.xpath("//h1/text()")[0].strip() == 'Email address the buyer should use to contact you'
-        assert (doc.xpath("//span[@class=\"question-heading-with-hint\"]/text()")[0].strip() ==
+        assert (doc.xpath("//span[@class=\"question-heading\"]/text()")[0].strip() ==
                 'Email address the buyer should use to contact you')
         assert (doc.xpath("//span[@class=\"question-advice\"]/text()")[0].strip() ==
                 'All communication about your application will be sent to this address.')


### PR DESCRIPTION
This pull request

- updates the govuk_frontend toolkit to the latest
- updates the digitalmarketplace frontend toolkit to the latest
  - [brings in the new radios/checkboxes](https://github.com/alphagov/digitalmarketplace-frontend-toolkit/pull/302)
- treats links with a `role="button"` as buttons (ie, "Apply for this opportunity" link)
- removes some unused classnames

💥  Explosion noise 💥 