### PR TITLE
Still show target element if any controlling element is still selected.

### DIFF
--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -120,12 +120,12 @@ $path: "/suppliers/static/images/";
 }
 
 ins {
-    text-decoration: none;
-    background-color: #cce0d6;
-    padding: 0 3px;
+  text-decoration: none;
+  background-color: #cce0d6;
+  padding: 0 3px;
 }
 
 del {
-    background-color: #efcfd1;
-    padding: 0 3px;
+  background-color: #efcfd1;
+  padding: 0 3px;
 }

--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "jquery": "1.11.2",
     "hogan": "3.0.2",
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
-    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#22.1.4",
+    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#22.1.6",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.19.2/jinja_govuk_template-0.19.2.tgz",
     "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#6.4.9"
   }


### PR DESCRIPTION
**Note: if this goes in before [the other frontend toolkit update](https://github.com/alphagov/digitalmarketplace-supplier-frontend/pull/688), the other one becomes irrelevant and should be closed rather than rebased and merged.**

***

Brings in the latest-latest frontend toolkit to kill the bug where two checkboxes pointing at the same target element might unintentionally hide that target element. ([more explanation here](https://github.com/alphagov/digitalmarketplace-frontend-toolkit/pull/322)).

## gifs

### before
![checks2](https://cloud.githubusercontent.com/assets/2454380/24454659/9808fd26-1484-11e7-8156-8fe1f4406f43.gif)

### now
![checks](https://cloud.githubusercontent.com/assets/2454380/24454669/a058d87a-1484-11e7-8b0d-57f071764dc5.gif)
