### PR TITLE
Fixes validation masthead on supplier creation

### DIFF
--- a/app/templates/suppliers/company_contact_details.html
+++ b/app/templates/suppliers/company_contact_details.html
@@ -17,7 +17,7 @@ with items = [
 
 {% block main_content %}
 
-{% if form.errors|length > 1 %}
+{% if form.errors|length >= 1 %}
     <div class="validation-masthead" role="group" aria-labelledby="validation-masthead-heading">
         <h1 class="validation-masthead-heading" id="validation-masthead-heading">
             There was a problem with the details you gave for:


### PR DESCRIPTION
Story: https://www.pivotaltracker.com/story/show/143115633

Changes template to show masthead if errors >= 1 instead of > 1