### PR TITLE
Supplier address rejig

### DIFF
--- a/app/main/forms/suppliers.py
+++ b/app/main/forms/suppliers.py
@@ -31,8 +31,8 @@ class EditSupplierForm(Form):
 
 class EditContactInformationForm(Form):
     id = IntegerField()
-    address1 = StripWhitespaceStringField('Business address')
-    address2 = StripWhitespaceStringField('Business address')
+    address1 = StripWhitespaceStringField('Registered office address')
+    address2 = StripWhitespaceStringField('Registered office address')
     city = StripWhitespaceStringField('Town or city')
     country = StripWhitespaceStringField()
     postcode = StripWhitespaceStringField()

--- a/app/main/forms/suppliers.py
+++ b/app/main/forms/suppliers.py
@@ -32,7 +32,6 @@ class EditSupplierForm(Form):
 class EditContactInformationForm(Form):
     id = IntegerField()
     address1 = StripWhitespaceStringField('Registered office address')
-    address2 = StripWhitespaceStringField('Registered office address')
     city = StripWhitespaceStringField('Town or city')
     postcode = StripWhitespaceStringField()
     website = StripWhitespaceStringField()

--- a/app/main/forms/suppliers.py
+++ b/app/main/forms/suppliers.py
@@ -34,7 +34,6 @@ class EditContactInformationForm(Form):
     address1 = StripWhitespaceStringField('Registered office address')
     address2 = StripWhitespaceStringField('Registered office address')
     city = StripWhitespaceStringField('Town or city')
-    country = StripWhitespaceStringField()
     postcode = StripWhitespaceStringField()
     website = StripWhitespaceStringField()
     phoneNumber = StripWhitespaceStringField('Phone number')

--- a/app/templates/suppliers/details.html
+++ b/app/templates/suppliers/details.html
@@ -64,7 +64,6 @@
         postcode = supplier.contact.get("postcode"),
         street_address = True,
         street_address_line_1 = supplier.contact.get("address1"),
-        street_address_line_2 = supplier.contact.get("address2"),
         locality = supplier.contact.get("city")
       %}
         {% include "toolkit/contact-details.html" %}

--- a/app/templates/suppliers/details.html
+++ b/app/templates/suppliers/details.html
@@ -56,7 +56,7 @@
     {{ summary.external_link(supplier.contact.website, supplier.contact.website)}}
   {% endcall %}
   {% call summary.row() %}
-    {{ summary.field_name('Address') }}
+    {{ summary.field_name('Registered office address') }}
     {% call summary.field() %}
       {%
         with
@@ -65,8 +65,7 @@
         street_address = True,
         street_address_line_1 = supplier.contact.get("address1"),
         street_address_line_2 = supplier.contact.get("address2"),
-        locality = supplier.contact.get("city"),
-        country = supplier.contact.get("country")
+        locality = supplier.contact.get("city")
       %}
         {% include "toolkit/contact-details.html" %}
       {% endwith %}

--- a/app/templates/suppliers/edit_supplier.html
+++ b/app/templates/suppliers/edit_supplier.html
@@ -87,7 +87,7 @@
 
       <div class="question">
         <label class="question-heading">
-          Business address
+          Registered office address
         </label>
         {{ forms.input('contact_id', contact_form.id.data, type='hidden') }}
         <div class="box-label" id="address1-label">Building and street</div>

--- a/app/templates/suppliers/edit_supplier.html
+++ b/app/templates/suppliers/edit_supplier.html
@@ -95,8 +95,6 @@
         {{ forms.input('contact_address2', contact_form.address2.data, errors=contact_form.address2.errors) }}
         <div class="box-label" id="city-label">Town or city</div>
         {{ forms.input('contact_city', contact_form.city.data, errors=contact_form.city.errors) }}
-        <div class="box-label" id="country-label">Country</div>
-        {{ forms.input('contact_country', contact_form.country.data, errors=contact_form.country.errors) }}
         <div class="box-label" id="postcode-label">Postcode</div>
         {{ forms.input('contact_postcode', contact_form.postcode.data, errors=contact_form.postcode.errors) }}
       </div>

--- a/app/templates/suppliers/edit_supplier.html
+++ b/app/templates/suppliers/edit_supplier.html
@@ -92,7 +92,6 @@
         {{ forms.input('contact_id', contact_form.id.data, type='hidden') }}
         <div class="box-label" id="address1-label">Building and street</div>
         {{ forms.input('contact_address1', contact_form.address1.data, errors=contact_form.address1.errors) }}
-        {{ forms.input('contact_address2', contact_form.address2.data, errors=contact_form.address2.errors) }}
         <div class="box-label" id="city-label">Town or city</div>
         {{ forms.input('contact_city', contact_form.city.data, errors=contact_form.city.errors) }}
         <div class="box-label" id="postcode-label">Postcode</div>

--- a/tests/app/main/test_suppliers.py
+++ b/tests/app/main/test_suppliers.py
@@ -715,13 +715,13 @@ class TestSupplierDetails(BaseApplicationTest):
                 "Supplier Description",
                 "Client One",
                 "Client Two",
-                "1 Street 2 Building",  # space-normalized together
+                "1 Street",  # "2 Building" is not shown, even though it's in the supplier's contactInformation
                 "supplier.dmdev",
                 "supplier@user.dmdev",
                 "Supplier Person",
                 "0800123123",
                 "Supplierville",
-                #  "Supplierland" is not shown on the page, even though it occurs in the supplier's contactInformation
+                #  "Supplierland" is not shown, even though it's in the supplier's contactInformation
                 "11 AB",
             ):
                 assert document.xpath("//*[normalize-space(string())=$t]", t=property_str), property_str
@@ -854,7 +854,6 @@ class TestSupplierUpdate(BaseApplicationTest):
                 "contact_contactName": "Supplier Person",
                 "contact_phoneNumber": "0800123123",
                 "contact_address1": "1 Street",
-                "contact_address2": "2 Building",
                 "contact_city": "Supplierville",
                 "contact_postcode": "11 AB",
             }
@@ -908,7 +907,6 @@ class TestSupplierUpdate(BaseApplicationTest):
                 'website': u'supplier.dmdev',
                 'city': u'Supplierville',
                 'address1': u'1 Street',
-                'address2': u'2 Building',
                 'email': u'supplier@user.dmdev',
                 'phoneNumber': u'0800123123',
                 'postcode': u'11 AB',
@@ -930,7 +928,6 @@ class TestSupplierUpdate(BaseApplicationTest):
             "contact_contactName": "  Supplier Person  ",
             "contact_phoneNumber": "  0800123123  ",
             "contact_address1": "  1 Street  ",
-            "contact_address2": "  2 Building  ",
             "contact_city": "  Supplierville  ",
             "contact_postcode": "  11 AB  "
         }
@@ -953,7 +950,6 @@ class TestSupplierUpdate(BaseApplicationTest):
                 'website': u'supplier.dmdev',
                 'city': u'Supplierville',
                 'address1': u'1 Street',
-                'address2': u'2 Building',
                 'email': u'supplier@user.dmdev',
                 'phoneNumber': u'0800123123',
                 'postcode': u'11 AB',
@@ -974,7 +970,6 @@ class TestSupplierUpdate(BaseApplicationTest):
             "contact_contactName": "Supplier Person",
             "contact_phoneNumber": "0800123123",
             "contact_address1": "1 Street",
-            "contact_address2": "2 Building",
             "contact_city": "Supplierville",
             "contact_postcode": "11 AB",
         })
@@ -993,7 +988,6 @@ class TestSupplierUpdate(BaseApplicationTest):
         assert 'value="Supplier Person"' in resp
         assert 'value="0800123123"' in resp
         assert 'value="1 Street"' in resp
-        assert 'value="2 Building"' in resp
         assert 'value="Supplierville"' in resp
         assert 'value="11 AB"' in resp
 

--- a/tests/app/main/test_suppliers.py
+++ b/tests/app/main/test_suppliers.py
@@ -721,7 +721,7 @@ class TestSupplierDetails(BaseApplicationTest):
                 "Supplier Person",
                 "0800123123",
                 "Supplierville",
-                "Supplierland",
+                #  "Supplierland" is not shown on the page, even though it occurs in the supplier's contactInformation
                 "11 AB",
             ):
                 assert document.xpath("//*[normalize-space(string())=$t]", t=property_str), property_str
@@ -856,7 +856,6 @@ class TestSupplierUpdate(BaseApplicationTest):
                 "contact_address1": "1 Street",
                 "contact_address2": "2 Building",
                 "contact_city": "Supplierville",
-                "contact_country": "Supplierland",
                 "contact_postcode": "11 AB",
             }
         data.update(kwargs)
@@ -908,7 +907,6 @@ class TestSupplierUpdate(BaseApplicationTest):
             {
                 'website': u'supplier.dmdev',
                 'city': u'Supplierville',
-                'country': u'Supplierland',
                 'address1': u'1 Street',
                 'address2': u'2 Building',
                 'email': u'supplier@user.dmdev',
@@ -934,7 +932,6 @@ class TestSupplierUpdate(BaseApplicationTest):
             "contact_address1": "  1 Street  ",
             "contact_address2": "  2 Building  ",
             "contact_city": "  Supplierville  ",
-            "contact_country": "  Supplierland  ",
             "contact_postcode": "  11 AB  "
         }
 
@@ -955,7 +952,6 @@ class TestSupplierUpdate(BaseApplicationTest):
             {
                 'website': u'supplier.dmdev',
                 'city': u'Supplierville',
-                'country': u'Supplierland',
                 'address1': u'1 Street',
                 'address2': u'2 Building',
                 'email': u'supplier@user.dmdev',
@@ -980,7 +976,6 @@ class TestSupplierUpdate(BaseApplicationTest):
             "contact_address1": "1 Street",
             "contact_address2": "2 Building",
             "contact_city": "Supplierville",
-            "contact_country": u"Supplierland",
             "contact_postcode": "11 AB",
         })
 
@@ -1000,7 +995,6 @@ class TestSupplierUpdate(BaseApplicationTest):
         assert 'value="1 Street"' in resp
         assert 'value="2 Building"' in resp
         assert 'value="Supplierville"' in resp
-        assert 'value="Supplierland"' in resp
         assert 'value="11 AB"' in resp
 
     def test_description_below_word_length(self, data_api_client):


### PR DESCRIPTION
For this Trello card: https://trello.com/c/8y0ApVRh/63-update-the-contact-address-front-end-1

* Removes `address2` and `country` fields from the displayed address and from the edit supplier details page 
* Updates wording to be "Registered office address"