### PR TITLE
Load the content for G10 and DOS3

### DIFF
--- a/app/main/__init__.py
+++ b/app/main/__init__.py
@@ -33,6 +33,17 @@ content_loader.load_manifest('g-cloud-9', 'services', 'edit_submission')
 content_loader.load_manifest('g-cloud-9', 'declaration', 'declaration')
 content_loader.load_messages('g-cloud-9', ['dates', 'urls', 'advice'])
 
+content_loader.load_manifest('g-cloud-10', 'services', 'edit_service')
+content_loader.load_manifest('g-cloud-10', 'services', 'edit_submission')
+content_loader.load_manifest('g-cloud-10', 'declaration', 'declaration')
+content_loader.load_messages('g-cloud-10', ['dates', 'urls', 'advice'])
+
+content_loader.load_manifest('digital-outcomes-and-specialists-3', 'declaration', 'declaration')
+content_loader.load_manifest('digital-outcomes-and-specialists-3', 'services', 'edit_submission')
+content_loader.load_manifest('digital-outcomes-and-specialists-3', 'services', 'edit_service')
+content_loader.load_manifest('digital-outcomes-and-specialists-3', 'briefs', 'edit_brief')
+content_loader.load_messages('digital-outcomes-and-specialists-3', ['dates', 'urls'])
+
 
 @main.after_request
 def add_cache_control(response):


### PR DESCRIPTION
We 100% need a better way to do this, but I've lost an afternoon trying to get it to dynamically load based on what frameworks are in the database (as we do in eg the admin app).  

Dynamic loading is complicated (or at least made very ugly and hard-codey) by the fact that G6 doesn't have `edit_submission` or `declaration`, and G9 is the only framework with `advice` messages, and so we end up specifying what to load per-framework or having a `try... except` around every single `load`.

I'm going to add it as a tech-debt ticket to fix this and do something consistent across all apps (I'm pretty sure the ticket already exists TBH), but in the interests of un-breaking preview I think we should go with this for the time being.