### PR TITLE
Use full words for variables in category-picker.js file

### DIFF
--- a/app/assets/javascripts/category-picker.js
+++ b/app/assets/javascripts/category-picker.js
@@ -75,8 +75,8 @@
   Categories.prototype.diff = function (oldState, newState) {
     var diff = []
 
-    oldState.each(function (idx) {
-      var newCategory = newState[idx]
+    oldState.each(function (index) {
+      var newCategory = newState[index]
       if (this.checked !== newCategory.checked) {
         diff.push(newCategory)
       }
@@ -164,8 +164,8 @@
 
     // make clicks on checkboxes update the categories state
     // TODO: looks like the event is triggered four times
-    $('#checkbox-tree__inputs').on('click', 'label', function (evt) {
-      var target = evt.target
+    $('#checkbox-tree__inputs').on('click', 'label', function (event) {
+      var target = event.target
       var targetNodeName = target.nodeName.toLowerCase()
       var categoryName
 


### PR DESCRIPTION
Super tiny change to use full words rather than their shortened versions as variable names.

'evt' -> 'event'
'idx' -> 'index'

This was something that @carolinegreen mentioned earlier but I forgot to make the change.
