### PR TITLE
New content-loader to use TemplateField subfields

### DIFF
--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -14,6 +14,7 @@ from dmapiclient.audit import AuditTypes
 from dmutils.email import send_email
 from dmutils.email.exceptions import EmailError
 from dmcontent.formats import format_service_price
+from dmcontent.questions import ContentQuestion
 from dmutils.formats import datetimeformat
 from dmutils import s3
 from dmutils.documents import (
@@ -185,10 +186,12 @@ def framework_submission_lots(framework_slug):
              draft_count=count_drafts_by_lot(drafts, lot['slug']),
              complete_count=count_drafts_by_lot(complete_drafts, lot['slug']))
         for lot in framework['lots']]
+
     lot_question = {
         option["value"]: option
-        for option in content_loader.get_question(framework_slug, 'services', 'lot')['options']
+        for option in ContentQuestion(content_loader.get_question(framework_slug, 'services', 'lot')).get('options')
     }
+
     lots = [{
         "title": lot_question[lot['slug']]['label'] if framework["status"] == "open" else lot["name"],
         'body': lot_question[lot['slug']]['description'],

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ werkzeug==0.10.4
 python-dateutil==2.4.2
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@24.1.0#egg=digitalmarketplace-utils==24.1.0
-git+https://github.com/alphagov/digitalmarketplace-content-loader.git@3.1.1#egg=digitalmarketplace-content-loader==3.1.1
+git+https://github.com/alphagov/digitalmarketplace-content-loader.git@3.3.0#egg=digitalmarketplace-content-loader==3.3.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@8.5.0#egg=digitalmarketplace-apiclient==8.5.0
 
 # For Cloud Foundry


### PR DESCRIPTION
* This will allow the TemplateField options.description to be rendered properly by the content loader; ContentLoader.get_question() otherwise just returns a dictionary that won't render TemplateFields.
* Bump content-loader dependency.