### PR TITLE
Allow suppliers to view their DOS services

### DIFF
--- a/app/main/__init__.py
+++ b/app/main/__init__.py
@@ -23,6 +23,7 @@ content_loader.load_messages('digital-outcomes-and-specialists', ['dates', 'urls
 
 content_loader.load_manifest('digital-outcomes-and-specialists-2', 'declaration', 'declaration')
 content_loader.load_manifest('digital-outcomes-and-specialists-2', 'services', 'edit_submission')
+content_loader.load_manifest('digital-outcomes-and-specialists-2', 'services', 'edit_service')
 content_loader.load_manifest('digital-outcomes-and-specialists-2', 'briefs', 'edit_brief')
 content_loader.load_manifest('digital-outcomes-and-specialists-2', 'brief-responses', 'edit_brief_response')
 content_loader.load_manifest('digital-outcomes-and-specialists-2', 'brief-responses', 'display_brief_response')

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -67,10 +67,12 @@ def remove_service(service_id):
     if not is_service_associated_with_supplier(service):
         abort(404)
 
+    # dos services should not be removable
+    if 'digital-outcomes-and-specialists' == service["frameworkFramework"]:
+        abort(404)
+
     # we don't actually need the content here, we're just probing to see whether service editing should be allowed for
     # this framework (signalled by the exsitence of the edit_service manifest
-    if 'digital-outcomes-and-specialists' in service["frameworkSlug"]:
-        abort(404)
     try:
         content_loader.get_manifest(service["frameworkSlug"], 'edit_service')
     except ContentNotFoundError:

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -69,6 +69,8 @@ def remove_service(service_id):
 
     # we don't actually need the content here, we're just probing to see whether service editing should be allowed for
     # this framework (signalled by the exsitence of the edit_service manifest
+    if 'digital-outcomes-and-specialists' in service["frameworkSlug"]:
+        abort(404)
     try:
         content_loader.get_manifest(service["frameworkSlug"], 'edit_service')
     except ContentNotFoundError:

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -68,11 +68,11 @@ def remove_service(service_id):
         abort(404)
 
     # dos services should not be removable
-    if 'digital-outcomes-and-specialists' == service["frameworkFramework"]:
+    if service["frameworkFramework"] == 'digital-outcomes-and-specialists':
         abort(404)
 
     # we don't actually need the content here, we're just probing to see whether service editing should be allowed for
-    # this framework (signalled by the exsitence of the edit_service manifest
+    # this framework (signalled by the existence of the edit_service manifest
     try:
         content_loader.get_manifest(service["frameworkSlug"], 'edit_service')
     except ContentNotFoundError:

--- a/app/templates/services/_base_service_page.html
+++ b/app/templates/services/_base_service_page.html
@@ -79,45 +79,7 @@
           field_headings_visible=False
         ) %}
           {% call summary.row() %}
-            {{ summary.field_name(question.label) }}
-            {% if question.is_empty %}
-              {% if framework and framework.status == 'open' and section.edit_questions %}
-                {% if lot.oneServiceLimit %}
-                  {% if question.empty_message %}
-                    {% call summary.field() %}
-                      <span class="summary-item-field-answer-required">{{ question.empty_message }}</span>
-                    {% endcall %}
-                  {% endif %}
-                {% else %}
-                  {{ summary.link('Answer question', url_for(".edit_service_submission", framework_slug=framework.slug, lot_slug=service_data.lot, service_id=service_id, section_id=section.id, question_slug=question.slug)) }}
-                {% endif %}
-              {% else %}
-                {# We need to call this (even if with nothing) to add the final column to the row, otherwise the row
-                   terminates early and the line separators between rows do not span the entire width of the table. #}
-                {% call summary.field(action=True) %}
-                {% endcall %}
-              {% endif %}
-            {% else %}
-              {{ summary[question.type](question.value, question.assurance) }}
-            {% endif %}
-            {% if framework.status == 'open' %}
-              {% if section.edit_questions and not question.is_empty %}
-                {% if lot.oneServiceLimit %}
-                  {{ summary.remove_link('Remove', url_for(".remove_subsection", framework_slug=framework.slug, lot_slug=service_data.lot, service_id=service_id, section_id=section.id, question_slug=question.slug)) }}
-                {% endif %}
-                {{ summary.edit_link('Edit', url_for(".edit_service_submission", framework_slug=framework.slug, lot_slug=service_data.lot, service_id=service_id, section_id=section.id, question_slug=question.slug)) }}
-              {% elif section.edit_questions and lot.oneServiceLimit %}
-                {% if lot.oneServiceLimit %}
-                  {% call summary.field() %}
-                  {% endcall %}
-                {% endif %}
-                {{ summary.edit_link('Add', url_for(".edit_service_submission", framework_slug=framework.slug, lot_slug=service_data.lot, service_id=service_id, section_id=section.id, question_slug=question.slug)) }}
-              {% else %}
-                {% call summary.field(action=True) %}
-                  {{ 'Optional' if question.get('optional') else '' }}
-                {% endcall %}
-              {% endif %}
-            {% endif %}
+            {% block summary_row scoped %}{% endblock %}
           {% endcall %}
         {% endcall %}
       {% endfor %}

--- a/app/templates/services/list_services.html
+++ b/app/templates/services/list_services.html
@@ -57,20 +57,10 @@
     empty_message="You don't have any services on the Digital Marketplace"
   ) %}
     {% call summary.row() %}
-
-     {# TODO this should be removed once we have a manifests for DOS services
-        and a public DOS service page on the buyer frontend (or a way to hide
-        the "View service" link from the supplier service page) #}
-      {% if item.frameworkFramework == 'digital-outcomes-and-specialists' %}
-        {% call summary.field(first=True, wide=wide) -%}
-          {{ item.serviceName or item.lotName }}
-        {%- endcall %}
-      {% else %}
-        {{ summary.service_link(
-            item.serviceName or item.lotName,
-            url_for('.edit_service', service_id=item.id)
-        ) }}
-      {% endif %}
+      {{ summary.service_link(
+          item.serviceName or item.lotName,
+          url_for('.edit_service', service_id=item.id)
+      ) }}
 
       {{ summary.text(item.frameworkName) }}
 

--- a/app/templates/services/service.html
+++ b/app/templates/services/service.html
@@ -57,6 +57,7 @@
 {% endblock %}
 
 {% block before_sections %}
+  {% if "digital-outcomes-and-specialists" not in service_data.frameworkSlug %}
     <div class="column-two-thirds">
       <div class="view-service-link">
         {%
@@ -68,6 +69,7 @@
         {% endwith %}
       </div>
     </div>
+  {% endif %}
   {% if error %}
     <div class="column-one-whole">
       {% with

--- a/app/templates/services/service.html
+++ b/app/templates/services/service.html
@@ -57,7 +57,7 @@
 {% endblock %}
 
 {% block before_sections %}
-  {% if "digital-outcomes-and-specialists" not in service_data.frameworkSlug %}
+  {% if "digital-outcomes-and-specialists" != service_data.frameworkFramework %}
     <div class="column-two-thirds">
       <div class="view-service-link">
         {%
@@ -89,7 +89,7 @@
 {% endblock %}
 
 {% block after_sections %}
-  {% if service_data.status == 'published' and not remove_requested and "digital-outcomes-and-specialists" not in service_data.frameworkSlug %}
+  {% if service_data.status == 'published' and not remove_requested and "digital-outcomes-and-specialists" != service_data.frameworkFramework %}
     <div class="column-two-thirds">
       <div class="edit-service-status-panel">
         <h2>Remove this service</h2>

--- a/app/templates/services/service.html
+++ b/app/templates/services/service.html
@@ -57,7 +57,7 @@
 {% endblock %}
 
 {% block before_sections %}
-  {% if "digital-outcomes-and-specialists" != service_data.frameworkFramework %}
+  {% if service_data.frameworkFramework != "digital-outcomes-and-specialists" %}
     <div class="column-two-thirds">
       <div class="view-service-link">
         {%
@@ -96,7 +96,7 @@
 {% endblock %}
 
 {% block after_sections %}
-  {% if service_data.status == 'published' and not remove_requested and "digital-outcomes-and-specialists" != service_data.frameworkFramework %}
+  {% if service_data.status == 'published' and not remove_requested and service_data.frameworkFramework != "digital-outcomes-and-specialists" %}
     <div class="column-two-thirds">
       <div class="edit-service-status-panel">
         <h2>Remove this service</h2>

--- a/app/templates/services/service.html
+++ b/app/templates/services/service.html
@@ -89,7 +89,7 @@
 {% endblock %}
 
 {% block after_sections %}
-  {% if service_data.status == 'published' and not remove_requested %}
+  {% if service_data.status == 'published' and not remove_requested and "digital-outcomes-and-specialists" not in service_data.frameworkSlug %}
     <div class="column-two-thirds">
       <div class="edit-service-status-panel">
         <h2>Remove this service</h2>

--- a/app/templates/services/service.html
+++ b/app/templates/services/service.html
@@ -88,6 +88,13 @@
   {% endif %}
 {% endblock %}
 
+{% block summary_row %}
+  {% if not question.is_empty %}
+    {{ summary.field_name(question.label) }}
+    {{ summary[question.type](question.value, question.assurance) }}
+  {% endif %}
+{% endblock %}
+
 {% block after_sections %}
   {% if service_data.status == 'published' and not remove_requested and "digital-outcomes-and-specialists" != service_data.frameworkFramework %}
     <div class="column-two-thirds">

--- a/app/templates/services/service_submission.html
+++ b/app/templates/services/service_submission.html
@@ -125,13 +125,53 @@
   {% endif %}
 {% endblock %}
 
-
 {% block edit_link %}
   {% if framework.status == 'open' %}
     {{ summary.top_link("Edit", url_for(".edit_service_submission", framework_slug=framework.slug, lot_slug=service_data.lot, service_id=service_id, section_id=section.id)) }}
   {% endif %}
 {% endblock %}
 
+{% block summary_row %}
+  {{ summary.field_name(question.label) }}
+  {% if question.is_empty %}
+    {% if framework and framework.status == 'open' and section.edit_questions %}
+      {% if lot.oneServiceLimit %}
+        {% if question.empty_message %}
+          {% call summary.field() %}
+            <span class="summary-item-field-answer-required">{{ question.empty_message }}</span>
+          {% endcall %}
+        {% endif %}
+      {% else %}
+        {{ summary.link('Answer question', url_for(".edit_service_submission", framework_slug=framework.slug, lot_slug=service_data.lot, service_id=service_id, section_id=section.id, question_slug=question.slug)) }}
+      {% endif %}
+    {% else %}
+      {# We need to call this (even if with nothing) to add the final column to the row, otherwise the row
+         terminates early and the line separators between rows do not span the entire width of the table. #}
+      {% call summary.field(action=True) %}
+      {% endcall %}
+    {% endif %}
+  {% else %}
+    {{ summary[question.type](question.value, question.assurance) }}
+  {% endif %}
+  {% if framework.status == 'open' %}
+    {% if section.edit_questions and not question.is_empty %}
+      {% if lot.oneServiceLimit %}
+        {{ summary.remove_link('Remove', url_for(".remove_subsection", framework_slug=framework.slug, lot_slug=service_data.lot, service_id=service_id, section_id=section.id, question_slug=question.slug)) }}
+      {% endif %}
+      {{ summary.edit_link('Edit', url_for(".edit_service_submission", framework_slug=framework.slug, lot_slug=service_data.lot, service_id=service_id, section_id=section.id, question_slug=question.slug)) }}
+    {% elif section.edit_questions and lot.oneServiceLimit %}
+      {% if lot.oneServiceLimit %}
+        {% call summary.field() %}
+        {% endcall %}
+      {% endif %}
+      {{ summary.edit_link('Add', url_for(".edit_service_submission", framework_slug=framework.slug, lot_slug=service_data.lot, service_id=service_id, section_id=section.id, question_slug=question.slug)) }}
+    {% else %}
+      {% call summary.field(action=True) %}
+        {{ 'Optional' if question.get('optional') else '' }}
+      {% endcall %}
+    {% endif %}
+  {% endif %}
+{% endblock %}
 
 {% block after_sections %}
   {% if not delete_requested %}

--- a/bower.json
+++ b/bower.json
@@ -7,6 +7,6 @@
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
     "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#22.2.5",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.19.2/jinja_govuk_template-0.19.2.tgz",
-    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#8.3.1"
+    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#8.7.0"
   }
 }

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -18,6 +18,8 @@ from tests.app.helpers import BaseApplicationTest, empty_g7_draft_service, empty
     # a tuple of framework_slug, framework_name, framework_editable_services
     ("g-cloud-6", "G-Cloud 6", True,),
     ("g-cloud-7", "G-Cloud 7", True,),
+    ("g-cloud-8", "G-Cloud 8", True,),
+    ("g-cloud-9", "G-Cloud 9", True,),
     ("digital-outcomes-and-specialists", "Digital outcomes and specialists", False,),
 ))
 def supplier_service_editing_fw_params(request):
@@ -203,7 +205,7 @@ class _BaseTestSupplierEditRemoveService(BaseApplicationTest):
 
 
 @mock.patch('app.main.views.services.data_api_client')
-class TestSupplierEditService(_BaseTestSupplierEditRemoveService):
+class SupplierEditServiceTestsSharedAcrossFrameworks(_BaseTestSupplierEditRemoveService):
     def test_should_view_public_service_with_correct_message(
             self, data_api_client, supplier_service_editing_fw_params
     ):
@@ -366,6 +368,37 @@ class TestSupplierEditService(_BaseTestSupplierEditRemoveService):
         res = self.client.get("/suppliers/services/123")
         assert res.status_code == 302
         assert res.location == 'http://localhost/login?next=%2Fsuppliers%2Fservices%2F123'
+
+
+class TestSupplierEditGCloudService(SupplierEditServiceTestsSharedAcrossFrameworks):
+    pass
+
+
+@mock.patch('app.main.views.services.data_api_client')
+class TestSupplierViewDosServices(_BaseTestSupplierEditRemoveService):
+    def test_supplier_can_view_their_dos_service_details(
+            self, data_api_client
+    ):
+        framework_slug, framework_name = "digital-outcomes-and-specialists-2", "Digital outcomes and specialists 2"
+        self.login()
+        self._setup_service(data_api_client, framework_slug, framework_name, service_status='published')
+
+        res = self.client.get('/suppliers/services/123')
+
+        assert res.status_code == 200
+
+        assert 'Service name 123' in res.get_data(as_text=True)
+
+    def test_no_link_to_public_service_page(self, data_api_client):
+        framework_slug, framework_name = "digital-outcomes-and-specialists-2", "Digital outcomes and specialists 2"
+        self.login()
+        self._setup_service(data_api_client, framework_slug, framework_name, service_status='published')
+
+        res = self.client.get('/suppliers/services/123')
+
+        assert res.status_code == 200
+
+        assert 'View service page on the Digital Marketplace' not in res.get_data(as_text=True)
 
 
 @mock.patch('app.main.views.services.data_api_client')

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -400,6 +400,18 @@ class TestSupplierViewDosServices(_BaseTestSupplierEditRemoveService):
 
         assert 'View service page on the Digital Marketplace' not in res.get_data(as_text=True)
 
+    def test_no_remove_service_section(self, data_api_client):
+        framework_slug, framework_name = "digital-outcomes-and-specialists-2", "Digital outcomes and specialists 2"
+        self.login()
+        self._setup_service(data_api_client, framework_slug, framework_name, service_status='published')
+
+        res = self.client.get('/suppliers/services/123')
+        
+        self.assert_not_in_strip_whitespace(
+            'Remove this service',
+            res.get_data(as_text=True)
+        )
+
 
 @mock.patch('app.main.views.services.data_api_client')
 class TestSupplierRemoveServiceEditInterplay(_BaseTestSupplierEditRemoveService):

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -219,11 +219,9 @@ class SupplierEditServiceTestsSharedAcrossFrameworks(_BaseTestSupplierEditRemove
         self.login()
         self._setup_service(
             data_api_client,
-            self.framework_slug,
-            self.framework_framework,
-            self.framework_name,
             service_status='published',
-            service_belongs_to_user=False
+            service_belongs_to_user=False,
+            **self.framework_kwargs
         )
 
         res = self.client.get('/suppliers/services/123')
@@ -233,10 +231,8 @@ class SupplierEditServiceTestsSharedAcrossFrameworks(_BaseTestSupplierEditRemove
     def test_should_redirect_to_login_if_not_logged_in(self, data_api_client):
         self._setup_service(
             data_api_client,
-            self.framework_slug,
-            self.framework_framework,
-            self.framework_name,
-            service_status='published'
+            service_status='published',
+            **self.framework_kwargs
         )
         res = self.client.get("/suppliers/services/123")
         assert res.status_code == 302
@@ -245,18 +241,18 @@ class SupplierEditServiceTestsSharedAcrossFrameworks(_BaseTestSupplierEditRemove
 
 @mock.patch('app.main.views.services.data_api_client')
 class TestSupplierEditGCloudService(SupplierEditServiceTestsSharedAcrossFrameworks):
-    framework_slug = "g-cloud-9"
-    framework_framework = "g-cloud"
-    framework_name = "G-Cloud 9"
+    framework_kwargs = {
+        "framework_slug": "g-cloud-9",
+        "framework_framework": "g-cloud",
+        "framework_name": "G-Cloud 9"
+    }
 
     def test_should_view_public_service_with_correct_message(self, data_api_client):
         self.login()
         self._setup_service(
             data_api_client,
-            self.framework_slug,
-            self.framework_framework,
-            self.framework_name,
-            service_status='published'
+            service_status='published',
+            **self.framework_kwargs
         )
 
         res = self.client.get('/suppliers/services/123')
@@ -299,10 +295,8 @@ class TestSupplierEditGCloudService(SupplierEditServiceTestsSharedAcrossFramewor
         self.login()
         self._setup_service(
             data_api_client,
-            self.framework_slug,
-            self.framework_framework,
-            self.framework_name,
-            service_status='published'
+            service_status='published',
+            **self.framework_kwargs
         )
 
         # this is meant to emulate a "service updated" message
@@ -351,10 +345,8 @@ class TestSupplierEditGCloudService(SupplierEditServiceTestsSharedAcrossFramewor
         self.login()
         self._setup_service(
             data_api_client,
-            self.framework_slug,
-            self.framework_framework,
-            self.framework_name,
-            service_status='enabled'
+            service_status='enabled',
+            **self.framework_kwargs
         )
 
         res = self.client.get('/suppliers/services/123')
@@ -376,10 +368,8 @@ class TestSupplierEditGCloudService(SupplierEditServiceTestsSharedAcrossFramewor
         self.login()
         self._setup_service(
             data_api_client,
-            self.framework_slug,
-            self.framework_framework,
-            self.framework_name,
-            service_status='disabled'
+            service_status='disabled',
+            **self.framework_kwargs
         )
 
         res = self.client.get('/suppliers/services/123')
@@ -400,18 +390,18 @@ class TestSupplierEditGCloudService(SupplierEditServiceTestsSharedAcrossFramewor
 class TestSupplierEditDosServices(SupplierEditServiceTestsSharedAcrossFrameworks):
     """Although the route tested is the edit service page, DOS services are not editable or removable and are only
     viewable at the moment"""
-    framework_slug = "digital-outcomes-and-specialists-2"
-    framework_framework = "digital-outcomes-and-specialists"
-    framework_name = "Digital outcomes and specialists 2"
+    framework_kwargs = {
+        "framework_slug": "digital-outcomes-and-specialists-2",
+        "framework_framework": "digital-outcomes-and-specialists",
+        "framework_name": "Digital outcomes and specialists 2"
+    }
 
     def test_supplier_can_view_their_dos_service_details(self, data_api_client):
         self.login()
         self._setup_service(
             data_api_client,
-            self.framework_slug,
-            self.framework_framework,
-            self.framework_name,
-            service_status='published'
+            service_status='published',
+            **self.framework_kwargs
         )
         res = self.client.get('/suppliers/services/123')
 
@@ -422,10 +412,8 @@ class TestSupplierEditDosServices(SupplierEditServiceTestsSharedAcrossFrameworks
         self.login()
         self._setup_service(
             data_api_client,
-            self.framework_slug,
-            self.framework_framework,
-            self.framework_name,
-            service_status='published'
+            service_status='published',
+            **self.framework_kwargs
         )
         res = self.client.get('/suppliers/services/123')
 
@@ -435,10 +423,8 @@ class TestSupplierEditDosServices(SupplierEditServiceTestsSharedAcrossFrameworks
         self.login()
         self._setup_service(
             data_api_client,
-            self.framework_slug,
-            self.framework_framework,
-            self.framework_name,
-            service_status='published'
+            service_status='published',
+            **self.framework_kwargs
         )
         res = self.client.get('/suppliers/services/123')
 

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -140,29 +140,6 @@ class TestListServices(BaseApplicationTest):
 
             assert "Special Lot Name" in res.get_data(as_text=True)
 
-    @mock.patch('app.main.views.services.data_api_client')
-    def test_shows_dos_service_name_without_edit_link(self, data_api_client):
-        with self.app.test_client():
-            self.login()
-
-            data_api_client.find_services.return_value = {
-                'services': [{
-                    'serviceName': 'Service name 123',
-                    'lotName': 'Special Lot Name',
-                    'status': 'published',
-                    'id': '123',
-                    'frameworkSlug': 'digital-outcomes-and-specialists-2',
-                    'frameworkFramework': 'digital-outcomes-and-specialists',
-                }]
-            }
-
-            res = self.client.get('/suppliers/services')
-            assert res.status_code == 200
-            data_api_client.find_services.assert_called_once_with(supplier_id=1234)
-
-            assert "Service name 123" in res.get_data(as_text=True)
-            assert "/suppliers/services/123" not in res.get_data(as_text=True)
-
 
 class TestListServicesLogin(BaseApplicationTest):
     @mock.patch('app.main.views.services.data_api_client')

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -15,9 +15,19 @@ from tests.app.helpers import BaseApplicationTest, empty_g7_draft_service, empty
 
 
 @pytest.fixture(params=(
-    # a tuple of framework_slug, framework_name, framework_editable_services
-    ("g-cloud-9", "G-Cloud 9", True,),
-    ("digital-outcomes-and-specialists-2", "Digital outcomes and specialists 2", False,),
+    # a tuple of framework_slug, framework_framework, framework_name, framework_editable_services
+    (
+        "g-cloud-9",
+        "g-cloud",
+        "G-Cloud 9",
+        True
+    ),
+    (
+        "digital-outcomes-and-specialists-2",
+        "digital-outcomes-and-specialists",
+        "Digital outcomes and specialists 2",
+        False
+    )
 ))
 def supplier_service_editing_fw_params(request):
     return request.param
@@ -170,6 +180,7 @@ class _BaseTestSupplierEditRemoveService(BaseApplicationTest):
             self,
             data_api_client,
             framework_slug,
+            framework_framework,
             framework_name,
             service_status="published",
             service_belongs_to_user=True,
@@ -182,6 +193,7 @@ class _BaseTestSupplierEditRemoveService(BaseApplicationTest):
                 'id': '123',
                 'frameworkName': framework_name,
                 'frameworkSlug': framework_slug,
+                'frameworkFramework': framework_framework,
                 'supplierId': 1234 if service_belongs_to_user else 1235,
             }
         }
@@ -208,6 +220,7 @@ class SupplierEditServiceTestsSharedAcrossFrameworks(_BaseTestSupplierEditRemove
         self._setup_service(
             data_api_client,
             self.framework_slug,
+            self.framework_framework,
             self.framework_name,
             service_status='published',
             service_belongs_to_user=False
@@ -219,7 +232,12 @@ class SupplierEditServiceTestsSharedAcrossFrameworks(_BaseTestSupplierEditRemove
 
     def test_should_redirect_to_login_if_not_logged_in(self, data_api_client):
         self._setup_service(
-            data_api_client, self.framework_slug, self.framework_name, service_status='published')
+            data_api_client,
+            self.framework_slug,
+            self.framework_framework,
+            self.framework_name,
+            service_status='published'
+        )
         res = self.client.get("/suppliers/services/123")
         assert res.status_code == 302
         assert res.location == 'http://localhost/login?next=%2Fsuppliers%2Fservices%2F123'
@@ -228,11 +246,18 @@ class SupplierEditServiceTestsSharedAcrossFrameworks(_BaseTestSupplierEditRemove
 @mock.patch('app.main.views.services.data_api_client')
 class TestSupplierEditGCloudService(SupplierEditServiceTestsSharedAcrossFrameworks):
     framework_slug = "g-cloud-9"
+    framework_framework = "g-cloud"
     framework_name = "G-Cloud 9"
 
     def test_should_view_public_service_with_correct_message(self, data_api_client):
         self.login()
-        self._setup_service(data_api_client, self.framework_slug, self.framework_name, service_status='published')
+        self._setup_service(
+            data_api_client,
+            self.framework_slug,
+            self.framework_framework,
+            self.framework_name,
+            service_status='published'
+        )
 
         res = self.client.get('/suppliers/services/123')
 
@@ -272,7 +297,13 @@ class TestSupplierEditGCloudService(SupplierEditServiceTestsSharedAcrossFramewor
 
     def test_should_view_public_service_with_update_message(self, data_api_client):
         self.login()
-        self._setup_service(data_api_client, self.framework_slug, self.framework_name, service_status='published')
+        self._setup_service(
+            data_api_client,
+            self.framework_slug,
+            self.framework_framework,
+            self.framework_name,
+            service_status='published'
+        )
 
         # this is meant to emulate a "service updated" message
         with self.client.session_transaction() as session:
@@ -318,7 +349,13 @@ class TestSupplierEditGCloudService(SupplierEditServiceTestsSharedAcrossFramewor
 
     def test_should_view_private_service_with_correct_message(self, data_api_client):
         self.login()
-        self._setup_service(data_api_client, self.framework_slug, self.framework_name, service_status='enabled')
+        self._setup_service(
+            data_api_client,
+            self.framework_slug,
+            self.framework_framework,
+            self.framework_name,
+            service_status='enabled'
+        )
 
         res = self.client.get('/suppliers/services/123')
 
@@ -337,7 +374,13 @@ class TestSupplierEditGCloudService(SupplierEditServiceTestsSharedAcrossFramewor
 
     def test_should_view_disabled_service_with_removed_message(self, data_api_client):
         self.login()
-        self._setup_service(data_api_client, self.framework_slug, self.framework_name, service_status='disabled')
+        self._setup_service(
+            data_api_client,
+            self.framework_slug,
+            self.framework_framework,
+            self.framework_name,
+            service_status='disabled'
+        )
 
         res = self.client.get('/suppliers/services/123')
 
@@ -358,11 +401,18 @@ class TestSupplierEditDosServices(SupplierEditServiceTestsSharedAcrossFrameworks
     """Although the route tested is the edit service page, DOS services are not editable or removable and are only
     viewable at the moment"""
     framework_slug = "digital-outcomes-and-specialists-2"
+    framework_framework = "digital-outcomes-and-specialists"
     framework_name = "Digital outcomes and specialists 2"
 
     def test_supplier_can_view_their_dos_service_details(self, data_api_client):
         self.login()
-        self._setup_service(data_api_client, self.framework_slug, self.framework_name, service_status='published')
+        self._setup_service(
+            data_api_client,
+            self.framework_slug,
+            self.framework_framework,
+            self.framework_name,
+            service_status='published'
+        )
         res = self.client.get('/suppliers/services/123')
 
         assert res.status_code == 200
@@ -370,14 +420,26 @@ class TestSupplierEditDosServices(SupplierEditServiceTestsSharedAcrossFrameworks
 
     def test_no_link_to_public_service_page(self, data_api_client):
         self.login()
-        self._setup_service(data_api_client, self.framework_slug, self.framework_name, service_status='published')
+        self._setup_service(
+            data_api_client,
+            self.framework_slug,
+            self.framework_framework,
+            self.framework_name,
+            service_status='published'
+        )
         res = self.client.get('/suppliers/services/123')
 
         assert 'View service page on the Digital Marketplace' not in res.get_data(as_text=True)
 
     def test_no_remove_service_section(self, data_api_client):
         self.login()
-        self._setup_service(data_api_client, self.framework_slug, self.framework_name, service_status='published')
+        self._setup_service(
+            data_api_client,
+            self.framework_slug,
+            self.framework_framework,
+            self.framework_name,
+            service_status='published'
+        )
         res = self.client.get('/suppliers/services/123')
 
         self.assert_not_in_strip_whitespace(
@@ -396,9 +458,16 @@ class TestSupplierRemoveServiceEditInterplay(_BaseTestSupplierEditRemoveService)
     def test_should_view_confirmation_message_if_first_remove_service_button_clicked(
             self, data_api_client, supplier_service_editing_fw_params
     ):
-        framework_slug, framework_name, framework_editable_services = supplier_service_editing_fw_params
+        framework_slug, framework_framework, framework_name, framework_editable_services = \
+            supplier_service_editing_fw_params
         self.login()
-        self._setup_service(data_api_client, framework_slug, framework_name, service_status='published')
+        self._setup_service(
+            data_api_client,
+            framework_slug,
+            framework_framework,
+            framework_name,
+            service_status='published'
+        )
 
         # NOTE two http requests performed here
         res = self.client.post('/suppliers/services/123/remove', follow_redirects=True)
@@ -430,9 +499,16 @@ class TestSupplierRemoveServiceEditInterplay(_BaseTestSupplierEditRemoveService)
     def test_should_view_correct_notification_message_if_service_removed(
             self, data_api_client, supplier_service_editing_fw_params
     ):
-        framework_slug, framework_name, framework_editable_services = supplier_service_editing_fw_params
+        framework_slug, framework_framework, framework_name, framework_editable_services = \
+            supplier_service_editing_fw_params
         self.login()
-        self._setup_service(data_api_client, framework_slug, framework_name, service_status='published')
+        self._setup_service(
+            data_api_client,
+            framework_slug,
+            framework_framework,
+            framework_name,
+            service_status='published'
+        )
 
         # NOTE two http requests performed here
         res = self.client.post(
@@ -466,7 +542,8 @@ class TestSupplierRemoveService(_BaseTestSupplierEditRemoveService):
             supplier_remove_service__service_status__expected_results,
             supplier_remove_service__post_data,
     ):
-        framework_slug, framework_name, framework_editable_services = supplier_service_editing_fw_params
+        framework_slug, framework_framework, framework_name, framework_editable_services = \
+            supplier_service_editing_fw_params
         service_status, service_belongs_to_user, expect_api_call_if_data, expected_status_code = \
             supplier_remove_service__service_status__expected_results
         post_data = supplier_remove_service__post_data
@@ -475,6 +552,7 @@ class TestSupplierRemoveService(_BaseTestSupplierEditRemoveService):
         self._setup_service(
             data_api_client,
             framework_slug,
+            framework_framework,
             framework_name,
             service_status=service_status,
             service_belongs_to_user=service_belongs_to_user,


### PR DESCRIPTION
Trello: https://trello.com/c/iptxy2Oy/397-allow-dos-suppliers-to-view-their-services

### Key functionality
- Page for all 4 DOS lots
- G cloud services should remain exactly the same
- No link to public service page for DOS services
- Should not be able to remove a DOS service
- Removed DOS services should the banner that they have been removed
- DOS services should have no links to edit their information
- User can not guess URLs and edit a DOS service
- Empty summary table rows are not shown (i.e. specialist roles and outcomes capabilities)
- Functional tests PR ready to go - https://github.com/alphagov/digitalmarketplace-functional-tests/pull/296

### View service list
![image](https://user-images.githubusercontent.com/7228605/27090258-9e966082-5054-11e7-9cd6-5a088b333143.png)

### Digital specialists
![image](https://user-images.githubusercontent.com/7228605/27295127-c35be810-5513-11e7-8ab4-11cc5712bf37.png)

### Digital outcomes
![image](https://user-images.githubusercontent.com/7228605/27295170-d92b4ce4-5513-11e7-87a9-2d8d5b821288.png)

### User research participants
![image](https://user-images.githubusercontent.com/7228605/27090395-00cd6e9e-5055-11e7-8de8-41ebcd6d0cec.png)

### User research labs
![image](https://user-images.githubusercontent.com/7228605/27090437-174f5024-5055-11e7-93b6-210f0a5120f9.png)


