### PR TITLE
Change "Pass" to "Successful" and deal with failed lots

### DIFF
--- a/app/main/helpers/services.py
+++ b/app/main/helpers/services.py
@@ -21,7 +21,7 @@ def get_drafts(apiclient, framework_slug):
     except APIError as e:
         abort(e.status_code)
 
-    complete_drafts = [draft for draft in drafts if draft['status'] == 'submitted']
+    complete_drafts = [draft for draft in drafts if draft['status'] in ('submitted', 'failed')]
     drafts = [draft for draft in drafts if draft['status'] == 'not-submitted']
 
     return drafts, complete_drafts

--- a/app/templates/frameworks/contract_start.html
+++ b/app/templates/frameworks/contract_start.html
@@ -64,7 +64,7 @@
         ) %}
           {% call summary.row() %}
             {{ summary.text(item.name) }}
-            {{ summary.text('Pass' if item.has_completed_draft else 'No application') }}
+            {{ summary.text(item.result) }}
           {% endcall %}
         {% endcall %}
       </div>

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -1909,14 +1909,16 @@ class TestFrameworkAgreement(BaseApplicationTest):
             data_api_client.find_draft_services.return_value = {
                 'services': [
                     {'lotSlug': 'saas', 'status': 'submitted'},
+                    {'lotSlug': 'saas', 'status': 'not-submitted'},
+                    {'lotSlug': 'paas', 'status': 'failed'},
                     {'lotSlug': 'scs', 'status': 'submitted'}
                 ]
             }
             expected_lots_and_statuses = [
-                ('Software as a Service', 'Pass'),
-                ('Platform as a Service', 'No application'),
+                ('Software as a Service', 'Successful'),
+                ('Platform as a Service', 'Unsuccessful'),
                 ('Infrastructure as a Service', 'No application'),
-                ('Specialist Cloud Services', 'Pass'),
+                ('Specialist Cloud Services', 'Successful'),
             ]
 
             res = self.client.get("/suppliers/frameworks/g-cloud-8/agreement")


### PR DESCRIPTION
For this story: https://www.pivotaltracker.com/story/show/144514369

Suppliers prefer the word "Successful" to "Pass", and it matches what we say in the emails to them.

Also, turns out the page was not dealing with DOS-style frameworks properly and showing failed lots as "No application".  This fixes it so that if a lot was submitted but failed it will show "Unsuccessul" rather than "No application".