### PR TITLE
Add appropriate captions to tables on supplier sign-up overview page

### DIFF
--- a/app/templates/suppliers/company_summary.html
+++ b/app/templates/suppliers/company_summary.html
@@ -39,10 +39,10 @@
 
   {{ summary.heading('Your company details') }}
   {% call summary.mapping_table(
-    caption="Summary table with content field as list",
+    caption="Your company details",
     field_headings=[
-      "Field name",
-      "Field value",
+      "Label",
+      "Value",
     ],
     field_headings_visible=False
   ) %}
@@ -80,10 +80,10 @@
 
   {{ summary.heading('Your login details') }}
   {% call summary.mapping_table(
-    caption="Summary table with content field as list",
+    caption="Your login details",
     field_headings=[
-      "Field name",
-      "Field value",
+      "Label",
+      "Value",
     ],
     field_headings_visible=False
   ) %}


### PR DESCRIPTION
Down to some sloppy copy-and-pasting from the frontend toolkit back in 2015 (check the Blame if you're interested) these tables never got a caption that matched the heading (useful for accessibility).

Functional tests just changed to look for caption rather than heading (to allow finding tables without headings, which we sometimes have), so they could no longer find the tables here.

I didn't notice the error because I didn't have a framework that could be applied to, so the test currently failing on Preview skipped when I ran them locally.
