### PR TITLE
removes hanging bullets and adds secondary bullet style

### DIFF
--- a/app/assets/scss/_supplier-declaration.scss
+++ b/app/assets/scss/_supplier-declaration.scss
@@ -9,13 +9,21 @@
   .question-heading li,
   .hint li {
 
+
     margin: 10px 0 10px 20px;
     list-style: disc;
 
-    @include media(1080px) {
-      margin-left: 0;
-    }
+    > ul {
+        li {
+          list-style: none;
+        } 
+      }
 
+    > ul li:before {
+      content: '\2013';
+      position: absolute;
+      margin-left: -20px;
+    }
   }
 
   .validation-wrapper li {


### PR DESCRIPTION
Everyone hates hanging bullets, so I removed them. Adds a secondary bullet style to make nested lists clearer.

Looks like this:
![screen shot 2017-02-28 at 14 19 03](https://cloud.githubusercontent.com/assets/8417288/23408762/2e2b7872-fdc1-11e6-8a86-ef8840f976cf.png)
