### PR TITLE
Service listing page: segregate by framework, adapt URL scheme

### DIFF
--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -203,7 +203,7 @@ def update_section(framework_slug, service_id, section_id):
 
 
 # we have to split these route definitions in two because without a fixed "/" separating the service_id and
-# trailing_path because otherwise it's not clearly defined where flask should start capturing trailing_path
+# trailing_path it's not clearly defined where flask should start capturing trailing_path
 @main.route("/services/<string:service_id>", defaults={"trailing_path": ""})
 @main.route("/services/<string:service_id>/<path:trailing_path>")
 @login_required
@@ -223,8 +223,8 @@ def redirect_direct_service_urls(service_id, trailing_path):
     # of views
     return redirect(url_for(
         ".edit_service",
-        service_id=service_id,
         framework_slug=service["frameworkSlug"],
+        service_id=service_id,
     ) + (trailing_path and ("/" + trailing_path)))
 
 

--- a/app/templates/services/edit_section.html
+++ b/app/templates/services/edit_section.html
@@ -1,6 +1,9 @@
 {% extends "services/_base_edit_section_page.html" %}
 
 {% block breadcrumb %}
+  {% set your_services_text %}
+    Your {{ service_data["frameworkName"] }} services
+  {% endset %}
   {%
     with items = [
       {
@@ -12,11 +15,11 @@
         "label": "Your account"
       },
       {
-        "link": url_for(".list_services"),
-        "label": "Current services"
+        "link": url_for(".list_services", framework_slug=service_data["frameworkSlug"]),
+        "label": your_services_text
       },
       {
-        "link": url_for(".edit_service", service_id=service_id),
+        "link": url_for(".edit_service", framework_slug=service_data["frameworkSlug"], service_id=service_id),
         "label": service_data["serviceName"]
       }
     ]
@@ -35,4 +38,4 @@
   {% endwith %}
 {% endblock %}
 
-{% block return_to_service %}{{ url_for(".edit_service", service_id=service_id) }}{% endblock %}
+{% block return_to_service %}{{ url_for(".edit_service", framework_slug=service_data["frameworkSlug"], service_id=service_id) }}{% endblock %}

--- a/app/templates/services/list_services.html
+++ b/app/templates/services/list_services.html
@@ -36,33 +36,34 @@
   {% endwith %}
   <div class="grid-row">
     <div class="column-two-thirds">
-      {% with
-        heading = "Current services"
-      %}
+      {% set heading %}
+        Your {{ framework.name }} services
+      {% endset %}
+      {% with smaller=true %}
         {% include 'toolkit/page-heading.html' %}
       {% endwith %}
     </div>
   </div>
 
+  {% set empty_message %}
+    You don’t have any {{ framework.name }} services on the Digital Marketplace
+  {% endset %}
   {% call(item) summary.list_table(
     services,
     caption='Current services',
     field_headings=[
       'Name',
-      'Framework',
       'Lot',
-      summary.hidden_field_heading("Action")
+      summary.hidden_field_heading("Status")
     ],
     field_headings_visible=True,
-    empty_message="You don't have any services on the Digital Marketplace"
+    empty_message=empty_message
   ) %}
     {% call summary.row() %}
       {{ summary.service_link(
           item.serviceName or item.lotName,
           url_for('.edit_service', service_id=item.id)
       ) }}
-
-      {{ summary.text(item.frameworkName) }}
 
       {{ summary.text(item.lotName or item.lot) }}
 

--- a/app/templates/services/list_services.html
+++ b/app/templates/services/list_services.html
@@ -62,7 +62,7 @@
     {% call summary.row() %}
       {{ summary.service_link(
           item.serviceName or item.lotName,
-          url_for('.edit_service', service_id=item.id)
+          url_for('.edit_service', framework_slug=item.frameworkSlug, service_id=item.id)
       ) }}
 
       {{ summary.text(item.lotName or item.lot) }}

--- a/app/templates/services/service.html
+++ b/app/templates/services/service.html
@@ -1,6 +1,9 @@
 {% extends "services/_base_service_page.html" %}
 
 {% block breadcrumb %}
+  {% set your_services_text %}
+    Your {{ service_data["frameworkName"] }} services
+  {% endset %}
   {%
     with items = [
       {
@@ -12,8 +15,8 @@
         "label": "Your account"
       },
       {
-        "link": url_for(".list_services"),
-        "label": "Current services"
+        "link": url_for(".list_services", framework_slug=service_data["frameworkSlug"]),
+        "label": your_services_text
       }
     ]
   %}
@@ -40,7 +43,7 @@
         <p class="banner-message">
           When you remove a service, you can only reinstate it by emailing <a href='mailto:enquiries@digitalmarketplace.service.gov.uk'>enquiries@digitalmarketplace.service.gov.uk</a>.
         </p>
-        <form class="banner-action" action="{{ url_for('.remove_service', service_id=service_id ) }}" method="POST">
+        <form class="banner-action" action="{{ url_for('.remove_service', framework_slug=service_data["frameworkSlug"], service_id=service_id ) }}" method="POST">
           <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
           <input type="hidden" name="remove_confirmed" value="true" />
             {%
@@ -84,7 +87,7 @@
 
 {% block edit_link %}
   {% if 'EDIT_SECTIONS' is active_feature %}
-    {{ summary.top_link("Edit", url_for(".edit_section", service_id=service_id, section_id=section.id)) }}
+    {{ summary.top_link("Edit", url_for(".edit_section", framework_slug=service_data["frameworkSlug"], service_id=service_id, section_id=section.id)) }}
   {% endif %}
 {% endblock %}
 
@@ -107,7 +110,7 @@
         <p>You’ll need to email
           <a href="mailto:enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.service.gov.uk</a>
            to reinstate your service.</p>
-        <form action="{{ url_for('.remove_service', service_id=service_id ) }}" method="POST">
+        <form action="{{ url_for('.remove_service', framework_slug=service_data["frameworkSlug"], service_id=service_id ) }}" method="POST">
           <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
             {%
               with

--- a/app/templates/suppliers/_frameworks_live.html
+++ b/app/templates/suppliers/_frameworks_live.html
@@ -1,9 +1,6 @@
 {% import "toolkit/summary-table.html" as summary %}
 
 {{ summary.heading("Current services") }}
-{% if frameworks.live %}
-  {{ summary.top_link('View services', url_for('.list_services')) }}
-{% endif %}
 {% call(framework) summary.list_table(
   frameworks.live,
   caption='Current services',
@@ -32,6 +29,7 @@
 
     {% if framework.onFramework and not framework.needs_to_complete_declaration %}
         {% call summary.field(action=True) %}
+            <a href="{{ url_for('.list_services', framework_slug=framework.slug) }}">View services</a><br>
             {% if framework.framework == 'digital-outcomes-and-specialists' %}
                 <a href="{{ url_for('.opportunities_dashboard', framework_slug=framework.slug) }}">View your opportunities</a><br>
             {% endif %}

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -185,12 +185,12 @@ class TestListServices(BaseApplicationTest):
 
             document = html.fromstring(res.get_data(as_text=True))
             assert document.xpath(
-                "//*[contains(@class, 'summary-item-no-content')][normalize-space(string())=$t]",
-                t=u"You don’t have any G-Cloud 909 services on the Digital Marketplace",
-            )
-            assert document.xpath(
                 "//h1[normalize-space(string())=$t]",
                 t=u"Your G-Cloud 909 services",
+            )
+            assert document.xpath(
+                "//*[contains(@class, 'summary-item-no-content')][normalize-space(string())=$t]",
+                t=u"You don’t have any G-Cloud 909 services on the Digital Marketplace",
             )
 
             data_api_client.find_services.assert_called_once_with(
@@ -255,7 +255,7 @@ class TestListServices(BaseApplicationTest):
             )
 
     @mock.patch('app.data_api_client')
-    def test_should_not_be_able_to_see_page_if_made_inactive(self, services_data_api_client):
+    def test_should_not_be_able_to_see_page_if_user_inactive(self, services_data_api_client):
         with self.app.test_client():
             self.login()
 
@@ -766,7 +766,7 @@ class TestSupplierRemoveService(_BaseTestSupplierEditRemoveService):
         assert response.status_code == expected_status_code
 
     @pytest.mark.parametrize("confirm", (False, True,))
-    def test_should_fail_if_incorrent_framework(
+    def test_should_fail_if_incorrect_framework(
             self,
             data_api_client,
             supplier_service_editing_fw_params,

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -151,7 +151,7 @@ class TestServiceHeirarchyRedirection(BaseApplicationTest):
                 self._mock_get_service_side_effect,
                 service_status,
                 framework_framework,
-                True,
+                service_belongs_to_user,
             )
             res = self.client.get('/suppliers/services/567/')
 


### PR DESCRIPTION
Story https://trello.com/c/I0beYt9w/40-1-allow-services-page-to-filter-by-framework

In short, a supplier's service listing page has been segregated to provide listings by framework. Though for the hierarchy to continue making _any_ sense, URLs of various pages living beneath `/suppliers/services/<service_id>` had to be moved to beneath `/suppliers/frameworks/<framework_slug>/services/<service_id>`.


The supplier dashboard has had its large "View services" link moved to the per-framework links: 
![20170731_servicelisting_00](https://user-images.githubusercontent.com/807447/28783232-991db5d2-7607-11e7-9b0d-422a97a495c4.png)


The actual listing page is now at `/suppliers/frameworks/<framework_slug>/services` and has had its heading changed appropriately:
![20170731_servicelisting_01](https://user-images.githubusercontent.com/807447/28783396-25b7b498-7608-11e7-83f7-30d7e0a92ffc.png)


Service detail pages have been moved to `/suppliers/frameworks/<framework_slug>/services/<service_id>` and its breadcrumb pointing back to the listing page has been adjusted appropriately:
![20170731_servicelisting_02](https://user-images.githubusercontent.com/807447/28783678-f9cc6be8-7608-11e7-880e-d75200ba8244.png)


The section editing page has been moved to `/suppliers/frameworks/<framework_slug>/services/<service_id>/edit/<section_name>` and "listing" breadcrumb has been similarly updated:
![20170731_servicelisting_03](https://user-images.githubusercontent.com/807447/28783789-5f2e4dee-7609-11e7-9b7b-07ca2c202a20.png)


The removal view has been moved too (though of course you can't see it from this screenshot):
![20170731_servicelisting_04](https://user-images.githubusercontent.com/807447/28783880-9c9aa042-7609-11e7-9cd6-1da9abcb764a.png)


A redirector has been added to cope with old links to services. This will universally redirect any URL beneath `/suppliers/services/<service_id>(/trailing/path)` to `/suppliers/frameworks/<framework_slug>/services/<service_id>(/trailing/path)` by looking up the services `framework_slug` (but notably only *after* checking access rights).