### PR TITLE
Bring in bugfix for show-hide questions in IE8

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "jquery": "1.11.2",
     "hogan": "3.0.2",
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
-    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#22.2.2",
+    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#22.2.5",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.19.2/jinja_govuk_template-0.19.2.tgz",
     "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#8.1.1"
   }


### PR DESCRIPTION
Brings in a bugfix to get the show-hide thing working for IE8 users applying to briefs.

It's been QA'd to the max by me, but it would be good to get someone else to look at it.

More context ->  https://github.com/alphagov/digitalmarketplace-frontend-toolkit/pull/334