### PR TITLE
Allow suppliers to view their applications

### DIFF
--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -1203,7 +1203,7 @@ def opportunities_dashboard(framework_slug):
     if not (framework['framework'] == 'digital-outcomes-and-specialists' and supplier_framework['onFramework']):
         abort(404)
     opportunities = data_api_client.find_brief_responses(
-        supplier_id=current_user.supplier_id,
+        supplier_id=current_user.supplier_id, framework=framework_slug
     )['briefResponses']
 
     return render_template(

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -1187,3 +1187,27 @@ def view_contract_variation(framework_slug, variation_slug):
         agreed_details=agreed_details,
         supplier_name=supplier_name,
     ), 400 if form_errors else 200
+
+
+@main.route('/frameworks/<framework_slug>/opportunities', methods=['GET'])
+@login_required
+def opportunities_dashboard(framework_slug):
+    try:
+        framework = data_api_client.get_framework(slug=framework_slug)['frameworks']
+        supplier_framework = data_api_client.get_supplier_framework_info(
+            supplier_id=current_user.supplier_id,
+            framework_slug=framework['slug']
+        )['frameworkInterest']
+    except APIError as e:
+        abort(e.status_code)
+    if not (framework['framework'] == 'digital-outcomes-and-specialists' and supplier_framework['onFramework']):
+        abort(404)
+    opportunities = data_api_client.find_brief_responses(
+        supplier_id=current_user.supplier_id,
+    )['briefResponses']
+
+    return render_template(
+        "suppliers/opportunities_dashboard.html",
+        framework=framework,
+        completed=opportunities
+    ), 200

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -63,7 +63,6 @@ def dashboard():
                 framework.get('onFramework') and framework.get('agreementReturned') is False
             )
         })
-
     return render_template(
         "suppliers/dashboard.html",
         supplier=supplier,

--- a/app/templates/briefs/view_response_result.html
+++ b/app/templates/briefs/view_response_result.html
@@ -148,8 +148,8 @@
 
   {%
     with
-      url = url_for(".dashboard"),
-      text = "Your account"
+      url = url_for(".opportunities_dashboard", framework_slug=brief.frameworkSlug),
+      text = "Your {} applications".format(brief.frameworkName)
   %}
     {% include "toolkit/secondary-action-link.html" %}
   {% endwith %}

--- a/app/templates/suppliers/_frameworks_live.html
+++ b/app/templates/suppliers/_frameworks_live.html
@@ -2,7 +2,7 @@
 
 {{ summary.heading("Current services") }}
 {% if frameworks.live %}
-  {{ summary.top_link('View', url_for('.list_services')) }}
+  {{ summary.top_link('View services', url_for('.list_services')) }}
 {% endif %}
 {% call(framework) summary.list_table(
   frameworks.live,
@@ -29,8 +29,14 @@
         </p>
       {% endif %}
     {% endcall %}
+
     {% if framework.onFramework and not framework.needs_to_complete_declaration %}
-      {{ summary.edit_link('View documents and ask a question', url_for('.framework_dashboard', framework_slug=framework.slug)) }}
+        {% call summary.field() %}
+            {% if framework.framework == 'digital-outcomes-and-specialists' %}
+                <a href="{{ url_for('.opportunities_dashboard', framework_slug=framework.slug) }}">View your opportunities</a><br>
+            {% endif %}
+            <a href="{{ url_for('.framework_dashboard', framework_slug=framework.slug) }}">View documents and ask a question</a>
+        {% endcall %}
     {% else %}
       {% call summary.field() %}
       {% endcall %}

--- a/app/templates/suppliers/_frameworks_live.html
+++ b/app/templates/suppliers/_frameworks_live.html
@@ -31,7 +31,7 @@
     {% endcall %}
 
     {% if framework.onFramework and not framework.needs_to_complete_declaration %}
-        {% call summary.field() %}
+        {% call summary.field(action=True) %}
             {% if framework.framework == 'digital-outcomes-and-specialists' %}
                 <a href="{{ url_for('.opportunities_dashboard', framework_slug=framework.slug) }}">View your opportunities</a><br>
             {% endif %}

--- a/app/templates/suppliers/opportunities_dashboard.html
+++ b/app/templates/suppliers/opportunities_dashboard.html
@@ -25,7 +25,8 @@
 
         <div class="column-two-thirds">
             {% with
-                heading = 'Your {} opportunities'.format(framework.name)
+                heading = 'Your {} opportunities'.format(framework.name),
+                smaller = True
             %}
             {% include 'toolkit/page-heading.html' %}
             {% endwith %}
@@ -34,11 +35,12 @@
 
   <p>
     <a href={{ "/{}/opportunities".format(framework.framework) }}>
-      Search for other opportunities on the Digital Marketplace
+      Search for opportunities
     </a>
   </p>
 
-{{ summary.heading("Completed", id="completed-opportunities") }}
+
+{{ summary.heading("Applications you’ve made", id="completed-opportunities") }}
 {% call(item) summary.list_table(
     completed|sort(attribute='brief.applicationsClosedAt'),
     caption="Completed opportunities",
@@ -52,7 +54,7 @@
 ) %}
 
     {% call summary.row() %}
-        {% call summary.field() %}
+        {% call summary.field(first=True, wide=True) %}
             <a href={{ "/{}/opportunities/{}".format(framework.framework, item.briefId) }}>{{ item.brief.title }}</a>
         {% endcall %}
         {{ summary.text(item.brief.applicationsClosedAt|dateformat) }}

--- a/app/templates/suppliers/opportunities_dashboard.html
+++ b/app/templates/suppliers/opportunities_dashboard.html
@@ -58,7 +58,7 @@
             <a href={{ "/{}/opportunities/{}".format(framework.framework, item.briefId) }}>{{ item.brief.title }}</a>
         {% endcall %}
         {{ summary.text(item.brief.applicationsClosedAt|dateformat) }}
-        {{ summary.link("View application", url_for(".view_response_result", brief_id=item.briefId)) if not item.brief.status == 'withdrawn' else summary.text() }}
+        {{ summary.edit_link("View application", url_for(".view_response_result", brief_id=item.briefId)) if not item.brief.status == 'withdrawn' else summary.text() }}
     {% endcall %}
 {% endcall %}
 

--- a/app/templates/suppliers/opportunities_dashboard.html
+++ b/app/templates/suppliers/opportunities_dashboard.html
@@ -1,0 +1,63 @@
+{% extends "_base_page.html" %}
+{% import "toolkit/summary-table.html" as summary %}
+{% block page_title %}Opportunities Overview - Digital Marketplace{% endblock %}
+
+{% block breadcrumb %}
+  {%
+    with items = [
+    {
+        "link": "/",
+        "label": "Digital Marketplace"
+    },
+    {
+        "link": url_for(".dashboard"),
+        "label": "Your account"
+    }
+    ]
+  %}
+    {% include "toolkit/breadcrumb.html" %}
+  {% endwith %}
+{% endblock %}
+
+{% block main_content %}
+
+    <div class="grid-row">
+
+        <div class="column-two-thirds">
+            {% with
+                heading = 'Your {} opportunities'.format(framework.name)
+            %}
+            {% include 'toolkit/page-heading.html' %}
+            {% endwith %}
+        </div>
+    </div>
+
+  <p>
+    <a href={{ "/{}/opportunities".format(framework.framework) }}>
+      Search for other opportunities on the Digital Marketplace
+    </a>
+  </p>
+
+{{ summary.heading("Completed", id="completed-opportunities") }}
+{% call(item) summary.list_table(
+    completed|sort(attribute='brief.applicationsClosedAt'),
+    caption="Completed opportunities",
+    empty_message="You haven’t applied to any opportunities",
+    field_headings=[
+        "Opportunity",
+        "Application closing date",
+        summary.hidden_field_heading("View")
+    ],
+    field_headings_visible=True
+) %}
+
+    {% call summary.row() %}
+        {% call summary.field() %}
+            <a href={{ "/{}/opportunities/{}".format(framework.framework, item.briefId) }}>{{ item.brief.title }}</a>
+        {% endcall %}
+        {{ summary.text(item.brief.applicationsClosedAt|dateformat) }}
+        {{ summary.link("View application", url_for(".view_response_result", brief_id=item.briefId)) if not item.brief.status == 'withdrawn' else summary.text() }}
+    {% endcall %}
+{% endcall %}
+
+{% endblock %}

--- a/app/templates/suppliers/opportunities_dashboard.html
+++ b/app/templates/suppliers/opportunities_dashboard.html
@@ -35,19 +35,19 @@
 
   <p>
     <a href={{ "/{}/opportunities".format(framework.framework) }}>
-      Search for opportunities
+      Search for other opportunities
     </a>
   </p>
 
 
 {{ summary.heading("Applications you’ve made", id="submitted-opportunities") }}
 {% call(item) summary.list_table(
-    completed|sort(attribute='brief.applicationsClosedAt'),
+    completed|sort(attribute='brief.applicationsClosedAt', reverse=True),
     caption="Completed opportunities",
     empty_message="You haven’t applied to any opportunities",
     field_headings=[
         "Opportunity",
-        "Application closing date",
+        "Closing date",
         summary.hidden_field_heading("View")
     ],
     field_headings_visible=True

--- a/app/templates/suppliers/opportunities_dashboard.html
+++ b/app/templates/suppliers/opportunities_dashboard.html
@@ -40,7 +40,7 @@
   </p>
 
 
-{{ summary.heading("Applications you’ve made", id="completed-opportunities") }}
+{{ summary.heading("Applications you’ve made", id="submitted-opportunities") }}
 {% call(item) summary.list_table(
     completed|sort(attribute='brief.applicationsClosedAt'),
     caption="Completed opportunities",

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ python-dateutil==2.4.2
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@27.1.0#egg=digitalmarketplace-utils==27.1.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.2.0#egg=digitalmarketplace-content-loader==4.2.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@8.5.0#egg=digitalmarketplace-apiclient==8.5.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@8.11.0#egg=digitalmarketplace-apiclient==8.11.0
 
 # Pinned requirements
 Jinja2==2.9.5

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -5843,7 +5843,7 @@ class TestOpportunitiesDashboard(BaseApplicationTest):
             }
         ]}
 
-    def get_table_rows(self, table_name, data_api_client):
+    def get_table_rows_by_id(self, table_id, data_api_client):
         """Helper function to get our 3 table rows as strings."""
         data_api_client.get_framework.return_value = self.framework_response
         data_api_client.get_supplier_framework_info.return_value = self.supplier_framework_response
@@ -5853,17 +5853,13 @@ class TestOpportunitiesDashboard(BaseApplicationTest):
             res = self.client.get(self.opportunities_dashboard_url)
 
             doc = html.fromstring(res.get_data(as_text=True))
-
-            xpath_string = (
-                "//*[@class='summary-item-heading'][normalize-space(text())='{}']"
-                "/following-sibling::table[1]"
-            ).format(table_name)
+            xpath_string = ".//*[@id='{}']/following-sibling::table[1]".format(table_id)
 
             table = doc.xpath(xpath_string)[0]
-            first_row, second_row, third_row = table.find_class('summary-item-row')
+            rows = table.find_class('summary-item-row')
 
             assert res.status_code == 200
-        return first_row.xpath('string()'), second_row.xpath('string()'), third_row.xpath('string()')
+        return [i.xpath('string()') for i in rows]
 
     def test_request_works_and_correct_data_is_fetched(self, data_api_client):
         data_api_client.get_supplier_framework_info.return_value = self.supplier_framework_response
@@ -5915,7 +5911,7 @@ class TestOpportunitiesDashboard(BaseApplicationTest):
 
     def test_completed_list_of_opportunities(self, data_api_client):
         """Assert the 'Completed opportunities' table on this page contains the correct values."""
-        first_row, second_row, third_row = self.get_table_rows('Completed', data_api_client)
+        first_row, second_row, third_row = self.get_table_rows_by_id('submitted-opportunities', data_api_client)
 
         assert 'Lowest date, submitted, mid id' in first_row
         assert 'Tuesday 6 June 2017' in first_row
@@ -5923,14 +5919,14 @@ class TestOpportunitiesDashboard(BaseApplicationTest):
 
     def test_completed_list_of_opportunities_ordered_by_applications_closed_at(self, data_api_client):
         """Assert the 'Completed opportunities' table on this page contains the brief responses in the correct order."""
-        first_row, second_row, third_row = self.get_table_rows('Completed', data_api_client)
+        first_row, second_row, third_row = self.get_table_rows_by_id('submitted-opportunities', data_api_client)
 
         assert 'Lowest date' in first_row
         assert 'Mid date' in second_row
         assert 'Highest date' in third_row
 
     def test_withdrawn_has_no_link_to_application(self, data_api_client):
-        first_row, second_row, third_row = self.get_table_rows('Completed', data_api_client)
+        first_row, second_row, third_row = self.get_table_rows_by_id('submitted-opportunities', data_api_client)
 
         assert 'View application' in first_row
         assert 'View application' not in second_row

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -5816,7 +5816,8 @@ class TestOpportunitiesDashboard(BaseApplicationTest):
                 'brief': {
                     'title': 'Highest date, submitted, lowest id',
                     'applicationsClosedAt': '2017-06-08T10:26:21.538917Z',
-                    'status': 'closed'
+                    'status': 'closed',
+                    'frameworkSlug': 'digital-outcomes-and-specialists-2'
                 },
                 'status': 'submitted',
             },
@@ -5825,7 +5826,8 @@ class TestOpportunitiesDashboard(BaseApplicationTest):
                 'brief': {
                     'title': 'Lowest date, submitted, mid id',
                     'applicationsClosedAt': '2017-06-06T10:26:21.538917Z',
-                    'status': 'closed'
+                    'status': 'closed',
+                    'frameworkSlug': 'digital-outcomes-and-specialists-2'
                 },
                 'status': 'submitted',
             },
@@ -5834,7 +5836,8 @@ class TestOpportunitiesDashboard(BaseApplicationTest):
                 'brief': {
                     'title': 'Mid date, submitted, highest id',
                     'applicationsClosedAt': '2017-06-07T10:26:21.538917Z',
-                    'status': 'withdrawn'
+                    'status': 'withdrawn',
+                    'frameworkSlug': 'digital-outcomes-and-specialists-2'
                 },
                 'status': 'submitted',
             }
@@ -5862,13 +5865,14 @@ class TestOpportunitiesDashboard(BaseApplicationTest):
             assert res.status_code == 200
         return first_row.xpath('string()'), second_row.xpath('string()'), third_row.xpath('string()')
 
-    def test_works_with_correct_data(self, data_api_client):
+    def test_request_works_and_correct_data_is_fetched(self, data_api_client):
         data_api_client.get_supplier_framework_info.return_value = self.supplier_framework_response
         data_api_client.get_framework.return_value = self.framework_response
         with self.client:
             self.login()
             resp = self.client.get(self.opportunities_dashboard_url)
             assert resp.status_code == 200
+            data_api_client.find_brief_responses.assert_called_once_with(supplier_id=1234, framework='digital-outcomes-and-specialists-2')
 
     def test_404_if_framework_does_not_exist(self, data_api_client):
         data_api_client.get_framework.side_effect = APIError(mock.Mock(status_code=404))
@@ -5887,7 +5891,7 @@ class TestOpportunitiesDashboard(BaseApplicationTest):
 
             assert resp.status_code == 404
 
-    def test_only_works_for_dos_to_view(self, data_api_client):
+    def test_404_if_framework_is_not_dos(self, data_api_client):
         self.framework_response['frameworks'].update({'slug': 'g-cloud-9', 'framework': 'g-cloud'})
         data_api_client.get_framework.return_value = self.framework_response
         data_api_client.get_supplier_framework_info.return_value = self.supplier_framework_response
@@ -5897,7 +5901,7 @@ class TestOpportunitiesDashboard(BaseApplicationTest):
 
             assert resp.status_code == 404
 
-    def test_must_be_on_framework_to_view(self, data_api_client):
+    def test_404_if_supplier_not_on_framework(self, data_api_client):
         data_api_client.get_framework.return_value = self.framework_response
         self.supplier_framework_response['frameworkInterest'].update(
             {'onFramework': False}

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -5880,12 +5880,12 @@ class TestOpportunitiesDashboard(BaseApplicationTest):
             assert resp.status_code == 404
 
     def test_only_works_for_dos_to_view(self, data_api_client):
-        self.framework_response['frameworks'].update({'framework': 'g-cloud-9'})
+        self.framework_response['frameworks'].update({'slug': 'g-cloud-9', 'framework': 'g-cloud'})
         data_api_client.get_framework.return_value = self.framework_response
         data_api_client.get_supplier_framework_info.return_value = self.supplier_framework_response
         with self.client:
             self.login()
-            resp = self.client.get(self.opportunities_dashboard_url)
+            resp = self.client.get('/suppliers/frameworks/g-cloud-9/opportunities')
 
             assert resp.status_code == 404
 

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -5868,7 +5868,10 @@ class TestOpportunitiesDashboard(BaseApplicationTest):
             self.login()
             resp = self.client.get(self.opportunities_dashboard_url)
             assert resp.status_code == 200
-            data_api_client.find_brief_responses.assert_called_once_with(supplier_id=1234, framework='digital-outcomes-and-specialists-2')
+            data_api_client.find_brief_responses.assert_called_once_with(
+                supplier_id=1234,
+                framework='digital-outcomes-and-specialists-2'
+            )
 
     def test_404_if_framework_does_not_exist(self, data_api_client):
         data_api_client.get_framework.side_effect = APIError(mock.Mock(status_code=404))
@@ -5913,17 +5916,17 @@ class TestOpportunitiesDashboard(BaseApplicationTest):
         """Assert the 'Completed opportunities' table on this page contains the correct values."""
         first_row, second_row, third_row = self.get_table_rows_by_id('submitted-opportunities', data_api_client)
 
-        assert 'Lowest date, submitted, mid id' in first_row
-        assert 'Tuesday 6 June 2017' in first_row
+        assert 'Highest date, submitted, lowest id' in first_row
+        assert 'Thursday 8 June 2017' in first_row
         assert 'View application' in first_row
 
     def test_completed_list_of_opportunities_ordered_by_applications_closed_at(self, data_api_client):
         """Assert the 'Completed opportunities' table on this page contains the brief responses in the correct order."""
         first_row, second_row, third_row = self.get_table_rows_by_id('submitted-opportunities', data_api_client)
 
-        assert 'Lowest date' in first_row
+        assert 'Highest date' in first_row
         assert 'Mid date' in second_row
-        assert 'Highest date' in third_row
+        assert 'Lowest date' in third_row
 
     def test_withdrawn_has_no_link_to_application(self, data_api_client):
         first_row, second_row, third_row = self.get_table_rows_by_id('submitted-opportunities', data_api_client)

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -5870,9 +5870,17 @@ class TestOpportunitiesDashboard(BaseApplicationTest):
             resp = self.client.get(self.opportunities_dashboard_url)
             assert resp.status_code == 200
 
-    def test_must_have_supplier_framework(self, data_api_client):
+    def test_404_if_framework_does_not_exist(self, data_api_client):
         data_api_client.get_framework.side_effect = APIError(mock.Mock(status_code=404))
-        data_api_client.get_supplier_framework_info.return_value = self.supplier_framework_response
+        with self.client:
+            self.login()
+            resp = self.client.get('/suppliers/frameworks/does-not-exist/opportunities')
+
+            assert resp.status_code == 404
+
+    def test_404_if_supplier_framework_does_not_exist(self, data_api_client):
+        data_api_client.get_framework.return_value = self.framework_response
+        data_api_client.get_supplier_framework_info.side_effect = APIError(mock.Mock(status_code=404))
         with self.client:
             self.login()
             resp = self.client.get(self.opportunities_dashboard_url)

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -5793,3 +5793,133 @@ class TestReuseFrameworkSupplierDeclarationForm(BaseApplicationTest):
             data = MultiDict({'framework_slug': 'digital-outcomes-and-specialists', 'reuse': falsey_value})
             form = ReuseDeclarationForm(data)
             assert form.reuse.data is False
+
+
+@mock.patch('app.main.views.frameworks.data_api_client', autospec=True)
+class TestOpportunitiesDashboard(BaseApplicationTest):
+    opportunities_dashboard_url = '/suppliers/frameworks/digital-outcomes-and-specialists-2/opportunities'
+
+    def setup_method(self, method):
+        super(TestOpportunitiesDashboard, self).setup_method(method)
+        self.framework_response = {
+            'frameworks': {
+                'slug': 'digital-outcomes-and-specialists-2',
+                'framework': 'digital-outcomes-and-specialists'
+            }
+        }
+        self.supplier_framework_response = {
+            'frameworkInterest': {'onFramework': True}
+        }
+        self.find_brief_responses_response = {'briefResponses': [
+            {
+                'briefId': 100,
+                'brief': {
+                    'title': 'Highest date, submitted, lowest id',
+                    'applicationsClosedAt': '2017-06-08T10:26:21.538917Z',
+                    'status': 'closed'
+                },
+                'status': 'submitted',
+            },
+            {
+                'briefId': 1829,
+                'brief': {
+                    'title': 'Lowest date, submitted, mid id',
+                    'applicationsClosedAt': '2017-06-06T10:26:21.538917Z',
+                    'status': 'closed'
+                },
+                'status': 'submitted',
+            },
+            {
+                'briefId': 4734,
+                'brief': {
+                    'title': 'Mid date, submitted, highest id',
+                    'applicationsClosedAt': '2017-06-07T10:26:21.538917Z',
+                    'status': 'withdrawn'
+                },
+                'status': 'submitted',
+            }
+        ]}
+
+    def get_table_rows(self, table_name, data_api_client):
+        """Helper function to get our 3 table rows as strings."""
+        data_api_client.get_framework.return_value = self.framework_response
+        data_api_client.get_supplier_framework_info.return_value = self.supplier_framework_response
+        data_api_client.find_brief_responses.return_value = self.find_brief_responses_response
+        with self.client:
+            self.login()
+            res = self.client.get(self.opportunities_dashboard_url)
+
+            doc = html.fromstring(res.get_data(as_text=True))
+
+            xpath_string = (
+                "//*[@class='summary-item-heading'][normalize-space(text())='{}']"
+                "/following-sibling::table[1]"
+            ).format(table_name)
+
+            table = doc.xpath(xpath_string)[0]
+            first_row, second_row, third_row = table.find_class('summary-item-row')
+
+            assert res.status_code == 200
+        return first_row.xpath('string()'), second_row.xpath('string()'), third_row.xpath('string()')
+
+    def test_works_with_correct_data(self, data_api_client):
+        data_api_client.get_supplier_framework_info.return_value = self.supplier_framework_response
+        data_api_client.get_framework.return_value = self.framework_response
+        with self.client:
+            self.login()
+            resp = self.client.get(self.opportunities_dashboard_url)
+            assert resp.status_code == 200
+
+    def test_must_have_supplier_framework(self, data_api_client):
+        data_api_client.get_framework.side_effect = APIError(mock.Mock(status_code=404))
+        data_api_client.get_supplier_framework_info.return_value = self.supplier_framework_response
+        with self.client:
+            self.login()
+            resp = self.client.get(self.opportunities_dashboard_url)
+
+            assert resp.status_code == 404
+
+    def test_only_works_for_dos_to_view(self, data_api_client):
+        self.framework_response['frameworks'].update({'framework': 'g-cloud-9'})
+        data_api_client.get_framework.return_value = self.framework_response
+        data_api_client.get_supplier_framework_info.return_value = self.supplier_framework_response
+        with self.client:
+            self.login()
+            resp = self.client.get(self.opportunities_dashboard_url)
+
+            assert resp.status_code == 404
+
+    def test_must_be_on_framework_to_view(self, data_api_client):
+        data_api_client.get_framework.return_value = self.framework_response
+        self.supplier_framework_response['frameworkInterest'].update(
+            {'onFramework': False}
+        )
+        data_api_client.get_supplier_framework_info.return_value = self.supplier_framework_response
+        with self.client:
+            self.login()
+            resp = self.client.get(self.opportunities_dashboard_url)
+
+            assert resp.status_code == 404
+
+    def test_completed_list_of_opportunities(self, data_api_client):
+        """Assert the 'Completed opportunities' table on this page contains the correct values."""
+        first_row, second_row, third_row = self.get_table_rows('Completed', data_api_client)
+
+        assert 'Lowest date, submitted, mid id' in first_row
+        assert 'Tuesday 6 June 2017' in first_row
+        assert 'View application' in first_row
+
+    def test_completed_list_of_opportunities_ordered_by_applications_closed_at(self, data_api_client):
+        """Assert the 'Completed opportunities' table on this page contains the brief responses in the correct order."""
+        first_row, second_row, third_row = self.get_table_rows('Completed', data_api_client)
+
+        assert 'Lowest date' in first_row
+        assert 'Mid date' in second_row
+        assert 'Highest date' in third_row
+
+    def test_withdrawn_has_no_link_to_application(self, data_api_client):
+        first_row, second_row, third_row = self.get_table_rows('Completed', data_api_client)
+
+        assert 'View application' in first_row
+        assert 'View application' not in second_row
+        assert 'View application' in third_row


### PR DESCRIPTION
User need
As a supplier, I want to see the opportunities I've applied for, so I can keep track of them

Add page suppliers/framework-slug/opportunities-overview to allow suppliers to view their applications to opportunities.
Add link to this page from supplier dash and from 'application complete' page
Template and view for this page
Tests
Small test refactor in tests/app/main/test_suppliers.py to add mocks to class instead of every method