### PR TITLE
Preserve line breaks for seeing your brief responses

### DIFF
--- a/app/templates/briefs/_brief_response_data.html
+++ b/app/templates/briefs/_brief_response_data.html
@@ -36,7 +36,7 @@
                           {% set followup_questions_already_displayed = followup_questions_already_displayed.extend([followup_question]) %}
 
                           {{ summary.field_name(question.question) }}
-                          {{ summary.text(item.unformat_data(brief_response)[followup_question]) }}
+                          {{ summary.text(item.unformat_data(brief_response)[followup_question] | preserve_line_breaks) }}
                         {% endcall %}
                       {% endfor %}
                     {% endif %}
@@ -45,7 +45,7 @@
                     {% if question.id not in followup_questions_already_displayed %}
                       {% call summary.row() %}
                         {{ summary.field_name(question.question) }}
-                        {{ summary.text(item.unformat_data(brief_response)[question.id]) }}
+                        {{ summary.text(item.unformat_data(brief_response)[question.id] | preserve_line_breaks) }}
                       {% endcall %}
                     {% endif %}
                   {% endif %}

--- a/app/templates/briefs/clarification_question.html
+++ b/app/templates/briefs/clarification_question.html
@@ -1,5 +1,4 @@
 {% extends "_base_page.html" %}
-{% import "toolkit/summary-table.html" as summary %}
 
 {% set message_sent = 'message_sent' in get_flashed_messages() %}
 

--- a/app/templates/briefs/question_and_answer_session.html
+++ b/app/templates/briefs/question_and_answer_session.html
@@ -1,5 +1,4 @@
 {% extends "_base_page.html" %}
-{% import "toolkit/summary-table.html" as summary %}
 
 {% block page_title %}{{ brief.title }} question and answer session details – Digital Marketplace{% endblock %}
 

--- a/app/templates/frameworks/submission_lots.html
+++ b/app/templates/frameworks/submission_lots.html
@@ -1,5 +1,5 @@
 {% extends "_base_page.html" %}
-{% import "toolkit/summary-table.html" as summary %}
+
 {% import "macros/submission.html" as submission %}
 
 {% block page_title %}Apply to {{ framework.name }} – Digital Marketplace{% endblock %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ Flask-WTF==0.12
 werkzeug==0.10.4
 python-dateutil==2.4.2
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@25.2.0#egg=digitalmarketplace-utils==25.2.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@27.1.0#egg=digitalmarketplace-utils==27.1.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.2.0#egg=digitalmarketplace-content-loader==4.2.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@8.5.0#egg=digitalmarketplace-apiclient==8.5.0
 

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -2026,7 +2026,10 @@ class TestFrameworkAgreementUpload(BaseApplicationTest):
             data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
                 on_framework=True)
             generate_timestamped_document_upload_path.return_value = 'my/path.pdf'
-            s3.return_value.save.side_effect = S3ResponseError(500, 'All fail')
+            s3.return_value.save.side_effect = S3ResponseError(
+                {'Error': {'Code': 500, 'Message': 'All fail'}},
+                'test_api_is_not_updated_and_email_not_sent_if_upload_fails'
+            )
 
             res = self.client.post(
                 '/suppliers/frameworks/g-cloud-7/agreement',
@@ -3613,7 +3616,10 @@ class TestFrameworkUpdatesPage(BaseApplicationTest):
     def test_should_be_a_503_if_connecting_to_amazon_fails(self, s3, data_api_client):
         data_api_client.get_framework.return_value = self.framework('open')
         # if s3 throws a 500-level error
-        s3.side_effect = S3ResponseError(500, 'Amazon has collapsed. The internet is over.')
+        s3.side_effect = S3ResponseError(
+            {'Error': {'Code': 500, 'Message': 'Amazon has collapsed. The internet is over.'}},
+            'test_should_be_a_503_if_connecting_to_amazon_fails'
+        )
 
         with self.app.test_client():
             self.login()


### PR DESCRIPTION
We're bringing in a new jinja filter that keeps line breaks (up to a maximum of two) for the large textarea content.

Specifically, it's going into:

- the "view your application page" for brief responses.  (Note there is no corresponding buyer page to see brief responses -- they only get CSVs/ODS files to download.)

| before | after |
|--------|-------|
| ![screen shot 2017-07-04 at 11 00 18](https://user-images.githubusercontent.com/2454380/27825988-5ae3a1d2-60a9-11e7-954e-f23a62371371.png)    | ![screen shot 2017-07-04 at 10 59 18](https://user-images.githubusercontent.com/2454380/27826011-6ecdb084-60a9-11e7-91a3-abd8041498d0.png)   |

**Note**
It's  _not_ going into the service editing summary page (either here or in the admin app) because the way we group the questions in the service editing screen relies on line breaks to differentiate the multiquestions from each other.  If we allow the `preserve_line_breaks` filter on the service editing screen, it becomes very hard to tell how many questions there are and what you've actually answered to each of them.
We don't have this problem on the public service listing though, so we're putting it into the buyer app.

[Here's a screenshot of the same content in the supplier interface (left side) versus the public service listing (right side)](https://user-images.githubusercontent.com/2454380/27826250-4c9addf6-60aa-11e7-88e8-bf625f652df7.png).  You can see that the left side is much harder to read.

Since suppliers aren't adding/editing services right now, this isn't a pressing concern, but it should be addressed by the next time that a framework opens. [I've created a Trello card for this issue](https://trello.com/c/bHzYU39v/560-it-doesnt-work-to-show-suppliers-linebreaks-when-editing-their-services) in the Catalogues Trello board.  
