### PR TITLE
Remove plain text logs in live

### DIFF
--- a/config.py
+++ b/config.py
@@ -75,6 +75,7 @@ class Config(object):
 
     # Logging
     DM_LOG_LEVEL = 'DEBUG'
+    DM_PLAIN_TEXT_LOGS = False
     DM_LOG_PATH = None
     DM_APP_NAME = 'supplier-frontend'
     DM_DOWNSTREAM_REQUEST_ID_HEADER = 'X-Amz-Cf-Id'
@@ -91,6 +92,7 @@ class Config(object):
 
 class Test(Config):
     DEBUG = True
+    DM_PLAIN_TEXT_LOGS = True
     DM_LOG_LEVEL = 'CRITICAL'
     WTF_CSRF_ENABLED = False
     SERVER_NAME = 'localhost'
@@ -111,6 +113,7 @@ class Test(Config):
 
 class Development(Config):
     DEBUG = True
+    DM_PLAIN_TEXT_LOGS = True
     SESSION_COOKIE_SECURE = False
 
     # Dates not formatted like YYYY-(0)M-(0)D will fail

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ Flask-WTF==0.12
 werkzeug==0.10.4
 python-dateutil==2.4.2
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@25.1.0#egg=digitalmarketplace-utils==25.1.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@25.2.0#egg=digitalmarketplace-utils==25.2.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.2.0#egg=digitalmarketplace-content-loader==4.2.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@8.5.0#egg=digitalmarketplace-apiclient==8.5.0
 


### PR DESCRIPTION
Trello card: https://trello.com/c/o3Jkp3rK

25.2.0 of utils will create json logs by default, unless the
DM_PLAIN_TEXT_LOGS config variable is set to True in the config.

This config variable is set in dev and test so that logs are more
legible/useful.

The other thing 25.2.0 does is log to stdout instead of file by default,
unless the DM_LOG_PATH config variable is set. In the PaaS
environment, we'll need to log to stdout so will overwrite this
variable. Logging to stdout is also more useful in dev and test.