### PR TITLE
Switch to using Python 3 by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,7 @@ cache:
     - node_modules
     - bower_components
 python:
-  - "2.7"
-  - "3.4"
+  - "3.6"
 before_install:
   - nvm install 4.2
 install:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,1 @@
-FROM digitalmarketplace/base-frontend:1.0.3
+FROM digitalmarketplace/base-frontend:2.0.2

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ run-app: show-environment virtualenv
 
 .PHONY: virtualenv
 virtualenv:
-	[ -z $$VIRTUAL_ENV ] && [ ! -d venv ] && virtualenv venv || true
+	[ -z $$VIRTUAL_ENV ] && [ ! -d venv ] && virtualenv -p python3 venv || true
 
 .PHONY: upgrade-pip
 upgrade-pip: virtualenv


### PR DESCRIPTION
Makes the app run with Python 3.6 in all live environments.

This also changes the default virtualenv to use python3.

We're dropping compatibility with Python 2 for the application code,
so this is removing python2 test runs from Travis and updating PY3
version to 3.6.