### PR TITLE
Set up docker image build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+.git
+*
+
+!app/
+!application.py
+!bower.json
+!config.py
+!gulpfile.js
+!package.json
+!requirements.txt
+!scripts/build.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,1 @@
+FROM digitalmarketplace/base-frontend

--- a/Makefile
+++ b/Makefile
@@ -46,4 +46,15 @@ show_environment:
 	@echo "Environment variables in use:"
 	@env | grep DM_ || true
 
-.PHONY: run_all run_app virtualenv requirements requirements_for_test npm_install frontend_build test test_flake8 test_python test_javascript show_environment
+
+docker-build:
+	$(if ${RELEASE_NAME},,$(eval export RELEASE_NAME=$(shell git describe)))
+	@echo "Building a docker image for ${RELEASE_NAME}..."
+	docker build --pull -t digitalmarketplace/supplier-frontend --build-arg release_name=${RELEASE_NAME} .
+	docker tag digitalmarketplace/supplier-frontend digitalmarketplace/supplier-frontend:${RELEASE_NAME}
+
+docker-push:
+	$(if ${RELEASE_NAME},,$(eval export RELEASE_NAME=$(shell git describe)))
+	docker push digitalmarketplace/supplier-frontend:${RELEASE_NAME}
+
+.PHONY: run_all run_app virtualenv requirements requirements_for_test npm_install frontend_build test test_flake8 test_python test_javascript show_environment docker-build docker-push

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "gulp": "3.8.7",
     "gulp-filelog": "0.4.1",
     "gulp-include": "1.1.1",
-    "gulp-sass": "2.0.4",
+    "gulp-sass": "3.1.0",
     "gulp-shell": "0.2.9",
     "gulp-uglify": "1.4.0",
     "gulp-sourcemaps": "1.5.2",


### PR DESCRIPTION
Adds Dockerfile and a make build-docker task.
New image is build on the base-api image, which has the ONBUILD
commands required to install api dependencies and copy the app
files.

This also adds a whitelist dockerignore. By default, docker will
use everything in the current directory (including eg .git) as
the build context and since our base images use `COPY .` the files
end up in the public container.

To avoid accidentally pushing any sensitive / modified files we're
using the .dockerignore as a whitelist: it will only copy the files
that are matched by the `!...` patterns.

Any new top-level files or directories used either during the app
runtime or the docker build process will need to be added to the
.dockerignore list or they won't be accessible from the image.

### Update gulp-sass to use a pre-built binary on Alpine

Older versions of gulp-sass don't recognize the Alpine pre-built
binary and recompile the bindings during the docker build, adding
a dependency on g++ and slowing down the build process.

There are no CHANGELOG notes for the gulp-sass 3.0 major update.