### PR TITLE
[140837783] - First question, no anchor

### DIFF
--- a/app/templates/frameworks/declaration_overview.html
+++ b/app/templates/frameworks/declaration_overview.html
@@ -98,12 +98,18 @@
             {% if section.editable %}
               {% if section_errors %}
                 {% call summary.field() %}
-                  <a href="{{ url_for(".framework_supplier_declaration", framework_slug=framework.slug, section_id=section.id, _anchor=question.id) }}">
-                    {% if supplier_framework.prefillDeclarationFromFrameworkSlug and section.prefill %}
-                      Review answer
-                    {% else %}
-                      Answer question
-                    {% endif %}
+                  {# We don't want a question anchor on the first question of each section; it should take them
+                     to the top of the page so all content is visible #}
+                  {% if section.questions[0].id == question.id -%}
+                    <a href="{{ url_for(".framework_supplier_declaration", framework_slug=framework.slug, section_id=section.id) }}">
+                  {% else -%}
+                    <a href="{{ url_for(".framework_supplier_declaration", framework_slug=framework.slug, section_id=section.id, _anchor=question.id) }}">
+                  {%- endif -%}
+                  {% if supplier_framework.prefillDeclarationFromFrameworkSlug and section.prefill %}
+                    Review answer
+                  {% else %}
+                    Answer question
+                  {% endif %}
                   </a>
                 {% endcall %}
               {% elif not question.is_empty %}

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -2329,8 +2329,7 @@ class TestDeclarationOverview(BaseApplicationTest):
                         "Services are cloud-related",
                         "Answer question",
                         ("Answer question",),
-                        ("/suppliers/frameworks/g-cloud-9/declaration/providing-suitable-services#"
-                         "servicesHaveOrSupport",),
+                        ("/suppliers/frameworks/g-cloud-9/declaration/providing-suitable-services",),
                         (),
                     ),
                     (
@@ -2373,7 +2372,7 @@ class TestDeclarationOverview(BaseApplicationTest):
                         "Organised crime or conspiracy convictions",
                         q_link_text_prefillable_section,
                         (q_link_text_prefillable_section,),
-                        ("/suppliers/frameworks/g-cloud-9/declaration/grounds-for-mandatory-exclusion#conspiracy",),
+                        ("/suppliers/frameworks/g-cloud-9/declaration/grounds-for-mandatory-exclusion",),
                         (),
                     ),
                     (
@@ -2418,7 +2417,7 @@ class TestDeclarationOverview(BaseApplicationTest):
                         q_link_text_prefillable_section,
                         (q_link_text_prefillable_section,),
                         ("/suppliers/frameworks/g-cloud-9/declaration/how-youll-deliver-your-"
-                            "services#subcontracting",),
+                            "services",),
                         (),
                     ),
                 ),
@@ -2447,8 +2446,7 @@ class TestDeclarationOverview(BaseApplicationTest):
                         "Services are cloud-related",
                         "Answer question",
                         ("Answer question",),
-                        ("/suppliers/frameworks/g-cloud-9/declaration/providing-suitable-services#"
-                         "servicesHaveOrSupport",),
+                        ("/suppliers/frameworks/g-cloud-9/declaration/providing-suitable-services",),
                         (),
                     ),
                     (


### PR DESCRIPTION
For each section in the supplier declaration, the first question's edit link should load without any anchors. This will ensure that the top of the page is visible, showing any section description/guidance/preamble for users who click the question-level edit rather than the section-level edit.