### PR TITLE
[#140222101]declaration overview: enable visibility in non-open framework statuses

### DIFF
--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -404,7 +404,10 @@ def framework_supplier_declaration_overview(framework_slug):
         # no longer can, so it's apparently "gone"
         abort(410)
 
-    content = content_loader.get_manifest(framework_slug, 'declaration').filter(sf["declaration"])
+    try:
+        content = content_loader.get_manifest(framework_slug, 'declaration').filter(sf["declaration"])
+    except ContentNotFoundError:
+        abort(404)
 
     # generate an (ordered) dict of the form {section_slug: (section, section_errors)}.
     # we must perform an actual validation for each section rather than rely on .answer_required as the latter won't

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -387,11 +387,22 @@ def reuse_framework_supplier_declaration_post(framework_slug):
 @main.route('/frameworks/<framework_slug>/declaration', methods=['GET'])
 @login_required
 def framework_supplier_declaration_overview(framework_slug):
-    framework = get_framework(data_api_client, framework_slug, allowed_statuses=['open'])
+    framework = get_framework(data_api_client, framework_slug, allowed_statuses=[
+        "open",
+        "pending",
+        "standstill",
+        "live",
+        "expired",
+    ])
 
     sf = data_api_client.get_supplier_framework_info(current_user.supplier_id, framework_slug)["frameworkInterest"]
     # ensure our declaration is a a dict
     sf["declaration"] = sf.get("declaration") or {}
+
+    if framework["status"] != "open" and sf["declaration"].get("status") != "complete":
+        # 410 - the thinking here is that the user probably *used to* be able to access a page at this url but they
+        # no longer can, so it's apparently "gone"
+        abort(410)
 
     content = content_loader.get_manifest(framework_slug, 'declaration').filter(sf["declaration"])
 

--- a/app/templates/frameworks/_submitted_services.html
+++ b/app/templates/frameworks/_submitted_services.html
@@ -13,8 +13,15 @@
       {% endif %}
     {% endfor %}
   </ul>
-  <a href="{{ url_for('.framework_submission_lots', framework_slug=framework.slug) }}">
-    View submitted services
-  </a>
+  <p>
+    <a href="{{ url_for('.framework_submission_lots', framework_slug=framework.slug) }}">
+      View submitted services
+    </a>
+  </p>
+  <p>
+    <a href="{{ url_for('.framework_supplier_declaration_overview', framework_slug=framework.slug) }}">
+      View your declaration
+    </a>
+  </p>
 </li>
 {% endif %}

--- a/app/templates/frameworks/declaration_overview.html
+++ b/app/templates/frameworks/declaration_overview.html
@@ -27,28 +27,30 @@
 
 
 {% macro make_declaration_button_block() %}
-  {% if validates %}
-    {% if supplier_framework.declaration.status != "complete" %}
-    <form method="POST" action="">
-      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
-      {%
-        with
-        advice = true,
-        type = "save",
-        label = "Make declaration"
-      %}
-        {% include "toolkit/button.html" %}
-      {% endwith %}
-    </form>
-    {% endif %}
-    <p>
-      You can come back and edit your answers at any time before
-      {% if supplier_framework.declaration.status == "complete" %}
-        {{ framework_dates.framework_close_date|nbsp }}.
-      {% else %}
-        the deadline.
+  {% if framework.status == "open" %}
+    {% if validates %}
+      {% if supplier_framework.declaration.status != "complete" %}
+      <form method="POST" action="">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+        {%
+          with
+          advice = true,
+          type = "save",
+          label = "Make declaration"
+        %}
+          {% include "toolkit/button.html" %}
+        {% endwith %}
+      </form>
       {% endif %}
-    </p>
+      <p>
+        You can come back and edit your answers at any time before
+        {% if supplier_framework.declaration.status == "complete" %}
+          {{ framework_dates.framework_close_date|nbsp }}.
+        {% else %}
+          the deadline.
+        {% endif %}
+      </p>
+    {% endif %}
   {% endif %}
 {% endmacro %}
 
@@ -64,7 +66,7 @@
       {% endwith %}
     </div>
     <div class="column-two-thirds">
-      {% if supplier_framework.declaration.status != "complete" %}
+      {% if framework.status == "open" and supplier_framework.declaration.status != "complete" %}
         <p>
           You must {% if not validates %}answer all questions and{% endif %} make your declaration 
           before {{ framework_dates.framework_close_date|nbsp }} to apply to {{ framework.name }}.

--- a/app/templates/frameworks/declaration_overview.html
+++ b/app/templates/frameworks/declaration_overview.html
@@ -17,7 +17,7 @@
       },
       {
         "link": url_for(".framework_dashboard", framework_slug=framework.slug),
-        "label": "Apply to " + framework.name
+        "label": ("Apply to "+framework.name) if framework.status == "open" else ("Your "+framework.name+" application")
       }
     ]
   %}

--- a/app/templates/frameworks/declaration_overview.html
+++ b/app/templates/frameworks/declaration_overview.html
@@ -96,7 +96,7 @@
           {% call summary.row() %}
             {{ summary.field_name(question.label|question_references(section.get_question)) }}
             {% if section.editable %}
-              {% if section_errors %}
+              {% if framework.status == 'open' and section_errors %}
                 {% call summary.field() %}
                   {# We don't want a question anchor on the first question of each section; it should take them
                      to the top of the page so all content is visible #}

--- a/tests/app/main/helpers/validation/test_g7_declaration.py
+++ b/tests/app/main/helpers/validation/test_g7_declaration.py
@@ -186,7 +186,7 @@ def test_error_if_mitigation_factors_not_provided_when_required():
     del submission['SQ3-1k']
 
     dependent_fields = [
-        'SQ2-2a', 'SQ3-1a' 'SQ3-1b', 'SQ3-1c', 'SQ3-1d', 'SQ3-1e', 'SQ3-1f', 'SQ3-1g',
+        'SQ2-2a', 'SQ3-1a', 'SQ3-1b', 'SQ3-1c', 'SQ3-1d', 'SQ3-1e', 'SQ3-1f', 'SQ3-1g',
         'SQ3-1h-i', 'SQ3-1h-ii', 'SQ3-1i-i', 'SQ3-1i-ii', 'SQ3-1j'
     ]
     for field in dependent_fields:

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -932,6 +932,20 @@ class TestFrameworksDashboard(BaseApplicationTest):
             extracted_guidance_links = self._extract_guidance_links(doc)
 
             assert extracted_guidance_links == OrderedDict((
+                ("You submitted:", (
+                    (
+                        'View submitted services',
+                        '/suppliers/frameworks/g-cloud-7/submissions',
+                        None,
+                        None,
+                    ),
+                    (
+                        "View your declaration",
+                        "/suppliers/frameworks/g-cloud-7/declaration",
+                        None,
+                        None,
+                    ),
+                )),
                 ("Legal documents", (
                     (
                         'Download the standard framework agreement',
@@ -1067,6 +1081,20 @@ class TestFrameworksDashboard(BaseApplicationTest):
             extracted_guidance_links = self._extract_guidance_links(doc)
 
             assert extracted_guidance_links == OrderedDict((
+                ("You submitted:", (
+                    (
+                        'View submitted services',
+                        '/suppliers/frameworks/g-cloud-8/submissions',
+                        None,
+                        None,
+                    ),
+                    (
+                        "View your declaration",
+                        "/suppliers/frameworks/g-cloud-8/declaration",
+                        None,
+                        None,
+                    ),
+                )),
                 ("Legal documents", (
                     (
                         'Read the standard framework agreement',
@@ -1177,6 +1205,20 @@ class TestFrameworksDashboard(BaseApplicationTest):
 
             extracted_guidance_links = self._extract_guidance_links(doc)
             assert extracted_guidance_links == OrderedDict((
+                ("You submitted:", (
+                    (
+                        'View submitted services',
+                        '/suppliers/frameworks/g-cloud-8/submissions',
+                        None,
+                        None,
+                    ),
+                    (
+                        "View your declaration",
+                        "/suppliers/frameworks/g-cloud-8/declaration",
+                        None,
+                        None,
+                    ),
+                )),
                 ('Legal documents', (
                     (
                         'Read the standard framework agreement',
@@ -1262,6 +1304,20 @@ class TestFrameworksDashboard(BaseApplicationTest):
 
             extracted_guidance_links = self._extract_guidance_links(doc)
             assert extracted_guidance_links == OrderedDict((
+                ("You submitted:", (
+                    (
+                        'View submitted services',
+                        '/suppliers/frameworks/g-cloud-8/submissions',
+                        None,
+                        None,
+                    ),
+                    (
+                        "View your declaration",
+                        "/suppliers/frameworks/g-cloud-8/declaration",
+                        None,
+                        None,
+                    ),
+                )),
                 ('Legal documents', (
                     (
                         'Read the standard framework agreement',
@@ -1341,6 +1397,20 @@ class TestFrameworksDashboard(BaseApplicationTest):
 
             extracted_guidance_links = self._extract_guidance_links(doc)
             assert extracted_guidance_links == OrderedDict((
+                ("You submitted:", (
+                    (
+                        'View submitted services',
+                        '/suppliers/frameworks/g-cloud-8/submissions',
+                        None,
+                        None,
+                    ),
+                    (
+                        "View your declaration",
+                        "/suppliers/frameworks/g-cloud-8/declaration",
+                        None,
+                        None,
+                    ),
+                )),
                 ('Legal documents', (
                     (
                         'Read the standard framework agreement',
@@ -1569,6 +1639,20 @@ class TestFrameworksDashboard(BaseApplicationTest):
 
             extracted_guidance_links = self._extract_guidance_links(doc)
             assert extracted_guidance_links == OrderedDict((
+                ("You submitted:", (
+                    (
+                        'View submitted services',
+                        '/suppliers/frameworks/g-cloud-8/submissions',
+                        None,
+                        None,
+                    ),
+                    (
+                        "View your declaration",
+                        "/suppliers/frameworks/g-cloud-8/declaration",
+                        None,
+                        None,
+                    ),
+                )),
                 ('Legal documents', (
                     (
                         'Read the standard framework agreement',

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -2978,6 +2978,21 @@ class TestDeclarationOverview(BaseApplicationTest):
             assert response.status_code == 200
             doc = html.fromstring(response.get_data(as_text=True))
 
+            assert [e.xpath("normalize-space(string())") for e in doc.xpath(
+                "//nav//*[@role='breadcrumbs']//a",
+            )] == [
+                "Digital Marketplace",
+                "Your account",
+                "Your F-Cumulus 0 application",
+            ]
+            assert doc.xpath(
+                "//nav//*[@role='breadcrumbs']//a/@href",
+            ) == [
+                "/",
+                "/suppliers",
+                "/suppliers/frameworks/{}".format(framework_slug),
+            ]
+
             # there shouldn't be any links to the "edit" page
             assert not any(
                 urljoin("/suppliers/frameworks/{}/declaration".format(framework_slug), a.attrib["href"]).startswith(

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -2738,15 +2738,24 @@ class TestDeclarationOverview(BaseApplicationTest):
     _g7_parametrization = tuple(
         (
             "g-cloud-7",
-            dict(FULL_G7_SUBMISSION, status=decl_status),
-            True,
+            declaration,
+            decl_valid,
             None,
             # G7 doesn't (yet?) have any "short names" for questions and so will be listing the answers in the
             # overview against their full verbose questions so any sections that we wanted to assert the content of
             # would require a reference copy of all its full question texts kept here. we don't want to do this so for
             # now don't assert any G7 sections...
             (),
-        ) for decl_status in ("started", "complete",)
+        ) for declaration, decl_valid in chain(
+            (
+                (dict(FULL_G7_SUBMISSION, status=decl_status), True)
+                for decl_status in ("started", "complete",)
+            ),
+            (
+                (empty_decl, False)
+                for empty_decl in (None, {})
+            ),
+        )
     )
 
     @pytest.mark.parametrize(

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -1194,12 +1194,12 @@ class TestFrameworksDashboard(BaseApplicationTest):
 
             assert not doc.xpath(
                 "//main//a[@href=$href or normalize-space(string())=$label]",
-                href="/frameworks/g-cloud-7/agreement",
+                href="/frameworks/g-cloud-8/agreement",
                 label="Sign and return your framework agreement",
             )
             assert not doc.xpath(
                 "//main//a[@href=$href or normalize-space(string())=$label]",
-                href="/suppliers/frameworks/g-cloud-7/agreements/result-letter.pdf",
+                href="/suppliers/frameworks/g-cloud-8/agreements/result-letter.pdf",
                 label="Download your application result letter",
             )
 
@@ -1298,7 +1298,7 @@ class TestFrameworksDashboard(BaseApplicationTest):
 
             assert not doc.xpath(
                 "//main//a[@href=$href or normalize-space(string())=$label]",
-                href="/frameworks/g-cloud-7/agreement",
+                href="/frameworks/g-cloud-8/agreement",
                 label="Sign and return your framework agreement",
             )
 
@@ -1391,7 +1391,7 @@ class TestFrameworksDashboard(BaseApplicationTest):
 
             assert not doc.xpath(
                 "//main//a[@href=$href or normalize-space(string())=$label]",
-                href="/frameworks/g-cloud-7/agreement",
+                href="/frameworks/g-cloud-8/agreement",
                 label="Sign and return your framework agreement",
             )
 
@@ -1633,7 +1633,7 @@ class TestFrameworksDashboard(BaseApplicationTest):
 
             assert not doc.xpath(
                 "//main//a[@href=$href or normalize-space(string())=$label]",
-                href="/frameworks/g-cloud-7/agreement",
+                href="/frameworks/g-cloud-8/agreement",
                 label="Sign and return your framework agreement",
             )
 

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -2379,7 +2379,7 @@ class TestDeclarationOverview(BaseApplicationTest):
     # "framework_slug,declaration,decl_valid,prefill_fw_slug,expected_sections"
     _common_parametrization = tuple(
         chain.from_iterable(chain(
-        ((
+        ((  # noqa
             "g-cloud-9",
             empty_declaration,
             False,
@@ -2494,7 +2494,7 @@ class TestDeclarationOverview(BaseApplicationTest):
                 ),
             ),
         ) for empty_declaration in (None, {})),  # two possible ways of specifying a "empty" declaration - test both
-        ((
+        ((  # noqa
             "g-cloud-9",
             {
                 "status": "started",
@@ -2607,7 +2607,7 @@ class TestDeclarationOverview(BaseApplicationTest):
                         (
                             "Subcontractors or consortia",
                             "yourself without the use of third parties (subcontractors) as a prime contractor, using "
-                                "third parties (subcontractors) to provide all services",
+                                "third parties (subcontractors) to provide all services",  # noqa
                             (),
                             (),
                             (
@@ -2619,7 +2619,7 @@ class TestDeclarationOverview(BaseApplicationTest):
                 ),
             ),
         ),),
-        ((
+        ((  # noqa
             "g-cloud-9",
             dict(status=declaration_status, **(valid_g9_declaration_base())),
             True,

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -2359,136 +2359,143 @@ class TestDeclarationOverview(BaseApplicationTest):
         row_heading, edit_href, rows = section_information
         return row_heading, None, rows
 
-    def _setup_data_api_client(self, data_api_client, framework_status, declaration, prefill_fw_slug):
+    def _setup_data_api_client(self, data_api_client, framework_status, framework_slug, declaration, prefill_fw_slug):
         data_api_client.get_framework.side_effect = _assert_args_and_return(
-            self.framework(slug="g-cloud-9", name="G-Cloud 9", status=framework_status),
-            "g-cloud-9",
+            self.framework(slug=framework_slug, name="F-Cumulus 0", status=framework_status),
+            framework_slug,
         )
         data_api_client.get_supplier_framework_info.side_effect = _assert_args_and_return(
             self.supplier_framework(
-                framework_slug="g-cloud-9",
+                framework_slug=framework_slug,
                 declaration=declaration,
                 prefill_declaration_from_framework_slug=prefill_fw_slug,
             ),
             1234,
-            "g-cloud-9",
+            framework_slug,
         )
         data_api_client.set_supplier_declaration.side_effect = AssertionError("This shouldn't be called")
 
     # corresponds to the parametrization args:
-    # "declaration,decl_valid,prefill_fw_slug,expected_pss,expected_gme,expected_dys"
+    # "framework_slug,declaration,decl_valid,prefill_fw_slug,expected_sections"
     _common_parametrization = tuple(
         chain.from_iterable(chain(
         ((
-            empty_declaration,  # noqa
+            "g-cloud-9",
+            empty_declaration,
             False,
             prefill_fw_slug,
-            (   # expected result for "Providing suitable services" section as returned by _extract_section_information
-                "Providing suitable services",
-                "/suppliers/frameworks/g-cloud-9/declaration/edit/providing-suitable-services",
-                (
+            (
+                (   # expected result for "Providing suitable services" section as returned by
+                    # _extract_section_information
+                    "Providing suitable services",
+                    "/suppliers/frameworks/g-cloud-9/declaration/edit/providing-suitable-services",
                     (
-                        "Services are cloud-related",
-                        "Answer question",
-                        ("Answer question",),
-                        ("/suppliers/frameworks/g-cloud-9/declaration/edit/providing-suitable-services",),
-                        (),
-                    ),
-                    (
-                        "Services in scope for G-Cloud",
-                        "Answer question",
-                        ("Answer question",),
-                        ("/suppliers/frameworks/g-cloud-9/declaration/edit/providing-suitable-services#"
-                         "servicesDoNotInclude",),
-                        (),
-                    ),
-                    (
-                        "Buyers pay for what they use",
-                        "Answer question",
-                        ("Answer question",),
-                        ("/suppliers/frameworks/g-cloud-9/declaration/edit/providing-suitable-services#payForWhatUse",),
-                        (),
-                    ),
-                    (
-                        "What your team will deliver",
-                        "Answer question",
-                        ("Answer question",),
-                        ("/suppliers/frameworks/g-cloud-9/declaration/edit/providing-suitable-"
-                            "services#offerServicesYourselves",),
-                        (),
-                    ),
-                    (
-                        "Contractual responsibility and accountability",
-                        "Answer question",
-                        ("Answer question",),
-                        ("/suppliers/frameworks/g-cloud-9/declaration/edit/providing-suitable-"
-                            "services#fullAccountability",),
-                        (),
-                    ),
-                ),
-            ),
-            (   # expected result for "Grounds for mandatory exclusion" section as returned by
-                # _extract_section_information
-                "Grounds for mandatory exclusion",
-                "/suppliers/frameworks/g-cloud-9/declaration/edit/grounds-for-mandatory-exclusion",
-                (
-                    (
-                        "Organised crime or conspiracy convictions",
-                        q_link_text_prefillable_section,
-                        (q_link_text_prefillable_section,),
-                        ("/suppliers/frameworks/g-cloud-9/declaration/edit/grounds-for-mandatory-exclusion",),
-                        (),
-                    ),
-                    (
-                        "Bribery or corruption convictions",
-                        q_link_text_prefillable_section,
-                        (q_link_text_prefillable_section,),
-                        ("/suppliers/frameworks/g-cloud-9/declaration/edit/grounds-for-mandatory-"
-                            "exclusion#corruptionBribery",),
-                        (),
-                    ),
-                    (
-                        "Fraud convictions",
-                        q_link_text_prefillable_section,
-                        (q_link_text_prefillable_section,),
-                        ("/suppliers/frameworks/g-cloud-9/declaration/edit/grounds-for-mandatory-"
-                            "exclusion#fraudAndTheft",),
-                        (),
-                    ),
-                    (
-                        "Terrorism convictions",
-                        q_link_text_prefillable_section,
-                        (q_link_text_prefillable_section,),
-                        ("/suppliers/frameworks/g-cloud-9/declaration/edit/grounds-for-mandatory-exclusion#terrorism",),
-                        (),
-                    ),
-                    (
-                        "Organised crime convictions",
-                        q_link_text_prefillable_section,
-                        (q_link_text_prefillable_section,),
-                        ("/suppliers/frameworks/g-cloud-9/declaration/edit/grounds-for-mandatory-"
-                            "exclusion#organisedCrime",),
-                        (),
+                        (
+                            "Services are cloud-related",
+                            "Answer question",
+                            ("Answer question",),
+                            ("/suppliers/frameworks/g-cloud-9/declaration/edit/providing-suitable-services",),
+                            (),
+                        ),
+                        (
+                            "Services in scope for G-Cloud",
+                            "Answer question",
+                            ("Answer question",),
+                            ("/suppliers/frameworks/g-cloud-9/declaration/edit/providing-suitable-"
+                                "services#servicesDoNotInclude",),
+                            (),
+                        ),
+                        (
+                            "Buyers pay for what they use",
+                            "Answer question",
+                            ("Answer question",),
+                            ("/suppliers/frameworks/g-cloud-9/declaration/edit/providing-suitable-"
+                                "services#payForWhatUse",),
+                            (),
+                        ),
+                        (
+                            "What your team will deliver",
+                            "Answer question",
+                            ("Answer question",),
+                            ("/suppliers/frameworks/g-cloud-9/declaration/edit/providing-suitable-"
+                                "services#offerServicesYourselves",),
+                            (),
+                        ),
+                        (
+                            "Contractual responsibility and accountability",
+                            "Answer question",
+                            ("Answer question",),
+                            ("/suppliers/frameworks/g-cloud-9/declaration/edit/providing-suitable-"
+                                "services#fullAccountability",),
+                            (),
+                        ),
                     ),
                 ),
-            ),
-            (   # expected result for "How you’ll deliver your services" section as returned by
-                # _extract_section_information
-                u"How you’ll deliver your services",
-                "/suppliers/frameworks/g-cloud-9/declaration/edit/how-youll-deliver-your-services",
-                (
+                (   # expected result for "Grounds for mandatory exclusion" section as returned by
+                    # _extract_section_information
+                    "Grounds for mandatory exclusion",
+                    "/suppliers/frameworks/g-cloud-9/declaration/edit/grounds-for-mandatory-exclusion",
                     (
-                        "Subcontractors or consortia",
-                        q_link_text_prefillable_section,
-                        (q_link_text_prefillable_section,),
-                        ("/suppliers/frameworks/g-cloud-9/declaration/edit/how-youll-deliver-your-"
-                            "services",),
-                        (),
+                        (
+                            "Organised crime or conspiracy convictions",
+                            q_link_text_prefillable_section,
+                            (q_link_text_prefillable_section,),
+                            ("/suppliers/frameworks/g-cloud-9/declaration/edit/grounds-for-mandatory-exclusion",),
+                            (),
+                        ),
+                        (
+                            "Bribery or corruption convictions",
+                            q_link_text_prefillable_section,
+                            (q_link_text_prefillable_section,),
+                            ("/suppliers/frameworks/g-cloud-9/declaration/edit/grounds-for-mandatory-"
+                                "exclusion#corruptionBribery",),
+                            (),
+                        ),
+                        (
+                            "Fraud convictions",
+                            q_link_text_prefillable_section,
+                            (q_link_text_prefillable_section,),
+                            ("/suppliers/frameworks/g-cloud-9/declaration/edit/grounds-for-mandatory-"
+                                "exclusion#fraudAndTheft",),
+                            (),
+                        ),
+                        (
+                            "Terrorism convictions",
+                            q_link_text_prefillable_section,
+                            (q_link_text_prefillable_section,),
+                            ("/suppliers/frameworks/g-cloud-9/declaration/edit/grounds-for-mandatory-"
+                                "exclusion#terrorism",),
+                            (),
+                        ),
+                        (
+                            "Organised crime convictions",
+                            q_link_text_prefillable_section,
+                            (q_link_text_prefillable_section,),
+                            ("/suppliers/frameworks/g-cloud-9/declaration/edit/grounds-for-mandatory-"
+                                "exclusion#organisedCrime",),
+                            (),
+                        ),
+                    ),
+                ),
+                (   # expected result for "How you’ll deliver your services" section as returned by
+                    # _extract_section_information
+                    u"How you’ll deliver your services",
+                    "/suppliers/frameworks/g-cloud-9/declaration/edit/how-youll-deliver-your-services",
+                    (
+                        (
+                            "Subcontractors or consortia",
+                            q_link_text_prefillable_section,
+                            (q_link_text_prefillable_section,),
+                            ("/suppliers/frameworks/g-cloud-9/declaration/edit/how-youll-deliver-your-"
+                                "services",),
+                            (),
+                        ),
                     ),
                 ),
             ),
         ) for empty_declaration in (None, {})),  # two possible ways of specifying a "empty" declaration - test both
         ((
+            "g-cloud-9",
             {
                 "status": "started",
                 "conspiracy": True,
@@ -2503,209 +2510,217 @@ class TestDeclarationOverview(BaseApplicationTest):
             },
             False,
             prefill_fw_slug,
-            (   # expected result for "Providing suitable services" section as returned by _extract_section_information
-                "Providing suitable services",
-                "/suppliers/frameworks/g-cloud-9/declaration/edit/providing-suitable-services",
-                (
+            (
+                (   # expected result for "Providing suitable services" section as returned by
+                    # _extract_section_information
+                    "Providing suitable services",
+                    "/suppliers/frameworks/g-cloud-9/declaration/edit/providing-suitable-services",
                     (
-                        "Services are cloud-related",
-                        "Answer question",
-                        ("Answer question",),
-                        ("/suppliers/frameworks/g-cloud-9/declaration/edit/providing-suitable-services",),
-                        (),
-                    ),
-                    (
-                        "Services in scope for G-Cloud",
-                        "Answer question",
-                        ("Answer question",),
-                        ("/suppliers/frameworks/g-cloud-9/declaration/edit/providing-suitable-services#"
-                         "servicesDoNotInclude",),
-                        (),
-                    ),
-                    (
-                        "Buyers pay for what they use",
-                        "Answer question",
-                        ("Answer question",),
-                        ("/suppliers/frameworks/g-cloud-9/declaration/edit/providing-suitable-services#payForWhatUse",),
-                        (),
-                    ),
-                    (
-                        "What your team will deliver",
-                        "Answer question",
-                        ("Answer question",),
-                        ("/suppliers/frameworks/g-cloud-9/declaration/edit/providing-suitable-"
-                            "services#offerServicesYourselves",),
-                        (),
-                    ),
-                    (
-                        "Contractual responsibility and accountability",
-                        "Answer question",
-                        ("Answer question",),
-                        ("/suppliers/frameworks/g-cloud-9/declaration/edit/providing-suitable-"
-                            "services#fullAccountability",),
-                        (),
-                    ),
-                ),
-            ),
-            (   # expected result for "Grounds for mandatory exclusion" section as returned by
-                # _extract_section_information
-                "Grounds for mandatory exclusion",
-                "/suppliers/frameworks/g-cloud-9/declaration/edit/grounds-for-mandatory-exclusion",
-                (
-                    (
-                        "Organised crime or conspiracy convictions",
-                        "Yes",
-                        (),
-                        (),
-                        (),
-                    ),
-                    (
-                        "Bribery or corruption convictions",
-                        "No",
-                        (),
-                        (),
-                        (),
-                    ),
-                    (
-                        "Fraud convictions",
-                        "Yes",
-                        (),
-                        (),
-                        (),
-                    ),
-                    (
-                        "Terrorism convictions",
-                        "No",
-                        (),
-                        (),
-                        (),
-                    ),
-                    (
-                        "Organised crime convictions",
-                        "Yes",
-                        (),
-                        (),
-                        (),
-                    ),
-                ),
-            ),
-            (   # expected result for "How you’ll deliver your services" section as returned by
-                # _extract_section_information
-                u"How you’ll deliver your services",
-                "/suppliers/frameworks/g-cloud-9/declaration/edit/how-youll-deliver-your-services",
-                (
-                    (
-                        "Subcontractors or consortia",
-                        "yourself without the use of third parties (subcontractors) as a prime contractor, using "
-                            "third parties (subcontractors) to provide all services",
-                        (),
-                        (),
                         (
-                            "yourself without the use of third parties (subcontractors)",
-                            "as a prime contractor, using third parties (subcontractors) to provide all services",
+                            "Services are cloud-related",
+                            "Answer question",
+                            ("Answer question",),
+                            ("/suppliers/frameworks/g-cloud-9/declaration/edit/providing-suitable-services",),
+                            (),
+                        ),
+                        (
+                            "Services in scope for G-Cloud",
+                            "Answer question",
+                            ("Answer question",),
+                            ("/suppliers/frameworks/g-cloud-9/declaration/edit/providing-suitable-"
+                                "services#servicesDoNotInclude",),
+                            (),
+                        ),
+                        (
+                            "Buyers pay for what they use",
+                            "Answer question",
+                            ("Answer question",),
+                            ("/suppliers/frameworks/g-cloud-9/declaration/edit/providing-suitable-"
+                                "services#payForWhatUse",),
+                            (),
+                        ),
+                        (
+                            "What your team will deliver",
+                            "Answer question",
+                            ("Answer question",),
+                            ("/suppliers/frameworks/g-cloud-9/declaration/edit/providing-suitable-"
+                                "services#offerServicesYourselves",),
+                            (),
+                        ),
+                        (
+                            "Contractual responsibility and accountability",
+                            "Answer question",
+                            ("Answer question",),
+                            ("/suppliers/frameworks/g-cloud-9/declaration/edit/providing-suitable-"
+                                "services#fullAccountability",),
+                            (),
+                        ),
+                    ),
+                ),
+                (   # expected result for "Grounds for mandatory exclusion" section as returned by
+                    # _extract_section_information
+                    "Grounds for mandatory exclusion",
+                    "/suppliers/frameworks/g-cloud-9/declaration/edit/grounds-for-mandatory-exclusion",
+                    (
+                        (
+                            "Organised crime or conspiracy convictions",
+                            "Yes",
+                            (),
+                            (),
+                            (),
+                        ),
+                        (
+                            "Bribery or corruption convictions",
+                            "No",
+                            (),
+                            (),
+                            (),
+                        ),
+                        (
+                            "Fraud convictions",
+                            "Yes",
+                            (),
+                            (),
+                            (),
+                        ),
+                        (
+                            "Terrorism convictions",
+                            "No",
+                            (),
+                            (),
+                            (),
+                        ),
+                        (
+                            "Organised crime convictions",
+                            "Yes",
+                            (),
+                            (),
+                            (),
+                        ),
+                    ),
+                ),
+                (   # expected result for "How you’ll deliver your services" section as returned by
+                    # _extract_section_information
+                    u"How you’ll deliver your services",
+                    "/suppliers/frameworks/g-cloud-9/declaration/edit/how-youll-deliver-your-services",
+                    (
+                        (
+                            "Subcontractors or consortia",
+                            "yourself without the use of third parties (subcontractors) as a prime contractor, using "
+                                "third parties (subcontractors) to provide all services",
+                            (),
+                            (),
+                            (
+                                "yourself without the use of third parties (subcontractors)",
+                                "as a prime contractor, using third parties (subcontractors) to provide all services",
+                            ),
                         ),
                     ),
                 ),
             ),
         ),),
         ((
+            "g-cloud-9",
             dict(status=declaration_status, **(valid_g9_declaration_base())),
             True,
             prefill_fw_slug,
-            (   # expected result for "Providing suitable services" section as returned by _extract_section_information
-                "Providing suitable services",
-                "/suppliers/frameworks/g-cloud-9/declaration/edit/providing-suitable-services",
-                (
+            (
+                (   # expected result for "Providing suitable services" section as returned by
+                    # _extract_section_information
+                    "Providing suitable services",
+                    "/suppliers/frameworks/g-cloud-9/declaration/edit/providing-suitable-services",
                     (
-                        "Services are cloud-related",
-                        "Yes",
-                        (),
-                        (),
-                        (),
-                    ),
-                    (
-                        "Services in scope for G-Cloud",
-                        "Yes",
-                        (),
-                        (),
-                        (),
-                    ),
-                    (
-                        "Buyers pay for what they use",
-                        "Yes",
-                        (),
-                        (),
-                        (),
-                    ),
-                    (
-                        "What your team will deliver",
-                        "No",
-                        (),
-                        (),
-                        (),
-                    ),
-                    (
-                        "Contractual responsibility and accountability",
-                        "Yes",
-                        (),
-                        (),
-                        (),
-                    ),
-                ),
-            ),
-            (   # expected result for "Grounds for mandatory exclusion" section as returned by
-                # _extract_section_information
-                "Grounds for mandatory exclusion",
-                "/suppliers/frameworks/g-cloud-9/declaration/edit/grounds-for-mandatory-exclusion",
-                (
-                    (
-                        "Organised crime or conspiracy convictions",
-                        "No",
-                        (),
-                        (),
-                        (),
-                    ),
-                    (
-                        "Bribery or corruption convictions",
-                        "Yes",
-                        (),
-                        (),
-                        (),
-                    ),
-                    (
-                        "Fraud convictions",
-                        "No",
-                        (),
-                        (),
-                        (),
-                    ),
-                    (
-                        "Terrorism convictions",
-                        "Yes",
-                        (),
-                        (),
-                        (),
-                    ),
-                    (
-                        "Organised crime convictions",
-                        "No",
-                        (),
-                        (),
-                        (),
+                        (
+                            "Services are cloud-related",
+                            "Yes",
+                            (),
+                            (),
+                            (),
+                        ),
+                        (
+                            "Services in scope for G-Cloud",
+                            "Yes",
+                            (),
+                            (),
+                            (),
+                        ),
+                        (
+                            "Buyers pay for what they use",
+                            "Yes",
+                            (),
+                            (),
+                            (),
+                        ),
+                        (
+                            "What your team will deliver",
+                            "No",
+                            (),
+                            (),
+                            (),
+                        ),
+                        (
+                            "Contractual responsibility and accountability",
+                            "Yes",
+                            (),
+                            (),
+                            (),
+                        ),
                     ),
                 ),
-            ),
-            (   # expected result for "How you’ll deliver your services" section as returned by
-                # _extract_section_information
-                u"How you’ll deliver your services",
-                "/suppliers/frameworks/g-cloud-9/declaration/edit/how-youll-deliver-your-services",
-                (
+                (   # expected result for "Grounds for mandatory exclusion" section as returned by
+                    # _extract_section_information
+                    "Grounds for mandatory exclusion",
+                    "/suppliers/frameworks/g-cloud-9/declaration/edit/grounds-for-mandatory-exclusion",
                     (
-                        "Subcontractors or consortia",
-                        "yourself without the use of third parties (subcontractors)",
-                        (),
-                        (),
-                        (),
+                        (
+                            "Organised crime or conspiracy convictions",
+                            "No",
+                            (),
+                            (),
+                            (),
+                        ),
+                        (
+                            "Bribery or corruption convictions",
+                            "Yes",
+                            (),
+                            (),
+                            (),
+                        ),
+                        (
+                            "Fraud convictions",
+                            "No",
+                            (),
+                            (),
+                            (),
+                        ),
+                        (
+                            "Terrorism convictions",
+                            "Yes",
+                            (),
+                            (),
+                            (),
+                        ),
+                        (
+                            "Organised crime convictions",
+                            "No",
+                            (),
+                            (),
+                            (),
+                        ),
+                    ),
+                ),
+                (   # expected result for "How you’ll deliver your services" section as returned by
+                    # _extract_section_information
+                    u"How you’ll deliver your services",
+                    "/suppliers/frameworks/g-cloud-9/declaration/edit/how-youll-deliver-your-services",
+                    (
+                        (
+                            "Subcontractors or consortia",
+                            "yourself without the use of third parties (subcontractors)",
+                            (),
+                            (),
+                            (),
+                        ),
                     ),
                 ),
             ),
@@ -2716,26 +2731,43 @@ class TestDeclarationOverview(BaseApplicationTest):
         ("some-previous-framework", "Review answer",),
     )))
 
+    # corresponds to the parametrization args:
+    # "framework_slug,declaration,decl_valid,prefill_fw_slug,expected_sections"
+    #
+    # this is more straightforward than _common_parametrization because we only have to care about non-open frameworks
+    _g7_parametrization = tuple(
+        (
+            "g-cloud-7",
+            dict(FULL_G7_SUBMISSION, status=decl_status),
+            True,
+            None,
+            # G7 doesn't (yet?) have any "short names" for questions and so will be listing the answers in the
+            # overview against their full verbose questions so any sections that we wanted to assert the content of
+            # would require a reference copy of all its full question texts kept here. we don't want to do this so for
+            # now don't assert any G7 sections...
+            (),
+        ) for decl_status in ("started", "complete",)
+    )
+
     @pytest.mark.parametrize(
-        "declaration,decl_valid,prefill_fw_slug,expected_pss,expected_gme,expected_dys",
+        "framework_slug,declaration,decl_valid,prefill_fw_slug,expected_sections",
         _common_parametrization,
     )
     def test_display_open(
-            self,
-            data_api_client,
-            declaration,
-            decl_valid,
-            prefill_fw_slug,
-            expected_pss,
-            expected_gme,
-            expected_dys
-            ):
-        self._setup_data_api_client(data_api_client, "open", declaration, prefill_fw_slug)
+        self,
+        data_api_client,
+        framework_slug,
+        declaration,
+        decl_valid,
+        prefill_fw_slug,
+        expected_sections,
+    ):
+        self._setup_data_api_client(data_api_client, "open", framework_slug, declaration, prefill_fw_slug)
 
         with self.app.test_client():
             self.login()
 
-            response = self.client.get("/suppliers/frameworks/g-cloud-9/declaration")
+            response = self.client.get("/suppliers/frameworks/{}/declaration".format(framework_slug))
             assert response.status_code == 200
             doc = html.fromstring(response.get_data(as_text=True))
 
@@ -2744,25 +2776,25 @@ class TestDeclarationOverview(BaseApplicationTest):
             )] == [
                 "Digital Marketplace",
                 "Your account",
-                "Apply to G-Cloud 9",
+                "Apply to F-Cumulus 0",
             ]
             assert doc.xpath(
                 "//nav//*[@role='breadcrumbs']//a/@href",
             ) == [
                 "/",
                 "/suppliers",
-                "/suppliers/frameworks/g-cloud-9",
+                "/suppliers/frameworks/{}".format(framework_slug),
             ]
 
             assert bool(doc.xpath(
                 "//p[contains(normalize-space(string()), $t)][contains(normalize-space(string()), $f)]",
                 t="You must answer all questions and make your declaration before",
-                f="G-Cloud 9",
+                f="F-Cumulus 0",
             )) is (not decl_valid)
             assert bool(doc.xpath(
                 "//p[contains(normalize-space(string()), $t)][contains(normalize-space(string()), $f)]",
                 t="You must make your declaration before",
-                f="G-Cloud 9",
+                f="F-Cumulus 0",
             )) is (decl_valid and declaration.get("status") != "complete")
 
             assert len(doc.xpath(
@@ -2792,7 +2824,7 @@ class TestDeclarationOverview(BaseApplicationTest):
                     "[not(starts-with(@href, $u)) or @href=$u]",
                     a="Answer question",
                     b="Review answer",
-                    u="/suppliers/frameworks/g-cloud-9/declaration/",
+                    u="/suppliers/frameworks/{}/declaration/".format(framework_slug),
                 )
 
             if decl_valid and declaration.get("status") != "complete":
@@ -2802,8 +2834,8 @@ class TestDeclarationOverview(BaseApplicationTest):
                 )
                 assert len(mdf_actions) == 2
                 assert all(
-                    urljoin("/suppliers/frameworks/g-cloud-9/declaration", action) ==
-                    "/suppliers/frameworks/g-cloud-9/declaration"
+                    urljoin("/suppliers/frameworks/{}/declaration".format(framework_slug), action) ==
+                    "/suppliers/frameworks/{}/declaration".format(framework_slug)
                     for action in mdf_actions
                 )
             else:
@@ -2812,62 +2844,61 @@ class TestDeclarationOverview(BaseApplicationTest):
             assert doc.xpath(
                 "//a[normalize-space(string())=$t][@href=$u]",
                 t="Return to application",
-                u="/suppliers/frameworks/g-cloud-9",
+                u="/suppliers/frameworks/{}".format(framework_slug),
             )
 
-            assert self._extract_section_information(doc, "Providing suitable services") == expected_pss
-            assert self._extract_section_information(doc, "Grounds for mandatory exclusion") == expected_gme
-            assert self._extract_section_information(doc, u"How you’ll deliver your services") == expected_dys
+            for expected_section in expected_sections:
+                assert self._extract_section_information(doc, expected_section[0]) == expected_section
 
     @pytest.mark.parametrize(
-        "declaration,decl_valid,prefill_fw_slug,expected_pss,expected_gme,expected_dys",
+        "framework_slug,declaration,decl_valid,prefill_fw_slug,expected_sections",
         tuple(
             (
+                framework_slug,
                 declaration,
                 decl_valid,
                 prefill_fw_slug,
-                expected_pss,
-                expected_gme,
-                expected_dys,
+                expected_sections,
             )
-            for declaration, decl_valid, prefill_fw_slug, expected_pss, expected_gme, expected_dys
-            in _common_parametrization
+            for framework_slug, declaration, decl_valid, prefill_fw_slug, expected_sections
+            in chain(_common_parametrization, _g7_parametrization)
             if (declaration or {}).get("status") == "complete"
         )
     )
     @pytest.mark.parametrize("framework_status", ("pending", "standstill", "live", "expired",))
     def test_display_closed(
-            self,
-            data_api_client,
-            framework_status,
-            declaration,
-            decl_valid,
-            prefill_fw_slug,
-            expected_pss,
-            expected_gme,
-            expected_dys
-            ):
-        self._setup_data_api_client(data_api_client, framework_status, declaration, prefill_fw_slug)
+        self,
+        data_api_client,
+        framework_status,
+        framework_slug,
+        declaration,
+        decl_valid,
+        prefill_fw_slug,
+        expected_sections,
+    ):
+        self._setup_data_api_client(data_api_client, framework_status, framework_slug, declaration, prefill_fw_slug)
 
         with self.app.test_client():
             self.login()
 
-            response = self.client.get("/suppliers/frameworks/g-cloud-9/declaration")
+            response = self.client.get("/suppliers/frameworks/{}/declaration".format(framework_slug))
             assert response.status_code == 200
             doc = html.fromstring(response.get_data(as_text=True))
 
             # there shouldn't be any links to the "edit" page
             assert not any(
-                urljoin("/suppliers/frameworks/g-cloud-9/declaration", a.attrib["href"]).startswith(
-                    "/suppliers/frameworks/g-cloud-9/declaration/edit/"
+                urljoin("/suppliers/frameworks/{}/declaration".format(framework_slug), a.attrib["href"]).startswith(
+                    "/suppliers/frameworks/{}/declaration/edit/".format(framework_slug)
                 )
                 for a in doc.xpath("//a[@href]")
             )
 
             # no submittable forms should be pointing at ourselves
             assert not any(
-                urljoin("/suppliers/frameworks/g-cloud-9/declaration", form.attrib["action"]) == \
-                    "/suppliers/frameworks/g-cloud-9/declaration"
+                urljoin(
+                    "/suppliers/frameworks/{}/declaration".format(framework_slug),
+                    form.attrib["action"],
+                ) == "/suppliers/frameworks/{}/declaration".format(framework_slug)
                 for form in doc.xpath("//form[.//input[@type='submit']]")
             )
 
@@ -2877,56 +2908,45 @@ class TestDeclarationOverview(BaseApplicationTest):
             assert not doc.xpath("//p[contains(normalize-space(string()), $t)]", t="make your declaration")
             assert not doc.xpath("//p[contains(normalize-space(string()), $t)]", t="edit your answers")
 
-            assert self._extract_section_information(
-                doc,
-                "Providing suitable services",
-                expect_edit_link=False,
-            ) == self._section_information_strip_edit_href(expected_pss)
-            assert self._extract_section_information(
-                doc,
-                "Grounds for mandatory exclusion",
-                expect_edit_link=False,
-            ) == self._section_information_strip_edit_href(expected_gme)
-            assert self._extract_section_information(
-                doc,
-                u"How you’ll deliver your services",
-                expect_edit_link=False,
-            ) == self._section_information_strip_edit_href(expected_dys)
+            for expected_section in expected_sections:
+                assert self._extract_section_information(
+                    doc,
+                    expected_section[0],
+                    expect_edit_link=False,
+                ) == self._section_information_strip_edit_href(expected_section)
 
     @pytest.mark.parametrize(
-        "declaration,decl_valid,prefill_fw_slug,expected_pss,expected_gme,expected_dys",
+        "framework_slug,declaration,decl_valid,prefill_fw_slug,expected_sections",
         tuple(
             (
+                framework_slug,
                 declaration,
                 decl_valid,
                 prefill_fw_slug,
-                expected_pss,
-                expected_gme,
-                expected_dys,
+                expected_sections,
             )
-            for declaration, decl_valid, prefill_fw_slug, expected_pss, expected_gme, expected_dys
-            in _common_parametrization
+            for framework_slug, declaration, decl_valid, prefill_fw_slug, expected_sections
+            in chain(_common_parametrization, _g7_parametrization)
             if (declaration or {}).get("status") != "complete"
         )
     )
     @pytest.mark.parametrize("framework_status", ("pending", "standstill", "live", "expired",))
     def test_error_closed(
-            self,
-            data_api_client,
-            framework_status,
-            declaration,
-            decl_valid,
-            prefill_fw_slug,
-            expected_pss,
-            expected_gme,
-            expected_dys,
-            ):
-        self._setup_data_api_client(data_api_client, framework_status, declaration, prefill_fw_slug)
+        self,
+        data_api_client,
+        framework_status,
+        framework_slug,
+        declaration,
+        decl_valid,
+        prefill_fw_slug,
+        expected_sections,
+    ):
+        self._setup_data_api_client(data_api_client, framework_status, framework_slug, declaration, prefill_fw_slug)
 
         with self.app.test_client():
             self.login()
 
-            response = self.client.get("/suppliers/frameworks/g-cloud-9/declaration")
+            response = self.client.get("/suppliers/frameworks/{}/declaration".format(framework_slug))
             assert response.status_code == 410
 
 

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -3057,6 +3057,16 @@ class TestDeclarationOverview(BaseApplicationTest):
             response = self.client.get("/suppliers/frameworks/{}/declaration".format(framework_slug))
             assert response.status_code == 410
 
+    @pytest.mark.parametrize("framework_status", ("coming", "open", "pending", "standstill", "live", "expired",))
+    def test_error_nonexistent_framework(self, data_api_client, framework_status):
+        self._setup_data_api_client(data_api_client, framework_status, "g-cloud-31415", {"status": "complete"}, None)
+
+        with self.app.test_client():
+            self.login()
+
+            response = self.client.get("/suppliers/frameworks/g-cloud-31415/declaration")
+            assert response.status_code == 404
+
 
 @mock.patch('app.main.views.frameworks.data_api_client', autospec=True)
 class TestDeclarationSubmit(BaseApplicationTest):

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -14,8 +14,6 @@ from freezegun import freeze_time
 from tests.app.helpers import BaseApplicationTest, empty_g7_draft_service, empty_g9_draft_service
 
 
-# this is mostly a workaround for pytest not being able to do parametrization with unittest-derived class methods
-# otherwise it doesn't get us much over function parametrization...
 @pytest.fixture(params=(
     # a tuple of framework_slug, framework_name, framework_editable_services
     ("g-cloud-6", "G-Cloud 6", True,),
@@ -26,9 +24,7 @@ def supplier_service_editing_fw_params(request):
     return request.param
 
 
-# and these fixtures really are just a workaround to not being able to use plain function parametrization in unittest-
-# derived classes and should be replaced with that as soon as we're able to do so. hence the hence the oddly specific
-# long names
+# find a better way of organizing this than using oddly specific long names
 @pytest.fixture(params=(
     # a tuple of service status, service_belongs_to_user, expect_api_call_if_data, expected_status_code
     ("published", True, True, 302,),


### PR DESCRIPTION
Story https://www.pivotaltracker.com/story/show/140222101

In the story it was decided to cope with all `complete` declarations for non-open frameworks and ignore whether a supplier was `onFramework` or not. Suppliers with non-`complete` declarations for a framework will receive a `410` (see code for reasoning).

One consequence of this is that non-open frameworks end up with no introductory text or paragraph on this page.

~~~Works back to G7 though in an ugly way because pre-G9 questions didn't tend to have "short" question text variants to use in the table. (screenshots coming...)~~~ ~~~~doesn't appear to work properly on G7, will need to look at this...~~~~ ok it does seem to work, it was just the mock declaration that was wrong...

~~~One thing still TBD is where/how this page will get linked to from the framework dashboard in non-open states. Currently it just isn't (but navigating to the url manually will allow a user to see this page, which could still be useful to allow an admin to direct a user to this page if there's some dispute...)~~~ @MuriloDalRi  has done this now