### PR TITLE
Update dockerfile/makefile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,1 @@
-FROM digitalmarketplace/base-frontend:3.0.0
+FROM digitalmarketplace/base-frontend:3.0.1

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ freeze-requirements:
 
 .PHONY: yarn-install
 yarn-install:
-	yarn
+	yarn install --frozen-lockfile  # We use --frozen-lockfile here so that Travis catches dependencies which need updating.
 
 .PHONY: frontend-build
 frontend-build:


### PR DESCRIPTION
Update Dockerfile to pull in v3.0.1 frontend-base which uses yarn --pure-lockfile; change Makefile to use --frozen-lockfile. "make yarn" is called by Travis and therefore will block us when we have outdated dependencies