### PR TITLE
Implement an email sign up capability for suppliers

### DIFF
--- a/app/main/forms/suppliers.py
+++ b/app/main/forms/suppliers.py
@@ -1,7 +1,7 @@
 from flask.ext.wtf import Form
 from wtforms import IntegerField
 from wtforms.validators import DataRequired, ValidationError, Length, Optional, Regexp
-from dmutils.forms import StripWhitespaceStringField
+from dmutils.forms import StripWhitespaceStringField, EmailField, EmailValidator
 
 
 def word_length(limit=None, message=None):
@@ -29,10 +29,8 @@ class EditContactInformationForm(Form):
     contactName = StripWhitespaceStringField('Contact name', validators=[
         DataRequired(message="You must provide a contact name"),
     ])
-    email = StripWhitespaceStringField('Contact email', validators=[
+    email = EmailField('Contact email', validators=[
         DataRequired(message="You must provide an email address"),
-        Regexp("^[^@^\s]+@[^@^\.^\s]+(\.[^@^\.^\s]+)+$",
-               message="Please enter a valid email address")
     ])
     phoneNumber = StripWhitespaceStringField('Contact phone number')
     address1 = StripWhitespaceStringField('Building and street')
@@ -70,8 +68,7 @@ class CompanyContactDetailsForm(Form):
     ])
     email_address = StripWhitespaceStringField('Contact email address', validators=[
         DataRequired(message="You must provide an email address."),
-        Regexp("^[^@^\s]+@[^@^\.^\s]+(\.[^@^\.^\s]+)+$",
-               message="You must provide a valid email address.")
+        EmailValidator(message="You must provide a valid email address."),
     ])
     phone_number = StripWhitespaceStringField('Contact phone number', validators=[
         DataRequired(message="You must provide a phone number."),
@@ -82,6 +79,5 @@ class CompanyContactDetailsForm(Form):
 class EmailAddressForm(Form):
     email_address = StripWhitespaceStringField('Email address', validators=[
         DataRequired(message="You must provide an email address."),
-        Regexp("^[^@^\s]+@[^@^\.^\s]+(\.[^@^\.^\s]+)+$",
-               message="You must provide a valid email address.")
+        EmailValidator(message="You must provide a valid email address."),
     ])

--- a/app/main/forms/suppliers.py
+++ b/app/main/forms/suppliers.py
@@ -29,7 +29,7 @@ class EditContactInformationForm(Form):
     contactName = StripWhitespaceStringField('Contact name', validators=[
         DataRequired(message="You must provide a contact name"),
     ])
-    email = EmailField('Contact email', validators=[
+    email = EmailField('Contact email address', validators=[
         DataRequired(message="You must provide an email address"),
     ])
     phoneNumber = StripWhitespaceStringField('Contact phone number')

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -2,7 +2,7 @@
 
 from itertools import chain
 
-from flask import render_template, request, redirect, url_for, abort, session, Markup
+from flask import render_template, request, redirect, url_for, abort, session, Markup, flash
 from flask_login import current_user, current_app
 import six
 
@@ -10,6 +10,7 @@ from dmapiclient import APIError
 from dmapiclient.audit import AuditTypes
 from dmutils.email import send_email, generate_token
 from dmutils.email.exceptions import EmailError
+from dmutils.email.dm_mailchimp import DMMailChimpClient
 from dmcontent.content_loader import ContentNotFoundError
 
 from ...main import main, content_loader
@@ -467,3 +468,48 @@ def create_your_account_complete():
         "suppliers/create_your_account_complete.html",
         email_address=email_address
     ), 200
+
+
+@main.route('/mailing-list', methods=["GET", "POST"])
+def join_open_framework_notification_mailing_list():
+    status = 200
+    if request.method == "POST":
+        form = EmailAddressForm(request.form)
+        if form.validate():
+            dmmc_client = DMMailChimpClient(
+                current_app.config["DM_MAILCHIMP_USERNAME"],
+                current_app.config["DM_MAILCHIMP_API_KEY"],
+                current_app.logger,
+            )
+
+            mc_response = dmmc_client.subscribe_new_email_to_list(
+                current_app.config["DM_MAILCHIMP_OPEN_FRAMEWORK_NOTIFICATION_MAILING_LIST_ID"],
+                form.data["email_address"],
+            )
+            # note we're signalling our flash messages in two separate ways here
+            if mc_response not in (True, False,):
+                # success
+
+                # this message will be consumed by the buyer app which has been converted to display raw "literal"
+                # content from the session
+                flash(Markup(render_template(
+                    "flashmessages/join_open_framework_notification_mailing_list_success.html",
+                    email_address=form.data["email_address"],
+                )), "success")
+
+                return redirect("/")
+            else:
+                # failure
+                flash("mailing_list_signup_error", "error")
+                status = 503
+                # fall through to re-display form with error
+        else:
+            status = 400
+            # fall through to re-display form with errors
+    else:
+        form = EmailAddressForm()
+
+    return render_template(
+        "suppliers/join_open_framework_notification_mailing_list.html",
+        form=form,
+    ), status

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -486,9 +486,23 @@ def join_open_framework_notification_mailing_list():
                 current_app.config["DM_MAILCHIMP_OPEN_FRAMEWORK_NOTIFICATION_MAILING_LIST_ID"],
                 form.data["email_address"],
             )
+
             # note we're signalling our flash messages in two separate ways here
             if mc_response not in (True, False,):
                 # success
+                data_api_client.create_audit_event(
+                    audit_type=AuditTypes.mailing_list_subscription,
+                    data={
+                        "subscribedEmail": form.data["email_address"],
+                        "mailchimp": {k: mc_response.get(k) for k in (
+                            "id",
+                            "unique_email_id",
+                            "timestamp_opt",
+                            "last_changed",
+                            "list_id",
+                        )},
+                    },
+                )
 
                 # this message will be consumed by the buyer app which has been converted to display raw "literal"
                 # content from the session

--- a/app/templates/flashmessages/join_open_framework_notification_mailing_list_success.html
+++ b/app/templates/flashmessages/join_open_framework_notification_mailing_list_success.html
@@ -1,0 +1,1 @@
+You will receive email notifications to {{ email_address }} when applications are opening.

--- a/app/templates/suppliers/join_open_framework_notification_mailing_list.html
+++ b/app/templates/suppliers/join_open_framework_notification_mailing_list.html
@@ -36,16 +36,15 @@
 {% endwith %}
 
 <div class="single-question-page">
-  {%
-  with
-      heading = "Sign up for Digital Marketplace email alerts",
-      smaller = True
-  %}
-  {% include "toolkit/page-heading.html" %}
-  {% endwith %}
-
   <div class="grid-row">
     <div class="column-two-thirds">
+      {%
+      with
+          heading = "Sign up for Digital Marketplace email alerts",
+          smaller = True
+      %}
+      {% include "toolkit/page-heading.html" %}
+      {% endwith %}
       <form method="POST" action="">
           <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
           {% set question_advice %}

--- a/app/templates/suppliers/join_open_framework_notification_mailing_list.html
+++ b/app/templates/suppliers/join_open_framework_notification_mailing_list.html
@@ -1,0 +1,81 @@
+{% extends "_base_page.html" %}
+
+{% block page_title %}Sign up for Digital Marketplace email alerts – Digital Marketplace{% endblock %}
+
+{% block breadcrumb %}
+{%
+  with items = [
+    {
+      "link": "/",
+      "label": "Digital Marketplace"
+    }
+  ]
+%}
+{% include "toolkit/breadcrumb.html" %}
+{% endwith %}
+{% endblock %}
+
+{% block main_content %}
+
+{% with messages = get_flashed_messages(with_categories=true) %}
+  {% if messages %}
+    {% for category, message in messages %}
+      {% if category == "error" and message == "mailing_list_signup_error" %}
+        {% set message %}
+          The service is unavailable at the moment. If the problem continues please
+          contact <a href="mailto:enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.service.gov.uk</a>.
+        {% endset %}
+        {%
+          with type = "destructive"
+        %}
+          {% include "toolkit/notification-banner.html" %}
+        {% endwith %}
+      {% endif %}
+    {% endfor %}
+  {% endif %}
+{% endwith %}
+
+<div class="single-question-page">
+  {%
+  with
+      heading = "Sign up for Digital Marketplace email alerts",
+      smaller = True
+  %}
+  {% include "toolkit/page-heading.html" %}
+  {% endwith %}
+
+  <div class="grid-row">
+    <div class="column-two-thirds">
+      <form method="POST" action="">
+          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+          {% set question_advice %}
+            <p>
+              We’ll let you know when applications to sell your services will open.
+            </p>
+            <p>
+              You do not need to subscribe if you already have a supplier account.
+            </p>
+          {% endset %}
+          {%
+            with
+              question = "Email",
+              name = "email_address",
+              value = form.email_address.data,
+              error = form.email_address.errors[0],
+              question_advice = question_advice
+          %}
+            {% include "toolkit/forms/textbox.html" %}
+          {% endwith %}
+
+          {%
+            with
+              type = "save",
+              label = "Subscribe"
+          %}
+          {% include "toolkit/button.html" %}
+          {% endwith %}
+      </form>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/config.py
+++ b/config.py
@@ -33,6 +33,10 @@ class Config(object):
     DM_SUBMISSIONS_BUCKET = None
     DM_ASSETS_URL = None
 
+    DM_MAILCHIMP_USERNAME = None
+    DM_MAILCHIMP_API_KEY = None
+    DM_MAILCHIMP_OPEN_FRAMEWORK_NOTIFICATION_MAILING_LIST_ID = None
+
     DEBUG = False
 
     RESET_PASSWORD_EMAIL_NAME = 'Digital Marketplace Admin'
@@ -99,6 +103,10 @@ class Test(Config):
     SHARED_EMAIL_KEY = "KEY"
     DM_CLARIFICATION_QUESTION_EMAIL = 'digitalmarketplace@mailinator.com'
 
+    DM_MAILCHIMP_USERNAME = 'not_a_real_username'
+    DM_MAILCHIMP_API_KEY = 'not_a_real_key'
+    DM_MAILCHIMP_OPEN_FRAMEWORK_NOTIFICATION_MAILING_LIST_ID = "not_a_real_mailing_list"
+
     FEATURE_FLAGS_EDIT_SECTIONS = enabled_since('2015-06-03')
     FEATURE_FLAGS_CONTRACT_VARIATION = enabled_since('2016-08-11')
 
@@ -131,6 +139,10 @@ class Development(Config):
     DM_MANDRILL_API_KEY = "not_a_real_key"
     SHARED_EMAIL_KEY = "very_secret"
     SECRET_KEY = 'verySecretKey'
+
+    DM_MAILCHIMP_USERNAME = 'not_a_real_username'
+    DM_MAILCHIMP_API_KEY = 'not_a_real_key'
+    DM_MAILCHIMP_OPEN_FRAMEWORK_NOTIFICATION_MAILING_LIST_ID = "not_a_real_mailing_list"
 
 
 class Live(Config):

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -7,4 +7,4 @@ Flask-WTF==0.12
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@28.1.0#egg=digitalmarketplace-utils==28.1.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.2.0#egg=digitalmarketplace-content-loader==4.2.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@8.11.0#egg=digitalmarketplace-apiclient==8.11.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@10.4.0#egg=digitalmarketplace-apiclient==10.4.0

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -5,6 +5,6 @@ Flask==0.10.1
 Flask-Login==0.2.11
 Flask-WTF==0.12
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@27.1.2#egg=digitalmarketplace-utils==27.1.2
+git+https://github.com/alphagov/digitalmarketplace-utils.git@28.1.0#egg=digitalmarketplace-utils==28.1.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.2.0#egg=digitalmarketplace-content-loader==4.2.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@8.11.0#egg=digitalmarketplace-apiclient==8.11.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ Flask-WTF==0.12
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@28.1.0#egg=digitalmarketplace-utils==28.1.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.2.0#egg=digitalmarketplace-content-loader==4.2.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@8.11.0#egg=digitalmarketplace-apiclient==8.11.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@10.4.0#egg=digitalmarketplace-apiclient==10.4.0
 
 ## The following requirements were added by pip freeze:
 asn1crypto==0.22.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ Flask==0.10.1
 Flask-Login==0.2.11
 Flask-WTF==0.12
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@27.1.2#egg=digitalmarketplace-utils==27.1.2
+git+https://github.com/alphagov/digitalmarketplace-utils.git@28.1.0#egg=digitalmarketplace-utils==28.1.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.2.0#egg=digitalmarketplace-content-loader==4.2.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@8.11.0#egg=digitalmarketplace-apiclient==8.11.0
 

--- a/tests/app/helpers.py
+++ b/tests/app/helpers.py
@@ -10,6 +10,24 @@ from dmutils.formats import DATETIME_FORMAT
 import pytest
 
 
+# intended to be used as a mock's side_effect
+def assert_args_and_raise(e, *args, **kwargs):
+    def _inner(*inner_args, **inner_kwargs):
+        assert args == inner_args
+        assert kwargs == inner_kwargs
+        raise e
+    return _inner
+
+
+# intended to be used as a mock's side_effect
+def assert_args_and_return(retval, *args, **kwargs):
+    def _inner(*inner_args, **inner_kwargs):
+        assert args == inner_args
+        assert kwargs == inner_kwargs
+        return retval
+    return _inner
+
+
 FULL_G7_SUBMISSION = {
     "status": "complete",
     "PR1": "true",

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -23,7 +23,14 @@ from dmapiclient.audit import AuditTypes
 from dmutils.email.exceptions import EmailError
 from dmutils.s3 import S3ResponseError
 
-from ..helpers import BaseApplicationTest, FULL_G7_SUBMISSION, FakeMail, valid_g9_declaration_base
+from ..helpers import (
+    BaseApplicationTest,
+    FULL_G7_SUBMISSION,
+    FakeMail,
+    valid_g9_declaration_base,
+    assert_args_and_raise,
+    assert_args_and_return,
+)
 
 
 def _return_fake_s3_file_dict(directory, filename, ext, last_modified=None, size=None):
@@ -44,22 +51,6 @@ def get_g_cloud_8():
         slug='g-cloud-8',
         framework_agreement_version='v1.0'
     )
-
-
-def _assert_args_and_raise(e, *args, **kwargs):
-    def _inner(*inner_args, **inner_kwargs):
-        assert args == inner_args
-        assert kwargs == inner_kwargs
-        raise e
-    return _inner
-
-
-def _assert_args_and_return(retval, *args, **kwargs):
-    def _inner(*inner_args, **inner_kwargs):
-        assert args == inner_args
-        assert kwargs == inner_kwargs
-        return retval
-    return _inner
 
 
 @pytest.fixture(params=("GET", "POST"))
@@ -2343,11 +2334,11 @@ class TestDeclarationOverviewSubmit(BaseApplicationTest):
         with self.app.test_client():
             self.login()
 
-            data_api_client.get_framework.side_effect = _assert_args_and_return(
+            data_api_client.get_framework.side_effect = assert_args_and_return(
                 self.framework(status="open"),
                 "g-cloud-7",
             )
-            data_api_client.get_supplier_framework_info.side_effect = _assert_args_and_raise(
+            data_api_client.get_supplier_framework_info.side_effect = assert_args_and_raise(
                 APIError(mock.Mock(status_code=404)),
                 1234,
                 "g-cloud-7",
@@ -2362,11 +2353,11 @@ class TestDeclarationOverviewSubmit(BaseApplicationTest):
         with self.app.test_client():
             self.login()
 
-            data_api_client.get_framework.side_effect = _assert_args_and_return(
+            data_api_client.get_framework.side_effect = assert_args_and_return(
                 self.framework(status="coming"),
                 "g-cloud-7",
             )
-            data_api_client.get_supplier_framework_info.side_effect = _assert_args_and_return(
+            data_api_client.get_supplier_framework_info.side_effect = assert_args_and_return(
                 self.supplier_framework(framework_slug="g-cloud-7"),
                 1234,
                 "g-cloud-7",
@@ -2381,11 +2372,11 @@ class TestDeclarationOverviewSubmit(BaseApplicationTest):
         with self.app.test_client():
             self.login()
 
-            data_api_client.get_framework.side_effect = _assert_args_and_raise(
+            data_api_client.get_framework.side_effect = assert_args_and_raise(
                 APIError(mock.Mock(status_code=404)),
                 "muttoning-clouds",
             )
-            data_api_client.get_supplier_framework_info.side_effect = _assert_args_and_raise(
+            data_api_client.get_supplier_framework_info.side_effect = assert_args_and_raise(
                 APIError(mock.Mock(status_code=404)),
                 1234,
                 "muttoning-clouds",
@@ -2449,11 +2440,11 @@ class TestDeclarationOverview(BaseApplicationTest):
         return row_heading, None, rows
 
     def _setup_data_api_client(self, data_api_client, framework_status, framework_slug, declaration, prefill_fw_slug):
-        data_api_client.get_framework.side_effect = _assert_args_and_return(
+        data_api_client.get_framework.side_effect = assert_args_and_return(
             self.framework(slug=framework_slug, name="F-Cumulus 0", status=framework_status),
             framework_slug,
         )
-        data_api_client.get_supplier_framework_info.side_effect = _assert_args_and_return(
+        data_api_client.get_supplier_framework_info.side_effect = assert_args_and_return(
             self.supplier_framework(
                 framework_slug=framework_slug,
                 declaration=declaration,
@@ -3092,11 +3083,11 @@ class TestDeclarationSubmit(BaseApplicationTest):
         with self.app.test_client():
             self.login()
 
-            data_api_client.get_framework.side_effect = _assert_args_and_return(
+            data_api_client.get_framework.side_effect = assert_args_and_return(
                 self.framework(slug="g-cloud-9", name="G-Cloud 9", status="open"),
                 "g-cloud-9",
             )
-            data_api_client.get_supplier_framework_info.side_effect = _assert_args_and_return(
+            data_api_client.get_supplier_framework_info.side_effect = assert_args_and_return(
                 self.supplier_framework(
                     framework_slug="g-cloud-9",
                     declaration=invalid_declaration,
@@ -3118,11 +3109,11 @@ class TestDeclarationSubmit(BaseApplicationTest):
         with self.app.test_client():
             self.login()
 
-            data_api_client.get_framework.side_effect = _assert_args_and_return(
+            data_api_client.get_framework.side_effect = assert_args_and_return(
                 self.framework(slug="g-cloud-9", name="G-Cloud 9", status="open"),
                 "g-cloud-9",
             )
-            data_api_client.get_supplier_framework_info.side_effect = _assert_args_and_return(
+            data_api_client.get_supplier_framework_info.side_effect = assert_args_and_return(
                 self.supplier_framework(
                     framework_slug="g-cloud-9",
                     declaration=dict(status=declaration_status, **(valid_g9_declaration_base())),
@@ -3131,7 +3122,7 @@ class TestDeclarationSubmit(BaseApplicationTest):
                 1234,
                 "g-cloud-9",
             )
-            data_api_client.set_supplier_declaration.side_effect = _assert_args_and_return(
+            data_api_client.set_supplier_declaration.side_effect = assert_args_and_return(
                 dict(status="complete", **(valid_g9_declaration_base())),
                 1234,
                 "g-cloud-9",
@@ -3158,11 +3149,11 @@ class TestDeclarationSubmit(BaseApplicationTest):
         with self.app.test_client():
             self.login()
 
-            data_api_client.get_framework.side_effect = _assert_args_and_return(
+            data_api_client.get_framework.side_effect = assert_args_and_return(
                 self.framework(status=framework_status),
                 "g-cloud-7",
             )
-            data_api_client.get_supplier_framework_info.side_effect = _assert_args_and_return(
+            data_api_client.get_supplier_framework_info.side_effect = assert_args_and_return(
                 self.supplier_framework(framework_slug="g-cloud-7"),
                 1234,
                 "g-cloud-7",

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -116,7 +116,7 @@ class TestFrameworksDashboard(BaseApplicationTest):
             ),
             (
                 'Submitted by',
-                'User email@email.com Sunday 10 July 2016 at 22:20'
+                'User email@email.com Sunday 10 July 2016 at 10:20pm'
             ),
             (
                 'Countersignature',
@@ -1855,7 +1855,7 @@ class TestFrameworkAgreement(BaseApplicationTest):
 
             assert res.status_code == 200
             assert u'/suppliers/frameworks/g-cloud-7/agreement' == doc.xpath('//form')[1].action
-            assert u'Document uploaded Monday 2 November 2015 at 15:25' in data
+            assert u'Document uploaded Monday 2 November 2015 at 3:25pm' in data
             assert u'Your document has been uploaded' in data
 
     def test_upload_message_if_agreement_is_not_returned(self, data_api_client):
@@ -4692,7 +4692,7 @@ class TestSignatureUploadPage(BaseApplicationTest):
 
                 s3.return_value.get_key.assert_called_with('already/uploaded/file/path.pdf')
                 assert res.status_code == 200
-                assert "test.pdf, uploaded Sunday 10 July 2016 at 22:18" in res.get_data(as_text=True)
+                assert "test.pdf, uploaded Sunday 10 July 2016 at 10:18pm" in res.get_data(as_text=True)
 
     @mock.patch('dmutils.s3.S3')
     def test_signature_page_displays_file_upload_timestamp_if_no_filename_in_session(
@@ -4719,7 +4719,7 @@ class TestSignatureUploadPage(BaseApplicationTest):
                 )
                 s3.return_value.get_key.assert_called_with('already/uploaded/file/path.pdf')
                 assert res.status_code == 200
-                assert "Uploaded Sunday 10 July 2016 at 22:18" in res.get_data(as_text=True)
+                assert "Uploaded Sunday 10 July 2016 at 10:18pm" in res.get_data(as_text=True)
 
     @mock.patch('dmutils.s3.S3')
     def test_signature_page_allows_continuation_without_file_chosen_to_be_uploaded_if_an_uploaded_file_already_exists(
@@ -4828,7 +4828,7 @@ class TestContractReviewPage(BaseApplicationTest):
             assert res.status_code == 200
             page = res.get_data(as_text=True)
             assert u'Check the details you’ve given before returning the signature page for £unicodename' in page
-            assert '<tdclass="summary-item-field-first"><span>UploadedSunday10July2016at22:18</span></td>' in self.strip_all_whitespace(page)  # noqa
+            assert '<tdclass="summary-item-field-first"><span>UploadedSunday10July2016at10:18pm</span></td>' in self.strip_all_whitespace(page)  # noqa
 
     @mock.patch('dmutils.s3.S3')
     def test_contract_review_page_aborts_if_visited_when_information_required_to_return_agreement_does_not_exist(
@@ -5346,7 +5346,7 @@ class TestContractVariation(BaseApplicationTest):
 
         assert res.status_code == 200
         assert len(doc.xpath('//h2[contains(text(), "Contract variation status")]')) == 1
-        assert u"<span>William Drăyton<br />agreed@email.com<br />Friday 19 August 2016 at 16:47</span>" in page_text
+        assert u"<span>William Drăyton<br />agreed@email.com<br />Friday 19 August 2016 at 4:47pm</span>" in page_text
         assert len(doc.xpath('//label[contains(text(), "I accept these proposed changes")]')) == 0
         assert len(doc.xpath('//input[@value="Save and continue"]')) == 0
 

--- a/tests/app/main/test_suppliers.py
+++ b/tests/app/main/test_suppliers.py
@@ -3,11 +3,12 @@ from flask import session
 from lxml import html
 import mock
 import pytest
+from six.moves.urllib.parse import urlparse
 
 from dmapiclient import HTTPError
 from dmutils.email.exceptions import EmailError
 
-from tests.app.helpers import BaseApplicationTest
+from tests.app.helpers import BaseApplicationTest, assert_args_and_return
 
 find_frameworks_return_value = {
     "frameworks": [
@@ -1665,3 +1666,182 @@ class TestCreateSupplier(BaseApplicationTest):
 
             assert res.status_code == 200
             assert 'An email has been sent to my-email@example.com' in res.get_data(as_text=True)
+
+
+class TestJoinOpenFrameworkNotificationMailingList(BaseApplicationTest):
+    @staticmethod
+    def _common_page_asserts_and_get_form(doc):
+        assert tuple(h1.xpath("normalize-space(string())") for h1 in doc.xpath("//h1")) == (
+            "Sign up for Digital Marketplace email alerts",
+        )
+
+        form = next(
+            form for form in doc.xpath("//form[@method='POST']")
+            if urlparse(form.action)[2:] == ("/suppliers/mailing-list", "", "", "",) and
+            form.xpath(".//input[@name='email_address']")
+        )
+        assert form.xpath(".//input[@name='csrf_token']")
+        assert form.xpath(".//input[@type='submit'][@value='Subscribe']")
+
+        return form
+
+    @mock.patch("app.main.views.suppliers.DMMailChimpClient")
+    def test_get(self, mailchimp_client_class):
+        mailchimp_client_instance = mock.Mock(spec=("subscribe_new_email_to_list",))
+        mailchimp_client_instance.subscribe_new_email_to_list.side_effect = AssertionError("This should not be called")
+
+        mailchimp_client_class.side_effect = assert_args_and_return(
+            mailchimp_client_instance,
+            "not_a_real_username",
+            "not_a_real_key",
+            mock.ANY,
+        )
+
+        response = self.client.get(
+            "/suppliers/mailing-list",
+        )
+        assert response.status_code == 200
+        doc = html.fromstring(response.get_data(as_text=True), base_url="/suppliers/mailing-list")
+
+        assert not doc.xpath(
+            "//*[normalize-space(string())=$t]",
+            t="You must provide a valid email address.",
+        )
+        assert not doc.xpath(
+            "//*[normalize-space(string())=$t]",
+            t="You must provide an email address.",
+        )
+        assert not doc.xpath("//*[contains(@class, 'validation-message')]")
+
+        form = self._common_page_asserts_and_get_form(doc)
+
+        # we have already tested for the existence of input[@name='email_address']
+        assert not any(inp.value for inp in form.xpath(".//input[@name='email_address']"))
+
+        self.assert_no_flashes()
+
+    @pytest.mark.parametrize("email_address_value,expected_validation_message", (
+        ("pint@twopence", "You must provide a valid email address.",),
+        ("", "You must provide an email address.",),
+    ))
+    @mock.patch("app.main.views.suppliers.DMMailChimpClient")
+    def test_post_invalid_email(self, mailchimp_client_class, email_address_value, expected_validation_message):
+        mailchimp_client_instance = mock.Mock(spec=("subscribe_new_email_to_list",))
+        mailchimp_client_instance.subscribe_new_email_to_list.side_effect = AssertionError("This should not be called")
+
+        mailchimp_client_class.side_effect = assert_args_and_return(
+            mailchimp_client_instance,
+            "not_a_real_username",
+            "not_a_real_key",
+            mock.ANY,
+        )
+
+        response = self.client.post(
+            "/suppliers/mailing-list",
+            data={
+                "email_address": email_address_value,
+            },
+        )
+        assert response.status_code == 400
+        doc = html.fromstring(response.get_data(as_text=True), base_url="/suppliers/mailing-list")
+
+        form = self._common_page_asserts_and_get_form(doc)
+        assert tuple(inp.value for inp in form.xpath(".//input[@name='email_address']")) == (
+            email_address_value,
+        )
+
+        assert doc.xpath(
+            "//label[@for='input-email_address']//*[contains(@class, 'validation-message')]"
+            "[normalize-space(string())=$t]",
+            t=expected_validation_message,
+        )
+
+        self.assert_no_flashes()
+
+    @pytest.mark.parametrize("mc_retval", (True, False,))
+    @mock.patch("app.main.views.suppliers.DMMailChimpClient")
+    def test_post_valid_email_failure(self, mailchimp_client_class, mc_retval):
+        mailchimp_client_instance = mock.Mock(spec=("subscribe_new_email_to_list",))
+        mailchimp_client_instance.subscribe_new_email_to_list.side_effect = assert_args_and_return(
+            mc_retval,
+            "not_a_real_mailing_list",
+            "squinting@ger.ty",
+        )
+
+        mailchimp_client_class.side_effect = assert_args_and_return(
+            mailchimp_client_instance,
+            "not_a_real_username",
+            "not_a_real_key",
+            mock.ANY,
+        )
+
+        response = self.client.post(
+            "/suppliers/mailing-list",
+            data={
+                "email_address": "squinting@ger.ty",
+            },
+        )
+        assert response.status_code == 503
+        doc = html.fromstring(response.get_data(as_text=True), base_url="/suppliers/mailing-list")
+
+        assert mailchimp_client_instance.subscribe_new_email_to_list.called is True
+
+        form = self._common_page_asserts_and_get_form(doc)
+        assert tuple(inp.value for inp in form.xpath(".//input[@name='email_address']")) == (
+            "squinting@ger.ty",
+        )
+
+        assert not doc.xpath(
+            "//*[normalize-space(string())=$t]",
+            t="You must provide a valid email address.",
+        )
+        assert not doc.xpath(
+            "//*[normalize-space(string())=$t]",
+            t="You must provide an email address.",
+        )
+        assert not doc.xpath("//*[contains(@class, 'validation-message')]")
+
+        assert doc.xpath(
+            "//*[contains(@class, 'banner-destructive-without-action')][contains(normalize-space(string()), $t)]//"
+            "a[@href=$m][normalize-space(string())=$e]",
+            t="The service is unavailable at the moment",
+            m="mailto:enquiries@digitalmarketplace.service.gov.uk",
+            e="enquiries@digitalmarketplace.service.gov.uk",
+        )
+
+        # flash message should have been consumed by view's own page rendering
+        self.assert_no_flashes()
+
+    @mock.patch("app.main.views.suppliers.DMMailChimpClient")
+    def test_post_valid_email_success(self, mailchimp_client_class):
+        mailchimp_client_instance = mock.Mock(spec=("subscribe_new_email_to_list",))
+        mailchimp_client_instance.subscribe_new_email_to_list.side_effect = assert_args_and_return(
+            {"someConvincing": "jsonResponse"},
+            "not_a_real_mailing_list",
+            "qu&rt@four.pence",
+        )
+
+        mailchimp_client_class.side_effect = assert_args_and_return(
+            mailchimp_client_instance,
+            "not_a_real_username",
+            "not_a_real_key",
+            mock.ANY,
+        )
+
+        response = self.client.post(
+            "/suppliers/mailing-list",
+            data={
+                # no, ampersands are probably not valid in this position in an email address but they are accepted
+                # by our regex and we want to be able to check their escaping in the flash message
+                "email_address": "qu&rt@four.pence",
+            },
+        )
+
+        assert response.status_code == 302
+        assert response.location == "http://localhost/"
+        assert mailchimp_client_instance.subscribe_new_email_to_list.called is True
+
+        self.assert_flashes(
+            "You will receive email notifications to qu&amp;rt@four.pence when applications are opening.",
+            "success",
+        )


### PR DESCRIPTION
Story https://trello.com/c/V8bUSjq8/77-implement-an-email-sign-up-capability-for-suppliers-2

This story adds a `/supplier/mailing-list` view which will allow a (non-)user to sign up to a mailchimp mailing list:

![20170912_mailing_list_before](https://user-images.githubusercontent.com/807447/30327190-17df1320-97c3-11e7-959c-4682893b3892.png)

Taking its its mailchimp configuration from the config variables `DM_MAILCHIMP_USERNAME`, `DM_MAILCHIMP_API_KEY` and `DM_MAILCHIMP_OPEN_FRAMEWORK_NOTIFICATION_MAILING_LIST_ID`. If this fails for some reason the user is brought back to the same page with an error flash message:

![20170912_mailing_list_failure](https://user-images.githubusercontent.com/807447/30327290-6dbe8082-97c3-11e7-9784-33d225284866.png)

On success, they are redirected to the DM root page complete with success flash message using georgian flashing:

![20170912_mailing_list_success](https://user-images.githubusercontent.com/807447/30327345-9eaf5bee-97c3-11e7-91f3-d11510f4c972.png)

As part of this I consolidated the app's email form field validation:

![20170912_mailing_list_invalid](https://user-images.githubusercontent.com/807447/30327396-c94bd562-97c3-11e7-8a92-b5d80e5bcf18.png)
![20170912_mailing_list_blank](https://user-images.githubusercontent.com/807447/30327407-d417d1da-97c3-11e7-8726-d45cdaac34ce.png)



