### PR TITLE
Do not show remove service confirmation message for DOS

### DIFF
--- a/app/templates/services/service.html
+++ b/app/templates/services/service.html
@@ -32,7 +32,7 @@
       %}
         {% include "toolkit/notification-banner.html" %}
       {% endwith %}
-    {% elif remove_requested %}
+    {% elif remove_requested and service_data.frameworkFramework != "digital-outcomes-and-specialists" %}
       <div class="banner-destructive-with-action">
         <p class="banner-message">
           Are you sure you want to remove your service?

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -399,7 +399,7 @@ class TestSupplierEditDosServices(SupplierEditServiceTestsSharedAcrossFrameworks
             **self.framework_kwargs
         )
         res = self.client.get('/suppliers/services/123')
-
+        assert res.status_code == 200
         assert 'View service page on the Digital Marketplace' not in res.get_data(as_text=True)
 
     def test_no_remove_service_section(self, data_api_client):
@@ -410,9 +410,23 @@ class TestSupplierEditDosServices(SupplierEditServiceTestsSharedAcrossFrameworks
             **self.framework_kwargs
         )
         res = self.client.get('/suppliers/services/123')
-
+        assert res.status_code == 200
         self.assert_not_in_strip_whitespace(
             'Remove this service',
+            res.get_data(as_text=True)
+        )
+
+    def test_no_remove_service_confirmation_prompt(self, data_api_client):
+        self.login()
+        self._setup_service(
+            data_api_client,
+            service_status='published',
+            **self.framework_kwargs
+        )
+        res = self.client.get('/suppliers/services/123?remove_requested=True')
+        assert res.status_code == 200
+        self.assert_not_in_strip_whitespace(
+            'Are you sure you want to remove your service?',
             res.get_data(as_text=True)
         )
 


### PR DESCRIPTION
Bug as spotted by Andrew - https://trello.com/c/iptxy2Oy/397-allow-dos-suppliers-to-view-their-services

If the user 'hacked' the url and added `remove_requested=True` the url of a DOS service they should not see the removal confirmation that you usually would for GCloud services.

We decided to not show the message rather than 404 as it's more forgiving to a user.

Before picture:
![image](https://user-images.githubusercontent.com/7228605/27338203-7b110aea-55cc-11e7-9725-bdf8e82241c5.png)

After picture:
![image](https://user-images.githubusercontent.com/7228605/27338221-89f98a50-55cc-11e7-9c55-197a9a594c5d.png)

