### PR TITLE
Add javascript stuff for category-picker

### DIFF
--- a/app/assets/javascripts/_details.polyfill.js
+++ b/app/assets/javascripts/_details.polyfill.js
@@ -1,0 +1,191 @@
+// <details> polyfill
+// http://caniuse.com/#feat=details
+
+// FF Support for HTML5's <details> and <summary>
+// https://bugzilla.mozilla.org/show_bug.cgi?id=591737
+
+// http://www.sitepoint.com/fixing-the-details-element/
+
+;(function () {
+  'use strict'
+
+  var NATIVE_DETAILS = typeof document.createElement('details').open === 'boolean'
+
+  // Add event construct for modern browsers or IE
+  // which fires the callback with a pre-converted target reference
+  function addEvent (node, type, callback) {
+    if (node.addEventListener) {
+      node.addEventListener(type, function (e) {
+        callback(e, e.target)
+      }, false)
+    } else if (node.attachEvent) {
+      node.attachEvent('on' + type, function (e) {
+        callback(e, e.srcElement)
+      })
+    }
+  }
+
+  // Handle cross-modal click events
+  function addClickEvent (node, callback) {
+    // Prevent space(32) from scrolling the page
+    addEvent(node, 'keypress', function (e, target) {
+      if (target.nodeName === 'SUMMARY') {
+        if (e.keyCode === 32) {
+          if (e.preventDefault) {
+            e.preventDefault()
+          } else {
+            e.returnValue = false
+          }
+        }
+      }
+    })
+    // When the key comes up - check if it is enter(13) or space(32)
+    addEvent(node, 'keyup', function (e, target) {
+      if (e.keyCode === 13 || e.keyCode === 32) { callback(e, target) }
+    })
+    addEvent(node, 'mouseup', function (e, target) {
+      callback(e, target)
+    })
+  }
+
+  // Get the nearest ancestor element of a node that matches a given tag name
+  function getAncestor (node, match) {
+    do {
+      if (!node || node.nodeName.toLowerCase() === match) {
+        break
+      }
+      node = node.parentNode
+    } while (node)
+
+    return node
+  }
+
+  // Create a started flag so we can prevent the initialisation
+  // function firing from both DOMContentLoaded and window.onload
+  var started = false
+
+  // Initialisation function
+  function addDetailsPolyfill (list) {
+    // If this has already happened, just return
+    // else set the flag so it doesn't happen again
+    if (started) {
+      return
+    }
+    started = true
+
+    // Get the collection of details elements, but if that's empty
+    // then we don't need to bother with the rest of the scripting
+    if ((list = document.getElementsByTagName('details')).length === 0) {
+      return
+    }
+
+    // else iterate through them to apply their initial state
+    var n = list.length
+    var i = 0
+    for (i; i < n; i++) {
+      var details = list[i]
+
+      // Save shortcuts to the inner summary and content elements
+      details.__summary = details.getElementsByTagName('summary').item(0)
+      details.__content = details.getElementsByTagName('div').item(0)
+
+      // If the content doesn't have an ID, assign it one now
+      // which we'll need for the summary's aria-controls assignment
+      if (!details.__content.id) {
+        details.__content.id = 'details-content-' + i
+      }
+
+      // Add ARIA role="group" to details
+      details.setAttribute('role', 'group')
+
+      // Add role=button to summary
+      details.__summary.setAttribute('role', 'button')
+
+      // Add aria-controls
+      details.__summary.setAttribute('aria-controls', details.__content.id)
+
+      // Set tabIndex so the summary is keyboard accessible for non-native elements
+      // http://www.saliences.com/browserBugs/tabIndex.html
+      if (!NATIVE_DETAILS) {
+        details.__summary.tabIndex = 0
+      }
+
+      // Detect initial open state
+      var openAttr = details.getAttribute('open') !== null
+      if (openAttr === true) {
+        details.__summary.setAttribute('aria-expanded', 'true')
+        details.__content.setAttribute('aria-hidden', 'false')
+      } else {
+        details.__summary.setAttribute('aria-expanded', 'false')
+        details.__content.setAttribute('aria-hidden', 'true')
+        if (!NATIVE_DETAILS) {
+          details.__content.style.display = 'none'
+        }
+      }
+
+      // Create a circular reference from the summary back to its
+      // parent details element, for convenience in the click handler
+      details.__summary.__details = details
+
+      // If this is not a native implementation, create an arrow
+      // inside the summary
+      if (!NATIVE_DETAILS) {
+        var twisty = document.createElement('i')
+
+        if (openAttr === true) {
+          twisty.className = 'arrow arrow-open'
+          twisty.appendChild(document.createTextNode('\u25bc'))
+        } else {
+          twisty.className = 'arrow arrow-closed'
+          twisty.appendChild(document.createTextNode('\u25ba'))
+        }
+
+        details.__summary.__twisty = details.__summary.insertBefore(twisty, details.__summary.firstChild)
+        details.__summary.__twisty.setAttribute('aria-hidden', 'true')
+      }
+    }
+
+    // Define a statechange function that updates aria-expanded and style.display
+    // Also update the arrow position
+    function statechange (summary) {
+      var expanded = summary.__details.__summary.getAttribute('aria-expanded') === 'true'
+      var hidden = summary.__details.__content.getAttribute('aria-hidden') === 'true'
+
+      summary.__details.__summary.setAttribute('aria-expanded', (expanded ? 'false' : 'true'))
+      summary.__details.__content.setAttribute('aria-hidden', (hidden ? 'false' : 'true'))
+
+      if (!NATIVE_DETAILS) {
+        summary.__details.__content.style.display = (expanded ? 'none' : '')
+
+        var hasOpenAttr = summary.__details.getAttribute('open') !== null
+        if (!hasOpenAttr) {
+          summary.__details.setAttribute('open', 'open')
+        } else {
+          summary.__details.removeAttribute('open')
+        }
+      }
+
+      if (summary.__twisty) {
+        summary.__twisty.firstChild.nodeValue = (expanded ? '\u25ba' : '\u25bc')
+        summary.__twisty.setAttribute('class', (expanded ? 'arrow arrow-closed' : 'arrow arrow-open'))
+      }
+
+      return true
+    }
+
+    // Bind a click event to handle summary elements
+    addClickEvent(document, function (e, summary) {
+      if (!(summary = getAncestor(summary, 'summary'))) {
+        return true
+      }
+      return statechange(summary)
+    })
+  }
+
+  // Bind two load events for modern and older browsers
+  // If the first one fires it will set a flag to block the second one
+  // but if it's not supported then the second one will fire
+  addEvent(document, 'DOMContentLoaded', addDetailsPolyfill)
+  addEvent(window, 'load', addDetailsPolyfill)
+})()
+;// unfashionable, but safer

--- a/app/assets/javascripts/_stick-at-top-when-scrolling.js
+++ b/app/assets/javascripts/_stick-at-top-when-scrolling.js
@@ -1,0 +1,19 @@
+(function(GOVUK, GDM) {
+
+  GOVUK.GDM = GDM;
+
+  GDM.stickAtTopWhenScrolling = function() {
+
+    if (!GOVUK.stickAtTopWhenScrolling) return;
+
+    GOVUK.stickAtTopWhenScrolling.init();
+
+    $('#checkbox-tree__inputs').on('click', 'details', function () {
+      // immediately after the click, the details pane hasn't expanded yet
+      setTimeout(function () {
+        GOVUK.stopScrollingAtFooter.updateFooterTop()
+      }, 100)
+    })
+  }
+
+}).apply(this, [GOVUK||{}, GOVUK.GDM||{}]);

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -21,6 +21,7 @@
 //= include _selection-buttons.js
 //= include _shim-links-with-button-role.js
 //= include _stick-at-top-when-scrolling.js
+//= include category-picker.js
 
 (function(GOVUK, GDM) {
 

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -29,7 +29,7 @@
 
   var module;
 
-  if(typeof console === 'undefined') {
+  if((typeof console === 'undefined') || (typeof console.time === 'undefined') || (typeof console.timeEnd === 'undefined')) {
     console = {
       log: function () {},
       time: function () {},

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -14,10 +14,13 @@
 //= include ../../../bower_components/digitalmarketplace-frontend-toolkit/toolkit/javascripts/validation.js
 //= include ../../../node_modules/govuk_frontend_toolkit/javascripts/govuk/selection-buttons.js
 //= include ../../../node_modules/govuk_frontend_toolkit/javascripts/govuk/shim-links-with-button-role.js
+//= include ../../../node_modules/govuk_frontend_toolkit/javascripts/govuk/stick-at-top-when-scrolling.js
+//= include ../../../node_modules/govuk_frontend_toolkit/javascripts/govuk/stop-scrolling-at-footer.js
 //= include ../../../bower_components/digitalmarketplace-frontend-toolkit/toolkit/javascripts/show-hide-content.js
 //= include _analytics.js
 //= include _selection-buttons.js
 //= include _shim-links-with-button-role.js
+//= include _stick-at-top-when-scrolling.js
 
 (function(GOVUK, GDM) {
 

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -5,6 +5,8 @@
   directives to concatenate multiple Javascript files into one.
 */
 //= include ../../../node_modules/govuk_frontend_toolkit/javascripts/vendor/polyfills/bind.js
+//= include _details.polyfill.js
+
 //= include ../../../bower_components/jquery/dist/jquery.js
 //= include ../../../bower_components/hogan/web/builds/3.0.2/hogan-3.0.2.js
 //= include ../../../bower_components/digitalmarketplace-frontend-toolkit/toolkit/javascripts/list-entry.js

--- a/app/assets/javascripts/category-picker.js
+++ b/app/assets/javascripts/category-picker.js
@@ -1,0 +1,189 @@
+;(function(root) {
+
+  "use strict";
+
+  var GOVUK = root.GOVUK;
+
+  function _unique(array) {
+    return $.grep(array, function(el, index) {
+        return index === $.inArray(el, array);
+    });
+  }
+
+  // wrapper around the categories data
+  var Categories = function (_categories) {
+    var primaries = []
+    var self = this
+
+    this._containers = []
+    this._categories = _categories
+    this.save_last_state()
+  }
+  Categories.prototype.save_last_state = function () {
+    this._lastState = $.extend(true, {}, this._categories)
+  }
+  Categories.prototype.tick_by_name = function (category_names) {
+    var self = this
+
+    this.save_last_state()
+    $(this._categories).each(function () {
+      var category = this
+      var subcategories
+      if ($.inArray(category.value, category_names) !== -1) {
+        category.checked = !category.checked
+      }
+    })
+  }
+  Categories.prototype.all = function () {
+    return this._categories
+  }
+  Categories.prototype.get_primaries = function () {
+    var parents = []
+    $.each(this._categories, function () {
+      parents.push(this.parent)
+    })
+    return _unique(parents)
+  }
+  Categories.prototype.get_children_for = function (value) {
+    return $(this._categories).filter(function () {
+      return this.parent === value
+    })
+  }
+  Categories.prototype.get_parent_for = function (category) {
+    var category_parent = category.parent
+
+    return $(this.get_primaries()).filter(function () { return this.value === category_parent })[0]
+  }
+  Categories.prototype.get_filtered_names = function (filter) {
+    return $(this._categories).filter(filter).map(function () { return this.value })
+  }
+  Categories.prototype.get_checked = function (dedupe) {
+    var results = $(this._categories).filter(function () { return this.checked })
+    var unique_results = []
+
+    if(dedupe === undefined) {
+        return results
+    }
+
+    // de-dupe results
+    $(results).each(function () {
+      var category_name = this.value
+      if ($.inArray(category_name, unique_results) === -1) {
+        unique_results.push(category_name)
+      }
+    })
+    return unique_results
+  }
+  Categories.prototype.diff = function (oldState, newState) {
+    var diff = []
+
+    oldState.each(function (idx) {
+      var newCategory = newState[idx]
+      if (this.checked !== newCategory.checked) {
+        diff.push(newCategory)
+      }
+    })
+    return diff
+  }
+  Categories.prototype.get_changes = function () {
+    return this.diff(this._lastState, this._categories)
+  }
+
+  var categoryPicker = function () {
+    var categories_data = $('#checkbox-tree__inputs input[type=checkbox]').map(function () {
+      var $input = $(this)
+      var $label = $input.parent()
+
+      return {
+        'value': $.trim($label.text()),
+        'id': $input.attr('id'),
+        'parent': $input.parents('details').find('.categories-heading').text(),
+        'checked': $input.is(':checked')
+      }
+    })
+    var globalCategories = new Categories(categories_data)
+
+    function setCounter () {
+      var checked = globalCategories.get_checked(true).length
+      var suffix = (checked === 1) ? 'category' : 'categories'
+      $counter.html('<strong>' + checked + '</strong> ' + suffix + ' selected.')
+    }
+
+    var $counter = $('#counter')
+
+    function renderCategories () {
+      var updatedCategories = globalCategories.get_changes()
+
+      $(updatedCategories).each(function () {
+        var $input = $('#' + this.id)
+        var action = (this.checked) ? 'addClass' : 'removeClass'
+
+        $input.attr('checked', this.checked)
+        $input.parent('label')[action]('selected')
+      })
+      setCounter()
+    }
+
+    function setParentContextCounters () {
+      var parents = globalCategories.get_primaries()
+      $.each(parents, function() {
+        setParentContextCounter(this)
+      })
+    }
+
+    function setParentContextCounter (parentCategory) {
+      var childCategories = globalCategories.get_children_for(parentCategory)
+      var checkedCategories = globalCategories.get_checked()
+      var checkedChildCategories = $.map(childCategories, function (category) {
+        return $.inArray(category, checkedCategories) < 0 ? null : category.value
+      })
+
+      // write the message
+      var parentContext = childCategories.length + ' categories'
+      parentContext += (checkedChildCategories.length) ? ', ' + checkedChildCategories.length + ' selected' : ''
+
+      // update the .categories-summary span
+      $('.categories-heading:contains("' + parentCategory + '")').next().text(parentContext)
+    }
+
+    renderCategories()
+    setCounter()
+    setParentContextCounters()
+
+    // make clicks on checkboxes update the categories state
+    // TODO: looks like the event is triggered four times
+    $('#checkbox-tree__inputs').on('click', 'label', function (evt) {
+      var target = evt.target
+      var targetNodeName = target.nodeName.toLowerCase()
+      var categoryName
+
+      function getLabelTextForInput (input) {
+        var text = ''
+        var siblings = $(input).parent().contents().each(function () {
+          var childNode = this
+          if (childNode.nodeType === 3) { // text node
+            text += $(childNode).text()
+          }
+        })
+        return $.trim(text)
+      }
+
+      function updateView (categoryName) {
+        globalCategories.tick_by_name([categoryName])
+        renderCategories()
+        setParentContextCounters()
+        setCounter()
+
+      }
+
+      if (targetNodeName === 'input') {
+        categoryName = getLabelTextForInput(target)
+        updateView(categoryName)
+      }
+    })
+  }
+
+  root.GOVUK.GDM.categoryPicker = categoryPicker
+  categoryPicker()
+
+})(window);

--- a/app/assets/javascripts/category-picker.js
+++ b/app/assets/javascripts/category-picker.js
@@ -13,7 +13,6 @@
   // wrapper around the categories data
   var Categories = function (_categories) {
     var primaries = []
-    var self = this
 
     this._containers = []
     this._categories = _categories
@@ -23,7 +22,6 @@
     this._lastState = $.extend(true, {}, this._categories)
   }
   Categories.prototype.tick_by_name = function (category_names) {
-    var self = this
 
     this.save_last_state()
     $(this._categories).each(function () {

--- a/app/assets/javascripts/category-picker.js
+++ b/app/assets/javascripts/category-picker.js
@@ -101,13 +101,27 @@
     })
     var globalCategories = new Categories(categories_data)
 
+    function appendCounter(id) {
+       var $_counter = $('#' + id)
+
+       if(!$_counter.length) {
+         $('.checkbox-tree__counter')
+           .find('div')
+           .append($("<p>", {"id": id, "role": "status", "aria-live": "polite"}))
+
+         $_counter = $('#' + id)
+       }
+
+       return $_counter
+    }
+
     function setCounter () {
       var checked = globalCategories.get_checked(true).length
       var suffix = (checked === 1) ? 'category' : 'categories'
       $counter.html('<strong>' + checked + '</strong> ' + suffix + ' selected.')
     }
 
-    var $counter = $('#counter')
+    var $counter = appendCounter('counter')
 
     function renderCategories () {
       var updatedCategories = globalCategories.get_changes()

--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -129,12 +129,3 @@ del {
     background-color: #efcfd1;
     padding: 0 3px;
 }
-
-.checkbox-tree__counter {
-  padding: 0;
-  margin: -13px 0 0 0;
-
-  #counter {
-    padding: 20px 0 15px 0;
-  }
-}

--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -129,3 +129,12 @@ del {
     background-color: #efcfd1;
     padding: 0 3px;
 }
+
+.checkbox-tree__counter {
+  padding: 0;
+  margin: -13px 0 0 0;
+
+  #counter {
+    padding: 20px 0 15px 0;
+  }
+}

--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "jquery": "1.11.2",
     "hogan": "3.0.2",
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
-    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#22.1.0",
+    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#22.1.3",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.19.2/jinja_govuk_template-0.19.2.tgz",
     "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#6.4.4"
   }


### PR DESCRIPTION
The javascript that runs overtop of the category-picker currently makes the assumption that there is only one category-picker component on a page, so it doesn't really work on [the "examples" page of the frontend toolkit](http://alphagov.github.io/digitalmarketplace-frontend-toolkit/forms/checkbox-tree.html) where there are multiple of them.

That being so, I've kept it in the supplier app for the time being until it can be further generalised.

It's also worth pointing out that we don't have a way of including javascript on a per-question basis in the app, so I've just added all the category-picker-specific stuff to the general `application.js` file.  It won't cause any problems or anything, it's just something to be aware of.

This pull request:
- adds a polyfill so that the `<details>` element works on older browsers
- sticks the `counter` element to the top of the browser while scrolling through categories
- handles the logic for the category-picker
  - will tick and untick all non-unique categories at once
  - it will update the counter
  - it will update the number of selected categories within each parent grouping
- brings in the new frontend toolkit with the needed corresponding markup

***

## gifs

### sticky counter element
sticks at the top and unsticks at the bottom (even if the page changes size) 
![sticky_counter](https://cloud.githubusercontent.com/assets/2454380/23605289/eafdbd0c-0253-11e7-9d8f-d8d9f8f84cd3.gif)

### updates the counter as elements are ticked
![counter_updated](https://cloud.githubusercontent.com/assets/2454380/23605286/eae46460-0253-11e7-9210-581ef8fb21b4.gif)

### updates the parent context as child categories are ticked
![parent_context](https://cloud.githubusercontent.com/assets/2454380/23605288/eafbe34c-0253-11e7-963f-4a30ec24a875.gif)

### will select/unselect all child categories with the same name
![multiple_categories](https://cloud.githubusercontent.com/assets/2454380/23605287/eaf028fe-0253-11e7-9838-b8b1b03321a2.gif)


