### PR TITLE
join_open_framework_notification_mailing_list: return 400 status code in some mailchimp call failure cases

### DIFF
--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -513,7 +513,12 @@ def join_open_framework_notification_mailing_list():
             else:
                 # failure
                 flash("mailing_list_signup_error", "error")
-                status = 503
+                if mc_response:
+                    # this is a case where we think the error is *probably* the user's fault in some way
+                    status = 400
+                else:
+                    # this is a case where we have no idea so should probably be alert to it
+                    status = 503
                 # fall through to re-display form with error
         else:
             status = 400

--- a/tests/app/main/test_suppliers.py
+++ b/tests/app/main/test_suppliers.py
@@ -1726,9 +1726,12 @@ class TestJoinOpenFrameworkNotificationMailingList(BaseApplicationTest):
 
         self.assert_no_flashes()
 
-    @pytest.mark.parametrize("mc_retval", (True, False,))
+    @pytest.mark.parametrize("mc_retval,expected_status", (
+        (True, 400),
+        (False, 503),
+    ))
     @mock.patch("app.main.views.suppliers.DMMailChimpClient")
-    def test_post_valid_email_failure(self, mailchimp_client_class, data_api_client, mc_retval):
+    def test_post_valid_email_failure(self, mailchimp_client_class, data_api_client, mc_retval, expected_status):
         data_api_client.create_audit_event.side_effect = AssertionError("This should not be called")
         mailchimp_client_instance = mock.Mock(spec=("subscribe_new_email_to_list",))
         mailchimp_client_instance.subscribe_new_email_to_list.side_effect = assert_args_and_return(
@@ -1750,7 +1753,7 @@ class TestJoinOpenFrameworkNotificationMailingList(BaseApplicationTest):
                 "email_address": "squinting@ger.ty",
             },
         )
-        assert response.status_code == 503
+        assert response.status_code == expected_status
         doc = html.fromstring(response.get_data(as_text=True), base_url="/suppliers/mailing-list")
 
         assert mailchimp_client_instance.subscribe_new_email_to_list.called is True


### PR DESCRIPTION
Story https://trello.com/c/g93M7T3f/104-503-responses-for-bad-email-addresses-should-be-400s

Those cases being the ones where we think the failure might somehow be due to the user's email address.

Debatable whether we want to apply this or remain alert to these failures. Note this still doesn't completely quieten these events - the `DMMailChimpClient` from `-utils` itself emits a log message, which we may want to downgrade to a warning in this, less severe, case. But that's a separate issue.