### PR TITLE
Bring in frontend toolkit updates

### DIFF
--- a/app/assets/javascripts/category-picker.js
+++ b/app/assets/javascripts/category-picker.js
@@ -100,7 +100,6 @@
       }
     })
     var globalCategories = new Categories(categories_data)
-
     function appendCounter(id) {
        var $_counter = $('#' + id)
 
@@ -164,19 +163,13 @@
 
     // make clicks on checkboxes update the categories state
     // TODO: looks like the event is triggered four times
-    $('#checkbox-tree__inputs').on('click', 'label', function (event) {
+    $('#checkbox-tree__inputs').on('click', 'input', function (event) {
       var target = event.target
       var targetNodeName = target.nodeName.toLowerCase()
       var categoryName
 
       function getLabelTextForInput (input) {
-        var text = ''
-        var siblings = $(input).parent().contents().each(function () {
-          var childNode = this
-          if (childNode.nodeType === 3) { // text node
-            text += $(childNode).text()
-          }
-        })
+        var text = $(input).siblings().first().text()
         return $.trim(text)
       }
 

--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "jquery": "1.11.2",
     "hogan": "3.0.2",
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
-    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#cg-update-toolkit",
+    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v23.0.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.19.2/jinja_govuk_template-0.19.2.tgz",
     "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#8.9.1"
   }

--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "jquery": "1.11.2",
     "hogan": "3.0.2",
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
-    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#22.2.5",
+    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#cg-update-toolkit",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.19.2/jinja_govuk_template-0.19.2.tgz",
     "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#8.9.1"
   }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -14,6 +14,7 @@ var repoRoot = __dirname + '/';
 var bowerRoot = repoRoot + 'bower_components';
 var npmRoot = repoRoot + 'node_modules';
 var govukToolkitRoot = npmRoot + '/govuk_frontend_toolkit';
+var govukElementsRoot = npmRoot + '/govuk-elements-sass';
 var dmToolkitRoot = bowerRoot + '/digitalmarketplace-frontend-toolkit/toolkit';
 var sspContentRoot = bowerRoot + '/digitalmarketplace-frameworks';
 var assetsFolder = repoRoot + 'app/assets';
@@ -40,6 +41,7 @@ var sassOptions = {
       assetsFolder + '/scss',
       dmToolkitRoot + '/scss',
       govukToolkitRoot + '/stylesheets',
+      govukElementsRoot + '/public/sass',
     ],
     sourceComments: true,
     errLogToConsole: true
@@ -51,6 +53,7 @@ var sassOptions = {
       assetsFolder + '/scss',
       dmToolkitRoot + '/scss',
       govukToolkitRoot + '/stylesheets',
+      govukElementsRoot + '/public/sass',
     ],
   },
 };

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "bower": "1.5.2",
     "del": "1.1.1",
     "govuk_frontend_toolkit": "5.0.3",
+    "govuk-elements-sass": "3.0.3",
     "gulp": "3.8.7",
     "gulp-filelog": "0.4.1",
     "gulp-include": "1.1.1",


### PR DESCRIPTION
Bring in Digital Marketplace frontend toolkit with the new buttons that work without javascript.  This was a breaking change, so GOV.UK Elements is now a dependency and there is new build process reflecting that.

Additionally the category picker was slightly altered to handle the new markup.

Relies on: https://github.com/alphagov/digitalmarketplace-frontend-toolkit/pull/353