### PR TITLE
Require Jinja pinned dependancy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,6 @@ git+https://github.com/alphagov/digitalmarketplace-apiclient.git@8.5.0#egg=digit
 
 # For Cloud Foundry
 gunicorn==19.4.5
+
+# Pinned requirements
+Jinja2==2.9.5


### PR DESCRIPTION
Flask requires Jinja but we found a bug with differing versions of Jinja on our different environments. We require all environments to run the same version and so therefore pin this dependancy.