### PR TITLE
Display new supplier fields

### DIFF
--- a/app/main/forms/suppliers.py
+++ b/app/main/forms/suppliers.py
@@ -1,5 +1,5 @@
 from flask.ext.wtf import Form
-from wtforms import IntegerField, FieldList
+from wtforms import IntegerField
 from wtforms.validators import DataRequired, ValidationError, Length, Optional, Regexp
 from dmutils.forms import StripWhitespaceStringField
 
@@ -22,28 +22,22 @@ class EditSupplierForm(Form):
     description = StripWhitespaceStringField('Supplier summary', validators=[
         word_length(50, 'Your summary must not be more than %d words')
     ])
-    clients = FieldList(StripWhitespaceStringField())
-
-    def validate_clients(form, field):
-        if len(field.data) > 10:
-            raise ValidationError('You must have 10 or fewer clients')
 
 
 class EditContactInformationForm(Form):
     id = IntegerField()
-    address1 = StripWhitespaceStringField('Registered office address')
-    city = StripWhitespaceStringField('Town or city')
-    postcode = StripWhitespaceStringField()
-    website = StripWhitespaceStringField()
-    phoneNumber = StripWhitespaceStringField('Phone number')
-    email = StripWhitespaceStringField('Email address', validators=[
+    contactName = StripWhitespaceStringField('Contact name', validators=[
+        DataRequired(message="You must provide a contact name"),
+    ])
+    email = StripWhitespaceStringField('Contact email', validators=[
         DataRequired(message="You must provide an email address"),
         Regexp("^[^@^\s]+@[^@^\.^\s]+(\.[^@^\.^\s]+)+$",
                message="Please enter a valid email address")
     ])
-    contactName = StripWhitespaceStringField('Contact name', validators=[
-        DataRequired(message="You must provide a contact name"),
-    ])
+    phoneNumber = StripWhitespaceStringField('Contact phone number')
+    address1 = StripWhitespaceStringField('Building and street')
+    city = StripWhitespaceStringField('Town or city')
+    postcode = StripWhitespaceStringField('Postcode')
 
 
 class DunsNumberForm(Form):
@@ -72,12 +66,12 @@ class CompanyContactDetailsForm(Form):
         DataRequired(message="You must provide a contact name."),
         Length(max=255, message="You must provide a contact name under 256 characters.")
     ])
-    email_address = StripWhitespaceStringField('Email address', validators=[
+    email_address = StripWhitespaceStringField('Contact email address', validators=[
         DataRequired(message="You must provide an email address."),
         Regexp("^[^@^\s]+@[^@^\.^\s]+(\.[^@^\.^\s]+)+$",
                message="You must provide a valid email address.")
     ])
-    phone_number = StripWhitespaceStringField('Phone number', validators=[
+    phone_number = StripWhitespaceStringField('Contact phone number', validators=[
         DataRequired(message="You must provide a phone number."),
         Length(max=20, message="You must provide a phone number under 20 characters.")
     ])

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -139,7 +139,6 @@ def update_supplier():
     supplier_form = EditSupplierForm(
         formdata=None,
         description=request.form['description'],
-        clients=filter(None, request.form.getlist('clients'))
     )
 
     contact_form = EditContactInformationForm(prefix='contact_')

--- a/app/templates/suppliers/companies_house_number.html
+++ b/app/templates/suppliers/companies_house_number.html
@@ -36,7 +36,7 @@
             value = form.companies_house_number.data,
             error = form.companies_house_number.errors[0],
             question_advice =
-            'This is a unique 8-character number given to your organisation by Companies House.
+            'This is a unique 8-character number given to your company by Companies House.
             Find your <a href="https://beta.companieshouse.gov.uk/">Companies House number</a>.
             ' | safe
         %}

--- a/app/templates/suppliers/dashboard.html
+++ b/app/templates/suppliers/dashboard.html
@@ -53,7 +53,7 @@
       {% include 'suppliers/_frameworks_live.html' %}
     </div>
     <div class="column-one-third dmspeak">
-      <h2 class="heading-xmedium">Your organisation</h2>
+      <h2 class="heading-xmedium">Your company</h2>
       <p>
         <a href="{{ url_for('.supplier_details') }}">Supplier details</a><br/>
         <a href="{{ url_for('.list_users') }}">Contributors</a>

--- a/app/templates/suppliers/details.html
+++ b/app/templates/suppliers/details.html
@@ -44,16 +44,12 @@
     {{ summary.text(supplier.contact.contactName) }}
   {% endcall %}
   {% call summary.row() %}
-    {{ summary.field_name('Email address') }}
+    {{ summary.field_name('Contact email') }}
     {{ summary.text(supplier.contact.email) }}
   {% endcall %}
   {% call summary.row() %}
-    {{ summary.field_name('Phone number') }}
+    {{ summary.field_name('Contact phone number') }}
     {{ summary.text(supplier.contact.phoneNumber) }}
-  {% endcall %}
-  {% call summary.row() %}
-    {{ summary.field_name('Website') }}
-    {{ summary.external_link(supplier.contact.website, supplier.contact.website)}}
   {% endcall %}
   {% call summary.row() %}
     {{ summary.field_name('Registered office address') }}
@@ -74,10 +70,51 @@
     {{ summary.field_name('Supplier summary') }}
     {{ summary.text(supplier.description) }}
   {% endcall %}
-  {% call summary.row() %}
-    {{ summary.field_name('Clients') }}
-    {{ summary.list(supplier.clients) }}
-  {% endcall %}
 {% endcall %}
 
+{{ summary.heading("Registration information", id="registration_information") }}
+{{ summary.description("This is used to process your applications and manage your participation on frameworks.") }}
+{% call(item) summary.mapping_table(
+  caption='Registration information',
+  field_headings=[
+    'Label',
+    'Value'
+  ],
+  field_headings_visible=False
+) %}
+
+  {% call summary.row() %}
+    {{ summary.field_name('Registered company name') }}
+    {{ summary.text(supplier.registeredName) }}
+  {% endcall %}
+  {% call summary.row() %}
+    {{ summary.field_name('Companies House number') }}
+    {{ summary.text(supplier.companiesHouseNumber) }}
+  {% endcall %}
+  {% call summary.row() %}
+    {{ summary.field_name('Where your business was established') }}
+    {{ summary.text(supplier.registrationCountry) }}
+  {% endcall %}
+  {% call summary.row() %}
+    {{ summary.field_name('Registration number') }}
+    {{ summary.text(supplier.otherCompanyRegistrationNumber) }}
+  {% endcall %}
+  {% call summary.row() %}
+    {{ summary.field_name('DUNS number') }}
+    {{ summary.text(supplier.dunsNumber) }}
+  {% endcall %}
+  {% call summary.row() %}
+    {{ summary.field_name('VAT number') }}
+    {{ summary.text(supplier.vatNumber) }}
+  {% endcall %}
+  {% call summary.row() %}
+    {{ summary.field_name('Trading status') }}
+    {{ summary.text(supplier.tradingStatus|capitalize_first) }}
+  {% endcall %}
+  {% call summary.row() %}
+    {{ summary.field_name('Company size') }}
+    {{ summary.text(supplier.organisationSize|capitalize_first) }}
+  {% endcall %}
+
+{% endcall %}
 {% endblock %}

--- a/app/templates/suppliers/details.html
+++ b/app/templates/suppliers/details.html
@@ -100,11 +100,11 @@
   {% if supplier.registrationCountry and not supplier.companiesHouseNumber %}
     {% call summary.row() %}
       {{ summary.field_name('Where your business was established') }}
-      {{ summary.text(supplier.registrationCountry) }}
+      {{ summary.text(supplier.registrationCountry|upper) }}
     {% endcall %}
   {% endif %}
 
-  {% if supplier.otherCompanyRegistrationNumber and not supplier.companiesHouseNumber and supplier.registrationCountry != 'UK' %}
+  {% if supplier.otherCompanyRegistrationNumber and not supplier.companiesHouseNumber and supplier.registrationCountry != 'gb' %}
     {% call summary.row() %}
       {{ summary.field_name('Registration number') }}
       {{ summary.text(supplier.otherCompanyRegistrationNumber) }}

--- a/app/templates/suppliers/details.html
+++ b/app/templates/suppliers/details.html
@@ -83,38 +83,61 @@
   field_headings_visible=False
 ) %}
 
-  {% call summary.row() %}
-    {{ summary.field_name('Registered company name') }}
-    {{ summary.text(supplier.registeredName) }}
-  {% endcall %}
-  {% call summary.row() %}
-    {{ summary.field_name('Companies House number') }}
-    {{ summary.text(supplier.companiesHouseNumber) }}
-  {% endcall %}
-  {% call summary.row() %}
-    {{ summary.field_name('Where your business was established') }}
-    {{ summary.text(supplier.registrationCountry) }}
-  {% endcall %}
-  {% call summary.row() %}
-    {{ summary.field_name('Registration number') }}
-    {{ summary.text(supplier.otherCompanyRegistrationNumber) }}
-  {% endcall %}
-  {% call summary.row() %}
-    {{ summary.field_name('DUNS number') }}
-    {{ summary.text(supplier.dunsNumber) }}
-  {% endcall %}
-  {% call summary.row() %}
-    {{ summary.field_name('VAT number') }}
-    {{ summary.text(supplier.vatNumber) }}
-  {% endcall %}
-  {% call summary.row() %}
-    {{ summary.field_name('Trading status') }}
-    {{ summary.text(supplier.tradingStatus|capitalize_first) }}
-  {% endcall %}
-  {% call summary.row() %}
-    {{ summary.field_name('Company size') }}
-    {{ summary.text(supplier.organisationSize|capitalize_first) }}
-  {% endcall %}
+  {% if supplier.registeredName %}
+    {% call summary.row() %}
+      {{ summary.field_name('Registered company name') }}
+      {{ summary.text(supplier.registeredName) }}
+    {% endcall %}
+  {% endif %}
+
+  {% if supplier.companiesHouseNumber %}
+    {% call summary.row() %}
+      {{ summary.field_name('Companies House number') }}
+      {{ summary.text(supplier.companiesHouseNumber) }}
+    {% endcall %}
+  {% endif %}
+
+  {% if supplier.registrationCountry and not supplier.companiesHouseNumber %}
+    {% call summary.row() %}
+      {{ summary.field_name('Where your business was established') }}
+      {{ summary.text(supplier.registrationCountry) }}
+    {% endcall %}
+  {% endif %}
+
+  {% if supplier.otherCompanyRegistrationNumber and not supplier.companiesHouseNumber and supplier.registrationCountry != 'UK' %}
+    {% call summary.row() %}
+      {{ summary.field_name('Registration number') }}
+      {{ summary.text(supplier.otherCompanyRegistrationNumber) }}
+    {% endcall %}
+  {% endif %}
+
+  {% if supplier.dunsNumber %}
+    {% call summary.row() %}
+      {{ summary.field_name('DUNS number') }}
+      {{ summary.text(supplier.dunsNumber) }}
+    {% endcall %}
+  {% endif %}
+
+  {% if supplier.vatNumber %}
+    {% call summary.row() %}
+      {{ summary.field_name('VAT number') }}
+      {{ summary.text(supplier.vatNumber) }}
+    {% endcall %}
+  {% endif %}
+
+  {% if supplier.tradingStatus %}
+    {% call summary.row() %}
+      {{ summary.field_name('Trading status') }}
+      {{ summary.text(supplier.tradingStatus|capitalize_first) }}
+    {% endcall %}
+  {% endif %}
+
+  {% if supplier.organisationSize %}
+    {% call summary.row() %}
+      {{ summary.field_name('Company size') }}
+      {{ summary.text(supplier.organisationSize|capitalize_first) }}
+    {% endcall %}
+  {% endif %}
 
 {% endcall %}
 {% endblock %}

--- a/app/templates/suppliers/edit_supplier.html
+++ b/app/templates/suppliers/edit_supplier.html
@@ -76,14 +76,10 @@
 
   <div class="grid-row">
     <div class="column-two-thirds">
-      {{ forms.question_textarea('description', 'Supplier summary', supplier_form.description.data, '50 words max', errors=supplier_form.description.errors, max_length_in_words=50) }}
-
-      {{ forms.question_list_entry('clients', 'Clients', supplier_form.clients.data, '1 client per box, max 10 clients', errors=supplier_form.clients.errors, item_name='client', number_of_items=10) }}
 
       {{ forms.question_input('contact_contactName', 'Contact name', contact_form.contactName.data, 'Primary contact', errors=contact_form.contactName.errors) }}
-      {{ forms.question_input('contact_website', 'Website', contact_form.website.data, errors=contact_form.website.errors) }}
-      {{ forms.question_input('contact_email', 'Email address', contact_form.email.data, errors=contact_form.email.errors) }}
-      {{ forms.question_input('contact_phoneNumber', 'Phone number', contact_form.phoneNumber.data, errors=contact_form.phoneNumber.errors) }}
+      {{ forms.question_input('contact_email', 'Contact email', contact_form.email.data, errors=contact_form.email.errors) }}
+      {{ forms.question_input('contact_phoneNumber', 'Contact phone number', contact_form.phoneNumber.data, errors=contact_form.phoneNumber.errors) }}
 
       <div class="question">
         <label class="question-heading">
@@ -98,6 +94,7 @@
         {{ forms.input('contact_postcode', contact_form.postcode.data, errors=contact_form.postcode.errors) }}
       </div>
 
+      {{ forms.question_textarea('description', 'Supplier summary', supplier_form.description.data, '50 words max', errors=supplier_form.description.errors, max_length_in_words=50) }}
     </div>
   </div>
 


### PR DESCRIPTION
For this story in Trello: https://trello.com/c/GFp7ncpN/62-update-the-supplier-page-to-expose-the-migrated-declaration-information-2

**THERE IS AN ACCOMPANYING LEGACY FUNCTIONAL TESTS PR TO MERGE AT THE SAME TIME**: https://github.com/alphagov/digitalmarketplace-functional-tests/pull/336

This adds the new "Registration information" section to the supplier details page, and also updates the edit supplier information form to only show the fields that are now displayed.  Wording is updated to match the prototype, and the fields on the edit page match the names of the fields on the display page (which previously they didn't 😞 ).

Updated page looks like this:
![screen shot 2017-08-29 at 18 23 32](https://user-images.githubusercontent.com/6525554/29834597-45995c94-8ce7-11e7-8860-2c2395d25325.png)

And like this for a supplier with more registration info:
![screen shot 2017-08-29 at 18 25 47](https://user-images.githubusercontent.com/6525554/29834711-9016ca04-8ce7-11e7-936c-ca5c9f1176c8.png)
