### PR TITLE
Change supplier declaration template column widths

### DIFF
--- a/app/templates/frameworks/declaration_overview.html
+++ b/app/templates/frameworks/declaration_overview.html
@@ -94,7 +94,7 @@
           field_headings_visible=False
         ) %}
           {% call summary.row() %}
-            {{ summary.field_name(question.label|question_references(section.get_question), two_thirds=true) }}
+            {{ summary.field_name(question.label|question_references(section.get_question)) }}
             {% if section.editable %}
               {% if section_errors %}
                 {% call summary.field() %}

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -2301,7 +2301,7 @@ class TestDeclarationOverview(BaseApplicationTest):
             tuple(
                 (
                     # contents of row heading
-                    row.xpath("normalize-space(string(./td[@class='summary-item-field-first-two-thirds']))"),
+                    row.xpath("normalize-space(string(./td[@class='summary-item-field-first']))"),
                     # full text contents of row "value"
                     row.xpath("normalize-space(string(./td[@class='summary-item-field']))"),
                     # full text contents of each a element in row value


### PR DESCRIPTION
We now have shorter questions in the supplier declaration, so we should reclaim the unused space and give it to the answers on the dashboard.

## Introducing the world's worst & least exemplative screenshots:
### Before:
<img width="1152" alt="screen shot 2017-03-13 at 15 36 24" src="https://cloud.githubusercontent.com/assets/2920760/23861738/e2932bac-0802-11e7-9437-cea739b4de68.png">

### After:
<img width="1117" alt="screen shot 2017-03-13 at 15 33 48" src="https://cloud.githubusercontent.com/assets/2920760/23861731/df82d5e8-0802-11e7-810a-e05718e75c07.png">


https://trello.com/c/qoqrHUaq/290-make-declaration-summary-page-summary-table-first-column-1-third-width