### PR TITLE
140507667-no-supplier-username-in-zendesk-clarification-question

### DIFF
--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -634,7 +634,6 @@ def framework_updates_email_clarification_question(framework_slug):
         email_body = render_template(
             "emails/clarification_question.html",
             supplier_id=current_user.supplier_id,
-            user_name=current_user.name,
             message=clarification_question
         )
         tags = ["clarification-question"]

--- a/app/templates/emails/clarification_question.html
+++ b/app/templates/emails/clarification_question.html
@@ -5,8 +5,6 @@
 </head>
 <body>
 Supplier ID: {{ supplier_id }}
-<br />
-User name: {{ user_name }}
 <br /><br />
 Clarification question asked:
 <br />

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -3492,7 +3492,7 @@ class TestSendClarificationQuestionEmail(BaseApplicationTest):
         if is_called:
             send_email.assert_any_call(
                 "digitalmarketplace@mailinator.com",
-                FakeMail('Supplier ID:', 'User name:'),
+                FakeMail('Supplier ID:'),
                 "MANDRILL",
                 "Test Framework clarification question",
                 "do-not-reply@digitalmarketplace.service.gov.uk",


### PR DESCRIPTION
* Remove user name from clarification email
* Update tests