### PR TITLE
Suppliers can upload service definition documents

### DIFF
--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -181,6 +181,7 @@ def update_section(framework_slug, service_id, section_id):
     posted_data = section.get_data(request.form)
 
     errors = None
+    # This utils method filters out any empty documents and validates against service document rules
     uploaded_documents, document_errors = upload_service_documents(
         s3.S3(current_app.config['DM_DOCUMENTS_BUCKET']),
         'documents',
@@ -538,6 +539,7 @@ def edit_service_submission(framework_slug, lot_slug, service_id, section_id, qu
         if request.files:
             uploader = s3.S3(current_app.config['DM_SUBMISSIONS_BUCKET'])
             documents_url = url_for('.dashboard', _external=True) + '/assets/'
+            # This utils method filters out any empty documents and validates against service document rules
             uploaded_documents, document_errors = upload_service_documents(
                 uploader, 'submissions', documents_url, draft, request.files, section,
                 public=False)

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -202,6 +202,7 @@ def update_section(framework_slug, service_id, section_id):
                 current_user.email_address)
         except HTTPError as e:
             errors = section.get_error_messages(e.message)
+            # If the service name is empty the final breadcrumb will disappear, so re-populate with the current name
             if not posted_data.get('serviceName', None):
                 posted_data['serviceName'] = service.get('serviceName', '')
 

--- a/app/templates/services/service.html
+++ b/app/templates/services/service.html
@@ -95,10 +95,16 @@
 {% endblock %}
 
 {% block summary_row %}
+  {{ summary.field_name(question.label) }}
   {% if not question.is_empty %}
-    {{ summary.field_name(question.label) }}
     {{ summary[question.type](question.value, question.assurance) }}
-  {% endif %}
+  {% else %}
+      {# We need to call this (even if with nothing) to add the final column to the row, otherwise the row
+         terminates early and the line separators between rows do not span the entire width of the table. #}
+      {% call summary.field() %}
+        <span class="summary-item-field-answer-required" align="left">{{ question.empty_message }}</span>
+      {% endcall %}
+    {% endif %}
 {% endblock %}
 
 {% block after_sections %}

--- a/app/templates/services/service.html
+++ b/app/templates/services/service.html
@@ -95,16 +95,18 @@
 {% endblock %}
 
 {% block summary_row %}
-  {{ summary.field_name(question.label) }}
-  {% if not question.is_empty %}
-    {{ summary[question.type](question.value, question.assurance) }}
-  {% else %}
+  {% if section.editable or not question.is_empty %}
+    {{ summary.field_name(question.label) }}
+    {% if question.is_empty %}
       {# We need to call this (even if with nothing) to add the final column to the row, otherwise the row
          terminates early and the line separators between rows do not span the entire width of the table. #}
       {% call summary.field() %}
         <span class="summary-item-field-answer-required" align="left">{{ question.empty_message }}</span>
       {% endcall %}
+    {% else %}
+      {{ summary[question.type](question.value, question.assurance) }}
     {% endif %}
+  {% endif %}
 {% endblock %}
 
 {% block after_sections %}

--- a/bower.json
+++ b/bower.json
@@ -7,6 +7,6 @@
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
     "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v24.3.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.19.2/jinja_govuk_template-0.19.2.tgz",
-    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#8.14.3"
+    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#9.3.1"
   }
 }

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
-[pytest]
+[tool:pytest]
 norecursedirs = venv* node_modules app/content bower_components

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -564,11 +564,11 @@ class TestSupplierEditGCloudService(SupplierEditServiceTestsSharedAcrossFramewor
         res = self.client.get("/suppliers/frameworks/{}/services/123".format(self.framework_kwargs["framework_slug"]))
 
         assert res.status_code == 200
-        # There's no serviceDefinitionDocumentURL in the test service data, but the row should still be shown
-        self.assert_in_strip_whitespace(
-            'Service definition document',
-            res.get_data(as_text=True)
-        )
+        page = res.get_data(as_text=True)
+
+        # There's no serviceDefinitionDocumentURL in the test service data, so a row with empty_message should be shown
+        self.assert_in_strip_whitespace('Service definition document', page)
+        self.assert_in_strip_whitespace('You haven’t added a service definition document', page)
 
 
 @mock.patch('app.main.views.services.data_api_client')


### PR DESCRIPTION
Tests will fail until this is merged:
 - [x] https://github.com/alphagov/digitalmarketplace-frameworks/pull/482

For this ticket: https://trello.com/c/tZwe5CNc/138-suppliers-can-upload-documents-when-editing-g-cloud-services

This adds a new Documents section to the "edit service" view for G-Cloud 9 services, with a row for service definition document that is visible even if there is no document uploaded (see screenshot below).  Rows will continue to not be shown for empty questions that are not editable (as happens on the DOS version of this page).  Most of the new tests here mirror the tests we have for file uploads during the submissions process

![intermediate improvement support digital marketplace 20171116](https://user-images.githubusercontent.com/6525554/32955573-4bdda71c-cbae-11e7-9eee-0559f7a854aa.png)
