### PR TITLE
Prefill declaration sections

### DIFF
--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -514,11 +514,8 @@ def framework_supplier_declaration(framework_slug, section_id=None):
         if len(errors) > 0:
             status_code = 400
         else:
-            validator = get_validator(framework, content, all_answers)
-            if validator.get_error_messages():
+            if not all_answers.get("status"):
                 all_answers.update({"status": "started"})
-            else:
-                all_answers.update({"status": "complete"})
             try:
                 data_api_client.set_supplier_declaration(
                     current_user.supplier_id,

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -488,6 +488,8 @@ def framework_supplier_declaration(framework_slug, section_id=None):
         # If there are section_errors it means that this section has not previously been completed
         if section_errors and section.prefill and supplier_framework['prefillDeclarationFromFrameworkSlug']:
             # Fetch the old declaration to pre-fill from and pass it through
+            # For now we pre-fill a whole section or none of the section
+            # TODO: In future we may need to pre-fill individual questions and add a 'prefilled' flag to the questions
             try:
                 prefill_from_slug = supplier_framework['prefillDeclarationFromFrameworkSlug']
                 framework_to_reuse = data_api_client.get_framework(prefill_from_slug)['frameworks']

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -474,7 +474,7 @@ def framework_supplier_declaration(framework_slug, section_id=None):
     supplier_framework = data_api_client.get_supplier_framework_info(
         current_user.supplier_id, framework_slug)['frameworkInterest']
     saved_declaration = supplier_framework.get('declaration', {})
-    section_has_been_prefilled_from = ""
+    name_of_framework_that_section_has_been_prefilled_from = ""
 
     if request.method == 'GET':
         errors = {}
@@ -498,7 +498,7 @@ def framework_supplier_declaration(framework_slug, section_id=None):
                     prefill_from_slug
                 )['declaration']
                 all_answers = declaration_to_reuse
-                section_has_been_prefilled_from = framework_to_reuse['name']
+                name_of_framework_that_section_has_been_prefilled_from = framework_to_reuse['name']
             except APIError as e:
                 if e.status_code != 404:
                     abort(e.status_code)
@@ -546,7 +546,7 @@ def framework_supplier_declaration(framework_slug, section_id=None):
         framework=framework,
         next_section=next_section,
         section=section,
-        section_has_been_prefilled_from=section_has_been_prefilled_from,
+        name_of_framework_that_section_has_been_prefilled_from=name_of_framework_that_section_has_been_prefilled_from,
         declaration_answers=all_answers,
         get_question=content.get_question,
         errors=errors

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -474,7 +474,7 @@ def framework_supplier_declaration(framework_slug, section_id=None):
     supplier_framework = data_api_client.get_supplier_framework_info(
         current_user.supplier_id, framework_slug)['frameworkInterest']
     saved_declaration = supplier_framework.get('declaration', {})
-    section_has_been_prefilled = False
+    section_has_been_prefilled_from = ""
 
     if request.method == 'GET':
         errors = {}
@@ -489,12 +489,14 @@ def framework_supplier_declaration(framework_slug, section_id=None):
         if section_errors and section.prefill and supplier_framework['prefillDeclarationFromFrameworkSlug']:
             # Fetch the old declaration to pre-fill from and pass it through
             try:
+                prefill_from_slug = supplier_framework['prefillDeclarationFromFrameworkSlug']
+                framework_to_reuse = data_api_client.get_framework(prefill_from_slug)['frameworks']
                 declaration_to_reuse = data_api_client.get_supplier_declaration(
                     current_user.supplier_id,
-                    supplier_framework['prefillDeclarationFromFrameworkSlug']
+                    prefill_from_slug
                 )['declaration']
                 all_answers = declaration_to_reuse
-                section_has_been_prefilled = True
+                section_has_been_prefilled_from = framework_to_reuse['name']
             except APIError as e:
                 if e.status_code != 404:
                     abort(e.status_code)
@@ -542,7 +544,7 @@ def framework_supplier_declaration(framework_slug, section_id=None):
         framework=framework,
         next_section=next_section,
         section=section,
-        section_has_been_prefilled=section_has_been_prefilled,
+        section_has_been_prefilled_from=section_has_been_prefilled_from,
         declaration_answers=all_answers,
         get_question=content.get_question,
         errors=errors

--- a/app/templates/frameworks/edit_declaration_section.html
+++ b/app/templates/frameworks/edit_declaration_section.html
@@ -34,6 +34,13 @@
     {% with errors = errors.values() %}
       {% include 'toolkit/forms/validation.html' %}
     {% endwith %}
+  {% elif section_has_been_prefilled_from %}
+    {% with
+       message = "Answers on this page are from an earlier declaration and need review.",
+       type = "information"
+    %}
+      {% include "toolkit/notification-banner.html" %}
+    {% endwith %}
   {% endif %}
 
   <form method="post" class="supplier-declaration">

--- a/app/templates/frameworks/edit_declaration_section.html
+++ b/app/templates/frameworks/edit_declaration_section.html
@@ -59,21 +59,19 @@
               </div>
             {% endif %}
             {% for question in section.questions %}
-              {% if errors and (errors[question.id] or question.type == 'multiquestion') %}
-                {{ forms[question.type](question, declaration_answers, errors, question_number=question.number, get_question=get_question) }}
-              {% else %}
                 {{ forms[question.type](
                     question,
                     declaration_answers,
-                    {},
+                    errors if errors and (errors[question.id] or question.type == 'multiquestion') else {},
                     question_number=question.number,
                     get_question=get_question,
                     message="This answer is from your {} declaration".format(section_has_been_prefilled_from)
-                            if (section_has_been_prefilled_from and declaration_answers.get(question.id) is not none)
+                            if section_has_been_prefilled_from and
+                                (declaration_answers.get(question.id) is not none or question.type == 'multiquestion')
                             else None
                     )
                 }}
-              {% endif %}
+
             {% endfor %}
 
             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />

--- a/app/templates/frameworks/edit_declaration_section.html
+++ b/app/templates/frameworks/edit_declaration_section.html
@@ -62,7 +62,17 @@
               {% if errors and (errors[question.id] or question.type == 'multiquestion') %}
                 {{ forms[question.type](question, declaration_answers, errors, question_number=question.number, get_question=get_question) }}
               {% else %}
-                {{ forms[question.type](question, declaration_answers, {}, question_number=question.number, get_question=get_question) }}
+                {{ forms[question.type](
+                    question,
+                    declaration_answers,
+                    {},
+                    question_number=question.number,
+                    get_question=get_question,
+                    message="This answer is from your {} declaration".format(section_has_been_prefilled_from)
+                            if (section_has_been_prefilled_from and declaration_answers.get(question.id) is not none)
+                            else None
+                    )
+                }}
               {% endif %}
             {% endfor %}
 

--- a/app/templates/frameworks/edit_declaration_section.html
+++ b/app/templates/frameworks/edit_declaration_section.html
@@ -34,7 +34,7 @@
     {% with errors = errors.values() %}
       {% include 'toolkit/forms/validation.html' %}
     {% endwith %}
-  {% elif section_has_been_prefilled_from %}
+  {% elif name_of_framework_that_section_has_been_prefilled_from %}
     {% with
        message = "Answers on this page are from an earlier declaration and need review.",
        type = "information"
@@ -65,11 +65,14 @@
                     errors if errors and (errors[question.id] or question.type == 'multiquestion') else {},
                     question_number=question.number,
                     get_question=get_question,
-                    message="This answer is from your {} declaration".format(section_has_been_prefilled_from)
-                            if section_has_been_prefilled_from and
-                                (declaration_answers.get(question.id) is not none or question.type == 'multiquestion')
-                            else None
-                    )
+                    message=(
+                            "This answer is from your {} declaration".format(name_of_framework_that_section_has_been_prefilled_from)
+                        if
+                            name_of_framework_that_section_has_been_prefilled_from and (declaration_answers.get(question.id) is not none or question.type == 'multiquestion')
+                        else
+                            None
+                            )
+                   )
                 }}
 
             {% endfor %}

--- a/app/templates/macros/toolkit_forms.html
+++ b/app/templates/macros/toolkit_forms.html
@@ -1,9 +1,9 @@
-{% macro text(question_content, service_data, errors, question_number=None, get_question=None) -%}
+{% macro text(question_content, service_data, errors) -%}
   {%
     with
-    question=question_content.question|question_references(get_question),
+    question=question_content.question|question_references(kwargs.get_question),
     question_advice=question_content.question_advice,
-    hint=(question_content.hint or '')|question_references(get_question),
+    hint=(question_content.hint or '')|question_references(kwargs.get_question),
     optional=question_content.optional,
     name=question_content.id,
     value=service_data[question_content.id],
@@ -12,130 +12,137 @@
     unit=question_content.unit,
     smaller=question_content.smaller,
     hidden=question_content.hidden,
-    error=errors.get(question_content.id)['message']|question_references(get_question)
+    error=errors.get(question_content.id)['message']|question_references(kwargs.get_question),
+    message=kwargs.message
   %}
     {% include "toolkit/forms/textbox.html" %}
   {% endwith %}
 {%- endmacro %}
 
-{% macro textbox_large(question_content, service_data, errors, question_number=None, get_question=None) -%}
+{% macro textbox_large(question_content, service_data, errors) -%}
   {%
     with
-    question=question_content.question|question_references(get_question),
+    question=question_content.question|question_references(kwargs.get_question),
     question_advice=question_content.question_advice,
-    hint=(question_content.hint or '')|question_references(get_question),
+    hint=(question_content.hint or '')|question_references(kwargs.get_question),
     optional=question_content.optional,
     name=question_content.id,
     value=service_data[question_content.id],
     large=True,
     max_length_in_words=question_content.max_length_in_words,
     hidden=question_content.hidden,
-    error=errors.get(question_content.id)['message']|question_references(get_question)
+    error=errors.get(question_content.id)['message']|question_references(kwargs.get_question),
+    message=kwargs.message
   %}
     {% include "toolkit/forms/textbox.html" %}
   {% endwith %}
 {%- endmacro %}
 
-{% macro list(question_content, service_data, errors, question_number=None, get_question=None) -%}
+{% macro list(question_content, service_data, errors) -%}
   {%
     with
     name=question_content.id,
     number_of_items=10,
-    question=question_content.question|question_references(get_question),
+    question=question_content.question|question_references(kwargs.get_question),
     question_advice=question_content.question_advice,
-    hint=(question_content.hint or '')|question_references(get_question),
+    hint=(question_content.hint or '')|question_references(kwargs.get_question),
     optional=question_content.optional,
     values=service_data[question_content.id],
     id=question_content.id,
     hidden=question_content.hidden,
-    error=errors.get(question_content.id)['message']|question_references(get_question)
+    error=errors.get(question_content.id)['message']|question_references(kwargs.get_question),
+    message=kwargs.message
   %}
     {% include "toolkit/forms/list-entry.html" %}
   {% endwith %}
 {%- endmacro %}
 
-{% macro checkboxes(question_content, service_data, errors, question_number=None, get_question=None) -%}
+{% macro checkboxes(question_content, service_data, errors) -%}
   {%
     with
     name=question_content.id,
-    question=question_content.question|question_references(get_question),
+    question=question_content.question|question_references(kwargs.get_question),
     question_advice=question_content.question_advice,
-    hint=(question_content.hint or '')|question_references(get_question),
+    hint=(question_content.hint or '')|question_references(kwargs.get_question),
     optional=question_content.optional,
     value=service_data[question_content.id],
     id=question_content.id,
     options=question_content.options,
     type='checkbox',
-    error=errors.get(question_content.id)['message']|question_references(get_question),
-    question_number=question_number,
+    error=errors.get(question_content.id)['message']|question_references(kwargs.get_question),
+    question_number=kwargs.question_number,
     hidden=question_content.hidden,
     followup=question_content.values_followup
+    message=kwargs.message
   %}
     {% include "toolkit/forms/selection-buttons.html" %}
   {% endwith %}
 {%- endmacro %}
 
-{% macro radios(question_content, service_data, errors, question_number=None, get_question=None) -%}
+{% macro radios(question_content, service_data, errors) -%}
   {%
     with
     name=question_content.id,
-    question=question_content.question|question_references(get_question),
+    question=question_content.question|question_references(kwargs.get_question),
     question_advice=question_content.question_advice,
-    hint=(question_content.hint or '')|question_references(get_question),
+    hint=(question_content.hint or '')|question_references(kwargs.get_question),
     hint_underneath=(question_content.hint_underneath or False),
     optional=question_content.optional,
     value=service_data[question_content.id],
     id=question_content.id,
     options=question_content.options,
     type='radio',
-    error=errors.get(question_content.id)['message']|question_references(get_question),
-    question_number=question_number,
+    error=errors.get(question_content.id)['message']|question_references(kwargs.get_question),
+    question_number=kwargs.question_number,
     hidden=question_content.hidden,
     followup=question_content.values_followup
+    message=kwargs.message
   %}
     {% include "toolkit/forms/selection-buttons.html" %}
   {% endwith %}
 {%- endmacro %}
 
-{% macro boolean(question_content, service_data, errors, question_number=None, get_question=None) -%}
+{% macro boolean(question_content, service_data, errors) -%}
   {%
     with
     name=question_content.id,
-    question=question_content.question|question_references(get_question),
+    question=question_content.question|question_references(kwargs.get_question),
     question_advice=question_content.question_advice,
-    hint=(question_content.hint or '')|question_references(get_question),
+    hint=(question_content.hint or '')|question_references(kwargs.get_question),
     optional=question_content.optional,
     value=service_data[question_content.id],
     id=question_content.id,
     type='boolean',
     hidden=question_content.hidden,
     followup=question_content.values_followup,
-    error=errors.get(question_content.id)['message']|question_references(get_question),
-    question_number=question_number
+    error=errors.get(question_content.id)['message']|question_references(kwargs.get_question),
+    question_number=kwargs.question_number,
+    message=kwargs.message
   %}
     {% include "toolkit/forms/selection-buttons.html" %}
   {% endwith %}
 {%- endmacro %}
 
-{% macro upload(question_content, service_data, errors, question_number=None, get_question=None) -%}
+{% macro upload(question_content, service_data, errors) -%}
   {%
     with
-    question=question_content.question|question_references(get_question),
+    question=question_content.question|question_references(kwargs.get_question),
     question_advice=question_content.question_advice,
-    hint=(question_content.hint or '')|question_references(get_question),
+    hint=(question_content.hint or '')|question_references(kwargs.get_question),
     optional=question_content.optional,
     name=question_content.id,
     value="Document uploaded {}".format(
       service_data[question_content.id]|parse_document_upload_time|datetimeformat
     ) if service_data[question_content.id] else service_data[question_content.id],
-    error=errors.get(question_content.id)['message']|question_references(get_question),
-    question_number=question_number
+    error=errors.get(question_content.id)['message']|question_references(kwargs.get_question),
+    question_number=kwargs.question_number,
+    message=kwargs.message
   %}
     {% include "toolkit/forms/upload.html" %}
   {% endwith %}
 {%- endmacro %}
 
-{% macro pricing(question_content, service_data, errors, question_number=None, get_question=None) -%}
+{% macro pricing(question_content, service_data, errors) -%}
   {%
     with
     name=question_content.id,
@@ -152,34 +159,36 @@
     hint=(question_content.hint or ''),
     optional=question_content.optional,
     id=question_content.id,
-    error=errors.get(question_content.id)['message']|question_references(get_question),
-    question_number=question_number
+    error=errors.get(question_content.id)['message']|question_references(kwargs.get_question),
+    question_number=kwargs.question_number,
+    message=kwargs.message
   %}
     {% include "toolkit/forms/pricing.html" %}
   {% endwith %}
 {%- endmacro %}
 
-{% macro number(question_content, service_data, errors, question_number=None, get_question=None) -%}
+{% macro number(question_content, service_data, errors) -%}
   {%
     with
     unit=question_content.unit,
     unit_in_full=question_content.unit_in_full,
     unit_position=question_content.unit_position,
-    question=question_content.question|question_references(get_question),
+    question=question_content.question|question_references(kwargs.get_question),
     question_advice=question_content.question_advice,
-    hint=(question_content.hint or '')|question_references(get_question),
+    hint=(question_content.hint or '')|question_references(kwargs.get_question),
     optional=question_content.optional,
     name=question_content.id,
     value=service_data[question_content.id],
-    error=errors.get(question_content.id)['message']|question_references(get_question),
-    question_number=question_number,
-    smaller=True
+    error=errors.get(question_content.id)['message']|question_references(kwargs.get_question),
+    question_number=kwargs.question_number,
+    smaller=True,
+    message=kwargs.message
   %}
     {% include "toolkit/forms/textbox.html" %}
   {% endwith %}
 {%- endmacro %}
 
-{% macro boolean_list(question_content, service_data, errors, question_number=None, get_question=None) -%}
+{% macro boolean_list(question_content, service_data, errors) -%}
   {% if question_content.boolean_list_questions %}
     <fieldset class="question question-boolean-list" id="{{ question_content.id }}">
         <legend>
@@ -215,23 +224,23 @@
               boolean_question_id: existing_value
             }
         %}
-          {{ boolean(boolean_question_content, data, errors) }}
+          {{ boolean(boolean_question_content, data, errors, message=kwargs.message) }}
         {% endwith %}
       {% endfor %}
     </fieldset>
   {% endif %}
 {%- endmacro %}
 
-{% macro multiquestion(question_content, service_data, errors, question_number=None, get_question=None) -%}
+{% macro multiquestion(question_content, service_data, errors) -%}
   <fieldset class="question" id="{{ question_content.id }}">
     <legend>
       <span class="visually-hidden">{{ question_content.name }}</span>
     </legend>
 
     <span class="question-heading">
-      {% if question_number is not none %}
+      {% if kwargs.question_number is not none %}
         <span class="question-number">
-          {{ question_number }}
+          {{ kwargs.question_number }}
         </span>
       {% endif %}
         {{ question_content.question }}
@@ -250,7 +259,7 @@
     {% import "macros/toolkit_forms.html" as forms %}
 
     {% for child_question in question_content.questions %}
-      {{ forms[child_question.type](child_question, service_data, errors if errors and errors[child_question.id] else {}) }}
+      {{ forms[child_question.type](child_question, service_data, errors if errors and errors[child_question.id] else {}, message=kwargs.message) }}
     {% endfor %}
   </fieldset>
 {%- endmacro %}

--- a/app/templates/macros/toolkit_forms.html
+++ b/app/templates/macros/toolkit_forms.html
@@ -72,7 +72,7 @@
     error=errors.get(question_content.id)['message']|question_references(kwargs.get_question),
     question_number=kwargs.question_number,
     hidden=question_content.hidden,
-    followup=question_content.values_followup
+    followup=question_content.values_followup,
     message=kwargs.message
   %}
     {% include "toolkit/forms/selection-buttons.html" %}
@@ -95,7 +95,7 @@
     error=errors.get(question_content.id)['message']|question_references(kwargs.get_question),
     question_number=kwargs.question_number,
     hidden=question_content.hidden,
-    followup=question_content.values_followup
+    followup=question_content.values_followup,
     message=kwargs.message
   %}
     {% include "toolkit/forms/selection-buttons.html" %}

--- a/app/templates/macros/toolkit_forms.html
+++ b/app/templates/macros/toolkit_forms.html
@@ -259,7 +259,19 @@
     {% import "macros/toolkit_forms.html" as forms %}
 
     {% for child_question in question_content.questions %}
-      {{ forms[child_question.type](child_question, service_data, errors if errors and errors[child_question.id] else {}, message=kwargs.message) }}
+      {{ forms[child_question.type](
+            child_question,
+            service_data,
+            errors if errors and errors[child_question.id] else {},
+            message=(
+                    kwargs.message
+                  if
+                    service_data.get(child_question.id) is not none
+                  else
+                    None
+                    )
+          )
+      }}
     {% endfor %}
   </fieldset>
 {%- endmacro %}

--- a/tests/app/helpers.py
+++ b/tests/app/helpers.py
@@ -312,7 +312,7 @@ class BaseApplicationTest(object):
                      'unitSingular': 'service', 'unitPlural': 'service'},
                 ]
             metaframework = "g-cloud"
-        elif slug == 'digital-outcomes-and-specialists':
+        elif 'digital-outcomes-and-specialists' in slug:
             lots = [
                 {'id': 1, 'slug': 'digital-specialists', 'name': 'Digital specialists', 'oneServiceLimit': True,
                  'unitSingular': 'service', 'unitPlural': 'service'},

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -2875,11 +2875,11 @@ class TestSupplierDeclaration(BaseApplicationTest):
             doc = html.fromstring(res.get_data(as_text=True))
 
             # Radio buttons have been pre-filled with the correct answers
-            assert len(doc.xpath('//input[@id="input-conspiracy-yes"]/@checked')) == 1
-            assert len(doc.xpath('//input[@id="input-corruptionBribery-no"]/@checked')) == 1
-            assert len(doc.xpath('//input[@id="input-fraudAndTheft-yes"]/@checked')) == 1
-            assert len(doc.xpath('//input[@id="input-terrorism-no"]/@checked')) == 1
-            assert len(doc.xpath('//input[@id="input-organisedCrime-no"]/@checked')) == 1
+            assert len(doc.xpath('//input[@id="input-conspiracy-1"][@value="True"]/@checked')) == 1
+            assert len(doc.xpath('//input[@id="input-corruptionBribery-2"][@value="False"]/@checked')) == 1
+            assert len(doc.xpath('//input[@id="input-fraudAndTheft-1"][@value="True"]/@checked')) == 1
+            assert len(doc.xpath('//input[@id="input-terrorism-2"][@value="False"]/@checked')) == 1
+            assert len(doc.xpath('//input[@id="input-organisedCrime-2"][@value="False"]/@checked')) == 1
 
             # Blue banner message is shown at top of page
             assert doc.xpath('normalize-space(string(//div[@class="banner-information-without-action"]))') == \
@@ -2931,17 +2931,19 @@ class TestSupplierDeclaration(BaseApplicationTest):
             doc = html.fromstring(res.get_data(as_text=True))
 
             # Radio buttons have been pre-filled with the correct answers
-            assert len(doc.xpath('//input[@id="input-conspiracy-yes"]/@checked')) == 1
-            assert len(doc.xpath('//input[@id="input-fraudAndTheft-yes"]/@checked')) == 1
-            assert len(doc.xpath('//input[@id="input-organisedCrime-no"]/@checked')) == 1
+            assert len(doc.xpath('//input[@id="input-conspiracy-1"][@value="True"]/@checked')) == 1
+            assert len(doc.xpath('//input[@id="input-fraudAndTheft-1"][@value="True"]/@checked')) == 1
+            assert len(doc.xpath('//input[@id="input-organisedCrime-2"][@value="False"]/@checked')) == 1
 
             # Radio buttons for missing keys exist but have not been pre-filled
-            assert len(doc.xpath('//input[@id="input-corruptionBribery-no"]')) == 1
-            assert len(doc.xpath('//input[@id="input-corruptionBribery-no"]/@checked')) == 0
-            assert len(doc.xpath('//input[@id="input-corruptionBribery-yes"]/@checked')) == 0
-            assert len(doc.xpath('//input[@id="input-terrorism-no"]')) == 1
-            assert len(doc.xpath('//input[@id="input-terrorism-no"]/@checked')) == 0
-            assert len(doc.xpath('//input[@id="input-terrorism-yes"]/@checked')) == 0
+            assert len(doc.xpath('//input[@id="input-corruptionBribery-1"]')) == 1
+            assert len(doc.xpath('//input[@id="input-corruptionBribery-2"]')) == 1
+            assert len(doc.xpath('//input[@id="input-corruptionBribery-1"]/@checked')) == 0
+            assert len(doc.xpath('//input[@id="input-corruptionBribery-2"]/@checked')) == 0
+            assert len(doc.xpath('//input[@id="input-terrorism-1"]')) == 1
+            assert len(doc.xpath('//input[@id="input-terrorism-2"]')) == 1
+            assert len(doc.xpath('//input[@id="input-terrorism-1"]/@checked')) == 0
+            assert len(doc.xpath('//input[@id="input-terrorism-2"]/@checked')) == 0
 
             # Blue banner message is shown at top of page
             assert doc.xpath('normalize-space(string(//div[@class="banner-information-without-action"]))') == \
@@ -3004,11 +3006,11 @@ class TestSupplierDeclaration(BaseApplicationTest):
             assert data_api_client.get_supplier_declaration.called is False
 
             # Radio buttons have been filled with the current answers; not those from previous declaration
-            assert len(doc.xpath('//input[@id="input-conspiracy-no"]/@checked')) == 1
-            assert len(doc.xpath('//input[@id="input-corruptionBribery-yes"]/@checked')) == 1
-            assert len(doc.xpath('//input[@id="input-fraudAndTheft-no"]/@checked')) == 1
-            assert len(doc.xpath('//input[@id="input-terrorism-yes"]/@checked')) == 1
-            assert len(doc.xpath('//input[@id="input-organisedCrime-no"]/@checked')) == 1
+            assert len(doc.xpath('//input[@id="input-conspiracy-2"][@value="False"]/@checked')) == 1
+            assert len(doc.xpath('//input[@id="input-corruptionBribery-1"][@value="True"]/@checked')) == 1
+            assert len(doc.xpath('//input[@id="input-fraudAndTheft-2"][@value="False"]/@checked')) == 1
+            assert len(doc.xpath('//input[@id="input-terrorism-1"][@value="True"]/@checked')) == 1
+            assert len(doc.xpath('//input[@id="input-organisedCrime-2"][@value="False"]/@checked')) == 1
 
             # No blue banner message is shown at top of page
             assert len(doc.xpath('//div[@class="banner-information-without-action"]')) == 0
@@ -3058,20 +3060,20 @@ class TestSupplierDeclaration(BaseApplicationTest):
             assert data_api_client.get_supplier_declaration.called is False
 
             # Radio buttons exist on page but have not been populated at all
-            assert len(doc.xpath('//input[@id="input-readUnderstoodGuidance-no"]')) == 1
-            assert len(doc.xpath('//input[@id="input-readUnderstoodGuidance-yes"]')) == 1
-            assert len(doc.xpath('//input[@id="input-readUnderstoodGuidance-no"]/@checked')) == 0
-            assert len(doc.xpath('//input[@id="input-readUnderstoodGuidance-yes"]/@checked')) == 0
+            assert len(doc.xpath('//input[@id="input-readUnderstoodGuidance-1"]')) == 1
+            assert len(doc.xpath('//input[@id="input-readUnderstoodGuidance-2"]')) == 1
+            assert len(doc.xpath('//input[@id="input-readUnderstoodGuidance-1"]/@checked')) == 0
+            assert len(doc.xpath('//input[@id="input-readUnderstoodGuidance-2"]/@checked')) == 0
 
-            assert len(doc.xpath('//input[@id="input-understandTool-no"]')) == 1
-            assert len(doc.xpath('//input[@id="input-understandTool-yes"]')) == 1
-            assert len(doc.xpath('//input[@id="input-understandTool-no"]/@checked')) == 0
-            assert len(doc.xpath('//input[@id="input-understandTool-yes"]/@checked')) == 0
+            assert len(doc.xpath('//input[@id="input-understandTool-1"]')) == 1
+            assert len(doc.xpath('//input[@id="input-understandTool-2"]')) == 1
+            assert len(doc.xpath('//input[@id="input-understandTool-1"]/@checked')) == 0
+            assert len(doc.xpath('//input[@id="input-understandTool-2"]/@checked')) == 0
 
-            assert len(doc.xpath('//input[@id="input-understandHowToAskQuestions-no"]')) == 1
-            assert len(doc.xpath('//input[@id="input-understandHowToAskQuestions-yes"]')) == 1
-            assert len(doc.xpath('//input[@id="input-understandHowToAskQuestions-no"]/@checked')) == 0
-            assert len(doc.xpath('//input[@id="input-understandHowToAskQuestions-yes"]/@checked')) == 0
+            assert len(doc.xpath('//input[@id="input-understandHowToAskQuestions-1"]')) == 1
+            assert len(doc.xpath('//input[@id="input-understandHowToAskQuestions-2"]')) == 1
+            assert len(doc.xpath('//input[@id="input-understandHowToAskQuestions-1"]/@checked')) == 0
+            assert len(doc.xpath('//input[@id="input-understandHowToAskQuestions-2"]/@checked')) == 0
 
             # No blue banner message is shown at top of page
             assert len(doc.xpath('//div[@class="banner-information-without-action"]')) == 0

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -2804,6 +2804,10 @@ class TestSupplierDeclaration(BaseApplicationTest):
             self.login()
 
             data_api_client.get_framework.return_value = self.framework(status='open')
+            data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
+                framework_slug="g-cloud-9",
+                declaration={}
+            )
             data_api_client.get_supplier_declaration.side_effect = APIError(mock.Mock(status_code=404))
 
             res = self.client.get(
@@ -2819,9 +2823,10 @@ class TestSupplierDeclaration(BaseApplicationTest):
             self.login()
 
             data_api_client.get_framework.return_value = self.framework(status='open')
-            data_api_client.get_supplier_declaration.return_value = {
-                "declaration": {"status": "started", "PR1": False}
-            }
+            data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
+                framework_slug="g-cloud-9",
+                declaration={"status": "started", "PR1": False}
+            )
 
             res = self.client.get(
                 '/suppliers/frameworks/g-cloud-7/declaration/g-cloud-7-essentials')
@@ -2835,9 +2840,10 @@ class TestSupplierDeclaration(BaseApplicationTest):
             self.login()
 
             data_api_client.get_framework.return_value = self.framework(status='open')
-            data_api_client.get_supplier_declaration.return_value = {
-                "declaration": {"status": "started"}
-            }
+            data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
+                framework_slug="g-cloud-7",
+                declaration={"status": "started"}
+            )
             res = self.client.post(
                 '/suppliers/frameworks/g-cloud-7/declaration/g-cloud-7-essentials',
                 data=FULL_G7_SUBMISSION)
@@ -2850,9 +2856,10 @@ class TestSupplierDeclaration(BaseApplicationTest):
             self.login()
 
             data_api_client.get_framework.return_value = self.framework(status='open')
-            data_api_client.get_supplier_declaration.return_value = {
-                "declaration": FULL_G7_SUBMISSION
-            }
+            data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
+                framework_slug="g-cloud-7",
+                declaration=FULL_G7_SUBMISSION
+            )
             res = self.client.post(
                 '/suppliers/frameworks/g-cloud-7/declaration/grounds-for-discretionary-exclusion',
                 data=FULL_G7_SUBMISSION)
@@ -2867,9 +2874,10 @@ class TestSupplierDeclaration(BaseApplicationTest):
             self.login()
 
             data_api_client.get_framework.return_value = self.framework(status='open')
-            data_api_client.get_supplier_declaration.return_value = {
-                "declaration": {"status": "started"}
-            }
+            data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
+                framework_slug="g-cloud-7",
+                declaration={"status": "started"}
+            )
             data_api_client.set_supplier_declaration.side_effect = APIError(mock.Mock(status_code=400))
 
             res = self.client.post(

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -2805,7 +2805,7 @@ class TestSupplierDeclaration(BaseApplicationTest):
 
             data_api_client.get_framework.return_value = self.framework(status='open')
             data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
-                framework_slug="g-cloud-9",
+                framework_slug="g-cloud-7",
                 declaration={}
             )
             data_api_client.get_supplier_declaration.side_effect = APIError(mock.Mock(status_code=404))
@@ -2824,7 +2824,7 @@ class TestSupplierDeclaration(BaseApplicationTest):
 
             data_api_client.get_framework.return_value = self.framework(status='open')
             data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
-                framework_slug="g-cloud-9",
+                framework_slug="g-cloud-7",
                 declaration={"status": "started", "PR1": False}
             )
 
@@ -2834,6 +2834,179 @@ class TestSupplierDeclaration(BaseApplicationTest):
             assert res.status_code == 200
             doc = html.fromstring(res.get_data(as_text=True))
             assert len(doc.xpath('//input[@id="input-PR1-2"]/@checked')) == 1
+
+    def test_get_with_with_prefilled_answers(self, data_api_client):
+        with self.app.test_client():
+            self.login()
+            # First call is for the current framework; second call for the framework to pre-fill from
+            data_api_client.get_framework.side_effect = [
+                self.framework(slug='g-cloud-9', name='G-Cloud 9', status='open'),
+                self.framework(slug='digital-outcomes-and-specialists-2', name='Digital Stuff 2', status='live'),
+            ]
+            # Current framework application information
+            data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
+                framework_slug="g-cloud-9",
+                declaration={"status": "started"},
+                prefill_declaration_from_framework_slug="digital-outcomes-and-specialists-2"
+            )
+            # The previous declaration to prefill from
+            data_api_client.get_supplier_declaration.return_value = {
+                'declaration': self.supplier_framework(
+                    framework_slug="digital-outcomes-and-specialists-2",
+                    declaration={"status": "complete",
+                                 "conspiracy": True,
+                                 "corruptionBribery": False,
+                                 "fraudAndTheft": True,
+                                 "terrorism": False,
+                                 "organisedCrime": False,
+                                 },
+                )["frameworkInterest"]["declaration"]
+            }
+
+            # The grounds-for-mandatory-exclusion section has "prefill: True" in the declaration manifest
+            res = self.client.get(
+                '/suppliers/frameworks/g-cloud-9/declaration/grounds-for-mandatory-exclusion')
+
+            assert res.status_code == 200
+            doc = html.fromstring(res.get_data(as_text=True))
+
+            # Radio buttons have been pre-filled with the correct answers
+            assert len(doc.xpath('//input[@id="input-conspiracy-yes"]/@checked')) == 1
+            assert len(doc.xpath('//input[@id="input-corruptionBribery-no"]/@checked')) == 1
+            assert len(doc.xpath('//input[@id="input-fraudAndTheft-yes"]/@checked')) == 1
+            assert len(doc.xpath('//input[@id="input-terrorism-no"]/@checked')) == 1
+            assert len(doc.xpath('//input[@id="input-organisedCrime-no"]/@checked')) == 1
+
+            # Blue banner message is shown at top of page
+            assert doc.xpath('normalize-space(//div[@class="banner-information-without-action"]/p/text())') == \
+                "Answers on this page are from an earlier declaration and need review."
+
+            # Blue information messages are shown next to each question
+            info_messages = doc.xpath('//div[@class="message-wrapper"]//span[@class="message-content"]')
+            assert len(info_messages) == 5
+            for message in info_messages:
+                assert self.strip_all_whitespace(message.text) == self.strip_all_whitespace(
+                    "This answer is from your Digital Stuff 2 declaration"
+                )
+
+    def test_answers_not_prefilled_if_section_has_already_been_saved(self, data_api_client):
+        with self.app.test_client():
+            self.login()
+            # First call is for the current framework; second call for the framework to pre-fill from should not happen
+            data_api_client.get_framework.side_effect = [
+                self.framework(slug='g-cloud-9', name='G-Cloud 9', status='open'),
+                self.framework(slug='digital-outcomes-and-specialists-2', name='Digital Stuff 2', status='live'),
+            ]
+            # Current framework application information with the grounds-for-mandatory-exclusion section complete
+            data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
+                framework_slug="g-cloud-9",
+                declaration={"status": "started",
+                             "conspiracy": False,
+                             "corruptionBribery": True,
+                             "fraudAndTheft": False,
+                             "terrorism": True,
+                             "organisedCrime": False,
+                             },
+                prefill_declaration_from_framework_slug="digital-outcomes-and-specialists-2"
+            )
+            # The previous declaration to prefill from - has relevant answers but should not ever be called
+            data_api_client.get_supplier_declaration.return_value = {
+                'declaration': self.supplier_framework(
+                    framework_slug="digital-outcomes-and-specialists-2",
+                    declaration={"status": "complete",
+                                 "conspiracy": True,
+                                 "corruptionBribery": False,
+                                 "fraudAndTheft": True,
+                                 "terrorism": False,
+                                 "organisedCrime": False,
+                                 },
+                )["frameworkInterest"]["declaration"]
+            }
+
+            # The grounds-for-mandatory-exclusion section has "prefill: True" in the declaration manifest
+            res = self.client.get(
+                '/suppliers/frameworks/g-cloud-9/declaration/grounds-for-mandatory-exclusion')
+
+            assert res.status_code == 200
+            doc = html.fromstring(res.get_data(as_text=True))
+
+            # Previous framework and declaration have not been fetched
+            data_api_client.get_framework.assert_called_once_with('g-cloud-9')
+            assert data_api_client.get_supplier_declaration.called is False
+
+            # Radio buttons have been filled with the current answers; not those from previous declaration
+            assert len(doc.xpath('//input[@id="input-conspiracy-no"]/@checked')) == 1
+            assert len(doc.xpath('//input[@id="input-corruptionBribery-yes"]/@checked')) == 1
+            assert len(doc.xpath('//input[@id="input-fraudAndTheft-no"]/@checked')) == 1
+            assert len(doc.xpath('//input[@id="input-terrorism-yes"]/@checked')) == 1
+            assert len(doc.xpath('//input[@id="input-organisedCrime-no"]/@checked')) == 1
+
+            # No blue banner message is shown at top of page
+            assert len(doc.xpath('//div[@class="banner-information-without-action"]')) == 0
+
+            # No blue information messages are shown next to each question
+            info_messages = doc.xpath('//div[@class="message-wrapper"]//span[@class="message-content"]')
+            assert len(info_messages) == 0
+
+    def test_answers_not_prefilled_if_section_marked_as_prefill_false(self, data_api_client):
+        with self.app.test_client():
+            self.login()
+            # First call is for the current framework; second call for the framework to pre-fill from should not happen
+            data_api_client.get_framework.side_effect = [
+                self.framework(slug='g-cloud-9', name='G-Cloud 9', status='open'),
+                self.framework(slug='digital-outcomes-and-specialists-2', name='Digital Stuff 2', status='live'),
+            ]
+            # Current framework application information
+            data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
+                framework_slug="g-cloud-9",
+                declaration={"status": "started"},
+                prefill_declaration_from_framework_slug="digital-outcomes-and-specialists-2"
+            )
+            # The previous declaration to prefill from - has relevant answers but should not ever be called
+            data_api_client.get_supplier_declaration.return_value = {
+                'declaration': self.supplier_framework(
+                    framework_slug="digital-outcomes-and-specialists-2",
+                    declaration={"status": "complete",
+                                 "readUnderstoodGuidance": True,
+                                 "understandTool": True,
+                                 "understandHowToAskQuestions": False,
+                                 },
+                )["frameworkInterest"]["declaration"]
+            }
+
+            # The how-you-apply section has "prefill: False" in the declaration manifest
+            res = self.client.get(
+                '/suppliers/frameworks/g-cloud-9/declaration/how-you-apply')
+
+            assert res.status_code == 200
+            doc = html.fromstring(res.get_data(as_text=True))
+
+            # Previous framework and declaration have not been fetched
+            data_api_client.get_framework.assert_called_once_with('g-cloud-9')
+            assert data_api_client.get_supplier_declaration.called is False
+
+            # Radio buttons exist on page but have not been populated at all
+            assert len(doc.xpath('//input[@id="input-readUnderstoodGuidance-no"]')) == 1
+            assert len(doc.xpath('//input[@id="input-readUnderstoodGuidance-yes"]')) == 1
+            assert len(doc.xpath('//input[@id="input-readUnderstoodGuidance-no"]/@checked')) == 0
+            assert len(doc.xpath('//input[@id="input-readUnderstoodGuidance-yes"]/@checked')) == 0
+
+            assert len(doc.xpath('//input[@id="input-understandTool-no"]')) == 1
+            assert len(doc.xpath('//input[@id="input-understandTool-yes"]')) == 1
+            assert len(doc.xpath('//input[@id="input-understandTool-no"]/@checked')) == 0
+            assert len(doc.xpath('//input[@id="input-understandTool-yes"]/@checked')) == 0
+
+            assert len(doc.xpath('//input[@id="input-understandHowToAskQuestions-no"]')) == 1
+            assert len(doc.xpath('//input[@id="input-understandHowToAskQuestions-yes"]')) == 1
+            assert len(doc.xpath('//input[@id="input-understandHowToAskQuestions-no"]/@checked')) == 0
+            assert len(doc.xpath('//input[@id="input-understandHowToAskQuestions-yes"]/@checked')) == 0
+
+            # No blue banner message is shown at top of page
+            assert len(doc.xpath('//div[@class="banner-information-without-action"]')) == 0
+
+            # No blue information messages are shown next to each question
+            info_messages = doc.xpath('//div[@class="message-wrapper"]//span[@class="message-content"]')
+            assert len(info_messages) == 0
 
     def test_post_valid_data(self, data_api_client):
         with self.app.test_client():


### PR DESCRIPTION
Here we have working code that pretty much completes:
https://www.pivotaltracker.com/story/show/138702601 (Pre-filling relevant declaration sections with answers from a previous framework)
https://www.pivotaltracker.com/story/show/138703089 (Adding blue banners and validation-style blue messages to pre-filled pages)

~~**NOTE**~~ 
~~!!!!!!!!! There are no new unit tests at all for this new behaviour :scream:  !!!!!!!!!~~

~~Feel free to pick this up and add some relevant tests.~~

~~Or review it and merge it in if you feel like seeing it all working on Friday, and on my honour I will add the required unit tests on Monday.~~

**UPDATE 26/2: Tests added and rebased up-to-date - now 100% ready for review.**

Here's a screenshot:
![screen shot 2017-02-26 at 12 13 36](https://cloud.githubusercontent.com/assets/6525554/23339578/b6cd2644-fc1d-11e6-9131-be2e5d43e6dd.png)
