### PR TITLE
[140828441] - Declaration overview fixes

### DIFF
--- a/app/templates/frameworks/declaration_overview.html
+++ b/app/templates/frameworks/declaration_overview.html
@@ -108,6 +108,11 @@
                 {% endcall %}
               {% elif not question.is_empty %}
                 {{ summary[question.type](question.value, question.assurance) }}
+              {% else %}
+                {# We need to call this (even if with nothing) to add the final column to the row, otherwise the row
+                   terminates early and the line separators between rows do not span the entire width of the table. #}
+                {% call summary.field(action=True) %}
+                {% endcall %}
               {% endif %}
             {% endif %}
           {% endcall %}

--- a/bower.json
+++ b/bower.json
@@ -7,6 +7,6 @@
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
     "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v21.0.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.19.2/jinja_govuk_template-0.19.2.tgz",
-    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#6.3.2"
+    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#6.3.5"
   }
 }


### PR DESCRIPTION
* Fixes a bug with the summary page where optional questions without answers break the table display.
* Pull in latest frameworks 6.3.5

Old:
<img width="1243" alt="screen shot 2017-03-01 at 08 46 18" src="https://cloud.githubusercontent.com/assets/2920760/23468496/e8daa008-fe98-11e6-8a55-1132a8e67348.png">

New:
<img width="1175" alt="screen shot 2017-03-01 at 16 05 58" src="https://cloud.githubusercontent.com/assets/2920760/23468560/0062ed48-fe99-11e6-8a05-93d8ac6e71ca.png">
