### PR TITLE
140127375-supplier-declaration-content-tweaks

### DIFF
--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -310,7 +310,7 @@ def reuse_framework_supplier_declaration(framework_slug):
         current_framework=current_framework,
         form=ReuseDeclarationForm(),
         old_framework=old_framework,
-        old_framework_application_close_date=date_parse(old_framework['application_close_date']).strftime('%B, %Y'),
+        old_framework_application_close_date=date_parse(old_framework['application_close_date']).strftime('%B %Y'),
     ), 200
 
 
@@ -333,7 +333,7 @@ def reuse_framework_supplier_declaration_post(framework_slug):
             form=form,
             form_errors=form_errors,
             old_framework=old_framework,
-            old_framework_application_close_date=date_parse(old_framework['application_close_date']).strftime('%B, %Y')
+            old_framework_application_close_date=date_parse(old_framework['application_close_date']).strftime('%B %Y')
         )
     if form.reuse.data:
         # They clicked OK! Check the POST data.

--- a/app/templates/frameworks/_framework_actions.html
+++ b/app/templates/frameworks/_framework_actions.html
@@ -35,8 +35,7 @@
     </a>
   {% endif %}
   <p class="browse-list-item-body">
-    Agree to the terms of the bid, provide supplier information and
-    confirm&nbsp;eligibility.
+    Confirm eligibility, agree to the application terms and provide supplier&nbsp;information.
   </p>
   {% if declaration_status == 'unstarted' and not counts.complete %}
   <div class="browse-list-item-status-quiet">

--- a/app/templates/frameworks/reuse_declaration.html
+++ b/app/templates/frameworks/reuse_declaration.html
@@ -47,7 +47,7 @@
         {% include "toolkit/page-heading.html" %}
       {% endwith %}
 
-      <p>In {{ old_framework_application_close_date }}, your organisation completed a declaration for {{ old_framework.name }}.</p>
+      <p>In {{ old_framework_application_close_date|nbsp }}, your organisation completed a declaration for {{ old_framework.name }}.</p>
       <p>You can reuse some of the answers from that declaration.</p>
       <br>
       <p>You’ll need to:</p>

--- a/app/templates/frameworks/start_declaration.html
+++ b/app/templates/frameworks/start_declaration.html
@@ -37,11 +37,11 @@
         {% include "toolkit/page-heading.html" %}
       {% endwith %}
 
-      <p>You must answer all questions in the declaration to confirm you meet the minimum standards for providing digital services to government.</p>
+      <p>You must make the supplier declaration to confirm you’re eligible to provide services through {{ framework.name }}.</p>
       <br>
-      <p>The Crown Commercial Service will review your answers. If you don’t meet the minimum standards, your application won’t be successful.</p>
+      <p>You can come back and change your answers before the application deadline at {{ framework_close_date }}.</p>
       <br>
-      <p>You can come back and change your answers at any time before the framework application deadline, {{ framework_close_date }}.</p>
+      <p>After the application deadline, the Crown Commercial Service will review your answers and let you know if your application has been successful.</p>
       <br><br>
       <a href='{{ url_for(".reuse_framework_supplier_declaration", framework_slug=framework.slug) }}' class="button-save" role="button">Start your declaration</a>
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ Flask-WTF==0.12
 werkzeug==0.10.4
 python-dateutil==2.4.2
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@24.0.4#egg=digitalmarketplace-utils==24.0.4
+git+https://github.com/alphagov/digitalmarketplace-utils.git@24.1.0#egg=digitalmarketplace-utils==24.1.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@3.1.1#egg=digitalmarketplace-content-loader==3.1.1
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@8.5.0#egg=digitalmarketplace-apiclient==8.5.0
 

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -5195,8 +5195,8 @@ class TestReuseFrameworkSupplierDeclaration(BaseApplicationTest):
 
         # Assert the success.
         assert resp.status_code == 200
-        expected = 'In March, 2011, your organisation completed a declaration for G-cloud 7.'
-        assert expected in ''.join(map(str, resp.response))
+        expected = 'In March&nbsp;2011, your organisation completed a declaration for G-cloud 7.'
+        assert expected in str(resp.data)
 
         # Assert expected api calls.
         data_api_client.get_framework.assert_called_once_with('g-cloud-8')


### PR DESCRIPTION
* On the framework overview page:
  * "Confirm eligibility, agree to the application terms and provide
supplier information"

* Start your declaration page:
  * "You must make the supplier declaration to confirm you’re eligible to
provide services through G-Cloud 9.
You can come back and change your answers before the application
deadline at 5pm BST, 11 April 2017.
After the application deadline, the Crown Commercial Service will review
your answers and let you know if your application has been successful."

* Reusing answers page:
  * Remove the comma between the month and the year

* Declaration overview page (application close date for G9):
  * GMT to BST
  * Don't allow the date to break over two lines - top of page and bottom