### PR TITLE
Update lockfile for new frameworks version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,1 @@
-FROM digitalmarketplace/base-frontend:3.0.0
+FROM digitalmarketplace/base-frontend:3.0.1

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ freeze-requirements:
 
 .PHONY: yarn-install
 yarn-install:
-	yarn
+	yarn install --frozen-lockfile  # We use --frozen-lockfile here so that Travis catches dependencies which need updating.
 
 .PHONY: frontend-build
 frontend-build:

--- a/yarn.lock
+++ b/yarn.lock
@@ -519,9 +519,9 @@ detect-file@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/detect-file/-/detect-file-1.0.0.tgz#f0d66d03672a825cb1b73bdb3fe62310c8e552b7"
 
-"digitalmarketplace-frameworks@https://github.com/alphagov/digitalmarketplace-frameworks.git#9.3.1":
+"digitalmarketplace-frameworks@https://github.com/alphagov/digitalmarketplace-frameworks.git#10.2.0":
   version "0.0.0"
-  resolved "https://github.com/alphagov/digitalmarketplace-frameworks.git#e434fa551f57a86f03a237b244671802a92c0291"
+  resolved "https://github.com/alphagov/digitalmarketplace-frameworks.git#ea0d37c23827bda76cfdab8517f2e665b441c5dc"
 
 "digitalmarketplace-frontend-toolkit@https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v27.0.0":
   version "0.0.1"


### PR DESCRIPTION
## Summary
We updated the frameworks repo but didn't re-install locally so the `yarn.lock` file got out-of-date.

Also start using frontend.base Docker v3.0.1 which changes the yarn command used to install dependencies.