### PR TITLE
(beginnings of) supplier dashboard reorganization

### DIFF
--- a/app/templates/suppliers/_frameworks_live.html
+++ b/app/templates/suppliers/_frameworks_live.html
@@ -1,43 +1,26 @@
-{% import "toolkit/summary-table.html" as summary %}
-
-{{ summary.heading("Current services") }}
-{% call(framework) summary.list_table(
-  frameworks.live,
-  caption='Current services',
-  field_headings=[
-    'Label',
-    'Value',
-    ''
-  ],
-  field_headings_visible=False,
-  empty_message="You don't have any services on the Digital Marketplace"
-) %}
-  {% call summary.row(complete=not framework.needs_to_complete_declaration) %}
-    {{ summary.field_name(framework.name) }}
-    {% call summary.field() %}
-      <p>
-        {{ framework.services_count }} service{{ 's' if framework.services_count != 1 }}
-      </p>
-      {% if framework.needs_to_complete_declaration %}
-        <p class="second-line">
-          <a href="{{ url_for('.framework_agreement', framework_slug=framework.slug) }}">
-            You must sign the framework agreement to sell these services
-          </a>
-        </p>
-      {% endif %}
-    {% endcall %}
-
-    {% if framework.onFramework and not framework.needs_to_complete_declaration %}
-        {% call summary.field(action=True) %}
-            <a href="{{ url_for('.list_services', framework_slug=framework.slug) }}">View services</a><br>
-            {% if framework.framework == 'digital-outcomes-and-specialists' %}
-                <a href="{{ url_for('.opportunities_dashboard', framework_slug=framework.slug) }}">View your opportunities</a><br>
-            {% endif %}
-            <a href="{{ url_for('.framework_dashboard', framework_slug=framework.slug) }}">View documents and ask a question</a>
-        {% endcall %}
+<div class="grid-row">
+  <div class="column-two-thirds dmspeak">
+  {% for framework in frameworks.live %}
+  {% if framework.onFramework %}
+    <h2 class="heading-xmedium">{{ framework.name }}</h2>
+    <p>
+    {% if framework.needs_to_complete_declaration %}
+      <a href="{{ url_for('.framework_agreement', framework_slug=framework.slug) }}">
+        You must sign the framework agreement to sell these services
+      </a>
     {% else %}
-      {% call summary.field() %}
-      {% endcall %}
+      <a href="{{ url_for('.list_services', framework_slug=framework.slug) }}">View services</a><br>
+      {% if framework.framework == 'digital-outcomes-and-specialists' %}
+        <a href="{{ url_for('.opportunities_dashboard', framework_slug=framework.slug) }}">View your opportunities</a><br>
+      {% endif %}
+      <a href="{{ url_for('.framework_dashboard', framework_slug=framework.slug) }}">View documents and ask a question</a>
     {% endif %}
-  {% endcall %}
-{% endcall %}
+    </p>
+  {% endif %}
+  {% else %}
+    <p>
+      You don't have any services on the Digital Marketplace
+    </p>
+  {% endfor %}
+  </div>
+</div>

--- a/tests/app/main/test_suppliers.py
+++ b/tests/app/main/test_suppliers.py
@@ -12,21 +12,34 @@ from tests.app.helpers import BaseApplicationTest
 find_frameworks_return_value = {
     "frameworks": [
         {
+            'status': 'expired',
+            'slug': 'h-cloud-88',
+            'name': 'H-Cloud 88',
+            'framework': 'g-cloud',
+        },
+        {
             'status': 'live',
             'slug': 'g-cloud-6',
             'name': 'G-Cloud 6',
-            "onFramework": True,
-            "agreementReturned": True,
+            'framework': 'g-cloud',
         },
         {
             'status': 'open',
             'slug': 'digital-outcomes-and-specialists',
             'name': 'Digital Outcomes and Specialists',
+            'framework': 'digital-outcomes-and-specialists',
+        },
+        {
+            'status': 'live',
+            'slug': 'digital-rhymes-and-reasons',
+            'name': 'Digital Rhymes and Reasons',
+            'framework': 'digital-outcomes-and-specialists',
         },
         {
             'status': 'open',
             'slug': 'g-cloud-7',
             'name': 'G-Cloud 7',
+            'framework': 'g-cloud',
         },
     ]
 }
@@ -169,8 +182,19 @@ class TestSuppliersDashboard(BaseApplicationTest):
         data_api_client.find_frameworks.return_value = find_frameworks_return_value
         data_api_client.get_supplier_frameworks.return_value = {
             'frameworkInterest': [
-                {'frameworkSlug': 'g-cloud-6', 'services_count': 99}
-            ]
+                {
+                    'frameworkSlug': 'h-cloud-88',
+                    'services_count': 12,
+                    "onFramework": True,
+                    "agreementReturned": True,
+                },
+                {
+                    'frameworkSlug': 'g-cloud-6',
+                    'services_count': 99,
+                    "onFramework": True,
+                    "agreementReturned": True,
+                },
+            ],
         }
         get_current_suppliers_users.side_effect = get_user
         with self.app.test_client():
@@ -194,12 +218,25 @@ class TestSuppliersDashboard(BaseApplicationTest):
                 t="View services",
                 u="/suppliers/frameworks/g-cloud-6/services",
             )
+
             assert not document.xpath(
                 "//*[(.//h2)[1][normalize-space(string())=$f]][.//a[normalize-space(string())=$t]]",
                 f="G-Cloud 7",
                 t="View services",
             )
             assert not document.xpath("//a[@href=$u]", u="/suppliers/frameworks/g-cloud-7/services")
+            assert not document.xpath(
+                "//*[(.//h2)[1][normalize-space(string())=$f]][.//a[normalize-space(string())=$t]]",
+                f="H-Cloud 88",
+                t="View services",
+            )
+            assert not document.xpath("//a[@href=$u]", u="/suppliers/frameworks/h-cloud-88/services")
+            assert not document.xpath(
+                "//*[(.//h2)[1][normalize-space(string())=$f]][.//a[normalize-space(string())=$t]]",
+                f="Digital Rhymes and Reasons",
+                t="View services",
+            )
+            assert not document.xpath("//a[@href=$u]", u="/suppliers/frameworks/digital-rhymes-and-reasons/services")
 
     def test_shows_dos_is_coming(
         self, get_current_suppliers_users, data_api_client

--- a/tests/app/main/test_suppliers.py
+++ b/tests/app/main/test_suppliers.py
@@ -189,13 +189,13 @@ class TestSuppliersDashboard(BaseApplicationTest):
             )
 
             assert document.xpath(
-                "//tr[./td[normalize-space(string())=$f]][.//a[normalize-space(string())=$t][@href=$u]]",
+                "//*[(.//h2)[1][normalize-space(string())=$f]][.//a[normalize-space(string())=$t][@href=$u]]",
                 f="G-Cloud 6",
                 t="View services",
                 u="/suppliers/frameworks/g-cloud-6/services",
             )
             assert not document.xpath(
-                "//tr[./td[normalize-space(string())=$f]][.//a[normalize-space(string())=$t]]",
+                "//*[(.//h2)[1][normalize-space(string())=$f]][.//a[normalize-space(string())=$t]]",
                 f="G-Cloud 7",
                 t="View services",
             )


### PR DESCRIPTION
**This sits on top of #726, so there will be a lot of chaff in the "files changed" section until that is merged.**

Story https://trello.com/c/5jTvXMoA/42-1-implement-new-layout-for-supplier-dashboard

This rather simply switches the layout of the listing of live frameworks a supplier is on from a table to a list of headed sections containing paragraphs of links:
![20170802_supplierdashboard](https://user-images.githubusercontent.com/807447/28877482-5f466e10-7794-11e7-867e-34bfc664f7ce.png)

~~~Affects a disappointingly small number of tests but we don't really have the time to flesh them out.~~~ No sorry I had to flesh them out slightly as the first time I pushed this it was broken in a way that the tests gave me no indication of.

~~~Still awaiting a final decision on the content for the text in the case a supplier is on no frameworks.~~~ We're sticking with the text as-is.