### PR TITLE
form macros: fix for boolean_list and multiquestion macros, add tests

### DIFF
--- a/app/templates/macros/toolkit_forms.html
+++ b/app/templates/macros/toolkit_forms.html
@@ -96,7 +96,8 @@
 {%- endmacro %}
 
 {#
-  we want to be able to import and use this file as though it's the toolkit's forms.html, so we just straight import
-  the macros we haven't modified
+  we want to be able to import and use this file as though it's the toolkit's forms.html, but imports don't seem to get
+  re-exported in jinja, so this seems to be the least-ugly way to forward definitions:
 #}
-{% from "toolkit/forms/macros/forms.html" import boolean_list, multiquestion %}
+{% macro boolean_list() %}{{ upstream_forms.boolean_list(*varargs, **kwargs) }}{% endmacro %}
+{% macro multiquestion() %}{{ upstream_forms.multiquestion(*varargs, **kwargs) }}{% endmacro %}

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -793,7 +793,7 @@ class TestSupplierRemoveService(_BaseTestSupplierEditRemoveService):
         assert data_api_client.update_service_status.called is False
 
 
-@mock.patch('app.main.views.services.data_api_client')
+@mock.patch('app.main.views.services.data_api_client', autospec=True)
 class TestSupplierEditUpdateServiceSection(BaseApplicationTest):
 
     empty_service = {
@@ -994,6 +994,16 @@ class TestSupplierEditUpdateServiceSectionG9(BaseApplicationTest):
         res = self.client.get('/suppliers/frameworks/g-cloud-9/services/321/edit/service-features-and-benefits')
 
         assert res.status_code == 200
+        document = html.fromstring(res.get_data(as_text=True))
+        assert tuple(
+            (elem.attrib["name"], elem.attrib["value"],)
+            for elem in document.xpath("//form//input[@name='serviceFeatures' or @name='serviceBenefits']")
+            if elem.attrib.get("value")
+        ) == (
+            ("serviceFeatures", "eight",),
+            ("serviceFeatures", "nine",),
+            ("serviceBenefits", "ten",),
+        )
 
     def test_questions_for_this_service_section_can_be_changed(self, data_api_client):
         data_api_client.get_service.return_value = self.base_service
@@ -1005,6 +1015,7 @@ class TestSupplierEditUpdateServiceSectionG9(BaseApplicationTest):
             })
 
         assert res.status_code == 302
+        assert res.location == "http://localhost/suppliers/frameworks/g-cloud-9/services/321"
         data_api_client.update_service.assert_called_once_with(
             '321',
             {

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -965,6 +965,62 @@ class TestSupplierEditUpdateServiceSection(BaseApplicationTest):
 
 
 @mock.patch('app.main.views.services.data_api_client', autospec=True)
+class TestSupplierEditUpdateServiceSectionG9(BaseApplicationTest):
+
+    base_service = {
+        'services': {
+            'serviceName': 'Service name 321',
+            'status': 'published',
+            'id': '321',
+            'frameworkSlug': 'g-cloud-9',
+            'frameworkName': 'G-Cloud 9',
+            'supplierId': 1234,
+            'supplierName': 'We supply almost any',
+            'lot': 'cloud-software',
+            'lotSlug': 'cloud-software',
+            'lotName': "Cloudy Softwares",
+            'serviceFeatures': ["eight", "nine"],
+            'serviceBenefits': ["ten"],
+        }
+    }
+
+    def setup_method(self, method):
+        super(TestSupplierEditUpdateServiceSectionG9, self).setup_method(method)
+        with self.app.test_client():
+            self.login()
+
+    def test_edit_page(self, data_api_client):
+        data_api_client.get_service.return_value = self.base_service
+        res = self.client.get('/suppliers/frameworks/g-cloud-9/services/321/edit/service-features-and-benefits')
+
+        assert res.status_code == 200
+
+    def test_questions_for_this_service_section_can_be_changed(self, data_api_client):
+        data_api_client.get_service.return_value = self.base_service
+        res = self.client.post(
+            '/suppliers/frameworks/g-cloud-9/services/321/edit/service-features-and-benefits',
+            data={
+                'serviceFeatures': ["one", "two"],
+                'serviceBenefits': ["three", "four"],
+            })
+
+        assert res.status_code == 302
+        data_api_client.update_service.assert_called_once_with(
+            '321',
+            {
+                'serviceFeatures': ["one", "two"],
+                'serviceBenefits': ["three", "four"],
+            },
+            'email@email.com',
+        )
+
+        self.assert_flashes(
+            {"updated_service_name": "Service name 321"},
+            "service_updated",
+        )
+
+
+@mock.patch('app.main.views.services.data_api_client', autospec=True)
 class TestCreateDraftService(BaseApplicationTest):
     def setup_method(self, method):
         super(TestCreateDraftService, self).setup_method(method)


### PR DESCRIPTION
Story https://trello.com/c/W3d7VMrO/72-supplier-app-use-frontend-toolkit-macros-3

Turns out jinja doesn't appear to re-export imported macros after all, but there wasn't a test covering these question types. so add a slightly ugly passthrough hack for the macros and add a couple of (very basic) tests for editing of G9 services.