### PR TITLE
Add default.nix

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -5,7 +5,7 @@
 # E402: module level import not at top of file
 # C901: too complex
 # W503: line break before binary operator
-exclude = venv,venv3,__pycache__,node_modules,bower_components
+exclude = venv*,__pycache__,node_modules,bower_components
 ignore = D203,W503
 max-complexity = 7
 max-line-length = 120

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-venv/
+venv*
 .DS_Store
 
 # Byte-compiled / optimized / DLL files

--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,6 @@ app/content
 
 # Front end generated assets
 app/static
+
+# local environment customizations
+local.nix

--- a/default.nix
+++ b/default.nix
@@ -11,6 +11,8 @@
       pkgs.nodejs
       pkgs.libffi
       pkgs.libyaml
+      # pip requires git to fetch some of its dependencies
+      pkgs.git
       # for `cryptography`
       pkgs.openssl
     ] ++ pkgs.stdenv.lib.optionals forDev ([

--- a/default.nix
+++ b/default.nix
@@ -43,7 +43,7 @@ in (with args; {
     LANG="en_GB.UTF-8";
 
     shellHook = ''
-      export PS1="\[\e[0;34m\](nix-shell\[\e[0m\]:\[\e[0;34m\]${shortName})\[\e[0;32m\]\u@\h\[\e[0m\]:\[\e[0m\]\[\e[0;34m\]\w\[\e[0m\]\$ "
+      export PS1="\[\e[0;36m\](nix-shell\[\e[0m\]:\[\e[0;36m\]${shortName})\[\e[0;32m\]\u@\h\[\e[0m\]:\[\e[0m\]\[\e[0;36m\]\w\[\e[0m\]\$ "
 
       if [ ! -e $VIRTUALENV_ROOT ]; then
         ${pythonPackages.virtualenv}/bin/virtualenv $VIRTUALENV_ROOT

--- a/default.nix
+++ b/default.nix
@@ -12,7 +12,7 @@
       pkgs.libffi
       pkgs.libyaml
       # for `cryptography`
-      pkgs.openssl_1_1_0
+      pkgs.openssl
     ] ++ pkgs.stdenv.lib.optionals forDev ([
         # for lxml
         pkgs.libxml2

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,46 @@
+{
+  pkgs ? import <nixpkgs> {},
+  pythonPackages ? pkgs.python36Packages,
+  forDev ? true
+}:
+{
+  digitalMarketplaceSupplierFrontendEnv = pkgs.stdenv.mkDerivation {
+    name = "digitalmarketplace-supplier-frontend-env";
+    buildInputs = [
+      pythonPackages.virtualenv
+      pkgs.nodejs
+      pkgs.libffi
+      pkgs.libyaml
+      # for `cryptography`
+      pkgs.openssl_1_1_0
+    ] ++ pkgs.stdenv.lib.optionals forDev ([
+        # for lxml
+        pkgs.libxml2
+        pkgs.libxslt
+        # for frontend tests
+        pkgs.phantomjs
+      ] ++ pkgs.stdenv.lib.optionals pkgs.stdenv.isDarwin [
+        # for watchdog... not that it works on darwin yet anyway, but it will/would need them
+        pkgs.darwin.apple_sdk.frameworks.CoreServices
+        pkgs.darwin.cf-private
+      ]
+    );
+
+    hardeningDisable = pkgs.stdenv.lib.optionals pkgs.stdenv.isDarwin [ "format" ];
+
+    VIRTUALENV_ROOT = "venv${pythonPackages.python.pythonVersion}";
+    VIRTUAL_ENV_DISABLE_PROMPT = "1";
+    SOURCE_DATE_EPOCH = "315532800";
+
+    # if we don't have this, we get unicode troubles in a --pure nix-shell
+    LANG="en_GB.UTF-8";
+
+    shellHook = ''
+      if [ ! -e $VIRTUALENV_ROOT ]; then
+        ${pythonPackages.virtualenv}/bin/virtualenv $VIRTUALENV_ROOT
+      fi
+      source $VIRTUALENV_ROOT/bin/activate
+      make requirements${pkgs.stdenv.lib.optionalString forDev "-dev"}
+    '';
+  };
+}

--- a/default.nix
+++ b/default.nix
@@ -10,6 +10,7 @@ let
 in (with args; {
   digitalMarketplaceSupplierFrontendEnv = (pkgs.stdenv.mkDerivation rec {
     name = "digitalmarketplace-supplier-frontend-env";
+    shortName = "dm-sup-fe";
     buildInputs = [
       pythonPackages.virtualenv
       pkgs.nodejs
@@ -42,6 +43,8 @@ in (with args; {
     LANG="en_GB.UTF-8";
 
     shellHook = ''
+      export PS1="\[\e[0;34m\](nix-shell\[\e[0m\]:\[\e[0;34m\]${shortName})\[\e[0;32m\]\u@\h\[\e[0m\]:\[\e[0m\]\[\e[0;34m\]\w\[\e[0m\]\$ "
+
       if [ ! -e $VIRTUALENV_ROOT ]; then
         ${pythonPackages.virtualenv}/bin/virtualenv $VIRTUALENV_ROOT
       fi

--- a/default.nix
+++ b/default.nix
@@ -1,10 +1,14 @@
-{
-  pkgs ? import <nixpkgs> {},
-  pythonPackages ? pkgs.python36Packages,
-  forDev ? true
-}:
-{
-  digitalMarketplaceSupplierFrontendEnv = pkgs.stdenv.mkDerivation {
+argsOuter@{...}:
+let
+  # specifying args defaults in this slightly non-standard way to allow us to include the default values in `args`
+  args = rec {
+    pkgs = import <nixpkgs> {};
+    pythonPackages = pkgs.python36Packages;
+    forDev = true;
+    localOverridesPath = ./local.nix;
+  } // argsOuter;
+in (with args; {
+  digitalMarketplaceSupplierFrontendEnv = (pkgs.stdenv.mkDerivation rec {
     name = "digitalmarketplace-supplier-frontend-env";
     buildInputs = [
       pythonPackages.virtualenv
@@ -44,5 +48,5 @@
       source $VIRTUALENV_ROOT/bin/activate
       make requirements${pkgs.stdenv.lib.optionalString forDev "-dev"}
     '';
-  };
-}
+  }).overrideAttrs (if builtins.pathExists localOverridesPath then (import localOverridesPath args) else (x: x));
+})

--- a/local.example.nix
+++ b/local.example.nix
@@ -1,0 +1,22 @@
+# default.nix calls out to the file local.nix if it exists, expecting a function which it will call, applying first
+# the args passed to the original default.nix and then `oldAttrs`, the attrset originally applied to mkDerivation.
+#
+# the function should return an attrset altered to the local user's desires, as they would wish to be applied to
+# mkDerivation to produce the env
+
+args: oldAttrs: oldAttrs // {
+  # here we add some of our favourite packages to the environment which aren't necessarily to everyone's tastes
+  buildInputs = oldAttrs.buildInputs ++ [
+    args.pkgs.vim
+    args.pythonPackages.ipython
+  ];
+
+  shellHook =  oldAttrs.shellHook + ''
+    # PS1 can't be set as a normal derivation attr as it gets clobbered early on in the upstream shellHook script
+    export PS1="⚡$PS1⚡"
+
+    # inject some whimsy into our session - note here we access a package which we don't actually end up
+    # explicitly exposing to the final environment
+    ${args.pkgs.fortune}/bin/fortune
+  '';
+}

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,7 @@ cssselect==0.9.1
 flake8==2.6.2
 flake8-putty==0.4.0
 freezegun==0.3.4
-lxml==3.4.4
+lxml==3.8.0
 mock==2.0.0
 pytest==2.8.2
 pytest-cov==2.2.0


### PR DESCRIPTION
This is something that's going to need extensively more of a writeup than this, but...

_Note: this is meant to be a strictly optional convenience for those of us who want to use it_

This `default.nix` allows users with a working nix install to simply perform a

```
$ nix-shell --pure .
```

in the repository root and get a fully working development environment with all dependencies.

(you may have to blow away your `node_modules/` and `bower_components/` directories before running `make run_all` to get them re-fetched again as they will have been constructed using a different node version)

You can choose the python version by editing the line

```
    pythonPackages = pkgs.python36Packages;
```

to, e.g., `pkgs.python27Packages`. I've set up `nix-shell` to use a separate virtualenv for each python version so you should be able to drop out & back in to different python versions without any extra fuss.

## Caveats

You'll notice that if you use the `--pure` flag with `nix-shell`, it gives you a really very pure environment - it won't even put `vi` in your environment. In fact, nothing from your underlying system installation. This is a great way of ensuring your build *is* actually pure and reproducible, but could indeed be quite annoying for day to day use. There are numerous approaches that could be taken to make this easier. It's up to you which one you prefer. Some suggestions:

* Don't use the `--pure` flag and live with the danger of mixed up libraries. This will allow you to continue using your underlying installed tools.
* Only use `nix-shell` for execution of the actual project commands, either dropping out of `nix-shell` whenever you're not using the project commands, or leaving another shell active in the same directory for performing those commands. This is *probably* the approach I'll take.
* Add your tool of choice to the dependencies using a `local.nix` based on the example at `local.example.nix`, causing nix to provide this tool for you. `local.nix` can be used to personally customize the shell environment in almost any way to your own taste.

Something to note is that this is not a *full* nixification - it just creates a virtualenv and calls pip at the last stage of its initialization. This means that the installed python modules aren't pure in the same way proper nix packages are. The worst effect this should have is maybe occasionally having to blow away your `venv*` dirs after you've updated your nix channels.

The `$PS1` I have provided may not be to everyone's taste. I tried to include a bunch of useful information in it, including a `shortName` for the project which some may find objectionable (so that it's clear if you've absent-mindedly `cd`'d to a different project directory while remaining in a `nix-shell`. As shown in the example, this can also be personalized in `local.example.nix`, or if you like we could sit down and bikeshed what to make the default one...

Mac users will, for now, have to comment out the `watchdog` dependency in `requirements_for_test.txt` as it appears to need some impure dependencies to access system libraries (?). But there are possibly a few workarounds for this that can be discussed. The first that comes to mind is adding the nix package for watchdog (`pythonPackages.watchdog`, which, strangely enough, *does* work fine on macos) to your `local.nix`.

*Some* Mac users (looking at you @Wynndow) have trouble running the frontend tests and node doesn't make it particularly easy to discover the reason for this. WIP.

...probably lots of stuff that I haven't mentioned, but I'd like to get this PR posted at least...