### PR TITLE
Bugfix service summary table when not editable

### DIFF
--- a/app/templates/services/_base_service_page.html
+++ b/app/templates/services/_base_service_page.html
@@ -91,6 +91,11 @@
                 {% else %}
                   {{ summary.link('Answer question', url_for(".edit_service_submission", framework_slug=framework.slug, lot_slug=service_data.lot, service_id=service_id, section_id=section.id, question_slug=question.slug)) }}
                 {% endif %}
+              {% else %}
+                {# We need to call this (even if with nothing) to add the final column to the row, otherwise the row
+                   terminates early and the line separators between rows do not span the entire width of the table. #}
+                {% call summary.field(action=True) %}
+                {% endcall %}
               {% endif %}
             {% else %}
               {{ summary[question.type](question.value, question.assurance) }}

--- a/bower.json
+++ b/bower.json
@@ -7,6 +7,6 @@
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
     "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#22.2.2",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.19.2/jinja_govuk_template-0.19.2.tgz",
-    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#7.1.0"
+    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#8.1.1"
   }
 }


### PR DESCRIPTION
Fixes this bug: https://www.pivotaltracker.com/story/show/144683417

Also pulls in the correct G-Cloud 9 framework agreement URLs, so tests passing depend on the following PR being merged (still waiting for the final-FINAL-v3 URL to update that though): 
 - [x] https://github.com/alphagov/digitalmarketplace-frameworks/pull/423

# BEFORE
![screen shot 2017-05-05 at 11 16 23](https://cloud.githubusercontent.com/assets/6525554/25742097/c323e0fc-3185-11e7-8ac5-4ef0e569151b.png)

# AFTER
![screen shot 2017-05-05 at 11 16 40](https://cloud.githubusercontent.com/assets/6525554/25742101/c62f57ea-3185-11e7-8ecf-19c3706e95a7.png)
