### PR TITLE
Ensure posted form does not have URI fragment identifier

### DIFF
--- a/app/templates/frameworks/edit_declaration_section.html
+++ b/app/templates/frameworks/edit_declaration_section.html
@@ -43,7 +43,7 @@
     {% endwith %}
   {% endif %}
 
-  <form method="post" class="supplier-declaration">
+  <form method="post" class="supplier-declaration" action="#" {# remove any fragment identifier as validation messages are at the top #}>
 
     <div class="grid-row">
         <div class="column-two-thirds">


### PR DESCRIPTION
The fragment identifier only comes into play when there is a validation
error to display, in which case the first error may be at the top
of the page, and the fragment id should be ignored.

See https://www.pivotaltracker.com/story/show/140504509