### PR TITLE
Store `supplierId` in brief clarification question audit event

### DIFF
--- a/app/main/helpers/briefs.py
+++ b/app/main/helpers/briefs.py
@@ -65,7 +65,7 @@ def send_brief_clarification_question(data_api_client, brief, clarification_ques
         user=current_user.email_address,
         object_type="briefs",
         object_id=brief['id'],
-        data={"question": clarification_question, "briefId": brief['id']})
+        data={"question": clarification_question, "briefId": brief['id'], "supplierId": current_user.supplier_id})
 
     # Send the supplier a copy of the question
     supplier_email_body = render_template(

--- a/tests/app/main/test_briefs.py
+++ b/tests/app/main/test_briefs.py
@@ -235,7 +235,7 @@ class TestSubmitClarificationQuestions(BaseApplicationTest):
         data_api_client.create_audit_event.assert_called_with(
             audit_type=AuditTypes.send_clarification_question,
             object_type='briefs',
-            data={'briefId': 1234, 'question': u'important question'},
+            data={'briefId': 1234, 'question': u'important question', 'supplierId': 1234},
             user='email@email.com',
             object_id=1234
         )


### PR DESCRIPTION
When a user asks a clarification question on a brief, we want to be able to be able to easily find the supplier the user belongs to so that we can notify them of changes to the brief.

We're pretty lax about what goes into audit events, so it seems like a good idea to keep track of the supplier ID in the audit event created when a clarification question is asked about a brief.