### PR TITLE
139477629-Shortlisting-content-error

### DIFF
--- a/app/templates/briefs/view_response_result.html
+++ b/app/templates/briefs/view_response_result.html
@@ -70,7 +70,7 @@
         <h3>Shortlist</h3>
         
         <p>When the opportunity closes, the buyer will score your evidence. If you’re one of the top {{ brief.get('numberOfSuppliers') }} suppliers, you'll go through to the evaluation stage.</p>
-        <p>If you’re not successful, the buyer will give you feedback on the evidence you provided.</p>
+        <p>The buyer will tell you if you're not successful.</p>
 
         <h3>Evaluation</h3>
 


### PR DESCRIPTION
As per ticket:
> Nicole has spotted an error in the copy on the 'what happens next' page.
We say that suppliers will provide feedback, when actually all they'll
do at shortlisting is tell a supplier they were not successful.

> It currently says:
'If you’re not successful, the buyer will give you feedback on the
evidence you provided.'

> #Could we please replace with:
'The buyer will tell you if you're not successful.'


https://www.pivotaltracker.com/story/show/139477629