### PR TITLE
Clarification around what we do with submitted service data

### DIFF
--- a/app/assets/scss/_framework-application.scss
+++ b/app/assets/scss/_framework-application.scss
@@ -16,15 +16,18 @@
 }
 
 .framework-dashboard {
-
   .browse-list-item {
-
     border-top: 1px solid $border-colour;
     padding-top: $gutter * 2/3;
 
     h2 {
       @include bold-24;
       margin-bottom: 5px;
+    }
+
+    ul {
+      list-style: disc;
+      margin: 0px 0 10px 20px;
     }
   }
 }

--- a/app/main/__init__.py
+++ b/app/main/__init__.py
@@ -36,7 +36,7 @@ content_loader.load_messages('g-cloud-8', ['dates', 'urls'])
 content_loader.load_manifest('g-cloud-9', 'services', 'edit_service')
 content_loader.load_manifest('g-cloud-9', 'services', 'edit_submission')
 content_loader.load_manifest('g-cloud-9', 'declaration', 'declaration')
-content_loader.load_messages('g-cloud-9', ['dates', 'urls'])
+content_loader.load_messages('g-cloud-9', ['dates', 'urls', 'advice'])
 
 
 @main.after_request

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -15,6 +15,7 @@ from dmutils.email import send_email
 from dmutils.email.exceptions import EmailError
 from dmcontent.formats import format_service_price
 from dmcontent.questions import ContentQuestion
+from dmcontent.errors import ContentNotFoundError
 from dmutils.formats import datetimeformat
 from dmutils import s3
 from dmutils.documents import (
@@ -83,6 +84,11 @@ def framework_dashboard(framework_slug):
 
     framework_dates = content_loader.get_message(framework_slug, 'dates')
     framework_urls = content_loader.get_message(framework_slug, 'urls')
+
+    try:
+        framework_advice = content_loader.get_message(framework_slug, 'advice')
+    except ContentNotFoundError:
+        framework_advice = None
 
     # filenames
     result_letter_filename = RESULT_LETTER_FILENAME
@@ -165,6 +171,7 @@ def framework_dashboard(framework_slug):
         result_letter_filename=result_letter_filename,
         supplier_framework=supplier_framework_info,
         supplier_is_on_framework=supplier_is_on_framework,
+        framework_advice=framework_advice,
     ), 200
 
 

--- a/app/templates/frameworks/_framework_actions.html
+++ b/app/templates/frameworks/_framework_actions.html
@@ -72,6 +72,11 @@
   <a class="browse-list-item-link" href="{{ url_for('.framework_submission_lots', framework_slug=framework.slug) }}">
     <span>Add, edit and complete services</span>
   </a>
+  {% if framework_advice.use_of_service_data %}
+    <div class="browse-list-item-body">
+      {{ framework_advice.use_of_service_data }}
+    </div>
+  {% endif %}
   {% if not counts.complete and not counts.draft %}
   <div class="browse-list-item-status-quiet">
     <p class="browse-list-item-status-title">You need to add and complete services</p>

--- a/app/templates/frameworks/_framework_actions.html
+++ b/app/templates/frameworks/_framework_actions.html
@@ -65,9 +65,7 @@
   </div>
   {% endif %}
 </li>
-{% endif %}
 
-{% if framework.status == 'open' %}
 <li class="browse-list-item">
   <a class="browse-list-item-link" href="{{ url_for('.framework_submission_lots', framework_slug=framework.slug) }}">
     <span>Add, edit and complete services</span>

--- a/bower.json
+++ b/bower.json
@@ -7,6 +7,6 @@
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
     "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#22.1.4",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.19.2/jinja_govuk_template-0.19.2.tgz",
-    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#6.4.8"
+    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#6.4.9"
   }
 }


### PR DESCRIPTION
## Summary
Ticket: https://trello.com/c/RhoLFz3M/322-clarification-around-what-we-do-with-submitted-service-data

This PR pulls in an updated frameworks repo which contains content to be displayed on the frameworks dashboard explicitly clarifying what we do with any data provided about services submitted to a framework. This is currently available in supplier guides but is not present anywhere on DM pages themselves.

It also adds bullet styling for unordered lists within browse-list-items on the framework dashboard only.

Depends on https://github.com/alphagov/digitalmarketplace-frameworks/pull/408

## Before
<img width="671" alt="screen shot 2017-03-16 at 11 59 36" src="https://cloud.githubusercontent.com/assets/2920760/23995139/2730a21e-0a40-11e7-9ccd-31bd9a446061.png">



## After
<img width="664" alt="screen shot 2017-03-16 at 12 00 13" src="https://cloud.githubusercontent.com/assets/2920760/23995135/25980a1e-0a40-11e7-94d3-28c0564ceb89.png">
