### PR TITLE
Remove hardcoded framework name

### DIFF
--- a/app/templates/briefs/not_is_supplier_eligible_for_brief_error.html
+++ b/app/templates/briefs/not_is_supplier_eligible_for_brief_error.html
@@ -15,7 +15,7 @@
       {% if reason == "supplier-not-on-role" or reason == "supplier-not-on-lot" %}
         you didn’t say you could provide
         {{ "this specialist role" if reason == "supplier-not-on-role" else "services in this category" }}
-        when you applied to the Digital Outcomes and Specialists framework.
+        when you applied to the {{ framework_name }} framework.
       {% elif reason == "supplier-not-on-framework" %}
         you’re not a {{ framework_name }} supplier.
       {% endif %}


### PR DESCRIPTION
This should be taken from the framework instead as it may be a DOS2 opportunity for example.