### PR TITLE
Finally turn on supplier editing G-Cloud services in prod

### DIFF
--- a/config.py
+++ b/config.py
@@ -166,6 +166,7 @@ class Preview(Live):
 
 class Production(Live):
     FEATURE_FLAGS_CONTRACT_VARIATION = enabled_since('2016-08-23')
+    FEATURE_FLAGS_EDIT_SECTIONS = enabled_since('2017-10-19')
 
     NOTIFY_TEMPLATES = {
         'create_user_account': '84f5d812-df9d-4ab8-804a-06f64f5abd30',


### PR DESCRIPTION
Optimistically setting the "Live" date for this coming Monday.
Ticket here: https://trello.com/c/j3iEdpmn/77-allow-suppliers-edit-their-g-cloud-service-listing

API PR forthcoming to acknowledge audit events up until then too.