### PR TITLE
[#139553967]service submission pages: merge generation of "You need to make the supplier declaration" banner, retarget

### DIFF
--- a/app/templates/frameworks/services.html
+++ b/app/templates/frameworks/services.html
@@ -47,13 +47,7 @@
   {% endwith %}
 
   {% if complete_drafts and declaration_status != 'complete' and framework.status == 'open' %}
-    {%
-      with
-      message = 'You need to <a href="'|safe + url_for('.framework_supplier_declaration_overview', framework_slug=framework.slug) + '">make the supplier&nbsp;declaration</a> before any services can be submitted'|safe,
-      type = 'warning'
-    %}
-      {% include 'toolkit/notification-banner.html' %}
-    {% endwith %}
+    {% include "partials/service_warning.html" %}
   {% endif %}
 
   {% with

--- a/app/templates/frameworks/submission_lots.html
+++ b/app/templates/frameworks/submission_lots.html
@@ -43,13 +43,7 @@
   {% endwith %}
 
   {% if complete_drafts and declaration_status != 'complete' and framework.status == 'open' %}
-    {%
-      with
-      message = 'You need to <a href="'|safe + url_for('.framework_supplier_declaration_overview', framework_slug=framework.slug) + '">make the supplier&nbsp;declaration</a> before any services can be submitted' | safe,
-      type = 'destructive'
-    %}
-      {% include 'toolkit/notification-banner.html' %}
-    {% endwith %}
+    {% include "partials/service_warning.html" %}
   {% endif %}
 
   <div class="grid-row">

--- a/app/templates/partials/service_warning.html
+++ b/app/templates/partials/service_warning.html
@@ -1,9 +1,9 @@
-{% if true %}
+{% with declaration_url = url_for('.framework_start_supplier_declaration' if declaration_status == 'unstarted' else '.framework_supplier_declaration_overview', framework_slug=framework.slug) %}
   {%
     with
-    message = 'This service will not be submitted at the deadline because the <a href="'|safe + url_for('.framework_supplier_declaration', framework_slug=framework.slug) + '">supplier&nbsp;declaration</a> hasn’t been made.' | safe,
+    message = 'You need to <a href="'|safe + declaration_url + '">make the supplier&nbsp;declaration</a> before any services can be submitted'|safe,
     type = 'warning'
   %}
     {% include 'toolkit/notification-banner.html' %}
   {% endwith %}
-{% endif %}
+{% endwith %}


### PR DESCRIPTION
Story https://www.pivotaltracker.com/story/show/139553967

Previously this code was duplicated between the submission and submission lot pages
and linked to the first question page of the declaration (the old way of doing things).
instead we now point at the declaration overview or the "start declaration" page
depending on the status of the declaration. also improve testing coverage of this
banner's presence/absence.