### PR TITLE
join_open_framework_notification_mailing_list: fix minor display issues

### DIFF
--- a/app/templates/suppliers/join_open_framework_notification_mailing_list.html
+++ b/app/templates/suppliers/join_open_framework_notification_mailing_list.html
@@ -35,46 +35,43 @@
   {% endif %}
 {% endwith %}
 
-<div class="single-question-page">
-  <div class="grid-row">
-    <div class="column-two-thirds">
-      {%
-      with
-          heading = "Sign up for Digital Marketplace email alerts",
-          smaller = True
-      %}
+<div class="grid-row">
+  <div class="column-two-thirds">
+    {%
+    with
+        heading = "Sign up for Digital Marketplace email alerts",
+        smaller = True
+    %}
       {% include "toolkit/page-heading.html" %}
-      {% endwith %}
-      <form method="POST" action="">
-          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
-          {% set question_advice %}
-            <p>
-              We’ll let you know when applications to sell your services will open.
-            </p>
-            <p>
-              You do not need to subscribe if you already have a supplier account.
-            </p>
-          {% endset %}
-          {%
-            with
-              question = "Email",
-              name = "email_address",
-              value = form.email_address.data,
-              error = form.email_address.errors[0],
-              question_advice = question_advice
-          %}
-            {% include "toolkit/forms/textbox.html" %}
-          {% endwith %}
-
-          {%
-            with
-              type = "save",
-              label = "Subscribe"
-          %}
-          {% include "toolkit/button.html" %}
-          {% endwith %}
-      </form>
+    {% endwith %}
+    <div class="dmspeak">
+      <p>
+        We’ll let you know when applications to sell your services will open.
+      </p>
+      <p>
+        You do not need to subscribe if you already have a supplier account.
+      </p>
     </div>
+    <form method="POST" action="">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+        {%
+          with
+            question = "Your email address",
+            name = "email_address",
+            value = form.email_address.data,
+            error = form.email_address.errors[0]
+        %}
+          {% include "toolkit/forms/textbox.html" %}
+        {% endwith %}
+
+        {%
+          with
+            type = "save",
+            label = "Subscribe"
+        %}
+        {% include "toolkit/button.html" %}
+        {% endwith %}
+    </form>
   </div>
 </div>
 {% endblock %}

--- a/app/templates/suppliers/join_open_framework_notification_mailing_list.html
+++ b/app/templates/suppliers/join_open_framework_notification_mailing_list.html
@@ -23,7 +23,7 @@
       {% if category == "error" and message == "mailing_list_signup_error" %}
         {% set message %}
           The service is unavailable at the moment. If the problem continues please
-          contact <a href="mailto:enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.service.gov.uk</a>.
+          contact <a href="mailto:enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.service.gov.uk</a>
         {% endset %}
         {%
           with type = "destructive"


### PR DESCRIPTION
Removal of fullstop on failure message and addition of "Your email address" field label.

Related discussion on trello: https://trello.com/c/V8bUSjq8/77-implement-an-email-sign-up-capability-for-suppliers-2

![image](https://user-images.githubusercontent.com/807447/30486731-561a973c-9a29-11e7-8c8a-9c63b2b36257.png)
