### PR TITLE
Pull in new content-loader for simplified slugs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ werkzeug==0.10.4
 python-dateutil==2.4.2
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@24.1.0#egg=digitalmarketplace-utils==24.1.0
-git+https://github.com/alphagov/digitalmarketplace-content-loader.git@3.5.0#egg=digitalmarketplace-content-loader==3.5.0
+git+https://github.com/alphagov/digitalmarketplace-content-loader.git@3.5.1#egg=digitalmarketplace-content-loader==3.5.1
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@8.5.0#egg=digitalmarketplace-apiclient==8.5.0
 
 # For Cloud Foundry


### PR DESCRIPTION
* As above. Pull in dm-content-loader 3.5.1, which will drop smart quotes from generated slugs.

#666