### PR TITLE
frameworks dependency bump

### DIFF
--- a/app/main/helpers/validation.py
+++ b/app/main/helpers/validation.py
@@ -194,7 +194,7 @@ class DOSValidator(DeclarationValidator):
             "mitigatingFactors": [
                 'misleadingInformation', 'confidentialInformation', 'influencedContractingAuthority',
                 'witheldSupportingDocuments', 'seriousMisrepresentation', 'significantOrPersistentDeficiencies',
-                'distortedCompetition', 'conflictOfInterest', 'distortedCompetition', 'graveProfessionalMisconduct',
+                'distortedCompetition', 'conflictOfInterest', 'distortingCompetition', 'graveProfessionalMisconduct',
                 'bankrupt', 'environmentalSocialLabourLaw', 'taxEvasion'
             ],
             # If you responded yes to either 36 or 37

--- a/bower.json
+++ b/bower.json
@@ -7,6 +7,6 @@
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
     "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v21.0.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.19.2/jinja_govuk_template-0.19.2.tgz",
-    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#6.3.1"
+    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#6.3.2"
   }
 }


### PR DESCRIPTION
This should fix multiquestion madness, but tests won't pass until https://github.com/alphagov/digitalmarketplace-frameworks/pull/393 is merged.

Before
![20170229_uk_before](https://cloud.githubusercontent.com/assets/807447/23415418/0bc1fcdc-fdd7-11e6-8af1-d59cd691d661.png)
After
![20170228_uk_after](https://cloud.githubusercontent.com/assets/807447/23415417/0bb36294-fdd7-11e6-8f85-8aa02015a22a.png)

~~~Also have slipped in a fix whereby the validator was expecting a field named `distortedCompetition` instead of  `distortingCompetition`.~~~

None of these changes were covered by the tests, which is a bit scary...