### PR TITLE
FLAKE8-do-flake8

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,14 @@
+[flake8]
+# Rule definitions: http://flake8.pycqa.org/en/latest/user/error-codes.html
+# D203: 1 blank line required before class docstring
+# F401: 'identifier' imported but unused
+# E402: module level import not at top of file
+# C901: too complex
+exclude = venv,venv3,__pycache__,node_modules,bower_components
+ignore = D203
+max-complexity = 7
+max-line-length = 120
+putty-ignore =
+    **/__init__.py : +F401
+    app/__init__.py, app/main/__init__.py, app/status/__init__.py : +E402
+    app/main/views/*.py : +C901

--- a/Makefile
+++ b/Makefile
@@ -31,10 +31,10 @@ npm_install: package.json
 frontend_build:
 	npm run --silent frontend-build:${GULP_ENVIRONMENT}
 
-test: show_environment test_pep8 test_python test_javascript
+test: show_environment test_flake8 test_python test_javascript
 
-test_pep8: virtualenv
-	${VIRTUALENV_ROOT}/bin/pep8 .
+test_flake8: virtualenv
+	${VIRTUALENV_ROOT}/bin/flake8 .
 
 test_python: virtualenv
 	${VIRTUALENV_ROOT}/bin/py.test ${PYTEST_ARGS}
@@ -46,4 +46,4 @@ show_environment:
 	@echo "Environment variables in use:"
 	@env | grep DM_ || true
 
-.PHONY: run_all run_app virtualenv requirements requirements_for_test npm_install frontend_build test test_pep8 test_python test_javascript show_environment
+.PHONY: run_all run_app virtualenv requirements requirements_for_test npm_install frontend_build test test_flake8 test_python test_javascript show_environment

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -1,12 +1,13 @@
 -r requirements.txt
-pytest==2.8.2
-pep8==1.5.7
-requests-mock==0.6.0
-mock==2.0.0
-lxml==3.4.4
-cssselect==0.9.1
-freezegun==0.3.4
-watchdog==0.8.3
 coverage==3.7.1
+cssselect==0.9.1
+flake8==2.6.2
+flake8-putty==0.4.0
+freezegun==0.3.4
+lxml==3.4.4
+mock==2.0.0
+pytest==2.8.2
 pytest-cov==2.2.0
 python-coveralls==2.5.0
+requests-mock==0.6.0
+watchdog==0.8.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,9 +1,2 @@
-[pep8]
-exclude = ./venv*,./bower_components,./node_modules
-max-line-length = 120
-
-[nosetests]
-nocapture = true
-
 [pytest]
 norecursedirs = venv* node_modules app/content bower_components


### PR DESCRIPTION
### Swap out pep8 checks for flake8

* New .flake8 file
  * Exclude virtualenvs, cache, bower and node stuff
  * Ignore blank line required before class docstring (pretty standard ignore)
  * Ignore unused imports in __init__ files
  * Ignore import not at top of file in _some_ __init__ files
  * Ignore complexity in views

* Makefile
  * New test_flake8 command to run flake8
  * Remove test_pep8 command
  * replace pep8 command with flake8 in test run command

* requirements_for_test
  * Remove pep8
  * Add flake8 and flake8-putty
  * Alphabetize

* setup.cfg
  * Remove unused pep8 and nose config entries