### PR TITLE
Bugfix: not validating Companies House strictly enough on frontend

### DIFF
--- a/app/main/forms/suppliers.py
+++ b/app/main/forms/suppliers.py
@@ -50,7 +50,9 @@ class DunsNumberForm(Form):
 class CompaniesHouseNumberForm(Form):
     companies_house_number = StripWhitespaceStringField('Companies house number', validators=[
         Optional(),
-        Length(min=8, max=8, message="Companies House numbers must have 8 characters.")
+        Regexp(r'^([0-9]{2}|[A-Za-z]{2})[0-9]{6}$',
+               message="Companies House numbers must have either 8 digits or 2 letters followed by 6 digits."
+               )
     ])
 
 

--- a/tests/app/main/test_suppliers.py
+++ b/tests/app/main/test_suppliers.py
@@ -1158,21 +1158,40 @@ class TestCreateSupplier(BaseApplicationTest):
         res = self.client.post(
             "/suppliers/companies-house-number",
             data={
-                'companies_house_number': "short"
+                'companies_house_number': "1234567"
             }
         )
         assert res.status_code == 400
-        assert "Companies House numbers must have 8 characters." in res.get_data(as_text=True)
+        assert ("Companies House numbers must have either 8 digits or 2 letters followed by 6 digits."
+                in
+                res.get_data(as_text=True)
+                )
 
     def test_should_be_an_error_if_companies_house_number_is_not_8_characters_long(self):
         res = self.client.post(
             "/suppliers/companies-house-number",
             data={
-                'companies_house_number': "muchtoolongtobecompanieshouse"
+                'companies_house_number': "123456789"
             }
         )
         assert res.status_code == 400
-        assert "Companies House numbers must have 8 characters." in res.get_data(as_text=True)
+        assert ("Companies House numbers must have either 8 digits or 2 letters followed by 6 digits."
+                in
+                res.get_data(as_text=True)
+                )
+
+    def test_should_be_an_error_if_companies_house_number_is_8_characters_but_invalid_format(self):
+        res = self.client.post(
+            "/suppliers/companies-house-number",
+            data={
+                'companies_house_number': "ABC12345"
+            }
+        )
+        assert res.status_code == 400
+        assert ("Companies House numbers must have either 8 digits or 2 letters followed by 6 digits."
+                in
+                res.get_data(as_text=True)
+                )
 
     def test_should_allow_valid_companies_house_number(self):
         with self.client as c:


### PR DESCRIPTION
We recently (in this commit: https://github.com/alphagov/digitalmarketplace-api/pull/626/commits/fd76ee0bb6f0edacf29ed239d78424650b05e00e) introduced a validator on the API to restrict Companies House numbers to valid formats, but didn't update validation in the frontend flow here at the same time.

Because nothing gets posted to the API until the final step of this flow it is currently possible to submit an invalid CH number here and then have the API post request fail when submitting the final step.

It's not ideal to have the same regex in two places, but this is a current production bug and this will fix it for now.