### PR TITLE
Add checkbox_tree component to supplier app

### DIFF
--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -16,9 +16,10 @@ $path: "/suppliers/static/images/";
 @import "shared_scss/_dmspeak.scss";
 
 /* Blocks shared between multiple selectors */
-@import "toolkit/shared_placeholders/_temporary-messages.scss";
-@import "toolkit/shared_placeholders/_placeholders.scss";
 @import "toolkit/shared_placeholders/_dm-typography.scss";
+@import "toolkit/shared_placeholders/_mixins.scss";
+@import "toolkit/shared_placeholders/_placeholders.scss";
+@import "toolkit/shared_placeholders/_temporary-messages.scss";
 
 #wrapper, .wrapper {
   @extend %site-width-container;
@@ -55,6 +56,7 @@ $path: "/suppliers/static/images/";
 @import "toolkit/forms/_upload.scss";
 @import "toolkit/forms/_validation.scss";
 @import "toolkit/forms/_combinations.scss";
+@import "toolkit/forms/_checkbox-tree.scss";
 @import "toolkit/search/_search-result.scss";
 
 

--- a/app/templates/macros/toolkit_forms.html
+++ b/app/templates/macros/toolkit_forms.html
@@ -126,6 +126,26 @@
   {% endwith %}
 {%- endmacro %}
 
+{% macro checkbox_tree(question_content, service_data, errors) -%}
+  {%
+    with
+    name=question_content.id,
+    question=question_content.question|question_references(kwargs.get_question),
+    question_advice=question_content.question_advice,
+    hint=(question_content.hint or '')|question_references(kwargs.get_question),
+    value=service_data[question_content.id],
+    id=question_content.id,
+    options=question_content.options,
+    type='checkbox_tree',
+    number_of_items=question_content.number_of_items,
+    question_number=kwargs.question_number,
+    hidden=question_content.hidden,
+    error=errors.get(question_content.id)['message']|question_references(kwargs.get_question)
+  %}
+    {% include "toolkit/forms/checkbox-tree.html" %}
+  {% endwith %}
+{%- endmacro %}
+
 {% macro upload(question_content, service_data, errors) -%}
   {%
     with

--- a/bower.json
+++ b/bower.json
@@ -5,8 +5,8 @@
     "jquery": "1.11.2",
     "hogan": "3.0.2",
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
-    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v21.0.0",
+    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#22.0.1",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.19.2/jinja_govuk_template-0.19.2.tgz",
-    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#6.3.5"
+    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#6.4.1"
   }
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ werkzeug==0.10.4
 python-dateutil==2.4.2
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@24.1.0#egg=digitalmarketplace-utils==24.1.0
-git+https://github.com/alphagov/digitalmarketplace-content-loader.git@3.3.0#egg=digitalmarketplace-content-loader==3.3.0
+git+https://github.com/alphagov/digitalmarketplace-content-loader.git@3.5.0#egg=digitalmarketplace-content-loader==3.5.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@8.5.0#egg=digitalmarketplace-apiclient==8.5.0
 
 # For Cloud Foundry


### PR DESCRIPTION
This pull request:
- pulls in the latest `frontend-toolkit` with the checkbox_tree pattern
- pulls in the latest `frameworks` with the new service categories
- pulls in the latest `content-loader` which knows how to process checkbox_tree data
- adds a wrapper macro for a `checkbox_tree` question
- brings in the ability to chain show/hide questions 

## gifs

### no child categories (looks like a flat list)
![checkbox_tree](https://cloud.githubusercontent.com/assets/2454380/23514219/8a0e9928-ff5e-11e6-83ce-f57e7654d1cd.gif)

### parent and child categories (has an open/close widget)
![checkbox_tree](https://cloud.githubusercontent.com/assets/2454380/23514739/1fe21442-ff60-11e6-81b8-4f8a607d42b8.gif)
