### PR TITLE
Bump content loader to 3.5.2 to fix niceToHaveRequirements validation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ werkzeug==0.10.4
 python-dateutil==2.4.2
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@24.1.0#egg=digitalmarketplace-utils==24.1.0
-git+https://github.com/alphagov/digitalmarketplace-content-loader.git@3.5.1#egg=digitalmarketplace-content-loader==3.5.1
+git+https://github.com/alphagov/digitalmarketplace-content-loader.git@3.5.2#egg=digitalmarketplace-content-loader==3.5.2
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@8.5.0#egg=digitalmarketplace-apiclient==8.5.0
 
 # For Cloud Foundry


### PR DESCRIPTION
niceToHaveRequirements page was 500'ing due to a bug with the content loader when validating questions that had not been answered. This should fix that. For further context please see the related PR for the content loader - https://github.com/alphagov/digitalmarketplace-content-loader/pull/33