### PR TITLE
Update to use camelCase keys from framework JSON

### DIFF
--- a/app/main/helpers/frameworks.py
+++ b/app/main/helpers/frameworks.py
@@ -46,8 +46,8 @@ def order_frameworks_for_reuse(frameworks):
     If a declaration has the reuse flag set and is the most recently closed framework then that's our framework.
     """
     return sorted(
-        filter(lambda i: i['allow_declaration_reuse'] and i['application_close_date'], frameworks),
-        key=lambda i: datetime.strptime(i['application_close_date'], DATETIME_FORMAT),
+        filter(lambda i: i['allowDeclarationReuse'] and i['applicationCloseDate'], frameworks),
+        key=lambda i: datetime.strptime(i['applicationCloseDate'], DATETIME_FORMAT),
         reverse=True
     )
 

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -344,7 +344,7 @@ def reuse_framework_supplier_declaration_post(framework_slug):
             form_errors=form_errors,
             old_framework=old_framework,
             old_framework_application_close_date=date_parse(old_framework['applicationCloseDate']).strftime('%B %Y')
-        )
+        ), 400
     if form.reuse.data:
         # They clicked OK! Check the POST data.
         try:

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -320,7 +320,7 @@ def reuse_framework_supplier_declaration(framework_slug):
         current_framework=current_framework,
         form=ReuseDeclarationForm(),
         old_framework=old_framework,
-        old_framework_application_close_date=date_parse(old_framework['application_close_date']).strftime('%B %Y'),
+        old_framework_application_close_date=date_parse(old_framework['applicationCloseDate']).strftime('%B %Y'),
     ), 200
 
 
@@ -343,14 +343,14 @@ def reuse_framework_supplier_declaration_post(framework_slug):
             form=form,
             form_errors=form_errors,
             old_framework=old_framework,
-            old_framework_application_close_date=date_parse(old_framework['application_close_date']).strftime('%B %Y')
+            old_framework_application_close_date=date_parse(old_framework['applicationCloseDate']).strftime('%B %Y')
         )
     if form.reuse.data:
         # They clicked OK! Check the POST data.
         try:
             framework_ok = data_api_client.get_framework(
                 form.old_framework_slug.data
-            )['frameworks']['allow_declaration_reuse']
+            )['frameworks']['allowDeclarationReuse']
             declaration_ok = False  # Default value
 
             if framework_ok:

--- a/tests/app/main/helpers/test_frameworks.py
+++ b/tests/app/main/helpers/test_frameworks.py
@@ -375,15 +375,15 @@ def test_order_frameworks_for_reuse():
     t12 = '2012-03-03T01:01:01.000000Z'
 
     fake_frameworks = [
-        {'allow_declaration_reuse': False, 'application_close_date': t09, 'extraneous_field': 'foo'},
-        {'allow_declaration_reuse': True, 'application_close_date': t12, 'extraneous_field': 'foo'},
-        {'allow_declaration_reuse': True, 'application_close_date': t07, 'extraneous_field': 'foo'},
+        {'allowDeclarationReuse': False, 'applicationCloseDate': t09, 'extraneousField': 'foo'},
+        {'allowDeclarationReuse': True, 'applicationCloseDate': t12, 'extraneousField': 'foo'},
+        {'allowDeclarationReuse': True, 'applicationCloseDate': t07, 'extraneousField': 'foo'},
     ]
     ordered = order_frameworks_for_reuse(fake_frameworks)
     assert len(ordered) == 2, "order_frameworks_for_reuse should only filter out inappropriate frameworks."
     assert ordered == [
-        {'allow_declaration_reuse': True, 'application_close_date': t12, 'extraneous_field': 'foo'},
-        {'allow_declaration_reuse': True, 'application_close_date': t07, 'extraneous_field': 'foo'}
+        {'allowDeclarationReuse': True, 'applicationCloseDate': t12, 'extraneousField': 'foo'},
+        {'allowDeclarationReuse': True, 'applicationCloseDate': t07, 'extraneousField': 'foo'}
     ], "order_frameworks_for_reuse should return appropriate frameworks."
 
 
@@ -394,9 +394,9 @@ def test_order_frameworks_for_reuse_none():
     t12 = '2012-03-03T01:01:01.000000Z'
 
     fake_frameworks = [
-        {'allow_declaration_reuse': False, 'application_close_date': t12, 'extraneous_field': 'foo'},
-        {'allow_declaration_reuse': False, 'application_close_date': t09, 'extraneous_field': 'foo'},
-        {'allow_declaration_reuse': False, 'application_close_date': t07, 'extraneous_field': 'foo'},
+        {'allowDeclarationReuse': False, 'applicationCloseDate': t12, 'extraneousField': 'foo'},
+        {'allowDeclarationReuse': False, 'applicationCloseDate': t09, 'extraneousField': 'foo'},
+        {'allowDeclarationReuse': False, 'applicationCloseDate': t07, 'extraneousField': 'foo'},
     ]
     ordered = order_frameworks_for_reuse(fake_frameworks)
 
@@ -410,13 +410,13 @@ def test_order_frameworks_for_reuse_one():
     t12 = '2012-03-03T01:01:01.000000Z'
 
     fake_frameworks = [
-        {'allow_declaration_reuse': False, 'application_close_date': t12, 'extraneous_field': 'foo'},
-        {'allow_declaration_reuse': False, 'application_close_date': t09, 'extraneous_field': 'foo'},
-        {'allow_declaration_reuse': True, 'application_close_date': t07, 'extraneous_field': 'foo'},
+        {'allowDeclarationReuse': False, 'applicationCloseDate': t12, 'extraneousField': 'foo'},
+        {'allowDeclarationReuse': False, 'applicationCloseDate': t09, 'extraneousField': 'foo'},
+        {'allowDeclarationReuse': True, 'applicationCloseDate': t07, 'extraneousField': 'foo'},
     ]
     ordered = order_frameworks_for_reuse(fake_frameworks)
 
-    assert ordered == [{'allow_declaration_reuse': True, 'application_close_date': t07, 'extraneous_field': 'foo'}]
+    assert ordered == [{'allowDeclarationReuse': True, 'applicationCloseDate': t07, 'extraneousField': 'foo'}]
 
 
 def test_order_frameworks_for_reuse_unordered():
@@ -429,22 +429,22 @@ def test_order_frameworks_for_reuse_unordered():
     t14 = '2014-03-03T01:01:01.000000Z'
 
     fake_frameworks = [
-        {'allow_declaration_reuse': True, 'application_close_date': t07, 'extraneous_field': 'foo'},
-        {'allow_declaration_reuse': True, 'application_close_date': t13, 'extraneous_field': 'foo'},
-        {'allow_declaration_reuse': True, 'application_close_date': t09, 'extraneous_field': 'foo'},
-        {'allow_declaration_reuse': True, 'application_close_date': t14, 'extraneous_field': 'foo'},
-        {'allow_declaration_reuse': True, 'application_close_date': t12, 'extraneous_field': 'foo'},
-        {'allow_declaration_reuse': True, 'application_close_date': t11, 'extraneous_field': 'foo'},
+        {'allowDeclarationReuse': True, 'applicationCloseDate': t07, 'extraneousField': 'foo'},
+        {'allowDeclarationReuse': True, 'applicationCloseDate': t13, 'extraneousField': 'foo'},
+        {'allowDeclarationReuse': True, 'applicationCloseDate': t09, 'extraneousField': 'foo'},
+        {'allowDeclarationReuse': True, 'applicationCloseDate': t14, 'extraneousField': 'foo'},
+        {'allowDeclarationReuse': True, 'applicationCloseDate': t12, 'extraneousField': 'foo'},
+        {'allowDeclarationReuse': True, 'applicationCloseDate': t11, 'extraneousField': 'foo'},
     ]
     ordered = order_frameworks_for_reuse(fake_frameworks)
 
     expected = [
-        {'allow_declaration_reuse': True, 'application_close_date': t14, 'extraneous_field': 'foo'},
-        {'allow_declaration_reuse': True, 'application_close_date': t13, 'extraneous_field': 'foo'},
-        {'allow_declaration_reuse': True, 'application_close_date': t12, 'extraneous_field': 'foo'},
-        {'allow_declaration_reuse': True, 'application_close_date': t11, 'extraneous_field': 'foo'},
-        {'allow_declaration_reuse': True, 'application_close_date': t09, 'extraneous_field': 'foo'},
-        {'allow_declaration_reuse': True, 'application_close_date': t07, 'extraneous_field': 'foo'}
+        {'allowDeclarationReuse': True, 'applicationCloseDate': t14, 'extraneousField': 'foo'},
+        {'allowDeclarationReuse': True, 'applicationCloseDate': t13, 'extraneousField': 'foo'},
+        {'allowDeclarationReuse': True, 'applicationCloseDate': t12, 'extraneousField': 'foo'},
+        {'allowDeclarationReuse': True, 'applicationCloseDate': t11, 'extraneousField': 'foo'},
+        {'allowDeclarationReuse': True, 'applicationCloseDate': t09, 'extraneousField': 'foo'},
+        {'allowDeclarationReuse': True, 'applicationCloseDate': t07, 'extraneousField': 'foo'}
     ]
 
     assert ordered == expected
@@ -453,8 +453,8 @@ def test_order_frameworks_for_reuse_unordered():
 @mock.patch('app.main.views.frameworks.data_api_client', autospec=True)
 def test_get_reusable_declaration(data_api_client):
     """Test happy path, should return the framework and declaration where
-    allow_declaration_reuse == True
-    application_close_date is closest to today
+    allowDeclarationReuse == True
+    applicationCloseDate is closest to today
     and declaration exists for that framework
     and declaration status is completed
     """
@@ -466,12 +466,12 @@ def test_get_reusable_declaration(data_api_client):
     t14 = '2014-03-03T01:01:01.000000Z'
 
     frameworks = [
-        {'x_field': 'foo', 'allow_declaration_reuse': True, 'application_close_date': t07, 'slug': 'ben-cloud-1'},
-        {'x_field': 'foo', 'allow_declaration_reuse': True, 'application_close_date': t09, 'slug': 'ben-cloud-2'},
-        {'x_field': 'foo', 'allow_declaration_reuse': True, 'application_close_date': t11, 'slug': 'ben-cloud-3'},
-        {'x_field': 'foo', 'allow_declaration_reuse': True, 'application_close_date': t12, 'slug': 'ben-cloud-4'},
-        {'x_field': 'foo', 'allow_declaration_reuse': True, 'application_close_date': t13, 'slug': 'ben-cloud-5'},
-        {'x_field': 'foo', 'allow_declaration_reuse': False, 'application_close_date': t14, 'slug': 'ben-cloud-alpha'},
+        {'x_field': 'foo', 'allowDeclarationReuse': True, 'applicationCloseDate': t07, 'slug': 'ben-cloud-1'},
+        {'x_field': 'foo', 'allowDeclarationReuse': True, 'applicationCloseDate': t09, 'slug': 'ben-cloud-2'},
+        {'x_field': 'foo', 'allowDeclarationReuse': True, 'applicationCloseDate': t11, 'slug': 'ben-cloud-3'},
+        {'x_field': 'foo', 'allowDeclarationReuse': True, 'applicationCloseDate': t12, 'slug': 'ben-cloud-4'},
+        {'x_field': 'foo', 'allowDeclarationReuse': True, 'applicationCloseDate': t13, 'slug': 'ben-cloud-5'},
+        {'x_field': 'foo', 'allowDeclarationReuse': False, 'applicationCloseDate': t14, 'slug': 'ben-cloud-alpha'},
     ]
     declarations = [
         {'x_field': 'foo', 'frameworkSlug': 'ben-cloud-4', 'onFramework': True},
@@ -494,7 +494,7 @@ def test_get_reusable_declaration_none(data_api_client):
     t14 = '2014-03-05T01:01:01.000000Z'
 
     frameworks = [
-        {'x_field': 'foo', 'allow_declaration_reuse': True, 'application_close_date': t14, 'slug': 'ben-cloud-5'},
+        {'x_field': 'foo', 'allowDeclarationReuse': True, 'applicationCloseDate': t14, 'slug': 'ben-cloud-5'},
     ]
     declarations = [
         {'x_field': 'foo', 'frameworkSlug': 'ben-cloud-4', 'onFramework': True},

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -5217,8 +5217,8 @@ class TestReuseFrameworkSupplierDeclaration(BaseApplicationTest):
         t07 = '2009-12-03T01:01:01.000000Z'
         framework = {
             'x_field': 'foo',
-            'allow_declaration_reuse': True,
-            'application_close_date': t07,
+            'allowDeclarationReuse': True,
+            'applicationCloseDate': t07,
             'slug': 'g-cloud-8',
             'name': 'g-cloud-8'
         }
@@ -5274,7 +5274,7 @@ class TestReuseFrameworkSupplierDeclaration(BaseApplicationTest):
         t09 = '2009-03-03T01:01:01.000000Z'
 
         frameworks = [
-            {'x_field': 'foo', 'allow_declaration_reuse': True, 'application_close_date': t09, 'slug': 'ben-cloud-2'},
+            {'x_field': 'foo', 'allowDeclarationReuse': True, 'applicationCloseDate': t09, 'slug': 'ben-cloud-2'},
         ]
         supplier_declarations = []
         data_api_client.find_frameworks.return_value = {'frameworks': frameworks}
@@ -5307,34 +5307,34 @@ class TestReuseFrameworkSupplierDeclaration(BaseApplicationTest):
         frameworks_response = [
             {
                 'x_field': 'foo',
-                'allow_declaration_reuse': True,
-                'application_close_date': t12,
+                'allowDeclarationReuse': True,
+                'applicationCloseDate': t12,
                 'slug': 'g-cloud-8',
                 'name': 'G-cloud 8'
             }, {
                 'x_field': 'foo',
-                'allow_declaration_reuse': True,
-                'application_close_date': t11,
+                'allowDeclarationReuse': True,
+                'applicationCloseDate': t11,
                 'slug': 'g-cloud-7',
                 'name': 'G-cloud 7'
             }, {
                 'x_field': 'foo',
-                'allow_declaration_reuse': True,
-                'application_close_date': t10,
+                'allowDeclarationReuse': True,
+                'applicationCloseDate': t10,
                 'slug': 'dos',
                 'name': 'Digital'
             }, {
                 'x_field': 'foo',
-                'allow_declaration_reuse': False,
-                'application_close_date': t09,
+                'allowDeclarationReuse': False,
+                'applicationCloseDate': t09,
                 'slug': 'g-cloud-6',
                 'name': 'G-cloud 6'
             },
         ]
         framework_response = {
             'x_field': 'foo',
-            'allow_declaration_reuse': True,
-            'application_close_date': t09,
+            'allowDeclarationReuse': True,
+            'applicationCloseDate': t09,
             'slug': 'g-cloud-8',
             'name': 'G-cloud 8'
         }
@@ -5401,7 +5401,7 @@ class TestReuseFrameworkSupplierDeclarationPost(BaseApplicationTest):
                 'onFramework': True
             }
         }
-        framework_response = {'frameworks': {'x_field': 'foo', 'allow_declaration_reuse': True}}
+        framework_response = {'frameworks': {'x_field': 'foo', 'allowDeclarationReuse': True}}
         data_api_client.get_framework.return_value = framework_response
 
         with self.client:
@@ -5432,9 +5432,9 @@ class TestReuseFrameworkSupplierDeclarationPost(BaseApplicationTest):
         """Assert 404 for non reusable framework."""
         data = {'reuse': 'true', 'old_framework_slug': 'digital-outcomes-and-specialists'}
 
-        # A framework with allow_declaration_reuse as False
+        # A framework with allowDeclarationReuse as False
         data_api_client.get_framework.return_value = {
-            'frameworks': {'x_field': 'foo', 'allow_declaration_reuse': False}
+            'frameworks': {'x_field': 'foo', 'allowDeclarationReuse': False}
         }
 
         # Do the post.
@@ -5443,7 +5443,7 @@ class TestReuseFrameworkSupplierDeclarationPost(BaseApplicationTest):
             data=data
         )
 
-        # Should get the framework and error on allow_declaration_reuse as False.
+        # Should get the framework and error on allowDeclarationReuse as False.
         data_api_client.get_framework.assert_called_once_with('digital-outcomes-and-specialists')
         # Should not do the declaration call if the framework is invalid
         assert not data_api_client.get_supplier_framework_info.called
@@ -5473,7 +5473,7 @@ class TestReuseFrameworkSupplierDeclarationPost(BaseApplicationTest):
     def test_reuse_non_existent_declaration_post(self, data_api_client):
         """Assert 404 for non existent declaration."""
         data = {'reuse': 'true', 'old_framework_slug': 'digital-outcomes-and-specialists-2'}
-        framework_response = {'frameworks': {'x_field': 'foo', 'allow_declaration_reuse': True}}
+        framework_response = {'frameworks': {'x_field': 'foo', 'allowDeclarationReuse': True}}
         data_api_client.get_framework.return_value = framework_response
 
         # Attach does not exist.


### PR DESCRIPTION
For this bug fix: https://www.pivotaltracker.com/story/show/141950783

Depends on this API change going in first:
 - [x] https://github.com/alphagov/digitalmarketplace-api/pull/553

The snake_case keys are on their way out - use the new camelCase versions instead.

Also a sneaky second commit to add a 400 response code when there's a validation error on the "reuse your old declaration" form.