### PR TITLE
140507667-no-supplier-name-in-zendesk-clarification-question

### DIFF
--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -636,7 +636,7 @@ def framework_updates_email_clarification_question(framework_slug):
         from_address = "suppliers+{}@digitalmarketplace.service.gov.uk".format(framework['slug'])
         email_body = render_template(
             "emails/clarification_question.html",
-            supplier_name=current_user.supplier_name,
+            supplier_id=current_user.supplier_id,
             user_name=current_user.name,
             message=clarification_question
         )

--- a/app/templates/emails/clarification_question.html
+++ b/app/templates/emails/clarification_question.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
 </head>
 <body>
-Supplier name: {{ supplier_name }}
+Supplier ID: {{ supplier_id }}
 <br />
 User name: {{ user_name }}
 <br /><br />


### PR DESCRIPTION
When we send supplier clarification questions into Zendesk, we currently
show:
* Supplier name
* User name

People will now be able to see this when they are answering the
question.  We need the people answering questions to be independent.

We need to change this to supplier ID so that it is not obvious who
asked the question

Changes:

* Change template to use supplier id
* Test