### PR TITLE
Remove unnecessary `with self.app.test_client()` calls in `test_frameworks.py`

### DIFF
--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -123,8 +123,7 @@ class TestFrameworksDashboard(BaseApplicationTest):
         )
 
     def test_framework_dashboard_shows_for_pending_if_declaration_exists(self, data_api_client, s3):
-        with self.app.test_client():
-            self.login()
+        self.login()
 
         data_api_client.get_framework.return_value = self.framework(status='pending')
         data_api_client.get_supplier_framework_info.return_value = self.supplier_framework()
@@ -138,8 +137,7 @@ class TestFrameworksDashboard(BaseApplicationTest):
         )) == 1
 
     def test_framework_dashboard_shows_for_live_if_declaration_exists(self, data_api_client, s3):
-        with self.app.test_client():
-            self.login()
+        self.login()
 
         data_api_client.get_framework.return_value = self.framework(status='live')
         data_api_client.get_supplier_framework_info.return_value = self.supplier_framework()
@@ -153,8 +151,7 @@ class TestFrameworksDashboard(BaseApplicationTest):
         )) == 1
 
     def test_does_not_show_for_live_if_no_declaration(self, data_api_client, s3):
-        with self.app.test_client():
-            self.login()
+        self.login()
 
         data_api_client.get_framework.return_value = self.framework(status='live')
         data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(declaration=None)
@@ -164,168 +161,159 @@ class TestFrameworksDashboard(BaseApplicationTest):
 
     @mock.patch('app.main.views.frameworks.send_email')
     def test_interest_registered_in_framework_on_post(self, send_email, data_api_client, s3):
-        with self.app.test_client():
-            self.login()
+        self.login()
 
-            data_api_client.get_framework.return_value = self.framework(status='open')
-            data_api_client.get_supplier_framework_info.return_value = self.supplier_framework()
-            res = self.client.post("/suppliers/frameworks/digital-outcomes-and-specialists")
+        data_api_client.get_framework.return_value = self.framework(status='open')
+        data_api_client.get_supplier_framework_info.return_value = self.supplier_framework()
+        res = self.client.post("/suppliers/frameworks/digital-outcomes-and-specialists")
 
-            assert res.status_code == 200
-            data_api_client.register_framework_interest.assert_called_once_with(
-                1234,
-                "digital-outcomes-and-specialists",
-                "email@email.com"
-            )
+        assert res.status_code == 200
+        data_api_client.register_framework_interest.assert_called_once_with(
+            1234,
+            "digital-outcomes-and-specialists",
+            "email@email.com"
+        )
 
     @mock.patch('app.main.views.frameworks.send_email')
     def test_email_sent_when_interest_registered_in_framework(self, send_email, data_api_client, s3):
-        with self.app.test_client():
-            self.login()
+        self.login()
 
-            data_api_client.get_framework.return_value = self.framework(status='open')
-            data_api_client.get_supplier_framework_info.return_value = self.supplier_framework()
-            data_api_client.find_users.return_value = {'users': [
-                {'emailAddress': 'email1', 'active': True},
-                {'emailAddress': 'email2', 'active': True},
-                {'emailAddress': 'email3', 'active': False}
-            ]}
-            res = self.client.post("/suppliers/frameworks/digital-outcomes-and-specialists")
+        data_api_client.get_framework.return_value = self.framework(status='open')
+        data_api_client.get_supplier_framework_info.return_value = self.supplier_framework()
+        data_api_client.find_users.return_value = {'users': [
+            {'emailAddress': 'email1', 'active': True},
+            {'emailAddress': 'email2', 'active': True},
+            {'emailAddress': 'email3', 'active': False}
+        ]}
+        res = self.client.post("/suppliers/frameworks/digital-outcomes-and-specialists")
 
-            assert res.status_code == 200
-            send_email.assert_called_once_with(
-                ['email1', 'email2'],
-                mock.ANY,
-                'MANDRILL',
-                'You started a G-Cloud 7 application',
-                'do-not-reply@digitalmarketplace.service.gov.uk',
-                'Digital Marketplace Admin',
-                ['digital-outcomes-and-specialists-application-started']
-            )
+        assert res.status_code == 200
+        send_email.assert_called_once_with(
+            ['email1', 'email2'],
+            mock.ANY,
+            'MANDRILL',
+            'You started a G-Cloud 7 application',
+            'do-not-reply@digitalmarketplace.service.gov.uk',
+            'Digital Marketplace Admin',
+            ['digital-outcomes-and-specialists-application-started']
+        )
 
     def test_interest_not_registered_in_framework_on_get(self, data_api_client, s3):
-        with self.app.test_client():
-            self.login()
+        self.login()
 
-            data_api_client.get_framework.return_value = self.framework(status='pending')
-            data_api_client.get_supplier_framework_info.return_value = self.supplier_framework()
-            res = self.client.get("/suppliers/frameworks/digital-outcomes-and-specialists")
+        data_api_client.get_framework.return_value = self.framework(status='pending')
+        data_api_client.get_supplier_framework_info.return_value = self.supplier_framework()
+        res = self.client.get("/suppliers/frameworks/digital-outcomes-and-specialists")
 
-            assert res.status_code == 200
-            assert data_api_client.register_framework_interest.called is False
+        assert res.status_code == 200
+        assert data_api_client.register_framework_interest.called is False
 
     def test_interest_set_but_no_declaration(self, data_api_client, s3):
-        with self.app.test_client():
-            self.login()
+        self.login()
 
-            data_api_client.get_framework.return_value = self.framework(status='pending')
-            data_api_client.get_framework_interest.return_value = {'frameworks': ['g-cloud-7']}
-            data_api_client.find_draft_services.return_value = {
-                "services": [
-                    {'serviceName': 'A service', 'status': 'submitted', 'lotSlug': 'iaas'}
-                ]
-            }
-            data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(declaration=None)
+        data_api_client.get_framework.return_value = self.framework(status='pending')
+        data_api_client.get_framework_interest.return_value = {'frameworks': ['g-cloud-7']}
+        data_api_client.find_draft_services.return_value = {
+            "services": [
+                {'serviceName': 'A service', 'status': 'submitted', 'lotSlug': 'iaas'}
+            ]
+        }
+        data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(declaration=None)
 
-            res = self.client.get("/suppliers/frameworks/g-cloud-7")
+        res = self.client.get("/suppliers/frameworks/g-cloud-7")
 
-            assert res.status_code == 200
+        assert res.status_code == 200
 
     def test_shows_gcloud_7_closed_message_if_pending_and_no_application_done(self, data_api_client, s3):
-        with self.app.test_client():
-            self.login()
+        self.login()
 
-            data_api_client.get_framework.return_value = self.framework(status='pending')
-            data_api_client.get_framework_interest.return_value = {'frameworks': ['g-cloud-7']}
-            data_api_client.find_draft_services.return_value = {
-                "services": [
-                    {'serviceName': 'A service', 'status': 'not-submitted'}
-                ]
-            }
-            data_api_client.get_supplier_framework_info.return_value = self.supplier_framework()
+        data_api_client.get_framework.return_value = self.framework(status='pending')
+        data_api_client.get_framework_interest.return_value = {'frameworks': ['g-cloud-7']}
+        data_api_client.find_draft_services.return_value = {
+            "services": [
+                {'serviceName': 'A service', 'status': 'not-submitted'}
+            ]
+        }
+        data_api_client.get_supplier_framework_info.return_value = self.supplier_framework()
 
-            res = self.client.get("/suppliers/frameworks/g-cloud-7")
-            assert res.status_code == 200
+        res = self.client.get("/suppliers/frameworks/g-cloud-7")
+        assert res.status_code == 200
 
-            doc = html.fromstring(res.get_data(as_text=True))
+        doc = html.fromstring(res.get_data(as_text=True))
 
-            heading = doc.xpath('//div[@class="summary-item-lede"]//h2[@class="summary-item-heading"]')
-            assert len(heading) > 0
-            assert u"G-Cloud 7 is closed for applications" in heading[0].xpath('text()')[0]
-            assert u"You didn't submit an application." in heading[0].xpath('../p[1]/text()')[0]
+        heading = doc.xpath('//div[@class="summary-item-lede"]//h2[@class="summary-item-heading"]')
+        assert len(heading) > 0
+        assert u"G-Cloud 7 is closed for applications" in heading[0].xpath('text()')[0]
+        assert u"You didn't submit an application." in heading[0].xpath('../p[1]/text()')[0]
 
     def test_shows_gcloud_7_closed_message_if_pending_and_application(self, data_api_client, s3):
-        with self.app.test_client():
-            self.login()
+        self.login()
 
-            data_api_client.get_framework.return_value = self.framework(status='pending')
-            data_api_client.get_framework_interest.return_value = {'frameworks': ['g-cloud-7']}
-            data_api_client.find_draft_services.return_value = {
-                "services": [
-                    {'serviceName': 'A service', 'status': 'submitted', 'lotSlug': 'iaas'}
-                ]
-            }
-            data_api_client.get_supplier_framework_info.return_value = self.supplier_framework()
+        data_api_client.get_framework.return_value = self.framework(status='pending')
+        data_api_client.get_framework_interest.return_value = {'frameworks': ['g-cloud-7']}
+        data_api_client.find_draft_services.return_value = {
+            "services": [
+                {'serviceName': 'A service', 'status': 'submitted', 'lotSlug': 'iaas'}
+            ]
+        }
+        data_api_client.get_supplier_framework_info.return_value = self.supplier_framework()
 
-            res = self.client.get("/suppliers/frameworks/g-cloud-7")
-            assert res.status_code == 200
+        res = self.client.get("/suppliers/frameworks/g-cloud-7")
+        assert res.status_code == 200
 
-            doc = html.fromstring(res.get_data(as_text=True))
-            heading = doc.xpath('//div[@class="summary-item-lede"]//h2[@class="summary-item-heading"]')
-            assert len(heading) > 0
-            assert u"G-Cloud 7 is closed for applications" in heading[0].xpath('text()')[0]
-            lede = doc.xpath('//div[@class="summary-item-lede"]')
-            assert u"You made your supplier declaration and submitted 1 service for consideration." in \
-                lede[0].xpath('./p[1]/text()')[0]
-            assert u"We’ll let you know the result of your application by " in \
-                lede[0].xpath('./p[2]/text()')[0]
+        doc = html.fromstring(res.get_data(as_text=True))
+        heading = doc.xpath('//div[@class="summary-item-lede"]//h2[@class="summary-item-heading"]')
+        assert len(heading) > 0
+        assert u"G-Cloud 7 is closed for applications" in heading[0].xpath('text()')[0]
+        lede = doc.xpath('//div[@class="summary-item-lede"]')
+        assert u"You made your supplier declaration and submitted 1 service for consideration." in \
+            lede[0].xpath('./p[1]/text()')[0]
+        assert u"We’ll let you know the result of your application by " in \
+            lede[0].xpath('./p[2]/text()')[0]
 
     def test_declaration_status_when_complete(self, data_api_client, s3):
-        with self.app.test_client():
-            self.login()
+        self.login()
 
-            data_api_client.get_framework.return_value = self.framework(status='open')
-            data_api_client.get_supplier_framework_info.return_value = self.supplier_framework()
+        data_api_client.get_framework.return_value = self.framework(status='open')
+        data_api_client.get_supplier_framework_info.return_value = self.supplier_framework()
 
-            res = self.client.get("/suppliers/frameworks/g-cloud-7")
-            assert res.status_code == 200
+        res = self.client.get("/suppliers/frameworks/g-cloud-7")
+        assert res.status_code == 200
 
-            doc = html.fromstring(res.get_data(as_text=True))
-            assert len(doc.xpath(u'//p/strong[contains(text(), "You’ve made the supplier declaration")]')) == 1
+        doc = html.fromstring(res.get_data(as_text=True))
+        assert len(doc.xpath(u'//p/strong[contains(text(), "You’ve made the supplier declaration")]')) == 1
 
     def test_declaration_status_when_started(self, data_api_client, s3):
-        with self.app.test_client():
-            self.login()
+        self.login()
 
-            submission = FULL_G7_SUBMISSION.copy()
-            # User has not yet submitted page 3 of the declaration
-            del submission['SQ2-1abcd']
-            del submission['SQ2-1e']
-            del submission['SQ2-1f']
-            del submission['SQ2-1ghijklmn']
+        submission = FULL_G7_SUBMISSION.copy()
+        # User has not yet submitted page 3 of the declaration
+        del submission['SQ2-1abcd']
+        del submission['SQ2-1e']
+        del submission['SQ2-1f']
+        del submission['SQ2-1ghijklmn']
 
-            data_api_client.get_framework.return_value = self.framework(status='open')
-            data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
-                declaration=submission, status='started')
+        data_api_client.get_framework.return_value = self.framework(status='open')
+        data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
+            declaration=submission, status='started')
 
-            res = self.client.get("/suppliers/frameworks/g-cloud-7")
-            assert res.status_code == 200
+        res = self.client.get("/suppliers/frameworks/g-cloud-7")
+        assert res.status_code == 200
 
-            doc = html.fromstring(res.get_data(as_text=True))
-            assert len(doc.xpath('//p[contains(text(), "You need to finish making the supplier declaration")]')) == 1
+        doc = html.fromstring(res.get_data(as_text=True))
+        assert len(doc.xpath('//p[contains(text(), "You need to finish making the supplier declaration")]')) == 1
 
     def test_declaration_status_when_not_complete(self, data_api_client, s3):
-        with self.app.test_client():
-            self.login()
+        self.login()
 
-            data_api_client.get_framework.return_value = self.framework(status='open')
-            data_api_client.get_supplier_framework_info.side_effect = APIError(mock.Mock(status_code=404))
+        data_api_client.get_framework.return_value = self.framework(status='open')
+        data_api_client.get_supplier_framework_info.side_effect = APIError(mock.Mock(status_code=404))
 
-            res = self.client.get("/suppliers/frameworks/g-cloud-7")
-            assert res.status_code == 200
+        res = self.client.get("/suppliers/frameworks/g-cloud-7")
+        assert res.status_code == 200
 
-            doc = html.fromstring(res.get_data(as_text=True))
-            assert len(doc.xpath('//p[contains(text(), "You need to make the supplier declaration")]')) == 1
+        doc = html.fromstring(res.get_data(as_text=True))
+        assert len(doc.xpath('//p[contains(text(), "You need to make the supplier declaration")]')) == 1
 
     def test_downloads_shown_open_framework(self, data_api_client, s3):
         files = [
@@ -345,78 +333,77 @@ class TestFrameworksDashboard(BaseApplicationTest):
             ) for section, filename, ext, last_modified in files
         ]
 
-        with self.app.test_client():
-            self.login()
+        self.login()
 
-            data_api_client.get_framework.return_value = self.framework(status='open')
-            data_api_client.get_supplier_framework_info.return_value = self.supplier_framework()
-            res = self.client.get("/suppliers/frameworks/g-cloud-7")
-            assert res.status_code == 200
+        data_api_client.get_framework.return_value = self.framework(status='open')
+        data_api_client.get_supplier_framework_info.return_value = self.supplier_framework()
+        res = self.client.get("/suppliers/frameworks/g-cloud-7")
+        assert res.status_code == 200
 
-            doc = html.fromstring(res.get_data(as_text=True))
-            extracted_guidance_links = self._extract_guidance_links(doc)
+        doc = html.fromstring(res.get_data(as_text=True))
+        extracted_guidance_links = self._extract_guidance_links(doc)
 
-            assert extracted_guidance_links == OrderedDict((
-                ("Guidance", (
-                    (
-                        "Download the invitation to apply",
-                        "/suppliers/frameworks/g-cloud-7/files/g-cloud-7-invitation.pdf",
-                        None,
-                        None,
-                    ),
-                    (
-                        "Read about how to apply",
-                        "https://www.gov.uk/guidance/g-cloud-suppliers-guide#how-to-apply",
-                        None,
-                        None,
-                    ),
-                )),
-                ("Legal documents", (
-                    (
-                        "Download the proposed framework agreement",
-                        "/suppliers/frameworks/g-cloud-7/files/g-cloud-7-proposed-framework-agreement.pdf",
-                        "Wednesday 1 June 2016",
-                        "2016-06-01T14:00:00.000Z",
-                    ),
-                    (
-                        u"Download the proposed \u2018call-off\u2019 contract",
-                        "/suppliers/frameworks/g-cloud-7/files/g-cloud-7-proposed-call-off.pdf",
-                        "Sunday 1 May 2016",
-                        "2016-05-01T14:00:00.000Z",
-                    ),
-                )),
-                ("Communications", (
-                    (
-                        "View communications and ask clarification questions",
-                        "/suppliers/frameworks/g-cloud-7/updates",
-                        "Monday 2 February 2015",
-                        "2015-02-02T14:00:00.000Z",
-                    ),
-                )),
-                ("Reporting", (
-                    (
-                        "Download the reporting template",
-                        "/suppliers/frameworks/g-cloud-7/files/g-cloud-7-reporting-template.xls",
-                        None,
-                        None,
-                    ),
-                )),
-            ))
-            assert not any(
-                doc.xpath("//main//a[contains(@href, $href_part)]", href_part=href_part)
-                for href_part in (
-                    "g-cloud-7-final-framework-agreement.pdf",
-                    "g-cloud-7-supplier-pack.zip",
-                )
+        assert extracted_guidance_links == OrderedDict((
+            ("Guidance", (
+                (
+                    "Download the invitation to apply",
+                    "/suppliers/frameworks/g-cloud-7/files/g-cloud-7-invitation.pdf",
+                    None,
+                    None,
+                ),
+                (
+                    "Read about how to apply",
+                    "https://www.gov.uk/guidance/g-cloud-suppliers-guide#how-to-apply",
+                    None,
+                    None,
+                ),
+            )),
+            ("Legal documents", (
+                (
+                    "Download the proposed framework agreement",
+                    "/suppliers/frameworks/g-cloud-7/files/g-cloud-7-proposed-framework-agreement.pdf",
+                    "Wednesday 1 June 2016",
+                    "2016-06-01T14:00:00.000Z",
+                ),
+                (
+                    u"Download the proposed \u2018call-off\u2019 contract",
+                    "/suppliers/frameworks/g-cloud-7/files/g-cloud-7-proposed-call-off.pdf",
+                    "Sunday 1 May 2016",
+                    "2016-05-01T14:00:00.000Z",
+                ),
+            )),
+            ("Communications", (
+                (
+                    "View communications and ask clarification questions",
+                    "/suppliers/frameworks/g-cloud-7/updates",
+                    "Monday 2 February 2015",
+                    "2015-02-02T14:00:00.000Z",
+                ),
+            )),
+            ("Reporting", (
+                (
+                    "Download the reporting template",
+                    "/suppliers/frameworks/g-cloud-7/files/g-cloud-7-reporting-template.xls",
+                    None,
+                    None,
+                ),
+            )),
+        ))
+        assert not any(
+            doc.xpath("//main//a[contains(@href, $href_part)]", href_part=href_part)
+            for href_part in (
+                "g-cloud-7-final-framework-agreement.pdf",
+                "g-cloud-7-supplier-pack.zip",
             )
-            assert len(doc.xpath(
-                "//main//p[contains(normalize-space(string()), $a)]",
-                a="until 5pm BST, 22 September 2015",
-            )) == 1
-            assert not doc.xpath(
-                "//main//table[normalize-space(string(./caption))=$b]",
-                b="Agreement details",
-            )
+        )
+        assert len(doc.xpath(
+            "//main//p[contains(normalize-space(string()), $a)]",
+            a="until 5pm BST, 22 September 2015",
+        )) == 1
+        assert not doc.xpath(
+            "//main//table[normalize-space(string(./caption))=$b]",
+            b="Agreement details",
+        )
 
     def test_downloads_shown_open_framework_clarification_questions_closed(self, data_api_client, s3):
         files = [
@@ -436,81 +423,80 @@ class TestFrameworksDashboard(BaseApplicationTest):
             ) for section, filename, ext, last_modified in files
         ]
 
-        with self.app.test_client():
-            self.login()
+        self.login()
 
-            data_api_client.get_framework.return_value = self.framework(
-                status="open",
-                clarification_questions_open=False,
-            )
-            data_api_client.get_supplier_framework_info.return_value = self.supplier_framework()
-            res = self.client.get("/suppliers/frameworks/g-cloud-7")
-            assert res.status_code == 200
+        data_api_client.get_framework.return_value = self.framework(
+            status="open",
+            clarification_questions_open=False,
+        )
+        data_api_client.get_supplier_framework_info.return_value = self.supplier_framework()
+        res = self.client.get("/suppliers/frameworks/g-cloud-7")
+        assert res.status_code == 200
 
-            doc = html.fromstring(res.get_data(as_text=True))
-            extracted_guidance_links = self._extract_guidance_links(doc)
+        doc = html.fromstring(res.get_data(as_text=True))
+        extracted_guidance_links = self._extract_guidance_links(doc)
 
-            assert extracted_guidance_links == OrderedDict((
-                ("Guidance", (
-                    (
-                        "Download the invitation to apply",
-                        "/suppliers/frameworks/g-cloud-7/files/g-cloud-7-invitation.pdf",
-                        None,
-                        None,
-                    ),
-                    (
-                        "Read about how to apply",
-                        "https://www.gov.uk/guidance/g-cloud-suppliers-guide#how-to-apply",
-                        None,
-                        None,
-                    ),
-                )),
-                ("Legal documents", (
-                    (
-                        "Download the proposed framework agreement",
-                        "/suppliers/frameworks/g-cloud-7/files/g-cloud-7-proposed-framework-agreement.pdf",
-                        "Wednesday 1 June 2016",
-                        "2016-06-01T14:00:00.000Z",
-                    ),
-                    (
-                        u"Download the proposed \u2018call-off\u2019 contract",
-                        "/suppliers/frameworks/g-cloud-7/files/g-cloud-7-proposed-call-off.pdf",
-                        "Sunday 1 May 2016",
-                        "2016-05-01T14:00:00.000Z",
-                    ),
-                )),
-                ("Communications", (
-                    (
-                        "View communications and clarification questions",
-                        "/suppliers/frameworks/g-cloud-7/updates",
-                        "Monday 2 February 2015",
-                        "2015-02-02T14:00:00.000Z",
-                    ),
-                )),
-                ("Reporting", (
-                    (
-                        "Download the reporting template",
-                        "/suppliers/frameworks/g-cloud-7/files/g-cloud-7-reporting-template.xls",
-                        None,
-                        None,
-                    ),
-                )),
-            ))
-            assert not any(
-                doc.xpath("//main//a[contains(@href, $href_part)]", href_part=href_part)
-                for href_part in (
-                    "g-cloud-7-final-framework-agreement.pdf",
-                    "g-cloud-7-supplier-pack.zip",
-                )
+        assert extracted_guidance_links == OrderedDict((
+            ("Guidance", (
+                (
+                    "Download the invitation to apply",
+                    "/suppliers/frameworks/g-cloud-7/files/g-cloud-7-invitation.pdf",
+                    None,
+                    None,
+                ),
+                (
+                    "Read about how to apply",
+                    "https://www.gov.uk/guidance/g-cloud-suppliers-guide#how-to-apply",
+                    None,
+                    None,
+                ),
+            )),
+            ("Legal documents", (
+                (
+                    "Download the proposed framework agreement",
+                    "/suppliers/frameworks/g-cloud-7/files/g-cloud-7-proposed-framework-agreement.pdf",
+                    "Wednesday 1 June 2016",
+                    "2016-06-01T14:00:00.000Z",
+                ),
+                (
+                    u"Download the proposed \u2018call-off\u2019 contract",
+                    "/suppliers/frameworks/g-cloud-7/files/g-cloud-7-proposed-call-off.pdf",
+                    "Sunday 1 May 2016",
+                    "2016-05-01T14:00:00.000Z",
+                ),
+            )),
+            ("Communications", (
+                (
+                    "View communications and clarification questions",
+                    "/suppliers/frameworks/g-cloud-7/updates",
+                    "Monday 2 February 2015",
+                    "2015-02-02T14:00:00.000Z",
+                ),
+            )),
+            ("Reporting", (
+                (
+                    "Download the reporting template",
+                    "/suppliers/frameworks/g-cloud-7/files/g-cloud-7-reporting-template.xls",
+                    None,
+                    None,
+                ),
+            )),
+        ))
+        assert not any(
+            doc.xpath("//main//a[contains(@href, $href_part)]", href_part=href_part)
+            for href_part in (
+                "g-cloud-7-final-framework-agreement.pdf",
+                "g-cloud-7-supplier-pack.zip",
             )
-            assert not doc.xpath(
-                "//main[contains(normalize-space(string()), $a)]",
-                a="until 5pm BST, 22 September 2015",
-            )
-            assert not doc.xpath(
-                "//main//table[normalize-space(string(./caption))=$b]",
-                b="Agreement details",
-            )
+        )
+        assert not doc.xpath(
+            "//main[contains(normalize-space(string()), $a)]",
+            a="until 5pm BST, 22 September 2015",
+        )
+        assert not doc.xpath(
+            "//main//table[normalize-space(string(./caption))=$b]",
+            b="Agreement details",
+        )
 
     def test_final_agreement_download_shown_open_framework(self, data_api_client, s3):
         files = [
@@ -530,78 +516,77 @@ class TestFrameworksDashboard(BaseApplicationTest):
             ) for section, filename, ext, last_modified in files
         ]
 
-        with self.app.test_client():
-            self.login()
+        self.login()
 
-            data_api_client.get_framework.return_value = self.framework(status='open')
-            data_api_client.get_supplier_framework_info.return_value = self.supplier_framework()
-            res = self.client.get("/suppliers/frameworks/g-cloud-7")
-            assert res.status_code == 200
+        data_api_client.get_framework.return_value = self.framework(status='open')
+        data_api_client.get_supplier_framework_info.return_value = self.supplier_framework()
+        res = self.client.get("/suppliers/frameworks/g-cloud-7")
+        assert res.status_code == 200
 
-            doc = html.fromstring(res.get_data(as_text=True))
-            extracted_guidance_links = self._extract_guidance_links(doc)
+        doc = html.fromstring(res.get_data(as_text=True))
+        extracted_guidance_links = self._extract_guidance_links(doc)
 
-            assert extracted_guidance_links == OrderedDict((
-                ("Guidance", (
-                    (
-                        "Download the invitation to apply",
-                        "/suppliers/frameworks/g-cloud-7/files/g-cloud-7-invitation.pdf",
-                        None,
-                        None,
-                    ),
-                    (
-                        "Read about how to apply",
-                        "https://www.gov.uk/guidance/g-cloud-suppliers-guide#how-to-apply",
-                        None,
-                        None,
-                    ),
-                )),
-                ("Legal documents", (
-                    (
-                        "Download the framework agreement",
-                        "/suppliers/frameworks/g-cloud-7/files/g-cloud-7-final-framework-agreement.pdf",
-                        "Thursday 2 June 2016",
-                        "2016-06-02T14:00:00.000Z",
-                    ),
-                    (
-                        u"Download the proposed \u2018call-off\u2019 contract",
-                        "/suppliers/frameworks/g-cloud-7/files/g-cloud-7-proposed-call-off.pdf",
-                        "Sunday 1 May 2016",
-                        "2016-05-01T14:00:00.000Z",
-                    ),
-                )),
-                ("Communications", (
-                    (
-                        "View communications and ask clarification questions",
-                        "/suppliers/frameworks/g-cloud-7/updates",
-                        "Monday 2 February 2015",
-                        "2015-02-02T14:00:00.000Z",
-                    ),
-                )),
-                ("Reporting", (
-                    (
-                        "Download the reporting template",
-                        "/suppliers/frameworks/g-cloud-7/files/g-cloud-7-reporting-template.xls",
-                        None,
-                        None,
-                    ),
-                )),
-            ))
-            assert not any(
-                doc.xpath("//main//a[contains(@href, $href_part)]", href_part=href_part)
-                for href_part in (
-                    "g-cloud-7-proposed-framework-agreement.pdf",
-                    "g-cloud-7-supplier-pack.zip",
-                )
+        assert extracted_guidance_links == OrderedDict((
+            ("Guidance", (
+                (
+                    "Download the invitation to apply",
+                    "/suppliers/frameworks/g-cloud-7/files/g-cloud-7-invitation.pdf",
+                    None,
+                    None,
+                ),
+                (
+                    "Read about how to apply",
+                    "https://www.gov.uk/guidance/g-cloud-suppliers-guide#how-to-apply",
+                    None,
+                    None,
+                ),
+            )),
+            ("Legal documents", (
+                (
+                    "Download the framework agreement",
+                    "/suppliers/frameworks/g-cloud-7/files/g-cloud-7-final-framework-agreement.pdf",
+                    "Thursday 2 June 2016",
+                    "2016-06-02T14:00:00.000Z",
+                ),
+                (
+                    u"Download the proposed \u2018call-off\u2019 contract",
+                    "/suppliers/frameworks/g-cloud-7/files/g-cloud-7-proposed-call-off.pdf",
+                    "Sunday 1 May 2016",
+                    "2016-05-01T14:00:00.000Z",
+                ),
+            )),
+            ("Communications", (
+                (
+                    "View communications and ask clarification questions",
+                    "/suppliers/frameworks/g-cloud-7/updates",
+                    "Monday 2 February 2015",
+                    "2015-02-02T14:00:00.000Z",
+                ),
+            )),
+            ("Reporting", (
+                (
+                    "Download the reporting template",
+                    "/suppliers/frameworks/g-cloud-7/files/g-cloud-7-reporting-template.xls",
+                    None,
+                    None,
+                ),
+            )),
+        ))
+        assert not any(
+            doc.xpath("//main//a[contains(@href, $href_part)]", href_part=href_part)
+            for href_part in (
+                "g-cloud-7-proposed-framework-agreement.pdf",
+                "g-cloud-7-supplier-pack.zip",
             )
-            assert len(doc.xpath(
-                "//main//p[contains(normalize-space(string()), $a)]",
-                a="until 5pm BST, 22 September 2015",
-            )) == 1
-            assert not doc.xpath(
-                "//main//table[normalize-space(string(./caption))=$b]",
-                b="Agreement details",
-            )
+        )
+        assert len(doc.xpath(
+            "//main//p[contains(normalize-space(string()), $a)]",
+            a="until 5pm BST, 22 September 2015",
+        )) == 1
+        assert not doc.xpath(
+            "//main//table[normalize-space(string(./caption))=$b]",
+            b="Agreement details",
+        )
 
     def test_no_updates_open_framework(self, data_api_client, s3):
         files = [
@@ -617,185 +602,177 @@ class TestFrameworksDashboard(BaseApplicationTest):
             ) for section, filename, ext, last_modified in files
         ]
 
-        with self.app.test_client():
-            self.login()
+        self.login()
 
-            data_api_client.get_framework.return_value = self.framework(status='open')
-            data_api_client.get_supplier_framework_info.return_value = self.supplier_framework()
-            res = self.client.get("/suppliers/frameworks/g-cloud-7")
-            assert res.status_code == 200
+        data_api_client.get_framework.return_value = self.framework(status='open')
+        data_api_client.get_supplier_framework_info.return_value = self.supplier_framework()
+        res = self.client.get("/suppliers/frameworks/g-cloud-7")
+        assert res.status_code == 200
 
-            doc = html.fromstring(res.get_data(as_text=True))
-            extracted_guidance_links = self._extract_guidance_links(doc)
+        doc = html.fromstring(res.get_data(as_text=True))
+        extracted_guidance_links = self._extract_guidance_links(doc)
 
-            assert (
-                "View communications and ask clarification questions",
-                "/suppliers/frameworks/g-cloud-7/updates",
-                None,
-                None,
-            ) in extracted_guidance_links["Communications"]
-            assert len(doc.xpath(
-                "//main//p[contains(normalize-space(string()), $a)]",
-                a="until 5pm BST, 22 September 2015",
-            )) == 1
-            assert not doc.xpath(
-                "//main//table[normalize-space(string(./caption))=$b]",
-                b="Agreement details",
-            )
+        assert (
+            "View communications and ask clarification questions",
+            "/suppliers/frameworks/g-cloud-7/updates",
+            None,
+            None,
+        ) in extracted_guidance_links["Communications"]
+        assert len(doc.xpath(
+            "//main//p[contains(normalize-space(string()), $a)]",
+            a="until 5pm BST, 22 September 2015",
+        )) == 1
+        assert not doc.xpath(
+            "//main//table[normalize-space(string(./caption))=$b]",
+            b="Agreement details",
+        )
 
     def test_no_files_exist_open_framework(self, data_api_client, s3):
         s3.return_value.list.return_value = []
 
-        with self.app.test_client():
-            self.login()
+        self.login()
 
-            data_api_client.get_framework.return_value = self.framework(status='open')
-            data_api_client.get_supplier_framework_info.return_value = self.supplier_framework()
-            res = self.client.get("/suppliers/frameworks/g-cloud-7")
-            assert res.status_code == 200
+        data_api_client.get_framework.return_value = self.framework(status='open')
+        data_api_client.get_supplier_framework_info.return_value = self.supplier_framework()
+        res = self.client.get("/suppliers/frameworks/g-cloud-7")
+        assert res.status_code == 200
 
-            doc = html.fromstring(res.get_data(as_text=True))
-            extracted_guidance_links = self._extract_guidance_links(doc)
+        doc = html.fromstring(res.get_data(as_text=True))
+        extracted_guidance_links = self._extract_guidance_links(doc)
 
-            assert extracted_guidance_links == OrderedDict((
-                ("Guidance", (
-                    (
-                        "Read about how to apply",
-                        "https://www.gov.uk/guidance/g-cloud-suppliers-guide#how-to-apply",
-                        None,
-                        None,
-                    ),
-                )),
-                ("Communications", (
-                    (
-                        "View communications and ask clarification questions",
-                        "/suppliers/frameworks/g-cloud-7/updates",
-                        None,
-                        None,
-                    ),
-                )),
-            ))
-            assert not any(
-                doc.xpath(
-                    "//a[contains(@href, $href_part) or normalize-space(string())=$label]",
-                    href_part=href_part,
-                    label=label,
-                ) for href_part, label in (
-                    (
-                        "g-cloud-7-invitation.pdf",
-                        "Download the invitation to apply",
-                    ),
-                    (
-                        "g-cloud-7-proposed-framework-agreement.pdf",
-                        "Download the proposed framework agreement",
-                    ),
-                    (
-                        "g-cloud-7-call-off.pdf",
-                        u"Download the proposed \u2018call-off\u2019 contract",
-                    ),
-                    (
-                        "g-cloud-7-reporting-template.xls",
-                        "Download the reporting template",
-                    ),
-                    (
-                        "result-letter.pdf",
-                        "Download your application result letter",
-                    ),
-                )
+        assert extracted_guidance_links == OrderedDict((
+            ("Guidance", (
+                (
+                    "Read about how to apply",
+                    "https://www.gov.uk/guidance/g-cloud-suppliers-guide#how-to-apply",
+                    None,
+                    None,
+                ),
+            )),
+            ("Communications", (
+                (
+                    "View communications and ask clarification questions",
+                    "/suppliers/frameworks/g-cloud-7/updates",
+                    None,
+                    None,
+                ),
+            )),
+        ))
+        assert not any(
+            doc.xpath(
+                "//a[contains(@href, $href_part) or normalize-space(string())=$label]",
+                href_part=href_part,
+                label=label,
+            ) for href_part, label in (
+                (
+                    "g-cloud-7-invitation.pdf",
+                    "Download the invitation to apply",
+                ),
+                (
+                    "g-cloud-7-proposed-framework-agreement.pdf",
+                    "Download the proposed framework agreement",
+                ),
+                (
+                    "g-cloud-7-call-off.pdf",
+                    u"Download the proposed \u2018call-off\u2019 contract",
+                ),
+                (
+                    "g-cloud-7-reporting-template.xls",
+                    "Download the reporting template",
+                ),
+                (
+                    "result-letter.pdf",
+                    "Download your application result letter",
+                ),
             )
-            assert len(doc.xpath(
-                "//main//p[contains(normalize-space(string()), $a)]",
-                a="until 5pm BST, 22 September 2015",
-            )) == 1
-            assert not doc.xpath(
-                "//main//table[normalize-space(string(./caption))=$b]",
-                b="Agreement details",
-            )
+        )
+        assert len(doc.xpath(
+            "//main//p[contains(normalize-space(string()), $a)]",
+            a="until 5pm BST, 22 September 2015",
+        )) == 1
+        assert not doc.xpath(
+            "//main//table[normalize-space(string(./caption))=$b]",
+            b="Agreement details",
+        )
 
     def test_returns_404_if_framework_does_not_exist(self, data_api_client, s3):
-        with self.app.test_client():
-            self.login()
-            data_api_client.get_framework.side_effect = APIError(mock.Mock(status_code=404))
+        self.login()
+        data_api_client.get_framework.side_effect = APIError(mock.Mock(status_code=404))
 
-            res = self.client.get('/suppliers/frameworks/does-not-exist')
+        res = self.client.get('/suppliers/frameworks/does-not-exist')
 
-            assert res.status_code == 404
+        assert res.status_code == 404
 
     def test_result_letter_is_shown_when_is_in_standstill(self, data_api_client, s3):
-        with self.app.test_client():
-            self.login()
+        self.login()
 
-            data_api_client.get_framework.return_value = self.framework(status='standstill')
-            data_api_client.find_draft_services.return_value = {
-                "services": [
-                    {'serviceName': 'A service', 'status': 'submitted', 'lotSlug': 'iaas'}
-                ]
-            }
-            data_api_client.get_supplier_framework_info.return_value = self.supplier_framework()
+        data_api_client.get_framework.return_value = self.framework(status='standstill')
+        data_api_client.find_draft_services.return_value = {
+            "services": [
+                {'serviceName': 'A service', 'status': 'submitted', 'lotSlug': 'iaas'}
+            ]
+        }
+        data_api_client.get_supplier_framework_info.return_value = self.supplier_framework()
 
-            res = self.client.get("/suppliers/frameworks/g-cloud-7")
+        res = self.client.get("/suppliers/frameworks/g-cloud-7")
 
-            data = res.get_data(as_text=True)
+        data = res.get_data(as_text=True)
 
-            assert u'Download your application result letter' in data
+        assert u'Download your application result letter' in data
 
     def test_result_letter_is_not_shown_when_not_in_standstill(self, data_api_client, s3):
-        with self.app.test_client():
-            self.login()
+        self.login()
 
-            data_api_client.get_framework.return_value = self.framework(status='pending')
-            data_api_client.find_draft_services.return_value = {
-                "services": [
-                    {'serviceName': 'A service', 'status': 'submitted', 'lotSlug': 'iaas'}
-                ]
-            }
-            data_api_client.get_supplier_framework_info.return_value = self.supplier_framework()
+        data_api_client.get_framework.return_value = self.framework(status='pending')
+        data_api_client.find_draft_services.return_value = {
+            "services": [
+                {'serviceName': 'A service', 'status': 'submitted', 'lotSlug': 'iaas'}
+            ]
+        }
+        data_api_client.get_supplier_framework_info.return_value = self.supplier_framework()
 
-            res = self.client.get("/suppliers/frameworks/g-cloud-7")
+        res = self.client.get("/suppliers/frameworks/g-cloud-7")
 
-            data = res.get_data(as_text=True)
+        data = res.get_data(as_text=True)
 
-            assert u'Download your application result letter' not in data
+        assert u'Download your application result letter' not in data
 
     def test_result_letter_is_not_shown_when_no_application(self, data_api_client, s3):
-        with self.app.test_client():
-            self.login()
-            data_api_client.get_framework.return_value = self.framework(status='standstill')
-            data_api_client.find_draft_services.return_value = {
-                "services": [
-                    {'serviceName': 'A service', 'status': 'not-submitted'}
-                ]
-            }
-            data_api_client.get_supplier_framework_info.return_value = self.supplier_framework()
+        self.login()
+        data_api_client.get_framework.return_value = self.framework(status='standstill')
+        data_api_client.find_draft_services.return_value = {
+            "services": [
+                {'serviceName': 'A service', 'status': 'not-submitted'}
+            ]
+        }
+        data_api_client.get_supplier_framework_info.return_value = self.supplier_framework()
 
-            res = self.client.get("/suppliers/frameworks/g-cloud-7")
+        res = self.client.get("/suppliers/frameworks/g-cloud-7")
 
-            data = res.get_data(as_text=True)
+        data = res.get_data(as_text=True)
 
-            assert u'Download your application result letter' not in data
+        assert u'Download your application result letter' not in data
 
     def test_link_to_unsigned_framework_agreement_is_shown_if_supplier_is_on_framework(self, data_api_client, s3):
-        with self.app.test_client():
-            self.login()
-            data_api_client.get_framework.return_value = self.framework(status='standstill')
-            data_api_client.find_draft_services.return_value = {
-                "services": [
-                    {'serviceName': 'A service', 'status': 'submitted', 'lotSlug': 'iaas'}
-                ]
-            }
-            data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
-                on_framework=True)
+        self.login()
+        data_api_client.get_framework.return_value = self.framework(status='standstill')
+        data_api_client.find_draft_services.return_value = {
+            "services": [
+                {'serviceName': 'A service', 'status': 'submitted', 'lotSlug': 'iaas'}
+            ]
+        }
+        data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
+            on_framework=True)
 
-            res = self.client.get("/suppliers/frameworks/g-cloud-7")
+        res = self.client.get("/suppliers/frameworks/g-cloud-7")
 
-            data = res.get_data(as_text=True)
+        data = res.get_data(as_text=True)
 
-            assert u'Sign and return your framework agreement' in data
-            assert u'Download your countersigned framework agreement' not in data
+        assert u'Sign and return your framework agreement' in data
+        assert u'Download your countersigned framework agreement' not in data
 
     def test_pending_success_message_is_explicit_if_supplier_is_on_framework(self, data_api_client, s3):
-        with self.app.test_client():
-            self.login()
+        self.login()
 
         data_api_client.get_framework.return_value = self.framework(status='standstill')
         data_api_client.find_draft_services.return_value = {
@@ -826,26 +803,24 @@ class TestFrameworksDashboard(BaseApplicationTest):
             assert equivocal_message not in data
 
     def test_link_to_framework_agreement_is_not_shown_if_supplier_is_not_on_framework(self, data_api_client, s3):
-        with self.app.test_client():
-            self.login()
+        self.login()
 
-            data_api_client.find_draft_services.return_value = {
-                "services": [
-                    {'serviceName': 'A service', 'status': 'submitted', 'lotSlug': 'iaas'}
-                ]
-            }
-            data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
-                on_framework=False)
+        data_api_client.find_draft_services.return_value = {
+            "services": [
+                {'serviceName': 'A service', 'status': 'submitted', 'lotSlug': 'iaas'}
+            ]
+        }
+        data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
+            on_framework=False)
 
-            res = self.client.get("/suppliers/frameworks/g-cloud-7")
+        res = self.client.get("/suppliers/frameworks/g-cloud-7")
 
-            data = res.get_data(as_text=True)
+        data = res.get_data(as_text=True)
 
-            assert u'Sign and return your framework agreement' not in data
+        assert u'Sign and return your framework agreement' not in data
 
     def test_pending_success_message_is_equivocal_if_supplier_is_on_framework(self, data_api_client, s3):
-        with self.app.test_client():
-            self.login()
+        self.login()
 
         data_api_client.get_framework.return_value = self.framework(status='standstill')
         data_api_client.find_draft_services.return_value = {
@@ -888,133 +863,132 @@ class TestFrameworksDashboard(BaseApplicationTest):
             ) for section, filename, ext, last_modified in files
         ]
 
-        with self.app.test_client():
-            self.login()
-            data_api_client.get_framework.return_value = self.framework(status='standstill')
-            data_api_client.find_draft_services.return_value = {
-                "services": [
-                    {'serviceName': 'A service', 'status': 'submitted', 'lotSlug': 'iaas'}
-                ]
-            }
-            data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
-                on_framework=True,
-                agreement_returned=True,
-                agreement_details=self._boring_agreement_details,
-                agreement_path='pathy/mc/path.face',
-                countersigned=True,
-                countersigned_path='g-cloud-7/agreements/1234/1234-countersigned-agreement.pdf',
-            )
+        self.login()
+        data_api_client.get_framework.return_value = self.framework(status='standstill')
+        data_api_client.find_draft_services.return_value = {
+            "services": [
+                {'serviceName': 'A service', 'status': 'submitted', 'lotSlug': 'iaas'}
+            ]
+        }
+        data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
+            on_framework=True,
+            agreement_returned=True,
+            agreement_details=self._boring_agreement_details,
+            agreement_path='pathy/mc/path.face',
+            countersigned=True,
+            countersigned_path='g-cloud-7/agreements/1234/1234-countersigned-agreement.pdf',
+        )
 
-            res = self.client.get("/suppliers/frameworks/g-cloud-7")
-            assert res.status_code == 200
+        res = self.client.get("/suppliers/frameworks/g-cloud-7")
+        assert res.status_code == 200
 
-            data = res.get_data(as_text=True)
+        data = res.get_data(as_text=True)
 
-            doc = html.fromstring(data)
+        doc = html.fromstring(data)
 
-            assert not doc.xpath(
-                "//main//a[@href=$href or normalize-space(string())=$label]",
-                href="/frameworks/g-cloud-7/agreement",
-                label="Sign and return your framework agreement",
-            )
+        assert not doc.xpath(
+            "//main//a[@href=$href or normalize-space(string())=$label]",
+            href="/frameworks/g-cloud-7/agreement",
+            label="Sign and return your framework agreement",
+        )
 
-            extracted_guidance_links = self._extract_guidance_links(doc)
+        extracted_guidance_links = self._extract_guidance_links(doc)
 
-            assert extracted_guidance_links == OrderedDict((
-                ("You submitted:", (
-                    (
-                        'View submitted services',
-                        '/suppliers/frameworks/g-cloud-7/submissions',
-                        None,
-                        None,
-                    ),
-                    (
-                        "View your declaration",
-                        "/suppliers/frameworks/g-cloud-7/declaration",
-                        None,
-                        None,
-                    ),
-                )),
-                ("Legal documents", (
-                    (
-                        'Download the standard framework agreement',
-                        '/suppliers/frameworks/g-cloud-7/files/g-cloud-7-final-framework-agreement.pdf',
-                        None,
-                        None,
-                    ),
-                    (
-                        "Download your signed framework agreement",
-                        "/suppliers/frameworks/g-cloud-7/agreements/pathy/mc/path.face",
-                        None,
-                        None,
-                    ),
-                    (
-                        u"Download your countersigned framework agreement",
-                        "/suppliers/frameworks/g-cloud-7/agreements/countersigned-agreement.pdf",
-                        None,
-                        None,
-                    ),
-                    (
-                        'Download your application result letter',
-                        '/suppliers/frameworks/g-cloud-7/agreements/result-letter.pdf',
-                        None,
-                        None,
-                    ),
-                    (
-                        'Download the call-off contract template',
-                        '/suppliers/frameworks/g-cloud-7/files/g-cloud-7-final-call-off.pdf',
-                        None,
-                        None,
-                    ),
-                )),
-                ("Guidance", (
-                    (
-                        'Download the invitation to apply',
-                        '/suppliers/frameworks/g-cloud-7/files/g-cloud-7-invitation.pdf',
-                        None,
-                        None,
-                    ),
-                    (
-                        "Read about how to sell your services",
-                        "https://www.gov.uk/guidance/g-cloud-suppliers-guide#how-to-apply",
-                        None,
-                        None,
-                    ),
-                )),
-                ("Communications", (
-                    (
-                        "View communications and clarification questions",
-                        "/suppliers/frameworks/g-cloud-7/updates",
-                        None,
-                        None,
-                    ),
-                )),
-                ('Reporting', (
-                    (
-                        'Download the reporting template',
-                        '/suppliers/frameworks/g-cloud-7/files/g-cloud-7-reporting-template.xls',
-                        None,
-                        None,
-                    ),
-                )),
-            ))
-            assert not doc.xpath(
-                "//main//table[normalize-space(string(./caption))=$b]",
-                b="Agreement details",
-            )
-            assert not doc.xpath(
-                "//main//p[contains(normalize-space(string()), $b)]",
-                b="You can start selling your",
-            )
-            # neither of these should exist because it's a pre-frameworkAgreementVersion framework
-            assert not doc.xpath(
-                "//main//p[contains(normalize-space(string()), $b)]",
-                b="Your original and counterpart signature pages",
-            )
-            assert not doc.xpath(
-                "//main//p[contains(normalize-space(string()), $b)]",
-                b="Your framework agreement signature page has been sent to the Crown Commercial Service",
-            )
+        assert extracted_guidance_links == OrderedDict((
+            ("You submitted:", (
+                (
+                    'View submitted services',
+                    '/suppliers/frameworks/g-cloud-7/submissions',
+                    None,
+                    None,
+                ),
+                (
+                    "View your declaration",
+                    "/suppliers/frameworks/g-cloud-7/declaration",
+                    None,
+                    None,
+                ),
+            )),
+            ("Legal documents", (
+                (
+                    'Download the standard framework agreement',
+                    '/suppliers/frameworks/g-cloud-7/files/g-cloud-7-final-framework-agreement.pdf',
+                    None,
+                    None,
+                ),
+                (
+                    "Download your signed framework agreement",
+                    "/suppliers/frameworks/g-cloud-7/agreements/pathy/mc/path.face",
+                    None,
+                    None,
+                ),
+                (
+                    u"Download your countersigned framework agreement",
+                    "/suppliers/frameworks/g-cloud-7/agreements/countersigned-agreement.pdf",
+                    None,
+                    None,
+                ),
+                (
+                    'Download your application result letter',
+                    '/suppliers/frameworks/g-cloud-7/agreements/result-letter.pdf',
+                    None,
+                    None,
+                ),
+                (
+                    'Download the call-off contract template',
+                    '/suppliers/frameworks/g-cloud-7/files/g-cloud-7-final-call-off.pdf',
+                    None,
+                    None,
+                ),
+            )),
+            ("Guidance", (
+                (
+                    'Download the invitation to apply',
+                    '/suppliers/frameworks/g-cloud-7/files/g-cloud-7-invitation.pdf',
+                    None,
+                    None,
+                ),
+                (
+                    "Read about how to sell your services",
+                    "https://www.gov.uk/guidance/g-cloud-suppliers-guide#how-to-apply",
+                    None,
+                    None,
+                ),
+            )),
+            ("Communications", (
+                (
+                    "View communications and clarification questions",
+                    "/suppliers/frameworks/g-cloud-7/updates",
+                    None,
+                    None,
+                ),
+            )),
+            ('Reporting', (
+                (
+                    'Download the reporting template',
+                    '/suppliers/frameworks/g-cloud-7/files/g-cloud-7-reporting-template.xls',
+                    None,
+                    None,
+                ),
+            )),
+        ))
+        assert not doc.xpath(
+            "//main//table[normalize-space(string(./caption))=$b]",
+            b="Agreement details",
+        )
+        assert not doc.xpath(
+            "//main//p[contains(normalize-space(string()), $b)]",
+            b="You can start selling your",
+        )
+        # neither of these should exist because it's a pre-frameworkAgreementVersion framework
+        assert not doc.xpath(
+            "//main//p[contains(normalize-space(string()), $b)]",
+            b="Your original and counterpart signature pages",
+        )
+        assert not doc.xpath(
+            "//main//p[contains(normalize-space(string()), $b)]",
+            b="Your framework agreement signature page has been sent to the Crown Commercial Service",
+        )
 
     def test_countersigned_framework_agreement_fav_framework(self, data_api_client, s3):
         # "fav" being "frameworkAgreementVersion"
@@ -1031,670 +1005,662 @@ class TestFrameworksDashboard(BaseApplicationTest):
             ) for section, filename, ext, last_modified in files
         ]
 
-        with self.app.test_client():
-            self.login()
-            data_api_client.get_framework.return_value = get_g_cloud_8()
-            data_api_client.find_draft_services.return_value = {
-                "services": [
-                    {'serviceName': 'A service', 'status': 'submitted', 'lotSlug': 'iaas'}
-                ]
-            }
-            data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
-                on_framework=True,
-                agreement_returned=True,
-                agreement_details=self._boring_agreement_details,
-                agreement_path='pathy/mc/path.face',
-                agreement_returned_at=self._boring_agreement_returned_at,
-                countersigned=True,
-                countersigned_path='g-cloud-8/agreements/1234/1234-countersigned-agreement.pdf',
-            )
+        self.login()
+        data_api_client.get_framework.return_value = get_g_cloud_8()
+        data_api_client.find_draft_services.return_value = {
+            "services": [
+                {'serviceName': 'A service', 'status': 'submitted', 'lotSlug': 'iaas'}
+            ]
+        }
+        data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
+            on_framework=True,
+            agreement_returned=True,
+            agreement_details=self._boring_agreement_details,
+            agreement_path='pathy/mc/path.face',
+            agreement_returned_at=self._boring_agreement_returned_at,
+            countersigned=True,
+            countersigned_path='g-cloud-8/agreements/1234/1234-countersigned-agreement.pdf',
+        )
 
-            res = self.client.get("/suppliers/frameworks/g-cloud-8")
-            assert res.status_code == 200
+        res = self.client.get("/suppliers/frameworks/g-cloud-8")
+        assert res.status_code == 200
 
-            data = res.get_data(as_text=True)
+        data = res.get_data(as_text=True)
 
-            doc = html.fromstring(data)
+        doc = html.fromstring(data)
 
-            assert not doc.xpath(
-                "//main//a[@href=$href or normalize-space(string())=$label]",
-                href="/frameworks/g-cloud-8/agreement",
-                label="Sign and return your framework agreement",
-            )
-            assert not doc.xpath(
-                "//main//a[@href=$href or normalize-space(string())=$label]",
-                href="/suppliers/frameworks/g-cloud-7/agreements/result-letter.pdf",
-                label="Download your application result letter",
-            )
+        assert not doc.xpath(
+            "//main//a[@href=$href or normalize-space(string())=$label]",
+            href="/frameworks/g-cloud-8/agreement",
+            label="Sign and return your framework agreement",
+        )
+        assert not doc.xpath(
+            "//main//a[@href=$href or normalize-space(string())=$label]",
+            href="/suppliers/frameworks/g-cloud-7/agreements/result-letter.pdf",
+            label="Download your application result letter",
+        )
 
-            extracted_guidance_links = self._extract_guidance_links(doc)
+        extracted_guidance_links = self._extract_guidance_links(doc)
 
-            assert extracted_guidance_links == OrderedDict((
-                ("You submitted:", (
-                    (
-                        'View submitted services',
-                        '/suppliers/frameworks/g-cloud-8/submissions',
-                        None,
-                        None,
-                    ),
-                    (
-                        "View your declaration",
-                        "/suppliers/frameworks/g-cloud-8/declaration",
-                        None,
-                        None,
-                    ),
-                )),
-                ("Legal documents", (
-                    (
-                        'Read the standard framework agreement',
-                        'https://www.gov.uk/government/publications/g-cloud-8-framework-agreement',
-                        None,
-                        None,
-                    ),
-                    (
-                        u"Download your \u2018original\u2019 framework agreement signature page",
-                        "/suppliers/frameworks/g-cloud-8/agreements/pathy/mc/path.face",
-                        None,
-                        None,
-                    ),
-                    (
-                        u"Download your \u2018counterpart\u2019 framework agreement signature page",
-                        "/suppliers/frameworks/g-cloud-8/agreements/countersigned-agreement.pdf",
-                        None,
-                        None,
-                    ),
-                    (
-                        'Download the call-off contract template',
-                        '/suppliers/frameworks/g-cloud-8/files/g-cloud-8-final-call-off.pdf',
-                        None,
-                        None,
-                    ),
-                )),
-                ("Guidance", (
-                    (
-                        'Download the invitation to apply',
-                        '/suppliers/frameworks/g-cloud-8/files/g-cloud-8-invitation.pdf',
-                        None,
-                        None,
-                    ),
-                    (
-                        "Read about how to sell your services",
-                        "https://www.gov.uk/guidance/g-cloud-suppliers-guide#how-to-apply",
-                        None,
-                        None,
-                    ),
-                )),
-                ("Communications", (
-                    (
-                        "View communications and clarification questions",
-                        "/suppliers/frameworks/g-cloud-8/updates",
-                        None,
-                        None,
-                    ),
-                )),
-                ('Reporting', (
-                    (
-                        'Download the reporting template',
-                        '/suppliers/frameworks/g-cloud-8/files/g-cloud-8-reporting-template.xls',
-                        None,
-                        None,
-                    ),
-                )),
-            ))
-            assert not doc.xpath(
-                "//main//table[normalize-space(string(./caption))=$b]",
-                b="Agreement details",
-            )
-            assert not doc.xpath(
-                "//main//p[contains(normalize-space(string()), $b)]",
-                b="You can start selling your",
-            )
-            assert doc.xpath(
-                "//main//p[contains(normalize-space(string()), $b)]",
-                b="Your original and counterpart signature pages",
-            )
-            assert not doc.xpath(
-                "//main//p[contains(normalize-space(string()), $b)]",
-                b="Your framework agreement signature page has been sent to the Crown Commercial Service",
-            )
+        assert extracted_guidance_links == OrderedDict((
+            ("You submitted:", (
+                (
+                    'View submitted services',
+                    '/suppliers/frameworks/g-cloud-8/submissions',
+                    None,
+                    None,
+                ),
+                (
+                    "View your declaration",
+                    "/suppliers/frameworks/g-cloud-8/declaration",
+                    None,
+                    None,
+                ),
+            )),
+            ("Legal documents", (
+                (
+                    'Read the standard framework agreement',
+                    'https://www.gov.uk/government/publications/g-cloud-8-framework-agreement',
+                    None,
+                    None,
+                ),
+                (
+                    u"Download your \u2018original\u2019 framework agreement signature page",
+                    "/suppliers/frameworks/g-cloud-8/agreements/pathy/mc/path.face",
+                    None,
+                    None,
+                ),
+                (
+                    u"Download your \u2018counterpart\u2019 framework agreement signature page",
+                    "/suppliers/frameworks/g-cloud-8/agreements/countersigned-agreement.pdf",
+                    None,
+                    None,
+                ),
+                (
+                    'Download the call-off contract template',
+                    '/suppliers/frameworks/g-cloud-8/files/g-cloud-8-final-call-off.pdf',
+                    None,
+                    None,
+                ),
+            )),
+            ("Guidance", (
+                (
+                    'Download the invitation to apply',
+                    '/suppliers/frameworks/g-cloud-8/files/g-cloud-8-invitation.pdf',
+                    None,
+                    None,
+                ),
+                (
+                    "Read about how to sell your services",
+                    "https://www.gov.uk/guidance/g-cloud-suppliers-guide#how-to-apply",
+                    None,
+                    None,
+                ),
+            )),
+            ("Communications", (
+                (
+                    "View communications and clarification questions",
+                    "/suppliers/frameworks/g-cloud-8/updates",
+                    None,
+                    None,
+                ),
+            )),
+            ('Reporting', (
+                (
+                    'Download the reporting template',
+                    '/suppliers/frameworks/g-cloud-8/files/g-cloud-8-reporting-template.xls',
+                    None,
+                    None,
+                ),
+            )),
+        ))
+        assert not doc.xpath(
+            "//main//table[normalize-space(string(./caption))=$b]",
+            b="Agreement details",
+        )
+        assert not doc.xpath(
+            "//main//p[contains(normalize-space(string()), $b)]",
+            b="You can start selling your",
+        )
+        assert doc.xpath(
+            "//main//p[contains(normalize-space(string()), $b)]",
+            b="Your original and counterpart signature pages",
+        )
+        assert not doc.xpath(
+            "//main//p[contains(normalize-space(string()), $b)]",
+            b="Your framework agreement signature page has been sent to the Crown Commercial Service",
+        )
 
     def test_shows_returned_agreement_details(self, data_api_client, s3):
-        with self.app.test_client():
-            self.login()
-            data_api_client.get_framework.return_value = get_g_cloud_8()
-            data_api_client.find_draft_services.return_value = {
-                "services": [
-                    {'serviceName': 'A service', 'status': 'submitted', 'lotSlug': 'iaas'}
-                ]
-            }
-            data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
-                on_framework=True,
-                agreement_returned=True,
-                agreement_details=self._boring_agreement_details,
-                agreement_path='g-cloud-8/agreements/123-framework-agreement.pdf',
-                agreement_returned_at=self._boring_agreement_returned_at,
-            )
+        self.login()
+        data_api_client.get_framework.return_value = get_g_cloud_8()
+        data_api_client.find_draft_services.return_value = {
+            "services": [
+                {'serviceName': 'A service', 'status': 'submitted', 'lotSlug': 'iaas'}
+            ]
+        }
+        data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
+            on_framework=True,
+            agreement_returned=True,
+            agreement_details=self._boring_agreement_details,
+            agreement_path='g-cloud-8/agreements/123-framework-agreement.pdf',
+            agreement_returned_at=self._boring_agreement_returned_at,
+        )
 
-            res = self.client.get("/suppliers/frameworks/g-cloud-8")
-            assert res.status_code == 200
+        res = self.client.get("/suppliers/frameworks/g-cloud-8")
+        assert res.status_code == 200
 
-            data = res.get_data(as_text=True)
-            doc = html.fromstring(data)
+        data = res.get_data(as_text=True)
+        doc = html.fromstring(data)
 
-            assert not doc.xpath(
-                "//main//a[@href=$href or normalize-space(string())=$label]",
-                href="/frameworks/g-cloud-8/agreement",
-                label="Sign and return your framework agreement",
-            )
-            assert not doc.xpath(
-                "//main//a[@href=$href or normalize-space(string())=$label]",
-                href="/suppliers/frameworks/g-cloud-8/agreements/result-letter.pdf",
-                label="Download your application result letter",
-            )
+        assert not doc.xpath(
+            "//main//a[@href=$href or normalize-space(string())=$label]",
+            href="/frameworks/g-cloud-8/agreement",
+            label="Sign and return your framework agreement",
+        )
+        assert not doc.xpath(
+            "//main//a[@href=$href or normalize-space(string())=$label]",
+            href="/suppliers/frameworks/g-cloud-8/agreements/result-letter.pdf",
+            label="Download your application result letter",
+        )
 
-            extracted_guidance_links = self._extract_guidance_links(doc)
-            assert extracted_guidance_links == OrderedDict((
-                ("You submitted:", (
-                    (
-                        'View submitted services',
-                        '/suppliers/frameworks/g-cloud-8/submissions',
-                        None,
-                        None,
-                    ),
-                    (
-                        "View your declaration",
-                        "/suppliers/frameworks/g-cloud-8/declaration",
-                        None,
-                        None,
-                    ),
-                )),
-                ('Legal documents', (
-                    (
-                        'Read the standard framework agreement',
-                        'https://www.gov.uk/government/publications/g-cloud-8-framework-agreement',
-                        None,
-                        None,
-                    ),
-                    (
-                        u'Download your \u2018original\u2019 framework agreement signature page',
-                        '/suppliers/frameworks/g-cloud-8/agreements/framework-agreement.pdf',
-                        None,
-                        None,
-                    ),
-                )),
-                ('Guidance', (
-                    (
-                        'Read about how to sell your services',
-                        'https://www.gov.uk/guidance/g-cloud-suppliers-guide#how-to-apply',
-                        None,
-                        None,
-                    ),
-                )),
-                ('Communications', (
-                    (
-                        'View communications and clarification questions',
-                        '/suppliers/frameworks/g-cloud-8/updates',
-                        None,
-                        None,
-                    ),
-                )),
-            ))
-            extracted_signing_details_table_rows = self._extract_signing_details_table_rows(doc)
-            assert extracted_signing_details_table_rows == \
-                self._boring_agreement_details_expected_table_results
-            assert len(doc.xpath(
-                "//main//h1[normalize-space(string())=$b]",
-                b="Your G-Cloud 8 application",
-            )) == 1
-            assert doc.xpath(
-                "//main//p[contains(normalize-space(string()), $b)]",
-                b="You can start selling your",
-            )
-            assert not doc.xpath(
-                "//main//p[contains(normalize-space(string()), $b)]",
-                b="Your original and counterpart signature pages",
-            )
-            assert doc.xpath(
-                "//main//p[contains(normalize-space(string()), $b)]",
-                b="Your framework agreement signature page has been sent to the Crown Commercial Service",
-            )
+        extracted_guidance_links = self._extract_guidance_links(doc)
+        assert extracted_guidance_links == OrderedDict((
+            ("You submitted:", (
+                (
+                    'View submitted services',
+                    '/suppliers/frameworks/g-cloud-8/submissions',
+                    None,
+                    None,
+                ),
+                (
+                    "View your declaration",
+                    "/suppliers/frameworks/g-cloud-8/declaration",
+                    None,
+                    None,
+                ),
+            )),
+            ('Legal documents', (
+                (
+                    'Read the standard framework agreement',
+                    'https://www.gov.uk/government/publications/g-cloud-8-framework-agreement',
+                    None,
+                    None,
+                ),
+                (
+                    u'Download your \u2018original\u2019 framework agreement signature page',
+                    '/suppliers/frameworks/g-cloud-8/agreements/framework-agreement.pdf',
+                    None,
+                    None,
+                ),
+            )),
+            ('Guidance', (
+                (
+                    'Read about how to sell your services',
+                    'https://www.gov.uk/guidance/g-cloud-suppliers-guide#how-to-apply',
+                    None,
+                    None,
+                ),
+            )),
+            ('Communications', (
+                (
+                    'View communications and clarification questions',
+                    '/suppliers/frameworks/g-cloud-8/updates',
+                    None,
+                    None,
+                ),
+            )),
+        ))
+        extracted_signing_details_table_rows = self._extract_signing_details_table_rows(doc)
+        assert extracted_signing_details_table_rows == \
+            self._boring_agreement_details_expected_table_results
+        assert len(doc.xpath(
+            "//main//h1[normalize-space(string())=$b]",
+            b="Your G-Cloud 8 application",
+        )) == 1
+        assert doc.xpath(
+            "//main//p[contains(normalize-space(string()), $b)]",
+            b="You can start selling your",
+        )
+        assert not doc.xpath(
+            "//main//p[contains(normalize-space(string()), $b)]",
+            b="Your original and counterpart signature pages",
+        )
+        assert doc.xpath(
+            "//main//p[contains(normalize-space(string()), $b)]",
+            b="Your framework agreement signature page has been sent to the Crown Commercial Service",
+        )
 
     def test_countersigned_but_no_countersigned_path(self, data_api_client, s3):
-        with self.app.test_client():
-            self.login()
-            data_api_client.get_framework.return_value = get_g_cloud_8()
-            data_api_client.find_draft_services.return_value = {
-                "services": [
-                    {'serviceName': 'A service', 'status': 'submitted', 'lotSlug': 'iaas'}
-                ]
-            }
-            data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
-                on_framework=True,
-                agreement_returned=True,
-                agreement_details=self._boring_agreement_details,
-                agreement_path='g-cloud-8/agreements/123-framework-agreement.pdf',
-                agreement_returned_at=self._boring_agreement_returned_at,
-                countersigned=True,
-                # note `countersigned_path` is not set: we're testing that the view behaves as though not countersigned
-                # i.e. is not depending on the `countersigned` property
-            )
+        self.login()
+        data_api_client.get_framework.return_value = get_g_cloud_8()
+        data_api_client.find_draft_services.return_value = {
+            "services": [
+                {'serviceName': 'A service', 'status': 'submitted', 'lotSlug': 'iaas'}
+            ]
+        }
+        data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
+            on_framework=True,
+            agreement_returned=True,
+            agreement_details=self._boring_agreement_details,
+            agreement_path='g-cloud-8/agreements/123-framework-agreement.pdf',
+            agreement_returned_at=self._boring_agreement_returned_at,
+            countersigned=True,
+            # note `countersigned_path` is not set: we're testing that the view behaves as though not countersigned
+            # i.e. is not depending on the `countersigned` property
+        )
 
-            res = self.client.get("/suppliers/frameworks/g-cloud-8")
-            assert res.status_code == 200
+        res = self.client.get("/suppliers/frameworks/g-cloud-8")
+        assert res.status_code == 200
 
-            data = res.get_data(as_text=True)
-            doc = html.fromstring(data)
+        data = res.get_data(as_text=True)
+        doc = html.fromstring(data)
 
-            assert not doc.xpath(
-                "//main//a[@href=$href or normalize-space(string())=$label]",
-                href="/frameworks/g-cloud-8/agreement",
-                label="Sign and return your framework agreement",
-            )
+        assert not doc.xpath(
+            "//main//a[@href=$href or normalize-space(string())=$label]",
+            href="/frameworks/g-cloud-8/agreement",
+            label="Sign and return your framework agreement",
+        )
 
-            extracted_guidance_links = self._extract_guidance_links(doc)
-            assert extracted_guidance_links == OrderedDict((
-                ("You submitted:", (
-                    (
-                        'View submitted services',
-                        '/suppliers/frameworks/g-cloud-8/submissions',
-                        None,
-                        None,
-                    ),
-                    (
-                        "View your declaration",
-                        "/suppliers/frameworks/g-cloud-8/declaration",
-                        None,
-                        None,
-                    ),
-                )),
-                ('Legal documents', (
-                    (
-                        'Read the standard framework agreement',
-                        'https://www.gov.uk/government/publications/g-cloud-8-framework-agreement',
-                        None,
-                        None,
-                    ),
-                    (
-                        u'Download your \u2018original\u2019 framework agreement signature page',
-                        '/suppliers/frameworks/g-cloud-8/agreements/framework-agreement.pdf',
-                        None,
-                        None,
-                    ),
-                )),
-                ('Guidance', (
-                    (
-                        'Read about how to sell your services',
-                        'https://www.gov.uk/guidance/g-cloud-suppliers-guide#how-to-apply',
-                        None,
-                        None,
-                    ),
-                )),
-                ('Communications', (
-                    (
-                        'View communications and clarification questions',
-                        '/suppliers/frameworks/g-cloud-8/updates',
-                        None,
-                        None,
-                    ),
-                )),
-            ))
-            extracted_signing_details_table_rows = self._extract_signing_details_table_rows(doc)
-            assert extracted_signing_details_table_rows == \
-                self._boring_agreement_details_expected_table_results
-            assert len(doc.xpath(
-                "//main//h1[normalize-space(string())=$b]",
-                b="Your G-Cloud 8 application",
-            )) == 1
-            assert doc.xpath(
-                "//main//p[contains(normalize-space(string()), $b)]",
-                b="You can start selling your",
-            )
-            assert not doc.xpath(
-                "//main//p[contains(normalize-space(string()), $b)]",
-                b="Your original and counterpart signature pages",
-            )
-            assert doc.xpath(
-                "//main//p[contains(normalize-space(string()), $b)]",
-                b="Your framework agreement signature page has been sent to the Crown Commercial Service",
-            )
+        extracted_guidance_links = self._extract_guidance_links(doc)
+        assert extracted_guidance_links == OrderedDict((
+            ("You submitted:", (
+                (
+                    'View submitted services',
+                    '/suppliers/frameworks/g-cloud-8/submissions',
+                    None,
+                    None,
+                ),
+                (
+                    "View your declaration",
+                    "/suppliers/frameworks/g-cloud-8/declaration",
+                    None,
+                    None,
+                ),
+            )),
+            ('Legal documents', (
+                (
+                    'Read the standard framework agreement',
+                    'https://www.gov.uk/government/publications/g-cloud-8-framework-agreement',
+                    None,
+                    None,
+                ),
+                (
+                    u'Download your \u2018original\u2019 framework agreement signature page',
+                    '/suppliers/frameworks/g-cloud-8/agreements/framework-agreement.pdf',
+                    None,
+                    None,
+                ),
+            )),
+            ('Guidance', (
+                (
+                    'Read about how to sell your services',
+                    'https://www.gov.uk/guidance/g-cloud-suppliers-guide#how-to-apply',
+                    None,
+                    None,
+                ),
+            )),
+            ('Communications', (
+                (
+                    'View communications and clarification questions',
+                    '/suppliers/frameworks/g-cloud-8/updates',
+                    None,
+                    None,
+                ),
+            )),
+        ))
+        extracted_signing_details_table_rows = self._extract_signing_details_table_rows(doc)
+        assert extracted_signing_details_table_rows == \
+            self._boring_agreement_details_expected_table_results
+        assert len(doc.xpath(
+            "//main//h1[normalize-space(string())=$b]",
+            b="Your G-Cloud 8 application",
+        )) == 1
+        assert doc.xpath(
+            "//main//p[contains(normalize-space(string()), $b)]",
+            b="You can start selling your",
+        )
+        assert not doc.xpath(
+            "//main//p[contains(normalize-space(string()), $b)]",
+            b="Your original and counterpart signature pages",
+        )
+        assert doc.xpath(
+            "//main//p[contains(normalize-space(string()), $b)]",
+            b="Your framework agreement signature page has been sent to the Crown Commercial Service",
+        )
 
     def test_shows_contract_variation_link_after_agreement_returned(self, data_api_client, s3):
-        with self.app.test_client():
-            self.login()
-            g8_with_variation = get_g_cloud_8()
-            g8_with_variation['frameworks']['variations'] = {"1": {"createdAt": "2018-08-16"}}
-            data_api_client.get_framework.return_value = g8_with_variation
-            data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
-                on_framework=True,
-                agreement_returned=True,
-                agreement_details=self._boring_agreement_details,
-                agreement_path='g-cloud-8/agreements/123-framework-agreement.pdf',
-                agreement_returned_at=self._boring_agreement_returned_at,
-            )
+        self.login()
+        g8_with_variation = get_g_cloud_8()
+        g8_with_variation['frameworks']['variations'] = {"1": {"createdAt": "2018-08-16"}}
+        data_api_client.get_framework.return_value = g8_with_variation
+        data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
+            on_framework=True,
+            agreement_returned=True,
+            agreement_details=self._boring_agreement_details,
+            agreement_path='g-cloud-8/agreements/123-framework-agreement.pdf',
+            agreement_returned_at=self._boring_agreement_returned_at,
+        )
 
-            res = self.client.get("/suppliers/frameworks/g-cloud-8")
-            assert res.status_code == 200
+        res = self.client.get("/suppliers/frameworks/g-cloud-8")
+        assert res.status_code == 200
 
-            data = res.get_data(as_text=True)
-            doc = html.fromstring(data)
+        data = res.get_data(as_text=True)
+        doc = html.fromstring(data)
 
-            assert not doc.xpath(
-                "//main//a[@href=$href or normalize-space(string())=$label]",
-                href="/frameworks/g-cloud-8/agreement",
-                label="Sign and return your framework agreement",
-            )
+        assert not doc.xpath(
+            "//main//a[@href=$href or normalize-space(string())=$label]",
+            href="/frameworks/g-cloud-8/agreement",
+            label="Sign and return your framework agreement",
+        )
 
-            extracted_guidance_links = self._extract_guidance_links(doc)
-            assert extracted_guidance_links == OrderedDict((
-                ("You submitted:", (
-                    (
-                        'View submitted services',
-                        '/suppliers/frameworks/g-cloud-8/submissions',
-                        None,
-                        None,
-                    ),
-                    (
-                        "View your declaration",
-                        "/suppliers/frameworks/g-cloud-8/declaration",
-                        None,
-                        None,
-                    ),
-                )),
-                ('Legal documents', (
-                    (
-                        'Read the standard framework agreement',
-                        'https://www.gov.uk/government/publications/g-cloud-8-framework-agreement',
-                        None,
-                        None,
-                    ),
-                    (
-                        u'Download your \u2018original\u2019 framework agreement signature page',
-                        '/suppliers/frameworks/g-cloud-8/agreements/framework-agreement.pdf',
-                        None,
-                        None,
-                    ),
-                    (
-                        'Read the proposed contract variation',
-                        '/suppliers/frameworks/g-cloud-8/contract-variation/1',
-                        None,
-                        None,
-                    ),
-                )),
-                ('Guidance', (
-                    (
-                        'Read about how to sell your services',
-                        'https://www.gov.uk/guidance/g-cloud-suppliers-guide#how-to-apply',
-                        None,
-                        None,
-                    ),
-                )),
-                ('Communications', (
-                    (
-                        'View communications and clarification questions',
-                        '/suppliers/frameworks/g-cloud-8/updates',
-                        None,
-                        None,
-                    ),
-                )),
-            ))
-            extracted_signing_details_table_rows = self._extract_signing_details_table_rows(doc)
-            assert extracted_signing_details_table_rows == \
-                self._boring_agreement_details_expected_table_results
-            assert doc.xpath(
-                "//main//p[contains(normalize-space(string()), $b)]",
-                b="You can start selling your",
-            )
-            assert not doc.xpath(
-                "//main//p[contains(normalize-space(string()), $b)]",
-                b="Your original and counterpart signature pages",
-            )
-            assert doc.xpath(
-                "//main//p[contains(normalize-space(string()), $b)]",
-                b="Your framework agreement signature page has been sent to the Crown Commercial Service",
-            )
+        extracted_guidance_links = self._extract_guidance_links(doc)
+        assert extracted_guidance_links == OrderedDict((
+            ("You submitted:", (
+                (
+                    'View submitted services',
+                    '/suppliers/frameworks/g-cloud-8/submissions',
+                    None,
+                    None,
+                ),
+                (
+                    "View your declaration",
+                    "/suppliers/frameworks/g-cloud-8/declaration",
+                    None,
+                    None,
+                ),
+            )),
+            ('Legal documents', (
+                (
+                    'Read the standard framework agreement',
+                    'https://www.gov.uk/government/publications/g-cloud-8-framework-agreement',
+                    None,
+                    None,
+                ),
+                (
+                    u'Download your \u2018original\u2019 framework agreement signature page',
+                    '/suppliers/frameworks/g-cloud-8/agreements/framework-agreement.pdf',
+                    None,
+                    None,
+                ),
+                (
+                    'Read the proposed contract variation',
+                    '/suppliers/frameworks/g-cloud-8/contract-variation/1',
+                    None,
+                    None,
+                ),
+            )),
+            ('Guidance', (
+                (
+                    'Read about how to sell your services',
+                    'https://www.gov.uk/guidance/g-cloud-suppliers-guide#how-to-apply',
+                    None,
+                    None,
+                ),
+            )),
+            ('Communications', (
+                (
+                    'View communications and clarification questions',
+                    '/suppliers/frameworks/g-cloud-8/updates',
+                    None,
+                    None,
+                ),
+            )),
+        ))
+        extracted_signing_details_table_rows = self._extract_signing_details_table_rows(doc)
+        assert extracted_signing_details_table_rows == \
+            self._boring_agreement_details_expected_table_results
+        assert doc.xpath(
+            "//main//p[contains(normalize-space(string()), $b)]",
+            b="You can start selling your",
+        )
+        assert not doc.xpath(
+            "//main//p[contains(normalize-space(string()), $b)]",
+            b="Your original and counterpart signature pages",
+        )
+        assert doc.xpath(
+            "//main//p[contains(normalize-space(string()), $b)]",
+            b="Your framework agreement signature page has been sent to the Crown Commercial Service",
+        )
 
     def test_does_not_show_contract_variation_link_if_feature_flagged_off(self, data_api_client, s3):
-        with self.app.test_client():
-            self.app.config['FEATURE_FLAGS_CONTRACT_VARIATION'] = False
-            self.login()
-            g8_with_variation = get_g_cloud_8()
-            g8_with_variation['frameworks']['variations'] = {"1": {"createdAt": "2018-08-16"}}
-            data_api_client.get_framework.return_value = g8_with_variation
-            data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
-                on_framework=True,
-                agreement_returned=True,
-                agreement_details=self._boring_agreement_details,
-                agreement_path='g-cloud-8/agreements/123-framework-agreement.pdf',
-                agreement_returned_at=self._boring_agreement_returned_at,
-            )
+        self.app.config['FEATURE_FLAGS_CONTRACT_VARIATION'] = False
+        self.login()
+        g8_with_variation = get_g_cloud_8()
+        g8_with_variation['frameworks']['variations'] = {"1": {"createdAt": "2018-08-16"}}
+        data_api_client.get_framework.return_value = g8_with_variation
+        data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
+            on_framework=True,
+            agreement_returned=True,
+            agreement_details=self._boring_agreement_details,
+            agreement_path='g-cloud-8/agreements/123-framework-agreement.pdf',
+            agreement_returned_at=self._boring_agreement_returned_at,
+        )
 
-            res = self.client.get("/suppliers/frameworks/g-cloud-8")
-            assert res.status_code == 200
+        res = self.client.get("/suppliers/frameworks/g-cloud-8")
+        assert res.status_code == 200
 
-            data = res.get_data(as_text=True)
-            doc = html.fromstring(data)
+        data = res.get_data(as_text=True)
+        doc = html.fromstring(data)
 
-            assert not doc.xpath(
-                "//main//a[@href=$href or normalize-space(string())=$label]",
-                href="/frameworks/g-cloud-7/agreement",
-                label="Sign and return your framework agreement",
-            )
+        assert not doc.xpath(
+            "//main//a[@href=$href or normalize-space(string())=$label]",
+            href="/frameworks/g-cloud-7/agreement",
+            label="Sign and return your framework agreement",
+        )
 
-            assert not doc.xpath(
-                "//main//a[contains(@href, $href_part) or normalize-space(string())=$label]",
-                href_part="contract-variation/1",
-                label="Read the proposed contract variation",
-            )
-            extracted_signing_details_table_rows = self._extract_signing_details_table_rows(doc)
-            assert extracted_signing_details_table_rows == \
-                self._boring_agreement_details_expected_table_results
-            assert doc.xpath(
-                "//main//p[contains(normalize-space(string()), $b)]",
-                b="You can start selling your",
-            )
-            assert not doc.xpath(
-                "//main//p[contains(normalize-space(string()), $b)]",
-                b="Your original and counterpart signature pages",
-            )
-            assert doc.xpath(
-                "//main//p[contains(normalize-space(string()), $b)]",
-                b="Your framework agreement signature page has been sent to the Crown Commercial Service",
-            )
+        assert not doc.xpath(
+            "//main//a[contains(@href, $href_part) or normalize-space(string())=$label]",
+            href_part="contract-variation/1",
+            label="Read the proposed contract variation",
+        )
+        extracted_signing_details_table_rows = self._extract_signing_details_table_rows(doc)
+        assert extracted_signing_details_table_rows == \
+            self._boring_agreement_details_expected_table_results
+        assert doc.xpath(
+            "//main//p[contains(normalize-space(string()), $b)]",
+            b="You can start selling your",
+        )
+        assert not doc.xpath(
+            "//main//p[contains(normalize-space(string()), $b)]",
+            b="Your original and counterpart signature pages",
+        )
+        assert doc.xpath(
+            "//main//p[contains(normalize-space(string()), $b)]",
+            b="Your framework agreement signature page has been sent to the Crown Commercial Service",
+        )
 
     def test_does_not_show_contract_variation_link_if_no_variation(self, data_api_client, s3):
-        with self.app.test_client():
-            self.login()
-            data_api_client.get_framework.return_value = get_g_cloud_8()
-            data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
-                on_framework=True,
-                agreement_returned=True,
-                agreement_details=self._boring_agreement_details,
-                agreement_path='g-cloud-8/agreements/123-framework-agreement.pdf',
-                agreement_returned_at=self._boring_agreement_returned_at,
-            )
+        self.login()
+        data_api_client.get_framework.return_value = get_g_cloud_8()
+        data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
+            on_framework=True,
+            agreement_returned=True,
+            agreement_details=self._boring_agreement_details,
+            agreement_path='g-cloud-8/agreements/123-framework-agreement.pdf',
+            agreement_returned_at=self._boring_agreement_returned_at,
+        )
 
-            res = self.client.get("/suppliers/frameworks/g-cloud-8")
-            assert res.status_code == 200
+        res = self.client.get("/suppliers/frameworks/g-cloud-8")
+        assert res.status_code == 200
 
-            data = res.get_data(as_text=True)
-            doc = html.fromstring(data)
+        data = res.get_data(as_text=True)
+        doc = html.fromstring(data)
 
-            assert not doc.xpath(
-                "//main//a[@href=$href or normalize-space(string())=$label]",
-                href="/frameworks/g-cloud-7/agreement",
-                label="Sign and return your framework agreement",
-            )
-            assert not doc.xpath(
-                "//main//a[normalize-space(string())=$label]",
-                label="Read the proposed contract variation",
-            )
-            extracted_signing_details_table_rows = self._extract_signing_details_table_rows(doc)
-            assert extracted_signing_details_table_rows == \
-                self._boring_agreement_details_expected_table_results
-            assert doc.xpath(
-                "//main//p[contains(normalize-space(string()), $b)]",
-                b="You can start selling your",
-            )
-            assert not doc.xpath(
-                "//main//p[contains(normalize-space(string()), $b)]",
-                b="Your original and counterpart signature pages",
-            )
-            assert doc.xpath(
-                "//main//p[contains(normalize-space(string()), $b)]",
-                b="Your framework agreement signature page has been sent to the Crown Commercial Service",
-            )
+        assert not doc.xpath(
+            "//main//a[@href=$href or normalize-space(string())=$label]",
+            href="/frameworks/g-cloud-7/agreement",
+            label="Sign and return your framework agreement",
+        )
+        assert not doc.xpath(
+            "//main//a[normalize-space(string())=$label]",
+            label="Read the proposed contract variation",
+        )
+        extracted_signing_details_table_rows = self._extract_signing_details_table_rows(doc)
+        assert extracted_signing_details_table_rows == \
+            self._boring_agreement_details_expected_table_results
+        assert doc.xpath(
+            "//main//p[contains(normalize-space(string()), $b)]",
+            b="You can start selling your",
+        )
+        assert not doc.xpath(
+            "//main//p[contains(normalize-space(string()), $b)]",
+            b="Your original and counterpart signature pages",
+        )
+        assert doc.xpath(
+            "//main//p[contains(normalize-space(string()), $b)]",
+            b="Your framework agreement signature page has been sent to the Crown Commercial Service",
+        )
 
     def test_does_not_show_contract_variation_link_if_agreement_not_returned(self, data_api_client, s3):
-        with self.app.test_client():
-            self.login()
-            g8_with_variation = get_g_cloud_8()
-            g8_with_variation['frameworks']['variations'] = {"1": {"createdAt": "2018-08-16"}}
-            data_api_client.get_framework.return_value = g8_with_variation
-            data_api_client.get_supplier_framework_info.return_value = self.supplier_framework()
+        self.login()
+        g8_with_variation = get_g_cloud_8()
+        g8_with_variation['frameworks']['variations'] = {"1": {"createdAt": "2018-08-16"}}
+        data_api_client.get_framework.return_value = g8_with_variation
+        data_api_client.get_supplier_framework_info.return_value = self.supplier_framework()
 
-            res = self.client.get("/suppliers/frameworks/g-cloud-8")
-            assert res.status_code == 200
+        res = self.client.get("/suppliers/frameworks/g-cloud-8")
+        assert res.status_code == 200
 
-            data = res.get_data(as_text=True)
-            doc = html.fromstring(data)
+        data = res.get_data(as_text=True)
+        doc = html.fromstring(data)
 
-            assert not doc.xpath(
-                "//main//a[@href=$href or normalize-space(string())=$label]",
-                href="/frameworks/g-cloud-7/agreement",
-                label="Sign and return your framework agreement",
-            )
-            assert not doc.xpath(
-                "//main//a[contains(@href, $href_part) or normalize-space(string())=$label]",
-                href_part="contract-variation/1",
-                label="Read the proposed contract variation",
-            )
-            assert not doc.xpath(
-                "//main//table[normalize-space(string(./caption))=$b]",
-                b="Agreement details",
-            )
-            assert not doc.xpath(
-                "//main//p[contains(normalize-space(string()), $b)]",
-                b="You can start selling your",
-            )
-            assert not doc.xpath(
-                "//main//p[contains(normalize-space(string()), $b)]",
-                b="Your original and counterpart signature pages",
-            )
-            assert not doc.xpath(
-                "//main//p[contains(normalize-space(string()), $b)]",
-                b="Your framework agreement signature page has been sent to the Crown Commercial Service",
-            )
+        assert not doc.xpath(
+            "//main//a[@href=$href or normalize-space(string())=$label]",
+            href="/frameworks/g-cloud-7/agreement",
+            label="Sign and return your framework agreement",
+        )
+        assert not doc.xpath(
+            "//main//a[contains(@href, $href_part) or normalize-space(string())=$label]",
+            href_part="contract-variation/1",
+            label="Read the proposed contract variation",
+        )
+        assert not doc.xpath(
+            "//main//table[normalize-space(string(./caption))=$b]",
+            b="Agreement details",
+        )
+        assert not doc.xpath(
+            "//main//p[contains(normalize-space(string()), $b)]",
+            b="You can start selling your",
+        )
+        assert not doc.xpath(
+            "//main//p[contains(normalize-space(string()), $b)]",
+            b="Your original and counterpart signature pages",
+        )
+        assert not doc.xpath(
+            "//main//p[contains(normalize-space(string()), $b)]",
+            b="Your framework agreement signature page has been sent to the Crown Commercial Service",
+        )
 
     def test_shows_contract_variation_alternate_link_text_after_agreed_by_ccs(self, data_api_client, s3):
-        with self.app.test_client():
-            self.login()
-            g8_with_variation = get_g_cloud_8()
-            g8_with_variation['frameworks']['variations'] = {
+        self.login()
+        g8_with_variation = get_g_cloud_8()
+        g8_with_variation['frameworks']['variations'] = {
+            "1": {
+                "createdAt": "2018-08-16",
+                "countersignedAt": "2018-10-01",
+                "countersignerName": "A.N. Other",
+                "countersignerRole": "Head honcho",
+            },
+        }
+        data_api_client.get_framework.return_value = g8_with_variation
+        data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
+            on_framework=True,
+            agreement_returned=True,
+            agreement_details=self._boring_agreement_details,
+            agreement_returned_at=self._boring_agreement_returned_at,
+            agreement_path='g-cloud-8/agreements/1234/1234-signed-agreement.pdf',
+            agreed_variations={
                 "1": {
-                    "createdAt": "2018-08-16",
-                    "countersignedAt": "2018-10-01",
-                    "countersignerName": "A.N. Other",
-                    "countersignerRole": "Head honcho",
+                    "agreedAt": "2016-08-19T15:47:08.116613Z",
+                    "agreedUserId": 1,
+                    "agreedUserEmail": "agreed@email.com",
+                    "agreedUserName": u"William Drăyton",
                 },
-            }
-            data_api_client.get_framework.return_value = g8_with_variation
-            data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
-                on_framework=True,
-                agreement_returned=True,
-                agreement_details=self._boring_agreement_details,
-                agreement_returned_at=self._boring_agreement_returned_at,
-                agreement_path='g-cloud-8/agreements/1234/1234-signed-agreement.pdf',
-                agreed_variations={
-                    "1": {
-                        "agreedAt": "2016-08-19T15:47:08.116613Z",
-                        "agreedUserId": 1,
-                        "agreedUserEmail": "agreed@email.com",
-                        "agreedUserName": u"William Drăyton",
-                    },
-                },
-            )
+            },
+        )
 
-            res = self.client.get("/suppliers/frameworks/g-cloud-8")
-            assert res.status_code == 200
+        res = self.client.get("/suppliers/frameworks/g-cloud-8")
+        assert res.status_code == 200
 
-            data = res.get_data(as_text=True)
-            doc = html.fromstring(data)
+        data = res.get_data(as_text=True)
+        doc = html.fromstring(data)
 
-            assert not doc.xpath(
-                "//main//a[@href=$href or normalize-space(string())=$label]",
-                href="/frameworks/g-cloud-8/agreement",
-                label="Sign and return your framework agreement",
-            )
+        assert not doc.xpath(
+            "//main//a[@href=$href or normalize-space(string())=$label]",
+            href="/frameworks/g-cloud-8/agreement",
+            label="Sign and return your framework agreement",
+        )
 
-            extracted_guidance_links = self._extract_guidance_links(doc)
-            assert extracted_guidance_links == OrderedDict((
-                ("You submitted:", (
-                    (
-                        'View submitted services',
-                        '/suppliers/frameworks/g-cloud-8/submissions',
-                        None,
-                        None,
-                    ),
-                    (
-                        "View your declaration",
-                        "/suppliers/frameworks/g-cloud-8/declaration",
-                        None,
-                        None,
-                    ),
-                )),
-                ('Legal documents', (
-                    (
-                        'Read the standard framework agreement',
-                        'https://www.gov.uk/government/publications/g-cloud-8-framework-agreement',
-                        None,
-                        None,
-                    ),
-                    (
-                        u'Download your \u2018original\u2019 framework agreement signature page',
-                        '/suppliers/frameworks/g-cloud-8/agreements/signed-agreement.pdf',
-                        None,
-                        None,
-                    ),
-                    (
-                        'View the signed contract variation',
-                        '/suppliers/frameworks/g-cloud-8/contract-variation/1',
-                        None,
-                        None,
-                    ),
-                )),
-                ('Guidance', (
-                    (
-                        'Read about how to sell your services',
-                        'https://www.gov.uk/guidance/g-cloud-suppliers-guide#how-to-apply',
-                        None,
-                        None,
-                    ),
-                )),
-                ('Communications', (
-                    (
-                        'View communications and clarification questions',
-                        '/suppliers/frameworks/g-cloud-8/updates',
-                        None,
-                        None,
-                    ),
-                )),
-            ))
-            assert not doc.xpath(
-                "//main//a[normalize-space(string())=$label]",
-                label="Read the proposed contract variation",
-            )
-            assert doc.xpath(
-                "//main//p[contains(normalize-space(string()), $b)]",
-                b="You can start selling your",
-            )
-            assert not doc.xpath(
-                "//main//p[contains(normalize-space(string()), $b)]",
-                b="Your original and counterpart signature pages",
-            )
-            assert doc.xpath(
-                "//main//p[contains(normalize-space(string()), $b)]",
-                b="Your framework agreement signature page has been sent to the Crown Commercial Service",
-            )
+        extracted_guidance_links = self._extract_guidance_links(doc)
+        assert extracted_guidance_links == OrderedDict((
+            ("You submitted:", (
+                (
+                    'View submitted services',
+                    '/suppliers/frameworks/g-cloud-8/submissions',
+                    None,
+                    None,
+                ),
+                (
+                    "View your declaration",
+                    "/suppliers/frameworks/g-cloud-8/declaration",
+                    None,
+                    None,
+                ),
+            )),
+            ('Legal documents', (
+                (
+                    'Read the standard framework agreement',
+                    'https://www.gov.uk/government/publications/g-cloud-8-framework-agreement',
+                    None,
+                    None,
+                ),
+                (
+                    u'Download your \u2018original\u2019 framework agreement signature page',
+                    '/suppliers/frameworks/g-cloud-8/agreements/signed-agreement.pdf',
+                    None,
+                    None,
+                ),
+                (
+                    'View the signed contract variation',
+                    '/suppliers/frameworks/g-cloud-8/contract-variation/1',
+                    None,
+                    None,
+                ),
+            )),
+            ('Guidance', (
+                (
+                    'Read about how to sell your services',
+                    'https://www.gov.uk/guidance/g-cloud-suppliers-guide#how-to-apply',
+                    None,
+                    None,
+                ),
+            )),
+            ('Communications', (
+                (
+                    'View communications and clarification questions',
+                    '/suppliers/frameworks/g-cloud-8/updates',
+                    None,
+                    None,
+                ),
+            )),
+        ))
+        assert not doc.xpath(
+            "//main//a[normalize-space(string())=$label]",
+            label="Read the proposed contract variation",
+        )
+        assert doc.xpath(
+            "//main//p[contains(normalize-space(string()), $b)]",
+            b="You can start selling your",
+        )
+        assert not doc.xpath(
+            "//main//p[contains(normalize-space(string()), $b)]",
+            b="Your original and counterpart signature pages",
+        )
+        assert doc.xpath(
+            "//main//p[contains(normalize-space(string()), $b)]",
+            b="Your framework agreement signature page has been sent to the Crown Commercial Service",
+        )
 
     @pytest.mark.parametrize('supplier_framework_kwargs,link_label,link_href', (
         ({'declaration': None}, 'Make supplier declaration', '/suppliers/frameworks/g-cloud-7/declaration/start'),
@@ -1702,55 +1668,52 @@ class TestFrameworksDashboard(BaseApplicationTest):
     ))
     def test_make_or_edit_supplier_declaration_shows_correct_page(self, data_api_client, s3, supplier_framework_kwargs,
                                                                   link_label, link_href):
-        with self.app.test_client():
-            self.login()
+        self.login()
 
-            data_api_client.get_framework.return_value = self.framework(status='open')
-            data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
-                **supplier_framework_kwargs)
+        data_api_client.get_framework.return_value = self.framework(status='open')
+        data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
+            **supplier_framework_kwargs)
 
-            response = self.client.get('/suppliers/frameworks/g-cloud-7')
-            document = html.fromstring(response.get_data(as_text=True))
+        response = self.client.get('/suppliers/frameworks/g-cloud-7')
+        document = html.fromstring(response.get_data(as_text=True))
 
-            assert document.xpath("//a[normalize-space(string())=$link_label]/@href", link_label=link_label)[0] \
-                == link_href
+        assert document.xpath("//a[normalize-space(string())=$link_label]/@href", link_label=link_label)[0] \
+            == link_href
 
     def test_dashboard_does_not_show_use_of_service_data_if_not_available(self, data_api_client, s3):
-        with self.app.test_client():
-            self.login()
+        self.login()
 
-            data_api_client.get_framework.return_value = self.framework(slug="g-cloud-8", name="G-Cloud 8",
-                                                                        status="open")
-            data_api_client.get_supplier_framework_info.return_value = self.supplier_framework()
+        data_api_client.get_framework.return_value = self.framework(slug="g-cloud-8", name="G-Cloud 8",
+                                                                    status="open")
+        data_api_client.get_supplier_framework_info.return_value = self.supplier_framework()
 
-            res = self.client.get("/suppliers/frameworks/g-cloud-8")
-            assert res.status_code == 200
+        res = self.client.get("/suppliers/frameworks/g-cloud-8")
+        assert res.status_code == 200
 
-            doc = html.fromstring(res.get_data(as_text=True))
+        doc = html.fromstring(res.get_data(as_text=True))
 
-            add_edit_complete_services = doc.xpath('//div[contains(@class, "framework-dashboard")]/div/li')[1]
-            use_of_data = add_edit_complete_services.xpath('//div[@class="browse-list-item-body"]')
+        add_edit_complete_services = doc.xpath('//div[contains(@class, "framework-dashboard")]/div/li')[1]
+        use_of_data = add_edit_complete_services.xpath('//div[@class="browse-list-item-body"]')
 
-            assert len(use_of_data) == 0
+        assert len(use_of_data) == 0
 
     def test_dashboard_shows_use_of_service_data_if_available(self, data_api_client, s3):
-        with self.app.test_client():
-            self.login()
+        self.login()
 
-            data_api_client.get_framework.return_value = self.framework(slug="g-cloud-9", name="G-Cloud 9",
-                                                                        status="open")
-            data_api_client.get_supplier_framework_info.return_value = self.supplier_framework()
+        data_api_client.get_framework.return_value = self.framework(slug="g-cloud-9", name="G-Cloud 9",
+                                                                    status="open")
+        data_api_client.get_supplier_framework_info.return_value = self.supplier_framework()
 
-            res = self.client.get("/suppliers/frameworks/g-cloud-9")
-            assert res.status_code == 200
+        res = self.client.get("/suppliers/frameworks/g-cloud-9")
+        assert res.status_code == 200
 
-            doc = html.fromstring(res.get_data(as_text=True))
+        doc = html.fromstring(res.get_data(as_text=True))
 
-            add_edit_complete_services = doc.xpath('//div[contains(@class, "framework-dashboard")]/div/li')[1]
-            use_of_data = add_edit_complete_services.xpath('//div[@class="browse-list-item-body"]')
+        add_edit_complete_services = doc.xpath('//div[contains(@class, "framework-dashboard")]/div/li')[1]
+        use_of_data = add_edit_complete_services.xpath('//div[@class="browse-list-item-body"]')
 
-            assert len(use_of_data) == 1
-            assert 'The service information you provide here:' in use_of_data[0].text_content()
+        assert len(use_of_data) == 1
+        assert 'The service information you provide here:' in use_of_data[0].text_content()
 
 
 @mock.patch('dmutils.s3.S3')
@@ -1773,9 +1736,8 @@ class TestFrameworksDashboardConfidenceBannerOnPage(BaseApplicationTest):
         }
         data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(status='complete')
 
-        with self.app.test_client():
-            self.login()
-            res = self.client.get("/suppliers/frameworks/g-cloud-8")
+        self.login()
+        res = self.client.get("/suppliers/frameworks/g-cloud-8")
         assert res.status_code == 200
         assert self.expected in str(res.data)
 
@@ -1789,9 +1751,8 @@ class TestFrameworksDashboardConfidenceBannerOnPage(BaseApplicationTest):
         }
         data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(status='complete')
 
-        with self.app.test_client():
-            self.login()
-            res = self.client.get("/suppliers/frameworks/g-cloud-8")
+        self.login()
+        res = self.client.get("/suppliers/frameworks/g-cloud-8")
         assert res.status_code == 200
         assert self.expected not in str(res.data)
 
@@ -1799,133 +1760,126 @@ class TestFrameworksDashboardConfidenceBannerOnPage(BaseApplicationTest):
 @mock.patch('app.main.views.frameworks.data_api_client', autospec=True)
 class TestFrameworkAgreement(BaseApplicationTest):
     def test_page_renders_if_all_ok(self, data_api_client):
-        with self.app.test_client():
-            self.login()
+        self.login()
 
-            data_api_client.get_framework.return_value = self.framework(status='standstill')
-            data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
-                on_framework=True)
+        data_api_client.get_framework.return_value = self.framework(status='standstill')
+        data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
+            on_framework=True)
 
-            res = self.client.get("/suppliers/frameworks/g-cloud-7/agreement")
-            data = res.get_data(as_text=True)
+        res = self.client.get("/suppliers/frameworks/g-cloud-7/agreement")
+        data = res.get_data(as_text=True)
 
-            assert res.status_code == 200
-            assert u'Send document to CCS' in data
-            assert u'Return your signed signature page' not in data
+        assert res.status_code == 200
+        assert u'Send document to CCS' in data
+        assert u'Return your signed signature page' not in data
 
     def test_page_returns_404_if_framework_in_wrong_state(self, data_api_client):
-        with self.app.test_client():
-            self.login()
+        self.login()
 
-            data_api_client.get_framework.return_value = self.framework(status='open')
-            data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
-                on_framework=True)
+        data_api_client.get_framework.return_value = self.framework(status='open')
+        data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
+            on_framework=True)
 
-            res = self.client.get("/suppliers/frameworks/g-cloud-7/agreement")
+        res = self.client.get("/suppliers/frameworks/g-cloud-7/agreement")
 
-            assert res.status_code == 404
+        assert res.status_code == 404
 
     def test_page_returns_404_if_supplier_not_on_framework(self, data_api_client):
-        with self.app.test_client():
-            self.login()
+        self.login()
 
-            data_api_client.get_framework.return_value = self.framework(status='standstill')
-            data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
-                on_framework=False)
+        data_api_client.get_framework.return_value = self.framework(status='standstill')
+        data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
+            on_framework=False)
 
-            res = self.client.get("/suppliers/frameworks/g-cloud-7/agreement")
+        res = self.client.get("/suppliers/frameworks/g-cloud-7/agreement")
 
-            assert res.status_code == 404
+        assert res.status_code == 404
 
     @mock.patch('dmutils.s3.S3')
     def test_upload_message_if_agreement_is_returned(self, s3, data_api_client):
-        with self.app.test_client():
-            self.login()
+        self.login()
 
-            data_api_client.get_framework.return_value = self.framework(status='standstill')
-            data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
-                on_framework=True, agreement_returned=True, agreement_returned_at='2015-11-02T15:25:56.000000Z'
-            )
+        data_api_client.get_framework.return_value = self.framework(status='standstill')
+        data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
+            on_framework=True, agreement_returned=True, agreement_returned_at='2015-11-02T15:25:56.000000Z'
+        )
 
-            res = self.client.get('/suppliers/frameworks/g-cloud-7/agreement')
-            data = res.get_data(as_text=True)
-            doc = html.fromstring(data)
+        res = self.client.get('/suppliers/frameworks/g-cloud-7/agreement')
+        data = res.get_data(as_text=True)
+        doc = html.fromstring(data)
 
-            assert res.status_code == 200
-            assert u'/suppliers/frameworks/g-cloud-7/agreement' == doc.xpath('//form')[1].action
-            assert u'Document uploaded Monday 2 November 2015 at 3:25pm' in data
-            assert u'Your document has been uploaded' in data
+        assert res.status_code == 200
+        assert u'/suppliers/frameworks/g-cloud-7/agreement' == doc.xpath('//form')[1].action
+        assert u'Document uploaded Monday 2 November 2015 at 3:25pm' in data
+        assert u'Your document has been uploaded' in data
 
     def test_upload_message_if_agreement_is_not_returned(self, data_api_client):
-        with self.app.test_client():
-            self.login()
+        self.login()
 
-            data_api_client.get_framework.return_value = self.framework(status='standstill')
-            data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
-                on_framework=True)
+        data_api_client.get_framework.return_value = self.framework(status='standstill')
+        data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
+            on_framework=True)
 
-            res = self.client.get('/suppliers/frameworks/g-cloud-7/agreement')
-            data = res.get_data(as_text=True)
-            doc = html.fromstring(data)
+        res = self.client.get('/suppliers/frameworks/g-cloud-7/agreement')
+        data = res.get_data(as_text=True)
+        doc = html.fromstring(data)
 
-            assert res.status_code == 200
-            assert u'/suppliers/frameworks/g-cloud-7/agreement' == doc.xpath('//form')[1].action
-            assert u'Document uploaded' not in data
-            assert u'Your document has been uploaded' not in data
+        assert res.status_code == 200
+        assert u'/suppliers/frameworks/g-cloud-7/agreement' == doc.xpath('//form')[1].action
+        assert u'Document uploaded' not in data
+        assert u'Your document has been uploaded' not in data
 
     def test_loads_contract_start_page_if_framework_agreement_version_exists(self, data_api_client):
-        with self.app.test_client():
-            self.login()
+        self.login()
 
-            data_api_client.get_framework.return_value = get_g_cloud_8()
-            data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
-                on_framework=True)
+        data_api_client.get_framework.return_value = get_g_cloud_8()
+        data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
+            on_framework=True)
 
-            res = self.client.get("/suppliers/frameworks/g-cloud-8/agreement")
-            data = res.get_data(as_text=True)
+        res = self.client.get("/suppliers/frameworks/g-cloud-8/agreement")
+        data = res.get_data(as_text=True)
 
-            assert res.status_code == 200
-            assert u'Return your signed signature page' in data
-            assert u'Send document to CCS' not in data
+        assert res.status_code == 200
+        assert u'Return your signed signature page' in data
+        assert u'Send document to CCS' not in data
 
     def test_two_lots_passed_on_contract_start_page(self, data_api_client):
-        with self.app.test_client():
-            self.login()
+        self.login()
 
-            data_api_client.get_framework.return_value = get_g_cloud_8()
-            data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
-                on_framework=True)
-            data_api_client.find_draft_services.return_value = {
-                'services': [
-                    {'lotSlug': 'saas', 'status': 'submitted'},
-                    {'lotSlug': 'saas', 'status': 'not-submitted'},
-                    {'lotSlug': 'paas', 'status': 'failed'},
-                    {'lotSlug': 'scs', 'status': 'submitted'}
-                ]
-            }
-            expected_lots_and_statuses = [
-                ('Software as a Service', 'Successful'),
-                ('Platform as a Service', 'Unsuccessful'),
-                ('Infrastructure as a Service', 'No application'),
-                ('Specialist Cloud Services', 'Successful'),
+        data_api_client.get_framework.return_value = get_g_cloud_8()
+        data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
+            on_framework=True)
+        data_api_client.find_draft_services.return_value = {
+            'services': [
+                {'lotSlug': 'saas', 'status': 'submitted'},
+                {'lotSlug': 'saas', 'status': 'not-submitted'},
+                {'lotSlug': 'paas', 'status': 'failed'},
+                {'lotSlug': 'scs', 'status': 'submitted'}
             ]
+        }
+        expected_lots_and_statuses = [
+            ('Software as a Service', 'Successful'),
+            ('Platform as a Service', 'Unsuccessful'),
+            ('Infrastructure as a Service', 'No application'),
+            ('Specialist Cloud Services', 'Successful'),
+        ]
 
-            res = self.client.get("/suppliers/frameworks/g-cloud-8/agreement")
-            doc = html.fromstring(res.get_data(as_text=True))
+        res = self.client.get("/suppliers/frameworks/g-cloud-8/agreement")
+        doc = html.fromstring(res.get_data(as_text=True))
 
-            assert res.status_code == 200
+        assert res.status_code == 200
 
-            lots_and_statuses = []
-            lot_table_rows = doc.xpath('//*[@id="content"]//table/tbody/tr')
-            for row in lot_table_rows:
-                cells = row.findall('./td')
-                lots_and_statuses.append(
-                    (cells[0].text_content().strip(), cells[1].text_content().strip())
-                )
+        lots_and_statuses = []
+        lot_table_rows = doc.xpath('//*[@id="content"]//table/tbody/tr')
+        for row in lot_table_rows:
+            cells = row.findall('./td')
+            lots_and_statuses.append(
+                (cells[0].text_content().strip(), cells[1].text_content().strip())
+            )
 
-            assert len(lots_and_statuses) == len(expected_lots_and_statuses)
-            for lot_and_status in lots_and_statuses:
-                assert lot_and_status in expected_lots_and_statuses
+        assert len(lots_and_statuses) == len(expected_lots_and_statuses)
+        for lot_and_status in lots_and_statuses:
+            assert lot_and_status in expected_lots_and_statuses
 
 
 @mock.patch('dmutils.s3.S3')
@@ -1933,290 +1887,279 @@ class TestFrameworkAgreement(BaseApplicationTest):
 @mock.patch('app.main.views.frameworks.data_api_client', autospec=True)
 class TestFrameworkAgreementUpload(BaseApplicationTest):
     def test_page_returns_404_if_framework_in_wrong_state(self, data_api_client, send_email, s3):
-        with self.app.test_client():
-            self.login()
+        self.login()
 
-            data_api_client.get_framework.return_value = self.framework(status='open')
+        data_api_client.get_framework.return_value = self.framework(status='open')
 
-            res = self.client.post(
-                '/suppliers/frameworks/g-cloud-7/agreement',
-                data={
-                    'agreement': (StringIO(b'doc'), 'test.pdf'),
-                }
-            )
+        res = self.client.post(
+            '/suppliers/frameworks/g-cloud-7/agreement',
+            data={
+                'agreement': (StringIO(b'doc'), 'test.pdf'),
+            }
+        )
 
-            assert res.status_code == 404
+        assert res.status_code == 404
 
     def test_page_returns_404_if_supplier_not_on_framework(self, data_api_client, send_email, s3):
-        with self.app.test_client():
-            self.login()
+        self.login()
 
-            data_api_client.get_framework.return_value = self.framework(status='standstill')
-            data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
-                on_framework=False)
+        data_api_client.get_framework.return_value = self.framework(status='standstill')
+        data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
+            on_framework=False)
 
-            res = self.client.post(
-                '/suppliers/frameworks/g-cloud-7/agreement',
-                data={
-                    'agreement': (StringIO(b'doc'), 'test.pdf'),
-                }
-            )
+        res = self.client.post(
+            '/suppliers/frameworks/g-cloud-7/agreement',
+            data={
+                'agreement': (StringIO(b'doc'), 'test.pdf'),
+            }
+        )
 
-            assert res.status_code == 404
+        assert res.status_code == 404
 
     @mock.patch('app.main.views.frameworks.file_is_less_than_5mb')
     def test_page_returns_400_if_file_is_too_large(self, file_is_less_than_5mb, data_api_client, send_email, s3):
-        with self.app.test_client():
-            self.login()
+        self.login()
 
-            data_api_client.get_framework.return_value = self.framework(status='standstill')
-            data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
-                on_framework=True)
-            file_is_less_than_5mb.return_value = False
+        data_api_client.get_framework.return_value = self.framework(status='standstill')
+        data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
+            on_framework=True)
+        file_is_less_than_5mb.return_value = False
 
-            res = self.client.post(
-                '/suppliers/frameworks/g-cloud-7/agreement',
-                data={
-                    'agreement': (StringIO(b'doc'), 'test.pdf'),
-                }
-            )
+        res = self.client.post(
+            '/suppliers/frameworks/g-cloud-7/agreement',
+            data={
+                'agreement': (StringIO(b'doc'), 'test.pdf'),
+            }
+        )
 
-            assert res.status_code == 400
-            assert u'Document must be less than 5MB' in res.get_data(as_text=True)
+        assert res.status_code == 400
+        assert u'Document must be less than 5MB' in res.get_data(as_text=True)
 
     @mock.patch('app.main.views.frameworks.file_is_empty')
     def test_page_returns_400_if_file_is_empty(self, file_is_empty, data_api_client, send_email, s3):
-        with self.app.test_client():
-            self.login()
+        self.login()
 
-            data_api_client.get_framework.return_value = self.framework(status='standstill')
-            data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
-                on_framework=True)
-            file_is_empty.return_value = True
+        data_api_client.get_framework.return_value = self.framework(status='standstill')
+        data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
+            on_framework=True)
+        file_is_empty.return_value = True
 
-            res = self.client.post(
-                '/suppliers/frameworks/g-cloud-7/agreement',
-                data={
-                    'agreement': (StringIO(b''), 'test.pdf'),
-                }
-            )
+        res = self.client.post(
+            '/suppliers/frameworks/g-cloud-7/agreement',
+            data={
+                'agreement': (StringIO(b''), 'test.pdf'),
+            }
+        )
 
-            assert res.status_code == 400
-            assert u'Document must not be empty' in res.get_data(as_text=True)
+        assert res.status_code == 400
+        assert u'Document must not be empty' in res.get_data(as_text=True)
 
     @mock.patch('app.main.views.frameworks.generate_timestamped_document_upload_path')
     def test_api_is_not_updated_and_email_not_sent_if_upload_fails(
         self, generate_timestamped_document_upload_path, data_api_client, send_email, s3
     ):
-        with self.app.test_client():
-            self.login()
+        self.login()
 
-            data_api_client.get_framework.return_value = self.framework(status='standstill')
-            data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
-                on_framework=True)
-            generate_timestamped_document_upload_path.return_value = 'my/path.pdf'
-            s3.return_value.save.side_effect = S3ResponseError(
-                {'Error': {'Code': 500, 'Message': 'All fail'}},
-                'test_api_is_not_updated_and_email_not_sent_if_upload_fails'
-            )
+        data_api_client.get_framework.return_value = self.framework(status='standstill')
+        data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
+            on_framework=True)
+        generate_timestamped_document_upload_path.return_value = 'my/path.pdf'
+        s3.return_value.save.side_effect = S3ResponseError(
+            {'Error': {'Code': 500, 'Message': 'All fail'}},
+            'test_api_is_not_updated_and_email_not_sent_if_upload_fails'
+        )
 
-            res = self.client.post(
-                '/suppliers/frameworks/g-cloud-7/agreement',
-                data={
-                    'agreement': (StringIO(b'doc'), 'test.pdf'),
-                }
-            )
+        res = self.client.post(
+            '/suppliers/frameworks/g-cloud-7/agreement',
+            data={
+                'agreement': (StringIO(b'doc'), 'test.pdf'),
+            }
+        )
 
-            assert res.status_code == 503
-            s3.return_value.save.assert_called_with(
-                'my/path.pdf',
-                mock.ANY,
-                acl='private',
-                download_filename='Supplier_Nme-1234-signed-framework-agreement.pdf'
-            )
+        assert res.status_code == 503
+        s3.return_value.save.assert_called_with(
+            'my/path.pdf',
+            mock.ANY,
+            acl='private',
+            download_filename='Supplier_Nme-1234-signed-framework-agreement.pdf'
+        )
 
-            assert data_api_client.create_framework_agreement.called is False
-            assert data_api_client.update_framework_agreement.called is False
-            assert data_api_client.sign_framework_agreement.called is False
-            assert send_email.called is False
+        assert data_api_client.create_framework_agreement.called is False
+        assert data_api_client.update_framework_agreement.called is False
+        assert data_api_client.sign_framework_agreement.called is False
+        assert send_email.called is False
 
     @mock.patch('app.main.views.frameworks.generate_timestamped_document_upload_path')
     def test_email_is_not_sent_if_api_create_framework_agreement_fails(
         self, generate_timestamped_document_upload_path, data_api_client, send_email, s3
     ):
-        with self.app.test_client():
-            self.login()
+        self.login()
 
-            data_api_client.get_framework.return_value = self.framework(status='standstill')
-            data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
-                on_framework=True)
-            generate_timestamped_document_upload_path.return_value = 'my/path.pdf'
-            data_api_client.create_framework_agreement.side_effect = APIError(mock.Mock(status_code=500))
+        data_api_client.get_framework.return_value = self.framework(status='standstill')
+        data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
+            on_framework=True)
+        generate_timestamped_document_upload_path.return_value = 'my/path.pdf'
+        data_api_client.create_framework_agreement.side_effect = APIError(mock.Mock(status_code=500))
 
-            res = self.client.post(
-                '/suppliers/frameworks/g-cloud-7/agreement',
-                data={
-                    'agreement': (StringIO(b'doc'), 'test.pdf'),
-                }
-            )
+        res = self.client.post(
+            '/suppliers/frameworks/g-cloud-7/agreement',
+            data={
+                'agreement': (StringIO(b'doc'), 'test.pdf'),
+            }
+        )
 
-            assert res.status_code == 500
-            assert data_api_client.create_framework_agreement.called is True
-            assert data_api_client.update_framework_agreement.called is False
-            assert data_api_client.sign_framework_agreement.called is False
-            assert send_email.called is False
+        assert res.status_code == 500
+        assert data_api_client.create_framework_agreement.called is True
+        assert data_api_client.update_framework_agreement.called is False
+        assert data_api_client.sign_framework_agreement.called is False
+        assert send_email.called is False
 
     @mock.patch('app.main.views.frameworks.generate_timestamped_document_upload_path')
     def test_email_is_not_sent_if_api_update_framework_agreement_fails(
         self, generate_timestamped_document_upload_path, data_api_client, send_email, s3
     ):
-        with self.app.test_client():
-            self.login()
+        self.login()
 
-            data_api_client.get_framework.return_value = self.framework(status='standstill')
-            data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
-                on_framework=True)
-            generate_timestamped_document_upload_path.return_value = 'my/path.pdf'
-            data_api_client.update_framework_agreement.side_effect = APIError(mock.Mock(status_code=500))
+        data_api_client.get_framework.return_value = self.framework(status='standstill')
+        data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
+            on_framework=True)
+        generate_timestamped_document_upload_path.return_value = 'my/path.pdf'
+        data_api_client.update_framework_agreement.side_effect = APIError(mock.Mock(status_code=500))
 
-            res = self.client.post(
-                '/suppliers/frameworks/g-cloud-7/agreement',
-                data={
-                    'agreement': (StringIO(b'doc'), 'test.pdf'),
-                }
-            )
+        res = self.client.post(
+            '/suppliers/frameworks/g-cloud-7/agreement',
+            data={
+                'agreement': (StringIO(b'doc'), 'test.pdf'),
+            }
+        )
 
-            assert res.status_code == 500
-            assert data_api_client.create_framework_agreement.called is True
-            assert data_api_client.update_framework_agreement.called is True
-            assert data_api_client.sign_framework_agreement.called is False
-            assert send_email.called is False
+        assert res.status_code == 500
+        assert data_api_client.create_framework_agreement.called is True
+        assert data_api_client.update_framework_agreement.called is True
+        assert data_api_client.sign_framework_agreement.called is False
+        assert send_email.called is False
 
     @mock.patch('app.main.views.frameworks.generate_timestamped_document_upload_path')
     def test_email_is_not_sent_if_api_sign_framework_agreement_fails(
         self, generate_timestamped_document_upload_path, data_api_client, send_email, s3
     ):
-        with self.app.test_client():
-            self.login()
+        self.login()
 
-            data_api_client.get_framework.return_value = self.framework(status='standstill')
-            data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
-                on_framework=True)
-            generate_timestamped_document_upload_path.return_value = 'my/path.pdf'
-            data_api_client.sign_framework_agreement.side_effect = APIError(mock.Mock(status_code=500))
+        data_api_client.get_framework.return_value = self.framework(status='standstill')
+        data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
+            on_framework=True)
+        generate_timestamped_document_upload_path.return_value = 'my/path.pdf'
+        data_api_client.sign_framework_agreement.side_effect = APIError(mock.Mock(status_code=500))
 
-            res = self.client.post(
-                '/suppliers/frameworks/g-cloud-7/agreement',
-                data={
-                    'agreement': (StringIO(b'doc'), 'test.pdf'),
-                }
-            )
+        res = self.client.post(
+            '/suppliers/frameworks/g-cloud-7/agreement',
+            data={
+                'agreement': (StringIO(b'doc'), 'test.pdf'),
+            }
+        )
 
-            assert res.status_code == 500
-            assert data_api_client.create_framework_agreement.called is True
-            assert data_api_client.update_framework_agreement.called is True
-            assert data_api_client.sign_framework_agreement.called is True
-            assert send_email.called is False
+        assert res.status_code == 500
+        assert data_api_client.create_framework_agreement.called is True
+        assert data_api_client.update_framework_agreement.called is True
+        assert data_api_client.sign_framework_agreement.called is True
+        assert send_email.called is False
 
     @mock.patch('app.main.views.frameworks.generate_timestamped_document_upload_path')
     def test_email_failure(
         self, generate_timestamped_document_upload_path, data_api_client, send_email, s3
     ):
-        with self.app.test_client():
-            self.login()
+        self.login()
 
-            data_api_client.get_framework.return_value = self.framework(status='standstill')
-            data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
-                on_framework=True)
-            generate_timestamped_document_upload_path.return_value = 'my/path.pdf'
-            send_email.side_effect = EmailError()
+        data_api_client.get_framework.return_value = self.framework(status='standstill')
+        data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
+            on_framework=True)
+        generate_timestamped_document_upload_path.return_value = 'my/path.pdf'
+        send_email.side_effect = EmailError()
 
-            res = self.client.post(
-                '/suppliers/frameworks/g-cloud-7/agreement',
-                data={
-                    'agreement': (StringIO(b'doc'), 'test.pdf'),
-                }
-            )
+        res = self.client.post(
+            '/suppliers/frameworks/g-cloud-7/agreement',
+            data={
+                'agreement': (StringIO(b'doc'), 'test.pdf'),
+            }
+        )
 
-            assert res.status_code == 503
-            assert send_email.called is True
+        assert res.status_code == 503
+        assert send_email.called is True
 
     @mock.patch('app.main.views.frameworks.generate_timestamped_document_upload_path')
     def test_upload_agreement_document(
         self, generate_timestamped_document_upload_path, data_api_client, send_email, s3
     ):
-        with self.app.test_client():
-            self.login()
+        self.login()
 
-            data_api_client.get_framework.return_value = self.framework(status='standstill')
-            data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
-                on_framework=True)
-            data_api_client.create_framework_agreement.return_value = {
-                "agreement": {"id": 20}
+        data_api_client.get_framework.return_value = self.framework(status='standstill')
+        data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
+            on_framework=True)
+        data_api_client.create_framework_agreement.return_value = {
+            "agreement": {"id": 20}
+        }
+        generate_timestamped_document_upload_path.return_value = 'my/path.pdf'
+
+        res = self.client.post(
+            '/suppliers/frameworks/g-cloud-7/agreement',
+            data={
+                'agreement': (StringIO(b'doc'), 'test.pdf'),
             }
-            generate_timestamped_document_upload_path.return_value = 'my/path.pdf'
+        )
 
-            res = self.client.post(
-                '/suppliers/frameworks/g-cloud-7/agreement',
-                data={
-                    'agreement': (StringIO(b'doc'), 'test.pdf'),
-                }
-            )
+        generate_timestamped_document_upload_path.assert_called_once_with(
+            'g-cloud-7',
+            1234,
+            'agreements',
+            'signed-framework-agreement.pdf'
+        )
 
-            generate_timestamped_document_upload_path.assert_called_once_with(
-                'g-cloud-7',
-                1234,
-                'agreements',
-                'signed-framework-agreement.pdf'
-            )
-
-            s3.return_value.save.assert_called_with(
-                'my/path.pdf',
-                mock.ANY,
-                acl='private',
-                download_filename='Supplier_Nme-1234-signed-framework-agreement.pdf'
-            )
-            data_api_client.create_framework_agreement.assert_called_with(
-                1234, 'g-cloud-7', 'email@email.com'
-            )
-            data_api_client.update_framework_agreement.assert_called_with(
-                20,
-                {"signedAgreementPath": 'my/path.pdf'},
-                'email@email.com'
-            )
-            data_api_client.sign_framework_agreement.assert_called_with(
-                20, 'email@email.com', {"uploaderUserId": 123}
-            )
-            assert res.status_code == 302
-            assert res.location == 'http://localhost/suppliers/frameworks/g-cloud-7/agreement'
+        s3.return_value.save.assert_called_with(
+            'my/path.pdf',
+            mock.ANY,
+            acl='private',
+            download_filename='Supplier_Nme-1234-signed-framework-agreement.pdf'
+        )
+        data_api_client.create_framework_agreement.assert_called_with(
+            1234, 'g-cloud-7', 'email@email.com'
+        )
+        data_api_client.update_framework_agreement.assert_called_with(
+            20,
+            {"signedAgreementPath": 'my/path.pdf'},
+            'email@email.com'
+        )
+        data_api_client.sign_framework_agreement.assert_called_with(
+            20, 'email@email.com', {"uploaderUserId": 123}
+        )
+        assert res.status_code == 302
+        assert res.location == 'http://localhost/suppliers/frameworks/g-cloud-7/agreement'
 
     @mock.patch('app.main.views.frameworks.generate_timestamped_document_upload_path')
     def test_upload_jpeg_agreement_document(
         self, generate_timestamped_document_upload_path, data_api_client, send_email, s3
     ):
-        with self.app.test_client():
-            self.login()
+        self.login()
 
-            data_api_client.get_framework.return_value = self.framework(status='standstill')
-            data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
-                on_framework=True)
-            generate_timestamped_document_upload_path.return_value = 'my/path.jpg'
+        data_api_client.get_framework.return_value = self.framework(status='standstill')
+        data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
+            on_framework=True)
+        generate_timestamped_document_upload_path.return_value = 'my/path.jpg'
 
-            res = self.client.post(
-                '/suppliers/frameworks/g-cloud-7/agreement',
-                data={
-                    'agreement': (StringIO(b'doc'), 'test.jpg'),
-                }
-            )
+        res = self.client.post(
+            '/suppliers/frameworks/g-cloud-7/agreement',
+            data={
+                'agreement': (StringIO(b'doc'), 'test.jpg'),
+            }
+        )
 
-            s3.return_value.save.assert_called_with(
-                'my/path.jpg',
-                mock.ANY,
-                acl='private',
-                download_filename='Supplier_Nme-1234-signed-framework-agreement.jpg'
-            )
-            assert res.status_code == 302
-            assert res.location == 'http://localhost/suppliers/frameworks/g-cloud-7/agreement'
+        s3.return_value.save.assert_called_with(
+            'my/path.jpg',
+            mock.ANY,
+            acl='private',
+            download_filename='Supplier_Nme-1234-signed-framework-agreement.jpg'
+        )
+        assert res.status_code == 302
+        assert res.location == 'http://localhost/suppliers/frameworks/g-cloud-7/agreement'
 
 
 @mock.patch('app.main.views.frameworks.data_api_client', autospec=True)
@@ -2225,22 +2168,20 @@ class TestFrameworkAgreementDocumentDownload(BaseApplicationTest):
     def test_download_document_fails_if_no_supplier_framework(self, S3, data_api_client):
         data_api_client.get_supplier_framework_info.side_effect = APIError(mock.Mock(status_code=404))
 
-        with self.app.test_client():
-            self.login()
+        self.login()
 
-            res = self.client.get('/suppliers/frameworks/g-cloud-7/agreements/example.pdf')
+        res = self.client.get('/suppliers/frameworks/g-cloud-7/agreements/example.pdf')
 
-            assert res.status_code == 404
+        assert res.status_code == 404
 
     def test_download_document_fails_if_no_supplier_declaration(self, S3, data_api_client):
         data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(declaration=None)
 
-        with self.app.test_client():
-            self.login()
+        self.login()
 
-            res = self.client.get('/suppliers/frameworks/g-cloud-7/agreements/example.pdf')
+        res = self.client.get('/suppliers/frameworks/g-cloud-7/agreements/example.pdf')
 
-            assert res.status_code == 404
+        assert res.status_code == 404
 
     def test_download_document(self, S3, data_api_client):
         data_api_client.get_supplier_framework_info.return_value = self.supplier_framework()
@@ -2249,15 +2190,14 @@ class TestFrameworkAgreementDocumentDownload(BaseApplicationTest):
         S3.return_value = uploader
         uploader.get_signed_url.return_value = 'http://url/path?param=value'
 
-        with self.app.test_client():
-            self.login()
+        self.login()
 
-            res = self.client.get('/suppliers/frameworks/g-cloud-7/agreements/example.pdf')
+        res = self.client.get('/suppliers/frameworks/g-cloud-7/agreements/example.pdf')
 
-            assert res.status_code == 302
-            assert res.location == 'http://asset-host/path?param=value'
-            uploader.get_signed_url.assert_called_with(
-                'g-cloud-7/agreements/1234/1234-example.pdf')
+        assert res.status_code == 302
+        assert res.location == 'http://asset-host/path?param=value'
+        uploader.get_signed_url.assert_called_with(
+            'g-cloud-7/agreements/1234/1234-example.pdf')
 
     def test_download_document_with_asset_url(self, S3, data_api_client):
         data_api_client.get_supplier_framework_info.return_value = self.supplier_framework()
@@ -2266,16 +2206,15 @@ class TestFrameworkAgreementDocumentDownload(BaseApplicationTest):
         S3.return_value = uploader
         uploader.get_signed_url.return_value = 'http://url/path?param=value'
 
-        with self.app.test_client():
-            self.app.config['DM_ASSETS_URL'] = 'https://example'
-            self.login()
+        self.app.config['DM_ASSETS_URL'] = 'https://example'
+        self.login()
 
-            res = self.client.get('/suppliers/frameworks/g-cloud-7/agreements/example.pdf')
+        res = self.client.get('/suppliers/frameworks/g-cloud-7/agreements/example.pdf')
 
-            assert res.status_code == 302
-            assert res.location == 'https://example/path?param=value'
-            uploader.get_signed_url.assert_called_with(
-                'g-cloud-7/agreements/1234/1234-example.pdf')
+        assert res.status_code == 302
+        assert res.location == 'https://example/path?param=value'
+        uploader.get_signed_url.assert_called_with(
+            'g-cloud-7/agreements/1234/1234-example.pdf')
 
 
 @mock.patch('dmutils.s3.S3')
@@ -2285,42 +2224,39 @@ class TestFrameworkDocumentDownload(BaseApplicationTest):
         S3.return_value = uploader
         uploader.get_signed_url.return_value = 'http://url/path?param=value'
 
-        with self.app.test_client():
-            self.login()
+        self.login()
 
-            res = self.client.get('/suppliers/frameworks/g-cloud-7/files/example.pdf')
+        res = self.client.get('/suppliers/frameworks/g-cloud-7/files/example.pdf')
 
-            assert res.status_code == 302
-            assert res.location == 'http://asset-host/path?param=value'
-            uploader.get_signed_url.assert_called_with('g-cloud-7/communications/example.pdf')
+        assert res.status_code == 302
+        assert res.location == 'http://asset-host/path?param=value'
+        uploader.get_signed_url.assert_called_with('g-cloud-7/communications/example.pdf')
 
     def test_download_document_returns_404_if_url_is_None(self, S3):
         uploader = mock.Mock()
         S3.return_value = uploader
         uploader.get_signed_url.return_value = None
 
-        with self.app.test_client():
-            self.login()
+        self.login()
 
-            res = self.client.get('/suppliers/frameworks/g-cloud-7/files/example.pdf')
+        res = self.client.get('/suppliers/frameworks/g-cloud-7/files/example.pdf')
 
-            assert res.status_code == 404
+        assert res.status_code == 404
 
 
 @mock.patch('app.main.views.frameworks.data_api_client', autospec=True)
 class TestStartSupplierDeclaration(BaseApplicationTest):
     def test_start_declaration_goes_to_declaration_overview_page(self, data_api_client):
-        with self.app.test_client():
-            self.login()
+        self.login()
 
-            data_api_client.get_framework.return_value = self.framework(status='open')
-            data_api_client.get_supplier_framework_info.return_value = self.supplier_framework()
+        data_api_client.get_framework.return_value = self.framework(status='open')
+        data_api_client.get_supplier_framework_info.return_value = self.supplier_framework()
 
-            response = self.client.get('/suppliers/frameworks/g-cloud-7/declaration/start')
-            document = html.fromstring(response.get_data(as_text=True))
+        response = self.client.get('/suppliers/frameworks/g-cloud-7/declaration/start')
+        document = html.fromstring(response.get_data(as_text=True))
 
-            assert document.xpath("//a[normalize-space(string(.))='Start your declaration']/@href")[0] \
-                == '/suppliers/frameworks/g-cloud-7/declaration/reuse'
+        assert document.xpath("//a[normalize-space(string(.))='Start your declaration']/@href")[0] \
+            == '/suppliers/frameworks/g-cloud-7/declaration/reuse'
 
 
 @mock.patch('app.main.views.frameworks.data_api_client', autospec=True)
@@ -2329,61 +2265,58 @@ class TestDeclarationOverviewSubmit(BaseApplicationTest):
         Behaviour common to both GET and POST views on path /suppliers/frameworks/g-cloud-7/declaration
     """
     def test_supplier_not_interested(self, data_api_client, get_or_post):
-        with self.app.test_client():
-            self.login()
+        self.login()
 
-            data_api_client.get_framework.side_effect = assert_args_and_return(
-                self.framework(status="open"),
-                "g-cloud-7",
-            )
-            data_api_client.get_supplier_framework_info.side_effect = assert_args_and_raise(
-                APIError(mock.Mock(status_code=404)),
-                1234,
-                "g-cloud-7",
-            )
-            data_api_client.set_supplier_declaration.side_effect = AssertionError("This shouldn't be called")
+        data_api_client.get_framework.side_effect = assert_args_and_return(
+            self.framework(status="open"),
+            "g-cloud-7",
+        )
+        data_api_client.get_supplier_framework_info.side_effect = assert_args_and_raise(
+            APIError(mock.Mock(status_code=404)),
+            1234,
+            "g-cloud-7",
+        )
+        data_api_client.set_supplier_declaration.side_effect = AssertionError("This shouldn't be called")
 
-            response = getattr(self.client, get_or_post.lower())("/suppliers/frameworks/g-cloud-7/declaration")
+        response = getattr(self.client, get_or_post.lower())("/suppliers/frameworks/g-cloud-7/declaration")
 
-            assert response.status_code == 404
+        assert response.status_code == 404
 
     def test_framework_coming(self, data_api_client, get_or_post):
-        with self.app.test_client():
-            self.login()
+        self.login()
 
-            data_api_client.get_framework.side_effect = assert_args_and_return(
-                self.framework(status="coming"),
-                "g-cloud-7",
-            )
-            data_api_client.get_supplier_framework_info.side_effect = assert_args_and_return(
-                self.supplier_framework(framework_slug="g-cloud-7"),
-                1234,
-                "g-cloud-7",
-            )
-            data_api_client.set_supplier_declaration.side_effect = AssertionError("This shouldn't be called")
+        data_api_client.get_framework.side_effect = assert_args_and_return(
+            self.framework(status="coming"),
+            "g-cloud-7",
+        )
+        data_api_client.get_supplier_framework_info.side_effect = assert_args_and_return(
+            self.supplier_framework(framework_slug="g-cloud-7"),
+            1234,
+            "g-cloud-7",
+        )
+        data_api_client.set_supplier_declaration.side_effect = AssertionError("This shouldn't be called")
 
-            response = getattr(self.client, get_or_post.lower())("/suppliers/frameworks/g-cloud-7/declaration")
+        response = getattr(self.client, get_or_post.lower())("/suppliers/frameworks/g-cloud-7/declaration")
 
-            assert response.status_code == 404
+        assert response.status_code == 404
 
     def test_framework_unknown(self, data_api_client, get_or_post):
-        with self.app.test_client():
-            self.login()
+        self.login()
 
-            data_api_client.get_framework.side_effect = assert_args_and_raise(
-                APIError(mock.Mock(status_code=404)),
-                "muttoning-clouds",
-            )
-            data_api_client.get_supplier_framework_info.side_effect = assert_args_and_raise(
-                APIError(mock.Mock(status_code=404)),
-                1234,
-                "muttoning-clouds",
-            )
-            data_api_client.set_supplier_declaration.side_effect = AssertionError("This shouldn't be called")
+        data_api_client.get_framework.side_effect = assert_args_and_raise(
+            APIError(mock.Mock(status_code=404)),
+            "muttoning-clouds",
+        )
+        data_api_client.get_supplier_framework_info.side_effect = assert_args_and_raise(
+            APIError(mock.Mock(status_code=404)),
+            1234,
+            "muttoning-clouds",
+        )
+        data_api_client.set_supplier_declaration.side_effect = AssertionError("This shouldn't be called")
 
-            response = getattr(self.client, get_or_post.lower())("/suppliers/frameworks/muttoning-clouds/declaration")
+        response = getattr(self.client, get_or_post.lower())("/suppliers/frameworks/muttoning-clouds/declaration")
 
-            assert response.status_code == 404
+        assert response.status_code == 404
 
 
 @mock.patch('app.main.views.frameworks.data_api_client', autospec=True)
@@ -2851,91 +2784,90 @@ class TestDeclarationOverview(BaseApplicationTest):
     ):
         self._setup_data_api_client(data_api_client, "open", framework_slug, declaration, prefill_fw_slug)
 
-        with self.app.test_client():
-            self.login()
+        self.login()
 
-            response = self.client.get("/suppliers/frameworks/{}/declaration".format(framework_slug))
-            assert response.status_code == 200
-            doc = html.fromstring(response.get_data(as_text=True))
+        response = self.client.get("/suppliers/frameworks/{}/declaration".format(framework_slug))
+        assert response.status_code == 200
+        doc = html.fromstring(response.get_data(as_text=True))
 
-            assert [e.xpath("normalize-space(string())") for e in doc.xpath(
-                "//nav//*[@role='breadcrumbs']//a",
-            )] == [
-                "Digital Marketplace",
-                "Your account",
-                "Apply to F-Cumulus 0",
-            ]
-            assert doc.xpath(
-                "//nav//*[@role='breadcrumbs']//a/@href",
-            ) == [
-                "/",
-                "/suppliers",
-                "/suppliers/frameworks/{}".format(framework_slug),
-            ]
+        assert [e.xpath("normalize-space(string())") for e in doc.xpath(
+            "//nav//*[@role='breadcrumbs']//a",
+        )] == [
+            "Digital Marketplace",
+            "Your account",
+            "Apply to F-Cumulus 0",
+        ]
+        assert doc.xpath(
+            "//nav//*[@role='breadcrumbs']//a/@href",
+        ) == [
+            "/",
+            "/suppliers",
+            "/suppliers/frameworks/{}".format(framework_slug),
+        ]
 
-            assert bool(doc.xpath(
-                "//p[contains(normalize-space(string()), $t)][contains(normalize-space(string()), $f)]",
-                t="You must answer all questions and make your declaration before",
-                f="F-Cumulus 0",
-            )) is (not decl_valid)
-            assert bool(doc.xpath(
-                "//p[contains(normalize-space(string()), $t)][contains(normalize-space(string()), $f)]",
-                t="You must make your declaration before",
-                f="F-Cumulus 0",
-            )) is (decl_valid and declaration.get("status") != "complete")
+        assert bool(doc.xpath(
+            "//p[contains(normalize-space(string()), $t)][contains(normalize-space(string()), $f)]",
+            t="You must answer all questions and make your declaration before",
+            f="F-Cumulus 0",
+        )) is (not decl_valid)
+        assert bool(doc.xpath(
+            "//p[contains(normalize-space(string()), $t)][contains(normalize-space(string()), $f)]",
+            t="You must make your declaration before",
+            f="F-Cumulus 0",
+        )) is (decl_valid and declaration.get("status") != "complete")
 
-            assert len(doc.xpath(
-                "//p[contains(normalize-space(string()), $t)]",
-                t="You can come back and edit your answers at any time before the deadline.",
-            )) == (2 if decl_valid and declaration.get("status") != "complete" else 0)
-            assert len(doc.xpath(
-                "//p[contains(normalize-space(string()), $t)][not(contains(normalize-space(string()), $d))]",
-                t="You can come back and edit your answers at any time",
-                d="deadline",
-            )) == (2 if decl_valid and declaration.get("status") == "complete" else 0)
+        assert len(doc.xpath(
+            "//p[contains(normalize-space(string()), $t)]",
+            t="You can come back and edit your answers at any time before the deadline.",
+        )) == (2 if decl_valid and declaration.get("status") != "complete" else 0)
+        assert len(doc.xpath(
+            "//p[contains(normalize-space(string()), $t)][not(contains(normalize-space(string()), $d))]",
+            t="You can come back and edit your answers at any time",
+            d="deadline",
+        )) == (2 if decl_valid and declaration.get("status") == "complete" else 0)
 
-            if prefill_fw_slug is None:
-                assert not doc.xpath("//a[normalize-space(string())=$t]", t="Review answer")
+        if prefill_fw_slug is None:
+            assert not doc.xpath("//a[normalize-space(string())=$t]", t="Review answer")
 
-            assert bool(doc.xpath(
-                "//a[normalize-space(string())=$a or normalize-space(string())=$b]",
+        assert bool(doc.xpath(
+            "//a[normalize-space(string())=$a or normalize-space(string())=$b]",
+            a="Answer question",
+            b="Review answer",
+        )) is (not decl_valid)
+        if not decl_valid:
+            # assert that all links with the label "Answer question" or "Review answer" link to some subpage (by
+            # asserting that there are none that don't, having previously determined that such-labelled links exist)
+            assert not doc.xpath(
+                # we want the href to *contain* $u but not *be* $u
+                "//a[normalize-space(string())=$a or normalize-space(string())=$b]"
+                "[not(starts-with(@href, $u)) or @href=$u]",
                 a="Answer question",
                 b="Review answer",
-            )) is (not decl_valid)
-            if not decl_valid:
-                # assert that all links with the label "Answer question" or "Review answer" link to some subpage (by
-                # asserting that there are none that don't, having previously determined that such-labelled links exist)
-                assert not doc.xpath(
-                    # we want the href to *contain* $u but not *be* $u
-                    "//a[normalize-space(string())=$a or normalize-space(string())=$b]"
-                    "[not(starts-with(@href, $u)) or @href=$u]",
-                    a="Answer question",
-                    b="Review answer",
-                    u="/suppliers/frameworks/{}/declaration/".format(framework_slug),
-                )
-
-            if decl_valid and declaration.get("status") != "complete":
-                mdf_actions = doc.xpath(
-                    "//form[@method='POST'][.//input[@value=$t][@type='submit']][.//input[@name='csrf_token']]/@action",
-                    t="Make declaration",
-                )
-                assert len(mdf_actions) == 2
-                assert all(
-                    urljoin("/suppliers/frameworks/{}/declaration".format(framework_slug), action) ==
-                    "/suppliers/frameworks/{}/declaration".format(framework_slug)
-                    for action in mdf_actions
-                )
-            else:
-                assert not doc.xpath("//input[@value=$t]", t="Make declaration")
-
-            assert doc.xpath(
-                "//a[normalize-space(string())=$t][@href=$u]",
-                t="Return to application",
-                u="/suppliers/frameworks/{}".format(framework_slug),
+                u="/suppliers/frameworks/{}/declaration/".format(framework_slug),
             )
 
-            for expected_section in expected_sections:
-                assert self._extract_section_information(doc, expected_section[0]) == expected_section
+        if decl_valid and declaration.get("status") != "complete":
+            mdf_actions = doc.xpath(
+                "//form[@method='POST'][.//input[@value=$t][@type='submit']][.//input[@name='csrf_token']]/@action",
+                t="Make declaration",
+            )
+            assert len(mdf_actions) == 2
+            assert all(
+                urljoin("/suppliers/frameworks/{}/declaration".format(framework_slug), action) ==
+                "/suppliers/frameworks/{}/declaration".format(framework_slug)
+                for action in mdf_actions
+            )
+        else:
+            assert not doc.xpath("//input[@value=$t]", t="Make declaration")
+
+        assert doc.xpath(
+            "//a[normalize-space(string())=$t][@href=$u]",
+            t="Return to application",
+            u="/suppliers/frameworks/{}".format(framework_slug),
+        )
+
+        for expected_section in expected_sections:
+            assert self._extract_section_information(doc, expected_section[0]) == expected_section
 
     @pytest.mark.parametrize(
         "framework_slug,declaration,decl_valid,prefill_fw_slug,expected_sections",
@@ -2965,57 +2897,56 @@ class TestDeclarationOverview(BaseApplicationTest):
     ):
         self._setup_data_api_client(data_api_client, framework_status, framework_slug, declaration, prefill_fw_slug)
 
-        with self.app.test_client():
-            self.login()
+        self.login()
 
-            response = self.client.get("/suppliers/frameworks/{}/declaration".format(framework_slug))
-            assert response.status_code == 200
-            doc = html.fromstring(response.get_data(as_text=True))
+        response = self.client.get("/suppliers/frameworks/{}/declaration".format(framework_slug))
+        assert response.status_code == 200
+        doc = html.fromstring(response.get_data(as_text=True))
 
-            assert [e.xpath("normalize-space(string())") for e in doc.xpath(
-                "//nav//*[@role='breadcrumbs']//a",
-            )] == [
-                "Digital Marketplace",
-                "Your account",
-                "Your F-Cumulus 0 application",
-            ]
-            assert doc.xpath(
-                "//nav//*[@role='breadcrumbs']//a/@href",
-            ) == [
-                "/",
-                "/suppliers",
-                "/suppliers/frameworks/{}".format(framework_slug),
-            ]
+        assert [e.xpath("normalize-space(string())") for e in doc.xpath(
+            "//nav//*[@role='breadcrumbs']//a",
+        )] == [
+            "Digital Marketplace",
+            "Your account",
+            "Your F-Cumulus 0 application",
+        ]
+        assert doc.xpath(
+            "//nav//*[@role='breadcrumbs']//a/@href",
+        ) == [
+            "/",
+            "/suppliers",
+            "/suppliers/frameworks/{}".format(framework_slug),
+        ]
 
-            # there shouldn't be any links to the "edit" page
-            assert not any(
-                urljoin("/suppliers/frameworks/{}/declaration".format(framework_slug), a.attrib["href"]).startswith(
-                    "/suppliers/frameworks/{}/declaration/edit/".format(framework_slug)
-                )
-                for a in doc.xpath("//a[@href]")
+        # there shouldn't be any links to the "edit" page
+        assert not any(
+            urljoin("/suppliers/frameworks/{}/declaration".format(framework_slug), a.attrib["href"]).startswith(
+                "/suppliers/frameworks/{}/declaration/edit/".format(framework_slug)
             )
+            for a in doc.xpath("//a[@href]")
+        )
 
-            # no submittable forms should be pointing at ourselves
-            assert not any(
-                urljoin(
-                    "/suppliers/frameworks/{}/declaration".format(framework_slug),
-                    form.attrib["action"],
-                ) == "/suppliers/frameworks/{}/declaration".format(framework_slug)
-                for form in doc.xpath("//form[.//input[@type='submit']]")
-            )
+        # no submittable forms should be pointing at ourselves
+        assert not any(
+            urljoin(
+                "/suppliers/frameworks/{}/declaration".format(framework_slug),
+                form.attrib["action"],
+            ) == "/suppliers/frameworks/{}/declaration".format(framework_slug)
+            for form in doc.xpath("//form[.//input[@type='submit']]")
+        )
 
-            assert not doc.xpath("//a[@href][normalize-space(string())=$label]", label="Answer question")
-            assert not doc.xpath("//a[@href][normalize-space(string())=$label]", label="Review answer")
+        assert not doc.xpath("//a[@href][normalize-space(string())=$label]", label="Answer question")
+        assert not doc.xpath("//a[@href][normalize-space(string())=$label]", label="Review answer")
 
-            assert not doc.xpath("//p[contains(normalize-space(string()), $t)]", t="make your declaration")
-            assert not doc.xpath("//p[contains(normalize-space(string()), $t)]", t="edit your answers")
+        assert not doc.xpath("//p[contains(normalize-space(string()), $t)]", t="make your declaration")
+        assert not doc.xpath("//p[contains(normalize-space(string()), $t)]", t="edit your answers")
 
-            for expected_section in expected_sections:
-                assert self._extract_section_information(
-                    doc,
-                    expected_section[0],
-                    expect_edit_link=False,
-                ) == self._section_information_strip_edit_href(expected_section)
+        for expected_section in expected_sections:
+            assert self._extract_section_information(
+                doc,
+                expected_section[0],
+                expect_edit_link=False,
+            ) == self._section_information_strip_edit_href(expected_section)
 
     @pytest.mark.parametrize(
         "framework_slug,declaration,decl_valid,prefill_fw_slug,expected_sections",
@@ -3045,21 +2976,19 @@ class TestDeclarationOverview(BaseApplicationTest):
     ):
         self._setup_data_api_client(data_api_client, framework_status, framework_slug, declaration, prefill_fw_slug)
 
-        with self.app.test_client():
-            self.login()
+        self.login()
 
-            response = self.client.get("/suppliers/frameworks/{}/declaration".format(framework_slug))
-            assert response.status_code == 410
+        response = self.client.get("/suppliers/frameworks/{}/declaration".format(framework_slug))
+        assert response.status_code == 410
 
     @pytest.mark.parametrize("framework_status", ("coming", "open", "pending", "standstill", "live", "expired",))
     def test_error_nonexistent_framework(self, data_api_client, framework_status):
         self._setup_data_api_client(data_api_client, framework_status, "g-cloud-31415", {"status": "complete"}, None)
 
-        with self.app.test_client():
-            self.login()
+        self.login()
 
-            response = self.client.get("/suppliers/frameworks/g-cloud-31415/declaration")
-            assert response.status_code == 404
+        response = self.client.get("/suppliers/frameworks/g-cloud-31415/declaration")
+        assert response.status_code == 404
 
 
 @mock.patch('app.main.views.frameworks.data_api_client', autospec=True)
@@ -3078,427 +3007,415 @@ class TestDeclarationSubmit(BaseApplicationTest):
         },
     ))
     def test_invalid_declaration(self, data_api_client, invalid_declaration, prefill_fw_slug):
-        with self.app.test_client():
-            self.login()
+        self.login()
 
-            data_api_client.get_framework.side_effect = assert_args_and_return(
-                self.framework(slug="g-cloud-9", name="G-Cloud 9", status="open"),
-                "g-cloud-9",
-            )
-            data_api_client.get_supplier_framework_info.side_effect = assert_args_and_return(
-                self.supplier_framework(
-                    framework_slug="g-cloud-9",
-                    declaration=invalid_declaration,
-                    prefill_declaration_from_framework_slug=prefill_fw_slug,  # should have zero effect
-                ),
-                1234,
-                "g-cloud-9",
-            )
-            data_api_client.set_supplier_declaration.side_effect = AssertionError("This shouldn't be called")
+        data_api_client.get_framework.side_effect = assert_args_and_return(
+            self.framework(slug="g-cloud-9", name="G-Cloud 9", status="open"),
+            "g-cloud-9",
+        )
+        data_api_client.get_supplier_framework_info.side_effect = assert_args_and_return(
+            self.supplier_framework(
+                framework_slug="g-cloud-9",
+                declaration=invalid_declaration,
+                prefill_declaration_from_framework_slug=prefill_fw_slug,  # should have zero effect
+            ),
+            1234,
+            "g-cloud-9",
+        )
+        data_api_client.set_supplier_declaration.side_effect = AssertionError("This shouldn't be called")
 
-            response = self.client.post("/suppliers/frameworks/g-cloud-9/declaration")
+        response = self.client.post("/suppliers/frameworks/g-cloud-9/declaration")
 
-            assert response.status_code == 400
+        assert response.status_code == 400
 
     @pytest.mark.parametrize("prefill_fw_slug", (None, "some-previous-framework",))
     @pytest.mark.parametrize("declaration_status", ("started", "complete",))
     @mock.patch("dmutils.s3.S3")  # needed by the framework dashboard which our request gets redirected to
     def test_valid_declaration(self, s3, data_api_client, prefill_fw_slug, declaration_status):
-        with self.app.test_client():
-            self.login()
+        self.login()
 
-            data_api_client.get_framework.side_effect = assert_args_and_return(
-                self.framework(slug="g-cloud-9", name="G-Cloud 9", status="open"),
-                "g-cloud-9",
-            )
-            data_api_client.get_supplier_framework_info.side_effect = assert_args_and_return(
-                self.supplier_framework(
-                    framework_slug="g-cloud-9",
-                    declaration=dict(status=declaration_status, **(valid_g9_declaration_base())),
-                    prefill_declaration_from_framework_slug=prefill_fw_slug,  # should have zero effect
-                ),
-                1234,
-                "g-cloud-9",
-            )
-            data_api_client.set_supplier_declaration.side_effect = assert_args_and_return(
-                dict(status="complete", **(valid_g9_declaration_base())),
-                1234,
-                "g-cloud-9",
-                dict(status="complete", **(valid_g9_declaration_base())),
-                "email@email.com",
-            )
+        data_api_client.get_framework.side_effect = assert_args_and_return(
+            self.framework(slug="g-cloud-9", name="G-Cloud 9", status="open"),
+            "g-cloud-9",
+        )
+        data_api_client.get_supplier_framework_info.side_effect = assert_args_and_return(
+            self.supplier_framework(
+                framework_slug="g-cloud-9",
+                declaration=dict(status=declaration_status, **(valid_g9_declaration_base())),
+                prefill_declaration_from_framework_slug=prefill_fw_slug,  # should have zero effect
+            ),
+            1234,
+            "g-cloud-9",
+        )
+        data_api_client.set_supplier_declaration.side_effect = assert_args_and_return(
+            dict(status="complete", **(valid_g9_declaration_base())),
+            1234,
+            "g-cloud-9",
+            dict(status="complete", **(valid_g9_declaration_base())),
+            "email@email.com",
+        )
 
-            response = self.client.post("/suppliers/frameworks/g-cloud-9/declaration", follow_redirects=True)
+        response = self.client.post("/suppliers/frameworks/g-cloud-9/declaration", follow_redirects=True)
 
-            # args of call are asserted by mock's side_effect
-            assert data_api_client.set_supplier_declaration.called is True
+        # args of call are asserted by mock's side_effect
+        assert data_api_client.set_supplier_declaration.called is True
 
-            # this will be the response from the redirected-to view
-            assert response.status_code == 200
-            doc = html.fromstring(response.get_data(as_text=True))
+        # this will be the response from the redirected-to view
+        assert response.status_code == 200
+        doc = html.fromstring(response.get_data(as_text=True))
 
-            assert doc.xpath(
-                "//*[@data-analytics='trackPageView'][@data-url=$k]",
-                k="/suppliers/frameworks/g-cloud-9/declaration_complete",
-            )
+        assert doc.xpath(
+            "//*[@data-analytics='trackPageView'][@data-url=$k]",
+            k="/suppliers/frameworks/g-cloud-9/declaration_complete",
+        )
 
     @pytest.mark.parametrize("framework_status", ("standstill", "pending", "live", "expired",))
     def test_closed_framework_state(self, data_api_client, framework_status):
-        with self.app.test_client():
-            self.login()
+        self.login()
 
-            data_api_client.get_framework.side_effect = assert_args_and_return(
-                self.framework(status=framework_status),
-                "g-cloud-7",
-            )
-            data_api_client.get_supplier_framework_info.side_effect = assert_args_and_return(
-                self.supplier_framework(framework_slug="g-cloud-7"),
-                1234,
-                "g-cloud-7",
-            )
-            data_api_client.set_supplier_declaration.side_effect = AssertionError("This shouldn't be called")
+        data_api_client.get_framework.side_effect = assert_args_and_return(
+            self.framework(status=framework_status),
+            "g-cloud-7",
+        )
+        data_api_client.get_supplier_framework_info.side_effect = assert_args_and_return(
+            self.supplier_framework(framework_slug="g-cloud-7"),
+            1234,
+            "g-cloud-7",
+        )
+        data_api_client.set_supplier_declaration.side_effect = AssertionError("This shouldn't be called")
 
-            response = self.client.post("/suppliers/frameworks/g-cloud-7/declaration")
+        response = self.client.post("/suppliers/frameworks/g-cloud-7/declaration")
 
-            assert response.status_code == 404
+        assert response.status_code == 404
 
 
 @mock.patch('app.main.views.frameworks.data_api_client', autospec=True)
 class TestSupplierDeclaration(BaseApplicationTest):
     @pytest.mark.parametrize("empty_declaration", ({}, None,))
     def test_get_with_no_previous_answers(self, data_api_client, empty_declaration):
-        with self.app.test_client():
-            self.login()
+        self.login()
 
-            data_api_client.get_framework.return_value = self.framework(status='open')
-            data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
-                framework_slug="g-cloud-7",
-                declaration=empty_declaration,
-            )
-            data_api_client.get_supplier_declaration.side_effect = APIError(mock.Mock(status_code=404))
+        data_api_client.get_framework.return_value = self.framework(status='open')
+        data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
+            framework_slug="g-cloud-7",
+            declaration=empty_declaration,
+        )
+        data_api_client.get_supplier_declaration.side_effect = APIError(mock.Mock(status_code=404))
 
-            res = self.client.get(
-                '/suppliers/frameworks/g-cloud-7/declaration/edit/g-cloud-7-essentials')
+        res = self.client.get(
+            '/suppliers/frameworks/g-cloud-7/declaration/edit/g-cloud-7-essentials')
 
-            assert res.status_code == 200
-            doc = html.fromstring(res.get_data(as_text=True))
-            assert doc.xpath('//input[@id="PR-1-yes"]/@checked') == []
-            assert doc.xpath('//input[@id="PR-1-no"]/@checked') == []
+        assert res.status_code == 200
+        doc = html.fromstring(res.get_data(as_text=True))
+        assert doc.xpath('//input[@id="PR-1-yes"]/@checked') == []
+        assert doc.xpath('//input[@id="PR-1-no"]/@checked') == []
 
     def test_get_with_with_previous_answers(self, data_api_client):
-        with self.app.test_client():
-            self.login()
+        self.login()
 
-            data_api_client.get_framework.return_value = self.framework(status='open')
-            data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
-                framework_slug="g-cloud-7",
-                declaration={"status": "started", "PR1": False}
-            )
+        data_api_client.get_framework.return_value = self.framework(status='open')
+        data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
+            framework_slug="g-cloud-7",
+            declaration={"status": "started", "PR1": False}
+        )
 
-            res = self.client.get(
-                '/suppliers/frameworks/g-cloud-7/declaration/edit/g-cloud-7-essentials')
+        res = self.client.get(
+            '/suppliers/frameworks/g-cloud-7/declaration/edit/g-cloud-7-essentials')
 
-            assert res.status_code == 200
-            doc = html.fromstring(res.get_data(as_text=True))
-            assert len(doc.xpath('//input[@id="input-PR1-2"]/@checked')) == 1
+        assert res.status_code == 200
+        doc = html.fromstring(res.get_data(as_text=True))
+        assert len(doc.xpath('//input[@id="input-PR1-2"]/@checked')) == 1
 
     def test_get_with_with_prefilled_answers(self, data_api_client):
-        with self.app.test_client():
-            self.login()
-            # Handle calls for both the current framework and for the framework to pre-fill from
-            data_api_client.get_framework.side_effect = lambda framework_slug: {
-                "g-cloud-9": self.framework(slug='g-cloud-9', name='G-Cloud 9', status='open'),
-                "digital-outcomes-and-specialists-2": self.framework(slug='digital-outcomes-and-specialists-2',
-                                                                     name='Digital Stuff 2', status='live'),
-            }[framework_slug]
+        self.login()
+        # Handle calls for both the current framework and for the framework to pre-fill from
+        data_api_client.get_framework.side_effect = lambda framework_slug: {
+            "g-cloud-9": self.framework(slug='g-cloud-9', name='G-Cloud 9', status='open'),
+            "digital-outcomes-and-specialists-2": self.framework(slug='digital-outcomes-and-specialists-2',
+                                                                 name='Digital Stuff 2', status='live'),
+        }[framework_slug]
 
-            # Current framework application information
-            data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
-                framework_slug="g-cloud-9",
-                declaration={"status": "started"},
-                prefill_declaration_from_framework_slug="digital-outcomes-and-specialists-2"
-            )
+        # Current framework application information
+        data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
+            framework_slug="g-cloud-9",
+            declaration={"status": "started"},
+            prefill_declaration_from_framework_slug="digital-outcomes-and-specialists-2"
+        )
 
-            # The previous declaration to prefill from
-            data_api_client.get_supplier_declaration.return_value = {
-                'declaration': self.supplier_framework(
-                    framework_slug="digital-outcomes-and-specialists-2",
-                    declaration={"status": "complete",
-                                 "conspiracy": True,
-                                 "corruptionBribery": False,
-                                 "fraudAndTheft": True,
-                                 "terrorism": False,
-                                 "organisedCrime": False,
-                                 },
-                )["frameworkInterest"]["declaration"]
-            }
-
-            # The grounds-for-mandatory-exclusion section has "prefill: True" in the declaration manifest
-            res = self.client.get(
-                '/suppliers/frameworks/g-cloud-9/declaration/edit/grounds-for-mandatory-exclusion')
-
-            assert res.status_code == 200
-            data_api_client.get_supplier_declaration.assert_called_once_with(1234, "digital-outcomes-and-specialists-2")
-            doc = html.fromstring(res.get_data(as_text=True))
-
-            # Radio buttons have been pre-filled with the correct answers
-            assert len(doc.xpath('//input[@id="input-conspiracy-1"][@value="True"]/@checked')) == 1
-            assert len(doc.xpath('//input[@id="input-corruptionBribery-2"][@value="False"]/@checked')) == 1
-            assert len(doc.xpath('//input[@id="input-fraudAndTheft-1"][@value="True"]/@checked')) == 1
-            assert len(doc.xpath('//input[@id="input-terrorism-2"][@value="False"]/@checked')) == 1
-            assert len(doc.xpath('//input[@id="input-organisedCrime-2"][@value="False"]/@checked')) == 1
-
-            # Blue banner message is shown at top of page
-            assert doc.xpath('normalize-space(string(//div[@class="banner-information-without-action"]))') == \
-                "Answers on this page are from an earlier declaration and need review."
-
-            # Blue information messages are shown next to each question
-            info_messages = doc.xpath('//div[@class="message-wrapper"]//span[@class="message-content"]')
-            assert len(info_messages) == 5
-            for message in info_messages:
-                assert self.strip_all_whitespace(message.text) == self.strip_all_whitespace(
-                    "This answer is from your Digital Stuff 2 declaration"
-                )
-
-    def test_get_with_with_partially_prefilled_answers(self, data_api_client):
-        with self.app.test_client():
-            self.login()
-            # Handle calls for both the current framework and for the framework to pre-fill from
-            data_api_client.get_framework.side_effect = lambda framework_slug: {
-                "g-cloud-9": self.framework(slug='g-cloud-9', name='G-Cloud 9', status='open'),
-                "digital-outcomes-and-specialists-2": self.framework(slug='digital-outcomes-and-specialists-2',
-                                                                     name='Digital Stuff 2', status='live'),
-            }[framework_slug]
-
-            # Current framework application information
-            data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
-                framework_slug="g-cloud-9",
-                declaration={"status": "started"},
-                prefill_declaration_from_framework_slug="digital-outcomes-and-specialists-2"
-            )
-
-            # The previous declaration to prefill from - missing "corruptionBribery" and "terrorism" keys
-            data_api_client.get_supplier_declaration.return_value = {
-                'declaration': self.supplier_framework(
-                    framework_slug="digital-outcomes-and-specialists-2",
-                    declaration={"status": "complete",
-                                 "conspiracy": True,
-                                 "fraudAndTheft": True,
-                                 "organisedCrime": False,
-                                 },
-                )["frameworkInterest"]["declaration"]
-            }
-
-            # The grounds-for-mandatory-exclusion section has "prefill: True" in the declaration manifest
-            res = self.client.get(
-                '/suppliers/frameworks/g-cloud-9/declaration/edit/grounds-for-mandatory-exclusion')
-
-            assert res.status_code == 200
-            data_api_client.get_supplier_declaration.assert_called_once_with(1234, "digital-outcomes-and-specialists-2")
-            doc = html.fromstring(res.get_data(as_text=True))
-
-            # Radio buttons have been pre-filled with the correct answers
-            assert len(doc.xpath('//input[@id="input-conspiracy-1"][@value="True"]/@checked')) == 1
-            assert len(doc.xpath('//input[@id="input-fraudAndTheft-1"][@value="True"]/@checked')) == 1
-            assert len(doc.xpath('//input[@id="input-organisedCrime-2"][@value="False"]/@checked')) == 1
-
-            # Radio buttons for missing keys exist but have not been pre-filled
-            assert len(doc.xpath('//input[@id="input-corruptionBribery-1"]')) == 1
-            assert len(doc.xpath('//input[@id="input-corruptionBribery-2"]')) == 1
-            assert len(doc.xpath('//input[@id="input-corruptionBribery-1"]/@checked')) == 0
-            assert len(doc.xpath('//input[@id="input-corruptionBribery-2"]/@checked')) == 0
-            assert len(doc.xpath('//input[@id="input-terrorism-1"]')) == 1
-            assert len(doc.xpath('//input[@id="input-terrorism-2"]')) == 1
-            assert len(doc.xpath('//input[@id="input-terrorism-1"]/@checked')) == 0
-            assert len(doc.xpath('//input[@id="input-terrorism-2"]/@checked')) == 0
-
-            # Blue banner message is shown at top of page
-            assert doc.xpath('normalize-space(string(//div[@class="banner-information-without-action"]))') == \
-                "Answers on this page are from an earlier declaration and need review."
-
-            # Blue information messages are shown next to pre-filled questions only
-            info_messages = doc.xpath('//div[@class="message-wrapper"]//span[@class="message-content"]')
-            assert len(info_messages) == 3
-            for message in info_messages:
-                assert self.strip_all_whitespace(message.text) == self.strip_all_whitespace(
-                    "This answer is from your Digital Stuff 2 declaration"
-                )
-
-    def test_answers_not_prefilled_if_section_has_already_been_saved(self, data_api_client):
-        with self.app.test_client():
-            self.login()
-            # Handle calls for both the current framework and for the framework to pre-fill from
-            data_api_client.get_framework.side_effect = lambda framework_slug: {
-                "g-cloud-9": self.framework(slug='g-cloud-9', name='G-Cloud 9', status='open'),
-                "digital-outcomes-and-specialists-2": self.framework(slug='digital-outcomes-and-specialists-2',
-                                                                     name='Digital Stuff 2', status='live'),
-            }[framework_slug]
-
-            # Current framework application information with the grounds-for-mandatory-exclusion section complete
-            data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
-                framework_slug="g-cloud-9",
-                declaration={"status": "started",
-                             "conspiracy": False,
-                             "corruptionBribery": True,
-                             "fraudAndTheft": False,
-                             "terrorism": True,
+        # The previous declaration to prefill from
+        data_api_client.get_supplier_declaration.return_value = {
+            'declaration': self.supplier_framework(
+                framework_slug="digital-outcomes-and-specialists-2",
+                declaration={"status": "complete",
+                             "conspiracy": True,
+                             "corruptionBribery": False,
+                             "fraudAndTheft": True,
+                             "terrorism": False,
                              "organisedCrime": False,
                              },
-                prefill_declaration_from_framework_slug="digital-outcomes-and-specialists-2"
+            )["frameworkInterest"]["declaration"]
+        }
+
+        # The grounds-for-mandatory-exclusion section has "prefill: True" in the declaration manifest
+        res = self.client.get(
+            '/suppliers/frameworks/g-cloud-9/declaration/edit/grounds-for-mandatory-exclusion')
+
+        assert res.status_code == 200
+        data_api_client.get_supplier_declaration.assert_called_once_with(1234, "digital-outcomes-and-specialists-2")
+        doc = html.fromstring(res.get_data(as_text=True))
+
+        # Radio buttons have been pre-filled with the correct answers
+        assert len(doc.xpath('//input[@id="input-conspiracy-1"][@value="True"]/@checked')) == 1
+        assert len(doc.xpath('//input[@id="input-corruptionBribery-2"][@value="False"]/@checked')) == 1
+        assert len(doc.xpath('//input[@id="input-fraudAndTheft-1"][@value="True"]/@checked')) == 1
+        assert len(doc.xpath('//input[@id="input-terrorism-2"][@value="False"]/@checked')) == 1
+        assert len(doc.xpath('//input[@id="input-organisedCrime-2"][@value="False"]/@checked')) == 1
+
+        # Blue banner message is shown at top of page
+        assert doc.xpath('normalize-space(string(//div[@class="banner-information-without-action"]))') == \
+            "Answers on this page are from an earlier declaration and need review."
+
+        # Blue information messages are shown next to each question
+        info_messages = doc.xpath('//div[@class="message-wrapper"]//span[@class="message-content"]')
+        assert len(info_messages) == 5
+        for message in info_messages:
+            assert self.strip_all_whitespace(message.text) == self.strip_all_whitespace(
+                "This answer is from your Digital Stuff 2 declaration"
             )
 
-            # The previous declaration to prefill from - has relevant answers but should not ever be called
-            data_api_client.get_supplier_declaration.return_value = {
-                'declaration': self.supplier_framework(
-                    framework_slug="digital-outcomes-and-specialists-2",
-                    declaration={"status": "complete",
-                                 "conspiracy": True,
-                                 "corruptionBribery": False,
-                                 "fraudAndTheft": True,
-                                 "terrorism": False,
-                                 "organisedCrime": False,
-                                 },
-                )["frameworkInterest"]["declaration"]
-            }
+    def test_get_with_with_partially_prefilled_answers(self, data_api_client):
+        self.login()
+        # Handle calls for both the current framework and for the framework to pre-fill from
+        data_api_client.get_framework.side_effect = lambda framework_slug: {
+            "g-cloud-9": self.framework(slug='g-cloud-9', name='G-Cloud 9', status='open'),
+            "digital-outcomes-and-specialists-2": self.framework(slug='digital-outcomes-and-specialists-2',
+                                                                 name='Digital Stuff 2', status='live'),
+        }[framework_slug]
 
-            # The grounds-for-mandatory-exclusion section has "prefill: True" in the declaration manifest
-            res = self.client.get(
-                '/suppliers/frameworks/g-cloud-9/declaration/edit/grounds-for-mandatory-exclusion')
+        # Current framework application information
+        data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
+            framework_slug="g-cloud-9",
+            declaration={"status": "started"},
+            prefill_declaration_from_framework_slug="digital-outcomes-and-specialists-2"
+        )
 
-            assert res.status_code == 200
-            doc = html.fromstring(res.get_data(as_text=True))
+        # The previous declaration to prefill from - missing "corruptionBribery" and "terrorism" keys
+        data_api_client.get_supplier_declaration.return_value = {
+            'declaration': self.supplier_framework(
+                framework_slug="digital-outcomes-and-specialists-2",
+                declaration={"status": "complete",
+                             "conspiracy": True,
+                             "fraudAndTheft": True,
+                             "organisedCrime": False,
+                             },
+            )["frameworkInterest"]["declaration"]
+        }
 
-            # Previous framework and declaration have not been fetched
-            data_api_client.get_framework.assert_called_once_with('g-cloud-9')
-            assert data_api_client.get_supplier_declaration.called is False
+        # The grounds-for-mandatory-exclusion section has "prefill: True" in the declaration manifest
+        res = self.client.get(
+            '/suppliers/frameworks/g-cloud-9/declaration/edit/grounds-for-mandatory-exclusion')
 
-            # Radio buttons have been filled with the current answers; not those from previous declaration
-            assert len(doc.xpath('//input[@id="input-conspiracy-2"][@value="False"]/@checked')) == 1
-            assert len(doc.xpath('//input[@id="input-corruptionBribery-1"][@value="True"]/@checked')) == 1
-            assert len(doc.xpath('//input[@id="input-fraudAndTheft-2"][@value="False"]/@checked')) == 1
-            assert len(doc.xpath('//input[@id="input-terrorism-1"][@value="True"]/@checked')) == 1
-            assert len(doc.xpath('//input[@id="input-organisedCrime-2"][@value="False"]/@checked')) == 1
+        assert res.status_code == 200
+        data_api_client.get_supplier_declaration.assert_called_once_with(1234, "digital-outcomes-and-specialists-2")
+        doc = html.fromstring(res.get_data(as_text=True))
 
-            # No blue banner message is shown at top of page
-            assert len(doc.xpath('//div[@class="banner-information-without-action"]')) == 0
+        # Radio buttons have been pre-filled with the correct answers
+        assert len(doc.xpath('//input[@id="input-conspiracy-1"][@value="True"]/@checked')) == 1
+        assert len(doc.xpath('//input[@id="input-fraudAndTheft-1"][@value="True"]/@checked')) == 1
+        assert len(doc.xpath('//input[@id="input-organisedCrime-2"][@value="False"]/@checked')) == 1
 
-            # No blue information messages are shown next to each question
-            info_messages = doc.xpath('//div[@class="message-wrapper"]//span[@class="message-content"]')
-            assert len(info_messages) == 0
+        # Radio buttons for missing keys exist but have not been pre-filled
+        assert len(doc.xpath('//input[@id="input-corruptionBribery-1"]')) == 1
+        assert len(doc.xpath('//input[@id="input-corruptionBribery-2"]')) == 1
+        assert len(doc.xpath('//input[@id="input-corruptionBribery-1"]/@checked')) == 0
+        assert len(doc.xpath('//input[@id="input-corruptionBribery-2"]/@checked')) == 0
+        assert len(doc.xpath('//input[@id="input-terrorism-1"]')) == 1
+        assert len(doc.xpath('//input[@id="input-terrorism-2"]')) == 1
+        assert len(doc.xpath('//input[@id="input-terrorism-1"]/@checked')) == 0
+        assert len(doc.xpath('//input[@id="input-terrorism-2"]/@checked')) == 0
+
+        # Blue banner message is shown at top of page
+        assert doc.xpath('normalize-space(string(//div[@class="banner-information-without-action"]))') == \
+            "Answers on this page are from an earlier declaration and need review."
+
+        # Blue information messages are shown next to pre-filled questions only
+        info_messages = doc.xpath('//div[@class="message-wrapper"]//span[@class="message-content"]')
+        assert len(info_messages) == 3
+        for message in info_messages:
+            assert self.strip_all_whitespace(message.text) == self.strip_all_whitespace(
+                "This answer is from your Digital Stuff 2 declaration"
+            )
+
+    def test_answers_not_prefilled_if_section_has_already_been_saved(self, data_api_client):
+        self.login()
+        # Handle calls for both the current framework and for the framework to pre-fill from
+        data_api_client.get_framework.side_effect = lambda framework_slug: {
+            "g-cloud-9": self.framework(slug='g-cloud-9', name='G-Cloud 9', status='open'),
+            "digital-outcomes-and-specialists-2": self.framework(slug='digital-outcomes-and-specialists-2',
+                                                                 name='Digital Stuff 2', status='live'),
+        }[framework_slug]
+
+        # Current framework application information with the grounds-for-mandatory-exclusion section complete
+        data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
+            framework_slug="g-cloud-9",
+            declaration={"status": "started",
+                         "conspiracy": False,
+                         "corruptionBribery": True,
+                         "fraudAndTheft": False,
+                         "terrorism": True,
+                         "organisedCrime": False,
+                         },
+            prefill_declaration_from_framework_slug="digital-outcomes-and-specialists-2"
+        )
+
+        # The previous declaration to prefill from - has relevant answers but should not ever be called
+        data_api_client.get_supplier_declaration.return_value = {
+            'declaration': self.supplier_framework(
+                framework_slug="digital-outcomes-and-specialists-2",
+                declaration={"status": "complete",
+                             "conspiracy": True,
+                             "corruptionBribery": False,
+                             "fraudAndTheft": True,
+                             "terrorism": False,
+                             "organisedCrime": False,
+                             },
+            )["frameworkInterest"]["declaration"]
+        }
+
+        # The grounds-for-mandatory-exclusion section has "prefill: True" in the declaration manifest
+        res = self.client.get(
+            '/suppliers/frameworks/g-cloud-9/declaration/edit/grounds-for-mandatory-exclusion')
+
+        assert res.status_code == 200
+        doc = html.fromstring(res.get_data(as_text=True))
+
+        # Previous framework and declaration have not been fetched
+        data_api_client.get_framework.assert_called_once_with('g-cloud-9')
+        assert data_api_client.get_supplier_declaration.called is False
+
+        # Radio buttons have been filled with the current answers; not those from previous declaration
+        assert len(doc.xpath('//input[@id="input-conspiracy-2"][@value="False"]/@checked')) == 1
+        assert len(doc.xpath('//input[@id="input-corruptionBribery-1"][@value="True"]/@checked')) == 1
+        assert len(doc.xpath('//input[@id="input-fraudAndTheft-2"][@value="False"]/@checked')) == 1
+        assert len(doc.xpath('//input[@id="input-terrorism-1"][@value="True"]/@checked')) == 1
+        assert len(doc.xpath('//input[@id="input-organisedCrime-2"][@value="False"]/@checked')) == 1
+
+        # No blue banner message is shown at top of page
+        assert len(doc.xpath('//div[@class="banner-information-without-action"]')) == 0
+
+        # No blue information messages are shown next to each question
+        info_messages = doc.xpath('//div[@class="message-wrapper"]//span[@class="message-content"]')
+        assert len(info_messages) == 0
 
     def test_answers_not_prefilled_if_section_marked_as_prefill_false(self, data_api_client):
-        with self.app.test_client():
-            self.login()
-            # Handle calls for both the current framework and for the framework to pre-fill from
-            data_api_client.get_framework.side_effect = lambda framework_slug: {
-                "g-cloud-9": self.framework(slug='g-cloud-9', name='G-Cloud 9', status='open'),
-                "digital-outcomes-and-specialists-2": self.framework(slug='digital-outcomes-and-specialists-2',
-                                                                     name='Digital Stuff 2', status='live'),
-            }[framework_slug]
+        self.login()
+        # Handle calls for both the current framework and for the framework to pre-fill from
+        data_api_client.get_framework.side_effect = lambda framework_slug: {
+            "g-cloud-9": self.framework(slug='g-cloud-9', name='G-Cloud 9', status='open'),
+            "digital-outcomes-and-specialists-2": self.framework(slug='digital-outcomes-and-specialists-2',
+                                                                 name='Digital Stuff 2', status='live'),
+        }[framework_slug]
 
-            # Current framework application information
-            data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
-                framework_slug="g-cloud-9",
-                declaration={"status": "started"},
-                prefill_declaration_from_framework_slug="digital-outcomes-and-specialists-2"
-            )
+        # Current framework application information
+        data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
+            framework_slug="g-cloud-9",
+            declaration={"status": "started"},
+            prefill_declaration_from_framework_slug="digital-outcomes-and-specialists-2"
+        )
 
-            # The previous declaration to prefill from - has relevant answers but should not ever be called
-            data_api_client.get_supplier_declaration.return_value = {
-                'declaration': self.supplier_framework(
-                    framework_slug="digital-outcomes-and-specialists-2",
-                    declaration={"status": "complete",
-                                 "readUnderstoodGuidance": True,
-                                 "understandTool": True,
-                                 "understandHowToAskQuestions": False,
-                                 },
-                )["frameworkInterest"]["declaration"]
-            }
+        # The previous declaration to prefill from - has relevant answers but should not ever be called
+        data_api_client.get_supplier_declaration.return_value = {
+            'declaration': self.supplier_framework(
+                framework_slug="digital-outcomes-and-specialists-2",
+                declaration={"status": "complete",
+                             "readUnderstoodGuidance": True,
+                             "understandTool": True,
+                             "understandHowToAskQuestions": False,
+                             },
+            )["frameworkInterest"]["declaration"]
+        }
 
-            # The how-you-apply section has "prefill: False" in the declaration manifest
-            res = self.client.get(
-                '/suppliers/frameworks/g-cloud-9/declaration/edit/how-you-apply')
+        # The how-you-apply section has "prefill: False" in the declaration manifest
+        res = self.client.get(
+            '/suppliers/frameworks/g-cloud-9/declaration/edit/how-you-apply')
 
-            assert res.status_code == 200
-            doc = html.fromstring(res.get_data(as_text=True))
+        assert res.status_code == 200
+        doc = html.fromstring(res.get_data(as_text=True))
 
-            # Previous framework and declaration have not been fetched
-            data_api_client.get_framework.assert_called_once_with('g-cloud-9')
-            assert data_api_client.get_supplier_declaration.called is False
+        # Previous framework and declaration have not been fetched
+        data_api_client.get_framework.assert_called_once_with('g-cloud-9')
+        assert data_api_client.get_supplier_declaration.called is False
 
-            # Radio buttons exist on page but have not been populated at all
-            assert len(doc.xpath('//input[@id="input-readUnderstoodGuidance-1"]')) == 1
-            assert len(doc.xpath('//input[@id="input-readUnderstoodGuidance-2"]')) == 1
-            assert len(doc.xpath('//input[@id="input-readUnderstoodGuidance-1"]/@checked')) == 0
-            assert len(doc.xpath('//input[@id="input-readUnderstoodGuidance-2"]/@checked')) == 0
+        # Radio buttons exist on page but have not been populated at all
+        assert len(doc.xpath('//input[@id="input-readUnderstoodGuidance-1"]')) == 1
+        assert len(doc.xpath('//input[@id="input-readUnderstoodGuidance-2"]')) == 1
+        assert len(doc.xpath('//input[@id="input-readUnderstoodGuidance-1"]/@checked')) == 0
+        assert len(doc.xpath('//input[@id="input-readUnderstoodGuidance-2"]/@checked')) == 0
 
-            assert len(doc.xpath('//input[@id="input-understandTool-1"]')) == 1
-            assert len(doc.xpath('//input[@id="input-understandTool-2"]')) == 1
-            assert len(doc.xpath('//input[@id="input-understandTool-1"]/@checked')) == 0
-            assert len(doc.xpath('//input[@id="input-understandTool-2"]/@checked')) == 0
+        assert len(doc.xpath('//input[@id="input-understandTool-1"]')) == 1
+        assert len(doc.xpath('//input[@id="input-understandTool-2"]')) == 1
+        assert len(doc.xpath('//input[@id="input-understandTool-1"]/@checked')) == 0
+        assert len(doc.xpath('//input[@id="input-understandTool-2"]/@checked')) == 0
 
-            assert len(doc.xpath('//input[@id="input-understandHowToAskQuestions-1"]')) == 1
-            assert len(doc.xpath('//input[@id="input-understandHowToAskQuestions-2"]')) == 1
-            assert len(doc.xpath('//input[@id="input-understandHowToAskQuestions-1"]/@checked')) == 0
-            assert len(doc.xpath('//input[@id="input-understandHowToAskQuestions-2"]/@checked')) == 0
+        assert len(doc.xpath('//input[@id="input-understandHowToAskQuestions-1"]')) == 1
+        assert len(doc.xpath('//input[@id="input-understandHowToAskQuestions-2"]')) == 1
+        assert len(doc.xpath('//input[@id="input-understandHowToAskQuestions-1"]/@checked')) == 0
+        assert len(doc.xpath('//input[@id="input-understandHowToAskQuestions-2"]/@checked')) == 0
 
-            # No blue banner message is shown at top of page
-            assert len(doc.xpath('//div[@class="banner-information-without-action"]')) == 0
+        # No blue banner message is shown at top of page
+        assert len(doc.xpath('//div[@class="banner-information-without-action"]')) == 0
 
-            # No blue information messages are shown next to each question
-            info_messages = doc.xpath('//div[@class="message-wrapper"]//span[@class="message-content"]')
-            assert len(info_messages) == 0
+        # No blue information messages are shown next to each question
+        info_messages = doc.xpath('//div[@class="message-wrapper"]//span[@class="message-content"]')
+        assert len(info_messages) == 0
 
     def test_post_valid_data(self, data_api_client):
-        with self.app.test_client():
-            self.login()
+        self.login()
 
-            data_api_client.get_framework.return_value = self.framework(status='open')
-            data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
-                framework_slug="g-cloud-7",
-                declaration={"status": "started"}
-            )
-            res = self.client.post(
-                '/suppliers/frameworks/g-cloud-7/declaration/edit/g-cloud-7-essentials',
-                data=FULL_G7_SUBMISSION)
+        data_api_client.get_framework.return_value = self.framework(status='open')
+        data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
+            framework_slug="g-cloud-7",
+            declaration={"status": "started"}
+        )
+        res = self.client.post(
+            '/suppliers/frameworks/g-cloud-7/declaration/edit/g-cloud-7-essentials',
+            data=FULL_G7_SUBMISSION)
 
-            assert res.status_code == 302
-            assert data_api_client.set_supplier_declaration.called is True
+        assert res.status_code == 302
+        assert data_api_client.set_supplier_declaration.called is True
 
     def test_post_valid_data_to_complete_declaration(self, data_api_client):
-        with self.app.test_client():
-            self.login()
+        self.login()
 
-            data_api_client.get_framework.return_value = self.framework(status='open')
-            data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
-                framework_slug="g-cloud-7",
-                declaration=FULL_G7_SUBMISSION
-            )
-            res = self.client.post(
-                '/suppliers/frameworks/g-cloud-7/declaration/edit/grounds-for-discretionary-exclusion',
-                data=FULL_G7_SUBMISSION)
+        data_api_client.get_framework.return_value = self.framework(status='open')
+        data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
+            framework_slug="g-cloud-7",
+            declaration=FULL_G7_SUBMISSION
+        )
+        res = self.client.post(
+            '/suppliers/frameworks/g-cloud-7/declaration/edit/grounds-for-discretionary-exclusion',
+            data=FULL_G7_SUBMISSION)
 
-            assert res.status_code == 302
-            assert res.location == 'http://localhost/suppliers/frameworks/g-cloud-7/declaration'
-            assert data_api_client.set_supplier_declaration.called is True
-            assert data_api_client.set_supplier_declaration.call_args[0][2]['status'] == 'complete'
+        assert res.status_code == 302
+        assert res.location == 'http://localhost/suppliers/frameworks/g-cloud-7/declaration'
+        assert data_api_client.set_supplier_declaration.called is True
+        assert data_api_client.set_supplier_declaration.call_args[0][2]['status'] == 'complete'
 
     def test_post_valid_data_with_api_failure(self, data_api_client):
-        with self.app.test_client():
-            self.login()
+        self.login()
 
-            data_api_client.get_framework.return_value = self.framework(status='open')
-            data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
-                framework_slug="g-cloud-7",
-                declaration={"status": "started"}
-            )
-            data_api_client.set_supplier_declaration.side_effect = APIError(mock.Mock(status_code=400))
+        data_api_client.get_framework.return_value = self.framework(status='open')
+        data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
+            framework_slug="g-cloud-7",
+            declaration={"status": "started"}
+        )
+        data_api_client.set_supplier_declaration.side_effect = APIError(mock.Mock(status_code=400))
 
-            res = self.client.post(
-                '/suppliers/frameworks/g-cloud-7/declaration/edit/g-cloud-7-essentials',
-                data=FULL_G7_SUBMISSION)
+        res = self.client.post(
+            '/suppliers/frameworks/g-cloud-7/declaration/edit/g-cloud-7-essentials',
+            data=FULL_G7_SUBMISSION)
 
-            assert res.status_code == 400
+        assert res.status_code == 400
 
     @mock.patch('app.main.helpers.validation.G7Validator.get_error_messages_for_page')
     def test_post_with_validation_errors(self, get_error_messages_for_page, data_api_client):
@@ -3506,76 +3423,73 @@ class TestSupplierDeclaration(BaseApplicationTest):
 
         For unit tests of the validation see :mod:`tests.app.main.helpers.test_frameworks`
         """
-        with self.app.test_client():
-            self.login()
+        self.login()
 
-            data_api_client.get_framework.return_value = self.framework(status='open')
-            get_error_messages_for_page.return_value = {'PR1': {'input_name': 'PR1', 'message': 'this is invalid'}}
+        data_api_client.get_framework.return_value = self.framework(status='open')
+        get_error_messages_for_page.return_value = {'PR1': {'input_name': 'PR1', 'message': 'this is invalid'}}
 
-            res = self.client.post(
-                '/suppliers/frameworks/g-cloud-7/declaration/edit/g-cloud-7-essentials',
-                data=FULL_G7_SUBMISSION)
+        res = self.client.post(
+            '/suppliers/frameworks/g-cloud-7/declaration/edit/g-cloud-7-essentials',
+            data=FULL_G7_SUBMISSION)
 
-            assert res.status_code == 400
-            assert data_api_client.set_supplier_declaration.called is False
+        assert res.status_code == 400
+        assert data_api_client.set_supplier_declaration.called is False
 
-            doc = html.fromstring(res.get_data(as_text=True))
-            elems = doc.cssselect('#input-PR1-1')
-            assert elems[0].value == 'True'
+        doc = html.fromstring(res.get_data(as_text=True))
+        elems = doc.cssselect('#input-PR1-1')
+        assert elems[0].value == 'True'
 
     def test_post_invalidating_previously_valid_page(self, data_api_client):
-        with self.app.test_client():
-            self.login()
+        self.login()
 
-            data_api_client.get_framework.return_value = self.framework(slug='g-cloud-9', status='open')
+        data_api_client.get_framework.return_value = self.framework(slug='g-cloud-9', status='open')
 
-            mock_supplier_framework = self.supplier_framework(
-                framework_slug="g-cloud-9",
-                declaration={
-                    "status": "started",
-                    "establishedInTheUK": False,
-                    "appropriateTradeRegisters": True,
-                    "appropriateTradeRegistersNumber": "242#353",
-                    "licenceOrMemberRequired": "licensed",
-                    "licenceOrMemberRequiredDetails": "Foo Bar",
-                },
-            )
-            data_api_client.get_supplier_framework_info.return_value = mock_supplier_framework
-            data_api_client.get_supplier_declaration.return_value = {
-                "declaration": mock_supplier_framework["frameworkInterest"]["declaration"],
-            }
+        mock_supplier_framework = self.supplier_framework(
+            framework_slug="g-cloud-9",
+            declaration={
+                "status": "started",
+                "establishedInTheUK": False,
+                "appropriateTradeRegisters": True,
+                "appropriateTradeRegistersNumber": "242#353",
+                "licenceOrMemberRequired": "licensed",
+                "licenceOrMemberRequiredDetails": "Foo Bar",
+            },
+        )
+        data_api_client.get_supplier_framework_info.return_value = mock_supplier_framework
+        data_api_client.get_supplier_declaration.return_value = {
+            "declaration": mock_supplier_framework["frameworkInterest"]["declaration"],
+        }
 
-            res = self.client.post(
-                '/suppliers/frameworks/g-cloud-9/declaration/edit/established-outside-the-uk',
-                data={
-                    "establishedInTheUK": "False",
-                    "appropriateTradeRegisters": "True",
-                    "appropriateTradeRegistersNumber": "242#353",
-                    "licenceOrMemberRequired": "licensed",
-                    # deliberately missing:
-                    "licenceOrMemberRequiredDetails": "",
-                },
-            )
+        res = self.client.post(
+            '/suppliers/frameworks/g-cloud-9/declaration/edit/established-outside-the-uk',
+            data={
+                "establishedInTheUK": "False",
+                "appropriateTradeRegisters": "True",
+                "appropriateTradeRegistersNumber": "242#353",
+                "licenceOrMemberRequired": "licensed",
+                # deliberately missing:
+                "licenceOrMemberRequiredDetails": "",
+            },
+        )
 
-            assert res.status_code == 400
-            assert data_api_client.set_supplier_declaration.called is False
+        assert res.status_code == 400
+        assert data_api_client.set_supplier_declaration.called is False
 
     def test_cannot_post_data_if_not_open(self, data_api_client):
-        with self.app.test_client():
-            self.login()
+        self.login()
 
-            data_api_client.get_framework.return_value = {
-                'frameworks': {'status': 'pending'}
-            }
-            data_api_client.get_supplier_declaration.return_value = {
-                "declaration": {"status": "started"}
-            }
-            res = self.client.post(
-                '/suppliers/frameworks/g-cloud-7/declaration/edit/g-cloud-7-essentials',
-                data=FULL_G7_SUBMISSION)
+        data_api_client.get_framework.return_value = {
+            'frameworks': {'status': 'pending'}
+        }
+        data_api_client.get_supplier_declaration.return_value = {
+            "declaration": {"status": "started"}
+        }
+        res = self.client.post(
+            '/suppliers/frameworks/g-cloud-7/declaration/edit/g-cloud-7-essentials',
+            data=FULL_G7_SUBMISSION)
 
-            assert res.status_code == 404
-            assert data_api_client.set_supplier_declaration.called is False
+        assert res.status_code == 404
+        assert data_api_client.set_supplier_declaration.called is False
 
 
 @mock.patch('app.main.views.frameworks.data_api_client')
@@ -3610,64 +3524,60 @@ class TestFrameworkUpdatesPage(BaseApplicationTest):
             'test_should_be_a_503_if_connecting_to_amazon_fails'
         )
 
-        with self.app.test_client():
-            self.login()
+        self.login()
 
-            response = self.client.get(
-                '/suppliers/frameworks/g-cloud-7/updates'
-            )
+        response = self.client.get(
+            '/suppliers/frameworks/g-cloud-7/updates'
+        )
 
-            assert response.status_code == 503
-            assert self.strip_all_whitespace(u"<h1>Sorry, we’re experiencing technical difficulties</h1>") in \
-                self.strip_all_whitespace(response.get_data(as_text=True))
+        assert response.status_code == 503
+        assert self.strip_all_whitespace(u"<h1>Sorry, we’re experiencing technical difficulties</h1>") in \
+            self.strip_all_whitespace(response.get_data(as_text=True))
 
     def test_empty_messages_exist_if_no_files_returned(self, s3, data_api_client):
         data_api_client.get_framework.return_value = self.framework('open')
 
-        with self.app.test_client():
-            self.login()
+        self.login()
 
-            response = self.client.get(
-                '/suppliers/frameworks/g-cloud-7/updates'
-            )
+        response = self.client.get(
+            '/suppliers/frameworks/g-cloud-7/updates'
+        )
 
-            assert response.status_code == 200
-            doc = html.fromstring(response.get_data(as_text=True))
-            self._assert_page_title_and_table_headings(doc, tables_exist=False)
+        assert response.status_code == 200
+        doc = html.fromstring(response.get_data(as_text=True))
+        self._assert_page_title_and_table_headings(doc, tables_exist=False)
 
-            for empty_message in [
-                '<p class="summary-item-no-content">No communications have been sent out.</p>',
-                '<p class="summary-item-no-content">No clarification questions and answers have been posted yet.</p>',
-            ]:
-                assert self.strip_all_whitespace(empty_message) in \
-                    self.strip_all_whitespace(response.get_data(as_text=True))
+        for empty_message in [
+            '<p class="summary-item-no-content">No communications have been sent out.</p>',
+            '<p class="summary-item-no-content">No clarification questions and answers have been posted yet.</p>',
+        ]:
+            assert self.strip_all_whitespace(empty_message) in \
+                self.strip_all_whitespace(response.get_data(as_text=True))
 
     def test_dates_for_open_framework_closed_for_questions(self, s3, data_api_client):
         data_api_client.get_framework.return_value = self.framework('open', clarification_questions_open=False)
 
-        with self.app.test_client():
-            self.login()
+        self.login()
 
-            response = self.client.get('/suppliers/frameworks/g-cloud-7/updates')
-            data = response.get_data(as_text=True)
+        response = self.client.get('/suppliers/frameworks/g-cloud-7/updates')
+        data = response.get_data(as_text=True)
 
-            assert response.status_code == 200
-            assert 'All clarification questions and answers will be published by 5pm BST, 29 September 2015.' in data
-            assert "The deadline for clarification questions is" not in data
+        assert response.status_code == 200
+        assert 'All clarification questions and answers will be published by 5pm BST, 29 September 2015.' in data
+        assert "The deadline for clarification questions is" not in data
 
     def test_dates_for_open_framework_open_for_questions(self, s3, data_api_client):
         data_api_client.get_framework.return_value = self.framework('open', clarification_questions_open=True)
         data_api_client.get_supplier_framework_info.return_value = self.supplier_framework()
 
-        with self.app.test_client():
-            self.login()
+        self.login()
 
-            response = self.client.get('/suppliers/frameworks/g-cloud-7/updates')
-            data = response.get_data(as_text=True)
+        response = self.client.get('/suppliers/frameworks/g-cloud-7/updates')
+        data = response.get_data(as_text=True)
 
-            assert response.status_code == 200
-            assert "All clarification questions and answers will be published by" not in data
-            assert 'The deadline for clarification questions is 5pm BST, 22 September 2015.' in data
+        assert response.status_code == 200
+        assert "All clarification questions and answers will be published by" not in data
+        assert 'The deadline for clarification questions is 5pm BST, 22 September 2015.' in data
 
     def test_the_tables_should_be_displayed_correctly(self, s3, data_api_client):
         data_api_client.get_framework.return_value = self.framework('open')
@@ -3686,33 +3596,32 @@ class TestFrameworkUpdatesPage(BaseApplicationTest):
             ) for section, filename, ext in files
         ]
 
-        with self.app.test_client():
-            self.login()
+        self.login()
 
-            response = self.client.get(
-                '/suppliers/frameworks/g-cloud-7/updates'
-            )
-            doc = html.fromstring(response.get_data(as_text=True))
-            self._assert_page_title_and_table_headings(doc)
+        response = self.client.get(
+            '/suppliers/frameworks/g-cloud-7/updates'
+        )
+        doc = html.fromstring(response.get_data(as_text=True))
+        self._assert_page_title_and_table_headings(doc)
 
-            tables = doc.xpath('//div[contains(@class, "updates-document-tables")]/table')
+        tables = doc.xpath('//div[contains(@class, "updates-document-tables")]/table')
 
-            # test that for each table, we have the right number of rows
-            for table in tables:
-                item_rows = table.findall('.//tr[@class="summary-item-row"]')
-                assert len(item_rows) == 2
+        # test that for each table, we have the right number of rows
+        for table in tables:
+            item_rows = table.findall('.//tr[@class="summary-item-row"]')
+            assert len(item_rows) == 2
 
-                # test that the file names and urls are right
-                for row in item_rows:
-                    section, filename, ext = files.pop(0)
-                    filename_link = row.find('.//a[@class="document-link-with-icon"]')
+            # test that the file names and urls are right
+            for row in item_rows:
+                section, filename, ext = files.pop(0)
+                filename_link = row.find('.//a[@class="document-link-with-icon"]')
 
-                    assert filename in filename_link.text_content()
-                    assert filename_link.get('href') == '/suppliers/frameworks/g-cloud-7/files/{}{}.{}'.format(
-                        section,
-                        filename.replace(' ', '%20'),
-                        ext,
-                    )
+                assert filename in filename_link.text_content()
+                assert filename_link.get('href') == '/suppliers/frameworks/g-cloud-7/files/{}{}.{}'.format(
+                    section,
+                    filename.replace(' ', '%20'),
+                    ext,
+                )
 
     def test_names_with_the_section_name_in_them_will_display_correctly(self, s3, data_api_client):
         data_api_client.get_framework.return_value = self.framework('open')
@@ -3729,73 +3638,69 @@ class TestFrameworkUpdatesPage(BaseApplicationTest):
             ) for section, filename, ext in files
         ]
 
-        with self.app.test_client():
-            self.login()
+        self.login()
 
-            response = self.client.get(
-                '/suppliers/frameworks/g-cloud-7/updates'
-            )
-            doc = html.fromstring(response.get_data(as_text=True))
-            self._assert_page_title_and_table_headings(doc)
+        response = self.client.get(
+            '/suppliers/frameworks/g-cloud-7/updates'
+        )
+        doc = html.fromstring(response.get_data(as_text=True))
+        self._assert_page_title_and_table_headings(doc)
 
-            tables = doc.xpath('//div[contains(@class, "updates-document-tables")]/table')
+        tables = doc.xpath('//div[contains(@class, "updates-document-tables")]/table')
 
-            # test that for each table, we have the right number of rows
-            for table in tables:
-                item_rows = table.findall('.//tr[@class="summary-item-row"]')
-                assert len(item_rows) == 1
+        # test that for each table, we have the right number of rows
+        for table in tables:
+            item_rows = table.findall('.//tr[@class="summary-item-row"]')
+            assert len(item_rows) == 1
 
-                # test that the file names and urls are right
-                for row in item_rows:
-                    section, filename, ext = files.pop(0)
-                    filename_link = row.find('.//a[@class="document-link-with-icon"]')
+            # test that the file names and urls are right
+            for row in item_rows:
+                section, filename, ext = files.pop(0)
+                filename_link = row.find('.//a[@class="document-link-with-icon"]')
 
-                    assert filename in filename_link.text_content()
-                    assert filename_link.get('href') == '/suppliers/frameworks/g-cloud-7/files/{}{}.{}'.format(
-                        section,
-                        filename.replace(' ', '%20'),
-                        ext,
-                    )
+                assert filename in filename_link.text_content()
+                assert filename_link.get('href') == '/suppliers/frameworks/g-cloud-7/files/{}{}.{}'.format(
+                    section,
+                    filename.replace(' ', '%20'),
+                    ext,
+                )
 
     def test_question_box_is_shown_if_countersigned_agreement_is_not_yet_returned(self, s3, data_api_client):
         data_api_client.get_framework.return_value = self.framework('live', clarification_questions_open=False)
         data_api_client.get_supplier_framework_info.return_value = self.supplier_framework()
 
-        with self.app.test_client():
-            self.login()
+        self.login()
 
-            response = self.client.get('/suppliers/frameworks/g-cloud-7/updates')
-            data = response.get_data(as_text=True)
+        response = self.client.get('/suppliers/frameworks/g-cloud-7/updates')
+        data = response.get_data(as_text=True)
 
-            assert response.status_code == 200
-            assert u'Ask a question about your G-Cloud 7 application' in data
+        assert response.status_code == 200
+        assert u'Ask a question about your G-Cloud 7 application' in data
 
     def test_no_question_box_shown_if_countersigned_agreement_is_returned(self, s3, data_api_client):
         data_api_client.get_framework.return_value = self.framework('live', clarification_questions_open=False)
         data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(countersigned_path="path")
 
-        with self.app.test_client():
-            self.login()
+        self.login()
 
-            response = self.client.get('/suppliers/frameworks/g-cloud-7/updates')
-            data = response.get_data(as_text=True)
+        response = self.client.get('/suppliers/frameworks/g-cloud-7/updates')
+        data = response.get_data(as_text=True)
 
-            assert response.status_code == 200
-            assert u'Ask a question about your G-Cloud 7 application' not in data
+        assert response.status_code == 200
+        assert u'Ask a question about your G-Cloud 7 application' not in data
 
 
 class TestSendClarificationQuestionEmail(BaseApplicationTest):
 
     def _send_email(self, clarification_question):
-        with self.app.test_client():
-            self.login()
+        self.login()
 
-            return self.client.post(
-                "/suppliers/frameworks/g-cloud-7/updates",
-                data={
-                    'clarification_question': clarification_question,
-                }
-            )
+        return self.client.post(
+            "/suppliers/frameworks/g-cloud-7/updates",
+            data={
+                'clarification_question': clarification_question,
+            }
+        )
 
     def _assert_clarification_email(self, send_email, is_called=True, succeeds=True):
 
@@ -3966,8 +3871,7 @@ class TestSendClarificationQuestionEmail(BaseApplicationTest):
 class TestG7ServicesList(BaseApplicationTest):
 
     def test_404_when_g7_pending_and_no_complete_services(self, count_unanswered, data_api_client):
-        with self.app.test_client():
-            self.login()
+        self.login()
         data_api_client.get_framework.return_value = self.framework(status='pending')
         data_api_client.find_draft_services.return_value = {'services': []}
         count_unanswered.return_value = 0
@@ -3975,8 +3879,7 @@ class TestG7ServicesList(BaseApplicationTest):
         assert response.status_code == 404
 
     def test_404_when_g7_pending_and_no_declaration(self, count_unanswered, data_api_client):
-        with self.app.test_client():
-            self.login()
+        self.login()
         data_api_client.get_framework.return_value = self.framework(status='pending')
         data_api_client.get_supplier_declaration.return_value = {
             "declaration": {"status": "started"}
@@ -3985,8 +3888,7 @@ class TestG7ServicesList(BaseApplicationTest):
         assert response.status_code == 404
 
     def test_no_404_when_g7_open_and_no_complete_services(self, count_unanswered, data_api_client):
-        with self.app.test_client():
-            self.login()
+        self.login()
         data_api_client.get_framework.return_value = self.framework(status='open')
         data_api_client.find_draft_services.return_value = {'services': []}
         count_unanswered.return_value = 0
@@ -3994,8 +3896,7 @@ class TestG7ServicesList(BaseApplicationTest):
         assert response.status_code == 200
 
     def test_no_404_when_g7_open_and_no_declaration(self, count_unanswered, data_api_client):
-        with self.app.test_client():
-            self.login()
+        self.login()
 
         data_api_client.get_framework.return_value = self.framework(status='open')
         data_api_client.get_supplier_declaration.return_value = {
@@ -4005,8 +3906,7 @@ class TestG7ServicesList(BaseApplicationTest):
         assert response.status_code == 200
 
     def test_shows_g7_message_if_pending_and_application_made(self, count_unanswered, data_api_client):
-        with self.app.test_client():
-            self.login()
+        self.login()
         data_api_client.get_framework.return_value = self.framework(status='pending')
         data_api_client.get_supplier_declaration.return_value = {'declaration': FULL_G7_SUBMISSION}  # noqa
         data_api_client.find_draft_services.return_value = {
@@ -4032,8 +3932,7 @@ class TestG7ServicesList(BaseApplicationTest):
         )
 
     def test_drafts_list_progress_count(self, count_unanswered, data_api_client):
-        with self.app.test_client():
-            self.login()
+        self.login()
 
         count_unanswered.return_value = 3, 1
         data_api_client.get_framework.return_value = self.framework(status='open')
@@ -4053,8 +3952,7 @@ class TestG7ServicesList(BaseApplicationTest):
         assert u'complete service' not in submissions.get_data(as_text=True)
 
     def test_drafts_list_can_be_completed(self, count_unanswered, data_api_client):
-        with self.app.test_client():
-            self.login()
+        self.login()
 
         count_unanswered.return_value = 0, 1
 
@@ -4072,8 +3970,7 @@ class TestG7ServicesList(BaseApplicationTest):
 
     @pytest.mark.parametrize("incomplete_declaration", ({}, {"status": "started"},))
     def test_drafts_list_completed(self, count_unanswered, data_api_client, incomplete_declaration):
-        with self.app.test_client():
-            self.login()
+        self.login()
 
         count_unanswered.return_value = 0, 1
 
@@ -4109,8 +4006,7 @@ class TestG7ServicesList(BaseApplicationTest):
             )
 
     def test_drafts_list_completed_with_declaration_status(self, count_unanswered, data_api_client):
-        with self.app.test_client():
-            self.login()
+        self.login()
 
         data_api_client.get_framework.return_value = self.framework(status='open')
         data_api_client.get_supplier_declaration.return_value = {
@@ -4137,8 +4033,7 @@ class TestG7ServicesList(BaseApplicationTest):
         )
 
     def test_drafts_list_services_were_submitted(self, count_unanswered, data_api_client):
-        with self.app.test_client():
-            self.login()
+        self.login()
 
         data_api_client.get_framework.return_value = self.framework(status='standstill')
         data_api_client.get_supplier_declaration.return_value = {
@@ -4158,8 +4053,7 @@ class TestG7ServicesList(BaseApplicationTest):
         assert u'1 complete service was submitted' in submissions.get_data(as_text=True)
 
     def test_dos_drafts_list_with_open_framework(self, count_unanswered, data_api_client):
-        with self.app.test_client():
-            self.login()
+        self.login()
 
         data_api_client.get_framework.return_value = self.framework(slug='digital-outcomes-and-specialists',
                                                                     status='open')
@@ -4187,8 +4081,7 @@ class TestG7ServicesList(BaseApplicationTest):
         )
 
     def test_dos_drafts_list_with_closed_framework(self, count_unanswered, data_api_client):
-        with self.app.test_client():
-            self.login()
+        self.login()
 
         data_api_client.get_framework.return_value = self.framework(slug="digital-outcomes-and-specialists",
                                                                     status='pending')
@@ -4214,44 +4107,41 @@ class TestG7ServicesList(BaseApplicationTest):
 @mock.patch('app.main.views.frameworks.data_api_client', autospec=True)
 class TestCreateFrameworkAgreement(BaseApplicationTest):
     def test_creates_framework_agreement_and_redirects_to_signer_details_page(self, data_api_client):
-        with self.app.test_client():
-            self.login()
+        self.login()
 
-            data_api_client.get_framework.return_value = self.framework(
-                slug='g-cloud-8', status='standstill', framework_agreement_version="1.0"
-            )
-            data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
-                on_framework=True)
-            data_api_client.create_framework_agreement.return_value = {"agreement": {"id": 789}}
+        data_api_client.get_framework.return_value = self.framework(
+            slug='g-cloud-8', status='standstill', framework_agreement_version="1.0"
+        )
+        data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
+            on_framework=True)
+        data_api_client.create_framework_agreement.return_value = {"agreement": {"id": 789}}
 
-            res = self.client.post("/suppliers/frameworks/g-cloud-8/create-agreement")
+        res = self.client.post("/suppliers/frameworks/g-cloud-8/create-agreement")
 
-            data_api_client.create_framework_agreement.assert_called_once_with(1234, 'g-cloud-8', 'email@email.com')
-            assert res.status_code == 302
-            assert res.location == 'http://localhost/suppliers/frameworks/g-cloud-8/789/signer-details'
+        data_api_client.create_framework_agreement.assert_called_once_with(1234, 'g-cloud-8', 'email@email.com')
+        assert res.status_code == 302
+        assert res.location == 'http://localhost/suppliers/frameworks/g-cloud-8/789/signer-details'
 
     def test_404_if_supplier_not_on_framework(self, data_api_client):
-        with self.app.test_client():
-            self.login()
+        self.login()
 
-            data_api_client.get_framework.return_value = self.framework(status='standstill')
+        data_api_client.get_framework.return_value = self.framework(status='standstill')
+        data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
+            on_framework=False)
+
+        res = self.client.post("/suppliers/frameworks/g-cloud-8/create-agreement")
+        assert res.status_code == 404
+
+    def test_404_if_framework_in_wrong_state(self, data_api_client):
+        self.login()
+        # Suppliers can only sign agreements in 'standstill' and 'live' lifecycle statuses
+        for status in ('coming', 'open', 'pending', 'expired'):
+            data_api_client.get_framework.return_value = self.framework(status=status)
             data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
-                on_framework=False)
+                on_framework=True)
 
             res = self.client.post("/suppliers/frameworks/g-cloud-8/create-agreement")
             assert res.status_code == 404
-
-    def test_404_if_framework_in_wrong_state(self, data_api_client):
-        with self.app.test_client():
-            self.login()
-            # Suppliers can only sign agreements in 'standstill' and 'live' lifecycle statuses
-            for status in ('coming', 'open', 'pending', 'expired'):
-                data_api_client.get_framework.return_value = self.framework(status=status)
-                data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
-                    on_framework=True)
-
-                res = self.client.post("/suppliers/frameworks/g-cloud-8/create-agreement")
-                assert res.status_code == 404
 
 
 @mock.patch("app.main.views.frameworks.data_api_client", autospec=True)
@@ -4420,20 +4310,19 @@ class TestSignerDetailsPage(BaseApplicationTest):
         supplier_framework = self.supplier_framework(framework_slug='g-cloud-8', on_framework=True)['frameworkInterest']
         return_supplier_framework.return_value = supplier_framework
 
-        with self.client as c:
-            self.login()
-            res = c.post(
-                "/suppliers/frameworks/g-cloud-8/234/signer-details",
-                data=signer_details
-            )
+        self.login()
+        res = self.client.post(
+            "/suppliers/frameworks/g-cloud-8/234/signer-details",
+            data=signer_details
+        )
 
-            assert res.status_code == 302
-            assert "suppliers/frameworks/g-cloud-8/234/signature-upload" in res.location
-            data_api_client.update_framework_agreement.assert_called_with(
-                234,
-                {'signedAgreementDetails': {'signerName': 'Josh Moss', 'signerRole': 'The Boss'}},
-                'email@email.com'
-            )
+        assert res.status_code == 302
+        assert "suppliers/frameworks/g-cloud-8/234/signature-upload" in res.location
+        data_api_client.update_framework_agreement.assert_called_with(
+            234,
+            {'signedAgreementDetails': {'signerName': 'Josh Moss', 'signerRole': 'The Boss'}},
+            'email@email.com'
+        )
 
     def test_provide_signer_details_form_with_valid_input_redirects_to_contract_review_page_if_file_already_uploaded(
             self, return_supplier_framework, data_api_client
@@ -4451,25 +4340,24 @@ class TestSignerDetailsPage(BaseApplicationTest):
         supplier_framework = self.supplier_framework(framework_slug='g-cloud-8', on_framework=True)['frameworkInterest']
         return_supplier_framework.return_value = supplier_framework
 
-        with self.client as c:
-            self.login()
+        self.login()
 
-            with self.client.session_transaction() as sess:
-                # An already uploaded file will also have set a filename in the session
-                sess['signature_page'] = 'test.pdf'
+        with self.client.session_transaction() as sess:
+            # An already uploaded file will also have set a filename in the session
+            sess['signature_page'] = 'test.pdf'
 
-            res = c.post(
-                "/suppliers/frameworks/g-cloud-8/234/signer-details",
-                data=signer_details
-            )
+        res = self.client.post(
+            "/suppliers/frameworks/g-cloud-8/234/signer-details",
+            data=signer_details
+        )
 
-            assert res.status_code == 302
-            assert "suppliers/frameworks/g-cloud-8/234/contract-review" in res.location
-            data_api_client.update_framework_agreement.assert_called_with(
-                234,
-                {'signedAgreementDetails': {'signerName': 'Josh Moss', 'signerRole': 'The Boss'}},
-                'email@email.com'
-            )
+        assert res.status_code == 302
+        assert "suppliers/frameworks/g-cloud-8/234/contract-review" in res.location
+        data_api_client.update_framework_agreement.assert_called_with(
+            234,
+            {'signedAgreementDetails': {'signerName': 'Josh Moss', 'signerRole': 'The Boss'}},
+            'email@email.com'
+        )
 
     def test_signer_details_form_redirects_to_signature_upload_page_if_file_in_session_but_no_signed_agreement_path(
             self, return_supplier_framework, data_api_client
@@ -4486,21 +4374,20 @@ class TestSignerDetailsPage(BaseApplicationTest):
         supplier_framework = self.supplier_framework(framework_slug='g-cloud-8', on_framework=True)['frameworkInterest']
         return_supplier_framework.return_value = supplier_framework
 
-        with self.client as c:
-            self.login()
+        self.login()
 
-            with self.client.session_transaction() as sess:
-                # We set a file name that could be from a previous framework agreement signing attempt but this
-                # agreement does not have a signedAgreementPath
-                sess['signature_page'] = 'test.pdf'
+        with self.client.session_transaction() as sess:
+            # We set a file name that could be from a previous framework agreement signing attempt but this
+            # agreement does not have a signedAgreementPath
+            sess['signature_page'] = 'test.pdf'
 
-            res = c.post(
-                "/suppliers/frameworks/g-cloud-8/234/signer-details",
-                data=signer_details
-            )
+        res = self.client.post(
+            "/suppliers/frameworks/g-cloud-8/234/signer-details",
+            data=signer_details
+        )
 
-            assert res.status_code == 302
-            assert "suppliers/frameworks/g-cloud-8/234/signature-upload" in res.location
+        assert res.status_code == 302
+        assert "suppliers/frameworks/g-cloud-8/234/signature-upload" in res.location
 
 
 @mock.patch("app.main.views.frameworks.data_api_client", autospec=True)
@@ -4584,170 +4471,161 @@ class TestSignatureUploadPage(BaseApplicationTest):
     def test_signature_upload_returns_400_if_file_is_empty(
         self, file_is_empty, s3, return_supplier_framework, data_api_client
     ):
-        with self.app.test_client():
-            self.login()
+        self.login()
 
-            data_api_client.get_framework.return_value = get_g_cloud_8()
-            data_api_client.get_framework_agreement.return_value = self.framework_agreement()
-            return_supplier_framework.return_value = self.supplier_framework(
-                framework_slug='g-cloud-8',
-                on_framework=True
-            )['frameworkInterest']
-            s3.return_value.get_key.return_value = None
-            file_is_empty.return_value = True
+        data_api_client.get_framework.return_value = get_g_cloud_8()
+        data_api_client.get_framework_agreement.return_value = self.framework_agreement()
+        return_supplier_framework.return_value = self.supplier_framework(
+            framework_slug='g-cloud-8',
+            on_framework=True
+        )['frameworkInterest']
+        s3.return_value.get_key.return_value = None
+        file_is_empty.return_value = True
 
-            res = self.client.post(
-                '/suppliers/frameworks/g-cloud-8/234/signature-upload',
-                data={
-                    'signature_page': (StringIO(b''), 'test.pdf'),
-                }
-            )
+        res = self.client.post(
+            '/suppliers/frameworks/g-cloud-8/234/signature-upload',
+            data={
+                'signature_page': (StringIO(b''), 'test.pdf'),
+            }
+        )
 
-            assert res.status_code == 400
-            assert 'The file must not be empty' in res.get_data(as_text=True)
+        assert res.status_code == 400
+        assert 'The file must not be empty' in res.get_data(as_text=True)
 
     @mock.patch('dmutils.s3.S3')
     @mock.patch('app.main.views.frameworks.file_is_image')
     def test_signature_upload_returns_400_if_file_is_not_image_or_pdf(
         self, file_is_image, s3, return_supplier_framework, data_api_client
     ):
-        with self.app.test_client():
-            self.login()
+        self.login()
 
-            data_api_client.get_framework.return_value = get_g_cloud_8()
-            data_api_client.get_framework_agreement.return_value = self.framework_agreement()
-            return_supplier_framework.return_value = self.supplier_framework(
-                framework_slug='g-cloud-8',
-                on_framework=True
-            )['frameworkInterest']
-            s3.return_value.get_key.return_value = None
-            file_is_image.return_value = False
+        data_api_client.get_framework.return_value = get_g_cloud_8()
+        data_api_client.get_framework_agreement.return_value = self.framework_agreement()
+        return_supplier_framework.return_value = self.supplier_framework(
+            framework_slug='g-cloud-8',
+            on_framework=True
+        )['frameworkInterest']
+        s3.return_value.get_key.return_value = None
+        file_is_image.return_value = False
 
-            res = self.client.post(
-                '/suppliers/frameworks/g-cloud-8/234/signature-upload',
-                data={
-                    'signature_page': (StringIO(b'asdf'), 'test.txt'),
-                }
-            )
+        res = self.client.post(
+            '/suppliers/frameworks/g-cloud-8/234/signature-upload',
+            data={
+                'signature_page': (StringIO(b'asdf'), 'test.txt'),
+            }
+        )
 
-            assert res.status_code == 400
-            assert 'The file must be a PDF, JPG or PNG' in res.get_data(as_text=True)
+        assert res.status_code == 400
+        assert 'The file must be a PDF, JPG or PNG' in res.get_data(as_text=True)
 
     @mock.patch('dmutils.s3.S3')
     @mock.patch('app.main.views.frameworks.file_is_less_than_5mb')
     def test_signature_upload_returns_400_if_file_is_larger_than_5mb(
         self, file_is_less_than_5mb, s3, return_supplier_framework, data_api_client
     ):
-        with self.app.test_client():
-            self.login()
+        self.login()
 
-            data_api_client.get_framework.return_value = get_g_cloud_8()
-            data_api_client.get_framework_agreement.return_value = self.framework_agreement()
-            return_supplier_framework.return_value = self.supplier_framework(
-                framework_slug='g-cloud-8',
-                on_framework=True
-            )['frameworkInterest']
-            s3.return_value.get_key.return_value = None
-            file_is_less_than_5mb.return_value = False
+        data_api_client.get_framework.return_value = get_g_cloud_8()
+        data_api_client.get_framework_agreement.return_value = self.framework_agreement()
+        return_supplier_framework.return_value = self.supplier_framework(
+            framework_slug='g-cloud-8',
+            on_framework=True
+        )['frameworkInterest']
+        s3.return_value.get_key.return_value = None
+        file_is_less_than_5mb.return_value = False
 
-            res = self.client.post(
-                '/suppliers/frameworks/g-cloud-8/234/signature-upload',
-                data={
-                    'signature_page': (StringIO(b'asdf'), 'test.jpg'),
-                }
-            )
+        res = self.client.post(
+            '/suppliers/frameworks/g-cloud-8/234/signature-upload',
+            data={
+                'signature_page': (StringIO(b'asdf'), 'test.jpg'),
+            }
+        )
 
-            assert res.status_code == 400
-            assert 'The file must be less than 5MB' in res.get_data(as_text=True)
+        assert res.status_code == 400
+        assert 'The file must be less than 5MB' in res.get_data(as_text=True)
 
     @mock.patch('dmutils.s3.S3')
     def test_signature_page_displays_uploaded_filename_and_timestamp(
         self, s3, return_supplier_framework, data_api_client
     ):
-        with self.app.test_client():
-            data_api_client.get_framework.return_value = get_g_cloud_8()
-            data_api_client.get_framework_agreement.return_value = self.framework_agreement(
-                signed_agreement_path='already/uploaded/file/path.pdf'
-            )
-            return_supplier_framework.return_value = self.supplier_framework(
-                framework_slug='g-cloud-8',
-                on_framework=True
-            )['frameworkInterest']
+        data_api_client.get_framework.return_value = get_g_cloud_8()
+        data_api_client.get_framework_agreement.return_value = self.framework_agreement(
+            signed_agreement_path='already/uploaded/file/path.pdf'
+        )
+        return_supplier_framework.return_value = self.supplier_framework(
+            framework_slug='g-cloud-8',
+            on_framework=True
+        )['frameworkInterest']
 
-            s3.return_value.get_key.return_value = {
-                'last_modified': '2016-07-10T21:18:00.000000Z'
-            }
+        s3.return_value.get_key.return_value = {
+            'last_modified': '2016-07-10T21:18:00.000000Z'
+        }
 
-            with self.client as c:
-                self.login()
+        self.login()
 
-                with self.client.session_transaction() as sess:
-                    sess['signature_page'] = 'test.pdf'
+        with self.client.session_transaction() as sess:
+            sess['signature_page'] = 'test.pdf'
 
-                res = c.get(
-                    '/suppliers/frameworks/g-cloud-8/234/signature-upload'
-                )
+        res = self.client.get(
+            '/suppliers/frameworks/g-cloud-8/234/signature-upload'
+        )
 
-                s3.return_value.get_key.assert_called_with('already/uploaded/file/path.pdf')
-                assert res.status_code == 200
-                assert "test.pdf, uploaded Sunday 10 July 2016 at 10:18pm" in res.get_data(as_text=True)
+        s3.return_value.get_key.assert_called_with('already/uploaded/file/path.pdf')
+        assert res.status_code == 200
+        assert "test.pdf, uploaded Sunday 10 July 2016 at 10:18pm" in res.get_data(as_text=True)
 
     @mock.patch('dmutils.s3.S3')
     def test_signature_page_displays_file_upload_timestamp_if_no_filename_in_session(
             self, s3, return_supplier_framework, data_api_client
     ):
-        with self.app.test_client():
-            data_api_client.get_framework.return_value = get_g_cloud_8()
-            data_api_client.get_framework_agreement.return_value = self.framework_agreement(
-                signed_agreement_path='already/uploaded/file/path.pdf'
-            )
-            return_supplier_framework.return_value = self.supplier_framework(
-                framework_slug='g-cloud-8',
-                on_framework=True
-            )['frameworkInterest']
+        data_api_client.get_framework.return_value = get_g_cloud_8()
+        data_api_client.get_framework_agreement.return_value = self.framework_agreement(
+            signed_agreement_path='already/uploaded/file/path.pdf'
+        )
+        return_supplier_framework.return_value = self.supplier_framework(
+            framework_slug='g-cloud-8',
+            on_framework=True
+        )['frameworkInterest']
 
-            s3.return_value.get_key.return_value = {
-                'last_modified': '2016-07-10T21:18:00.000000Z'
-            }
+        s3.return_value.get_key.return_value = {
+            'last_modified': '2016-07-10T21:18:00.000000Z'
+        }
 
-            with self.client as c:
-                self.login()
-                res = c.get(
-                    '/suppliers/frameworks/g-cloud-8/234/signature-upload'
-                )
-                s3.return_value.get_key.assert_called_with('already/uploaded/file/path.pdf')
-                assert res.status_code == 200
-                assert "Uploaded Sunday 10 July 2016 at 10:18pm" in res.get_data(as_text=True)
+        self.login()
+        res = self.client.get(
+            '/suppliers/frameworks/g-cloud-8/234/signature-upload'
+        )
+        s3.return_value.get_key.assert_called_with('already/uploaded/file/path.pdf')
+        assert res.status_code == 200
+        assert "Uploaded Sunday 10 July 2016 at 10:18pm" in res.get_data(as_text=True)
 
     @mock.patch('dmutils.s3.S3')
     def test_signature_page_allows_continuation_without_file_chosen_to_be_uploaded_if_an_uploaded_file_already_exists(
             self, s3, return_supplier_framework, data_api_client
     ):
-        with self.app.test_client():
-            data_api_client.get_framework.return_value = get_g_cloud_8()
-            data_api_client.get_framework_agreement.return_value = self.framework_agreement(
-                signed_agreement_path='already/uploaded/file/path.pdf'
-            )
-            return_supplier_framework.return_value = self.supplier_framework(
-                framework_slug='g-cloud-8',
-                on_framework=True
-            )['frameworkInterest']
+        data_api_client.get_framework.return_value = get_g_cloud_8()
+        data_api_client.get_framework_agreement.return_value = self.framework_agreement(
+            signed_agreement_path='already/uploaded/file/path.pdf'
+        )
+        return_supplier_framework.return_value = self.supplier_framework(
+            framework_slug='g-cloud-8',
+            on_framework=True
+        )['frameworkInterest']
 
-            s3.return_value.get_key.return_value = {
-                'last_modified': '2016-07-10T21:18:00.000000Z'
+        s3.return_value.get_key.return_value = {
+            'last_modified': '2016-07-10T21:18:00.000000Z'
+        }
+
+        self.login()
+        res = self.client.post(
+            '/suppliers/frameworks/g-cloud-8/234/signature-upload',
+            data={
+                'signature_page': (StringIO(b''), ''),
             }
-
-            with self.client as c:
-                self.login()
-                res = c.post(
-                    '/suppliers/frameworks/g-cloud-8/234/signature-upload',
-                    data={
-                        'signature_page': (StringIO(b''), ''),
-                    }
-                )
-                s3.return_value.get_key.assert_called_with('already/uploaded/file/path.pdf')
-                assert res.status_code == 302
-                assert res.location == 'http://localhost/suppliers/frameworks/g-cloud-8/234/contract-review'
+        )
+        s3.return_value.get_key.assert_called_with('already/uploaded/file/path.pdf')
+        assert res.status_code == 302
+        assert res.location == 'http://localhost/suppliers/frameworks/g-cloud-8/234/contract-review'
 
 
 @mock.patch("app.main.views.frameworks.data_api_client")
@@ -4758,104 +4636,101 @@ class TestContractReviewPage(BaseApplicationTest):
     def test_contract_review_page_loads_with_correct_supplier_and_signer_details_and_filename(
         self, s3, return_supplier_framework, data_api_client
     ):
-        with self.app.test_client():
-            self.login()
-            data_api_client.get_framework.return_value = get_g_cloud_8()
-            return_supplier_framework.return_value = self.supplier_framework(
-                framework_slug='g-cloud-8',
-                on_framework=True,
-                declaration={
-                    "primaryContact": "contact name",
-                    "primaryContactEmail": "email@email.com",
-                    "nameOfOrganisation": u"£unicodename"
-                },
-            )['frameworkInterest']
-            data_api_client.get_framework_agreement.return_value = self.framework_agreement(
-                signed_agreement_details={"signerName": "signer_name", "signerRole": "signer_role"},
-                signed_agreement_path="I/have/returned/my/agreement.pdf"
-            )
-            s3.return_value.get_key.return_value = {
-                'last_modified': '2016-07-10T21:18:00.000000Z'
-            }
+        self.login()
+        data_api_client.get_framework.return_value = get_g_cloud_8()
+        return_supplier_framework.return_value = self.supplier_framework(
+            framework_slug='g-cloud-8',
+            on_framework=True,
+            declaration={
+                "primaryContact": "contact name",
+                "primaryContactEmail": "email@email.com",
+                "nameOfOrganisation": u"£unicodename"
+            },
+        )['frameworkInterest']
+        data_api_client.get_framework_agreement.return_value = self.framework_agreement(
+            signed_agreement_details={"signerName": "signer_name", "signerRole": "signer_role"},
+            signed_agreement_path="I/have/returned/my/agreement.pdf"
+        )
+        s3.return_value.get_key.return_value = {
+            'last_modified': '2016-07-10T21:18:00.000000Z'
+        }
 
-            with self.client.session_transaction() as sess:
-                sess['signature_page'] = 'test.pdf'
+        with self.client.session_transaction() as sess:
+            sess['signature_page'] = 'test.pdf'
 
-            res = self.client.get(
-                "/suppliers/frameworks/g-cloud-8/234/contract-review"
-            )
-            assert res.status_code == 200
-            s3.return_value.get_key.assert_called_with('I/have/returned/my/agreement.pdf')
-            page = res.get_data(as_text=True)
-            page_without_whitespace = self.strip_all_whitespace(page)
-            assert u'Check the details you’ve given before returning the signature page for £unicodename' in page
-            assert '<tdclass="summary-item-field"><span><p>signer_name</p><p>signer_role</p></span></td>' \
-                in page_without_whitespace
-            assert u"I have the authority to return this agreement on behalf of £unicodename" in page
-            assert "Returning the signature page will notify the Crown Commercial Service and the primary contact you "
-            "gave in your G-Cloud 8 application, contact name at email@email.com." in page
-            assert '<tdclass="summary-item-field-first"><span>test.pdf</span></td>' in page_without_whitespace
+        res = self.client.get(
+            "/suppliers/frameworks/g-cloud-8/234/contract-review"
+        )
+        assert res.status_code == 200
+        s3.return_value.get_key.assert_called_with('I/have/returned/my/agreement.pdf')
+        page = res.get_data(as_text=True)
+        page_without_whitespace = self.strip_all_whitespace(page)
+        assert u'Check the details you’ve given before returning the signature page for £unicodename' in page
+        assert '<tdclass="summary-item-field"><span><p>signer_name</p><p>signer_role</p></span></td>' \
+            in page_without_whitespace
+        assert u"I have the authority to return this agreement on behalf of £unicodename" in page
+        assert "Returning the signature page will notify the Crown Commercial Service and the primary contact you "
+        "gave in your G-Cloud 8 application, contact name at email@email.com." in page
+        assert '<tdclass="summary-item-field-first"><span>test.pdf</span></td>' in page_without_whitespace
 
     @mock.patch('dmutils.s3.S3')
     def test_contract_review_page_loads_with_uploaded_time_of_file_if_no_filename_in_session(
             self, s3, return_supplier_framework, data_api_client
     ):
-        with self.app.test_client():
-            self.login()
-            data_api_client.get_framework.return_value = get_g_cloud_8()
-            return_supplier_framework.return_value = self.supplier_framework(
-                framework_slug='g-cloud-8',
-                on_framework=True,
-                declaration={
-                    "primaryContact": "contact name",
-                    "primaryContactEmail": "email@email.com",
-                    "nameOfOrganisation": u"£unicodename"
-                },
-            )['frameworkInterest']
-            data_api_client.get_framework_agreement.return_value = self.framework_agreement(
-                signed_agreement_details={"signerName": "signer_name", "signerRole": "signer_role"},
-                signed_agreement_path="I/have/returned/my/agreement.pdf"
-            )
-            s3.return_value.get_key.return_value = {
-                'last_modified': '2016-07-10T21:18:00.000000Z'
-            }
+        self.login()
+        data_api_client.get_framework.return_value = get_g_cloud_8()
+        return_supplier_framework.return_value = self.supplier_framework(
+            framework_slug='g-cloud-8',
+            on_framework=True,
+            declaration={
+                "primaryContact": "contact name",
+                "primaryContactEmail": "email@email.com",
+                "nameOfOrganisation": u"£unicodename"
+            },
+        )['frameworkInterest']
+        data_api_client.get_framework_agreement.return_value = self.framework_agreement(
+            signed_agreement_details={"signerName": "signer_name", "signerRole": "signer_role"},
+            signed_agreement_path="I/have/returned/my/agreement.pdf"
+        )
+        s3.return_value.get_key.return_value = {
+            'last_modified': '2016-07-10T21:18:00.000000Z'
+        }
 
-            res = self.client.get(
-                "/suppliers/frameworks/g-cloud-8/234/contract-review"
-            )
-            assert res.status_code == 200
-            page = res.get_data(as_text=True)
-            assert u'Check the details you’ve given before returning the signature page for £unicodename' in page
-            assert '<tdclass="summary-item-field-first"><span>UploadedSunday10July2016at10:18pm</span></td>' in self.strip_all_whitespace(page)  # noqa
+        res = self.client.get(
+            "/suppliers/frameworks/g-cloud-8/234/contract-review"
+        )
+        assert res.status_code == 200
+        page = res.get_data(as_text=True)
+        assert u'Check the details you’ve given before returning the signature page for £unicodename' in page
+        assert '<tdclass="summary-item-field-first"><span>UploadedSunday10July2016at10:18pm</span></td>' in self.strip_all_whitespace(page)  # noqa
 
     @mock.patch('dmutils.s3.S3')
     def test_contract_review_page_aborts_if_visited_when_information_required_to_return_agreement_does_not_exist(
         self, s3, return_supplier_framework, data_api_client
     ):
-        with self.app.test_client():
-            self.login()
-            data_api_client.get_framework.return_value = get_g_cloud_8()
-            return_supplier_framework.return_value = self.supplier_framework(
-                framework_slug='g-cloud-8',
-                on_framework=True,
-                declaration={
-                    "primaryContact": "contact name",
-                    "primaryContactEmail": "email@email.com",
-                    "nameOfOrganisation": u"£unicodename"
-                },
-            )['frameworkInterest']
-            data_api_client.get_framework_agreement.return_value = self.framework_agreement(
-                signed_agreement_details={"signerName": "signer_name", "signerRole": "signer_role"}
-                # No file has been uploaded
-            )
+        self.login()
+        data_api_client.get_framework.return_value = get_g_cloud_8()
+        return_supplier_framework.return_value = self.supplier_framework(
+            framework_slug='g-cloud-8',
+            on_framework=True,
+            declaration={
+                "primaryContact": "contact name",
+                "primaryContactEmail": "email@email.com",
+                "nameOfOrganisation": u"£unicodename"
+            },
+        )['frameworkInterest']
+        data_api_client.get_framework_agreement.return_value = self.framework_agreement(
+            signed_agreement_details={"signerName": "signer_name", "signerRole": "signer_role"}
+            # No file has been uploaded
+        )
 
-            # no file has been uploaded
-            s3.return_value.get_key.return_value = None
+        # no file has been uploaded
+        s3.return_value.get_key.return_value = None
 
-            res = self.client.get(
-                "/suppliers/frameworks/g-cloud-8/234/contract-review"
-            )
-            assert res.status_code == 404
+        res = self.client.get(
+            "/suppliers/frameworks/g-cloud-8/234/contract-review"
+        )
+        assert res.status_code == 404
 
     @mock.patch('app.main.views.frameworks.check_agreement_is_related_to_supplier_framework_or_abort')
     @mock.patch('dmutils.s3.S3')
@@ -4881,375 +4756,366 @@ class TestContractReviewPage(BaseApplicationTest):
     def test_return_400_response_and_no_email_sent_if_authorisation_not_checked(
             self, send_email, s3, return_supplier_framework, data_api_client
     ):
-        with self.app.test_client():
-            self.login()
-            data_api_client.get_framework.return_value = get_g_cloud_8()
-            return_supplier_framework.return_value = self.supplier_framework(
-                framework_slug='g-cloud-8',
-                on_framework=True,
-                declaration={
-                    "primaryContact": "contact name",
-                    "primaryContactEmail": "email@email.com",
-                    "nameOfOrganisation": u"£unicodename"
-                },
-            )['frameworkInterest']
-            data_api_client.get_framework_agreement.return_value = self.framework_agreement(
-                signed_agreement_details={"signerName": "signer_name", "signerRole": "signer_role"},
-                signed_agreement_path="I/have/returned/my/agreement.pdf"
-            )
-            s3.return_value.get_key.return_value = {
-                'last_modified': '2016-07-10T21:18:00.000000Z'
-            }
+        self.login()
+        data_api_client.get_framework.return_value = get_g_cloud_8()
+        return_supplier_framework.return_value = self.supplier_framework(
+            framework_slug='g-cloud-8',
+            on_framework=True,
+            declaration={
+                "primaryContact": "contact name",
+                "primaryContactEmail": "email@email.com",
+                "nameOfOrganisation": u"£unicodename"
+            },
+        )['frameworkInterest']
+        data_api_client.get_framework_agreement.return_value = self.framework_agreement(
+            signed_agreement_details={"signerName": "signer_name", "signerRole": "signer_role"},
+            signed_agreement_path="I/have/returned/my/agreement.pdf"
+        )
+        s3.return_value.get_key.return_value = {
+            'last_modified': '2016-07-10T21:18:00.000000Z'
+        }
 
-            res = self.client.post(
-                "/suppliers/frameworks/g-cloud-8/234/contract-review",
-                data={}
-            )
-            assert res.status_code == 400
-            page = res.get_data(as_text=True)
-            assert send_email.called is False
-            assert "You must confirm you have the authority to return the agreement" in page
+        res = self.client.post(
+            "/suppliers/frameworks/g-cloud-8/234/contract-review",
+            data={}
+        )
+        assert res.status_code == 400
+        page = res.get_data(as_text=True)
+        assert send_email.called is False
+        assert "You must confirm you have the authority to return the agreement" in page
 
     @mock.patch('dmutils.s3.S3')
     @mock.patch('app.main.views.frameworks.send_email')
     def test_valid_framework_agreement_returned_updates_api_and_sends_confirmation_emails_and_unsets_session(
         self, send_email, s3, return_supplier_framework, data_api_client
     ):
-        with self.app.test_client():
-            self.login()
-            data_api_client.get_framework.return_value = get_g_cloud_8()
-            return_supplier_framework.return_value = self.supplier_framework(
-                framework_slug='g-cloud-8',
-                on_framework=True,
-                declaration={
-                    "primaryContact": "contact name",
-                    "primaryContactEmail": "email2@email.com",
-                    "nameOfOrganisation": u"£unicodename"
-                },
-            )['frameworkInterest']
-            data_api_client.get_framework_agreement.return_value = self.framework_agreement(
-                signed_agreement_details={"signerName": "signer_name", "signerRole": "signer_role"},
-                signed_agreement_path="I/have/returned/my/agreement.pdf"
-            )
-            s3.return_value.get_key.return_value = {
-                'last_modified': '2016-07-10T21:18:00.000000Z'
+        self.login()
+        data_api_client.get_framework.return_value = get_g_cloud_8()
+        return_supplier_framework.return_value = self.supplier_framework(
+            framework_slug='g-cloud-8',
+            on_framework=True,
+            declaration={
+                "primaryContact": "contact name",
+                "primaryContactEmail": "email2@email.com",
+                "nameOfOrganisation": u"£unicodename"
+            },
+        )['frameworkInterest']
+        data_api_client.get_framework_agreement.return_value = self.framework_agreement(
+            signed_agreement_details={"signerName": "signer_name", "signerRole": "signer_role"},
+            signed_agreement_path="I/have/returned/my/agreement.pdf"
+        )
+        s3.return_value.get_key.return_value = {
+            'last_modified': '2016-07-10T21:18:00.000000Z'
+        }
+
+        with self.client.session_transaction() as sess:
+            sess['signature_page'] = 'test.pdf'
+
+        self.client.post(
+            "/suppliers/frameworks/g-cloud-8/234/contract-review",
+            data={
+                'authorisation': 'I have the authority to return this agreement on behalf of company name'
             }
+        )
 
-            with self.client.session_transaction() as sess:
-                sess['signature_page'] = 'test.pdf'
+        data_api_client.sign_framework_agreement.assert_called_once_with(
+            234,
+            'email@email.com',
+            {'uploaderUserId': 123}
+        )
 
-            self.client.post(
-                "/suppliers/frameworks/g-cloud-8/234/contract-review",
-                data={
-                    'authorisation': 'I have the authority to return this agreement on behalf of company name'
-                }
-            )
+        # Delcaration primaryContactEmail and current_user.email_address are different so expect two recipients
+        send_email.assert_called_once_with(
+            ['email2@email.com', 'email@email.com'],
+            mock.ANY,
+            'MANDRILL',
+            'Your G-Cloud 8 signature page has been received',
+            'do-not-reply@digitalmarketplace.service.gov.uk',
+            'Digital Marketplace Admin',
+            ['g-cloud-8-framework-agreement']
+        )
 
-            data_api_client.sign_framework_agreement.assert_called_once_with(
-                234,
-                'email@email.com',
-                {'uploaderUserId': 123}
-            )
-
-            # Delcaration primaryContactEmail and current_user.email_address are different so expect two recipients
-            send_email.assert_called_once_with(
-                ['email2@email.com', 'email@email.com'],
-                mock.ANY,
-                'MANDRILL',
-                'Your G-Cloud 8 signature page has been received',
-                'do-not-reply@digitalmarketplace.service.gov.uk',
-                'Digital Marketplace Admin',
-                ['g-cloud-8-framework-agreement']
-            )
-
-            # Check 'signature_page' has been removed from session
-            with self.client.session_transaction() as sess:
-                assert 'signature_page' not in sess
+        # Check 'signature_page' has been removed from session
+        with self.client.session_transaction() as sess:
+            assert 'signature_page' not in sess
 
     @mock.patch('dmutils.s3.S3')
     @mock.patch('app.main.views.frameworks.send_email')
     def test_valid_framework_agreement_returned_sends_only_one_confirmation_email_if_contact_email_addresses_are_equal(
         self, send_email, s3, return_supplier_framework, data_api_client
     ):
-        with self.app.test_client():
-            self.login()
-            data_api_client.get_framework.return_value = get_g_cloud_8()
-            return_supplier_framework.return_value = self.supplier_framework(
-                framework_slug='g-cloud-8',
-                on_framework=True,
-                declaration={
-                    "primaryContact": "contact name",
-                    "primaryContactEmail": "email@email.com",
-                    "nameOfOrganisation": u"£unicodename"
-                },
-            )['frameworkInterest']
-            data_api_client.get_framework_agreement.return_value = self.framework_agreement(
-                signed_agreement_details={"signerName": "signer_name", "signerRole": "signer_role"},
-                signed_agreement_path="I/have/returned/my/agreement.pdf"
-            )
-            s3.return_value.get_key.return_value = {
-                'last_modified': '2016-07-10T21:18:00.000000Z'
+        self.login()
+        data_api_client.get_framework.return_value = get_g_cloud_8()
+        return_supplier_framework.return_value = self.supplier_framework(
+            framework_slug='g-cloud-8',
+            on_framework=True,
+            declaration={
+                "primaryContact": "contact name",
+                "primaryContactEmail": "email@email.com",
+                "nameOfOrganisation": u"£unicodename"
+            },
+        )['frameworkInterest']
+        data_api_client.get_framework_agreement.return_value = self.framework_agreement(
+            signed_agreement_details={"signerName": "signer_name", "signerRole": "signer_role"},
+            signed_agreement_path="I/have/returned/my/agreement.pdf"
+        )
+        s3.return_value.get_key.return_value = {
+            'last_modified': '2016-07-10T21:18:00.000000Z'
+        }
+
+        self.client.post(
+            "/suppliers/frameworks/g-cloud-8/234/contract-review",
+            data={
+                'authorisation': 'I have the authority to return this agreement on behalf of company name'
             }
+        )
 
-            self.client.post(
-                "/suppliers/frameworks/g-cloud-8/234/contract-review",
-                data={
-                    'authorisation': 'I have the authority to return this agreement on behalf of company name'
-                }
-            )
-
-            send_email.assert_called_once_with(
-                ['email@email.com'],
-                mock.ANY,
-                'MANDRILL',
-                'Your G-Cloud 8 signature page has been received',
-                'do-not-reply@digitalmarketplace.service.gov.uk',
-                'Digital Marketplace Admin',
-                ['g-cloud-8-framework-agreement']
-            )
+        send_email.assert_called_once_with(
+            ['email@email.com'],
+            mock.ANY,
+            'MANDRILL',
+            'Your G-Cloud 8 signature page has been received',
+            'do-not-reply@digitalmarketplace.service.gov.uk',
+            'Digital Marketplace Admin',
+            ['g-cloud-8-framework-agreement']
+        )
 
     @mock.patch('dmutils.s3.S3')
     @mock.patch('app.main.views.frameworks.send_email')
     def test_return_503_response_if_mandrill_exception_raised_by_send_email(
             self, send_email, s3, return_supplier_framework, data_api_client
     ):
-        with self.app.test_client():
-            self.login()
-            data_api_client.get_framework.return_value = get_g_cloud_8()
-            return_supplier_framework.return_value = self.supplier_framework(
-                framework_slug='g-cloud-8',
-                on_framework=True,
-                declaration={
-                    "primaryContact": "contact name",
-                    "primaryContactEmail": "email@email.com",
-                    "nameOfOrganisation": u"£unicodename"
-                },
-            )['frameworkInterest']
-            data_api_client.get_framework_agreement.return_value = self.framework_agreement(
-                signed_agreement_details={"signerName": "signer_name", "signerRole": "signer_role"},
-                signed_agreement_path="I/have/returned/my/agreement.pdf"
-            )
-            s3.return_value.get_key.return_value = {
-                'last_modified': '2016-07-10T21:18:00.000000Z'
+        self.login()
+        data_api_client.get_framework.return_value = get_g_cloud_8()
+        return_supplier_framework.return_value = self.supplier_framework(
+            framework_slug='g-cloud-8',
+            on_framework=True,
+            declaration={
+                "primaryContact": "contact name",
+                "primaryContactEmail": "email@email.com",
+                "nameOfOrganisation": u"£unicodename"
+            },
+        )['frameworkInterest']
+        data_api_client.get_framework_agreement.return_value = self.framework_agreement(
+            signed_agreement_details={"signerName": "signer_name", "signerRole": "signer_role"},
+            signed_agreement_path="I/have/returned/my/agreement.pdf"
+        )
+        s3.return_value.get_key.return_value = {
+            'last_modified': '2016-07-10T21:18:00.000000Z'
+        }
+
+        send_email.side_effect = EmailError()
+
+        res = self.client.post(
+            "/suppliers/frameworks/g-cloud-8/234/contract-review",
+            data={
+                'authorisation': 'I have the authority to return this agreement on behalf of company name'
             }
+        )
 
-            send_email.side_effect = EmailError()
-
-            res = self.client.post(
-                "/suppliers/frameworks/g-cloud-8/234/contract-review",
-                data={
-                    'authorisation': 'I have the authority to return this agreement on behalf of company name'
-                }
-            )
-
-            assert res.status_code == 503
+        assert res.status_code == 503
 
     @mock.patch('dmutils.s3.S3')
     @mock.patch('app.main.views.frameworks.send_email')
     def test_email_not_sent_if_api_call_fails(
             self, send_email, s3, return_supplier_framework, data_api_client
     ):
-        with self.app.test_client():
-            self.login()
-            data_api_client.get_framework.return_value = get_g_cloud_8()
-            data_api_client.sign_framework_agreement.side_effect = APIError(mock.Mock(status_code=500))
-            return_supplier_framework.return_value = self.supplier_framework(
-                framework_slug='g-cloud-8',
-                on_framework=True,
-                declaration={
-                    "primaryContact": "contact name",
-                    "primaryContactEmail": "email@email.com",
-                    "nameOfOrganisation": u"£unicodename"
-                },
-            )['frameworkInterest']
-            data_api_client.get_framework_agreement.return_value = self.framework_agreement(
-                signed_agreement_details={"signerName": "signer_name", "signerRole": "signer_role"},
-                signed_agreement_path="I/have/returned/my/agreement.pdf"
-            )
-            s3.return_value.get_key.return_value = {
-                'last_modified': '2016-07-10T21:18:00.000000Z'
+        self.login()
+        data_api_client.get_framework.return_value = get_g_cloud_8()
+        data_api_client.sign_framework_agreement.side_effect = APIError(mock.Mock(status_code=500))
+        return_supplier_framework.return_value = self.supplier_framework(
+            framework_slug='g-cloud-8',
+            on_framework=True,
+            declaration={
+                "primaryContact": "contact name",
+                "primaryContactEmail": "email@email.com",
+                "nameOfOrganisation": u"£unicodename"
+            },
+        )['frameworkInterest']
+        data_api_client.get_framework_agreement.return_value = self.framework_agreement(
+            signed_agreement_details={"signerName": "signer_name", "signerRole": "signer_role"},
+            signed_agreement_path="I/have/returned/my/agreement.pdf"
+        )
+        s3.return_value.get_key.return_value = {
+            'last_modified': '2016-07-10T21:18:00.000000Z'
+        }
+
+        res = self.client.post(
+            "/suppliers/frameworks/g-cloud-8/234/contract-review",
+            data={
+                'authorisation': 'I have the authority to return this agreement on behalf of company name'
             }
+        )
 
-            res = self.client.post(
-                "/suppliers/frameworks/g-cloud-8/234/contract-review",
-                data={
-                    'authorisation': 'I have the authority to return this agreement on behalf of company name'
-                }
-            )
-
-            assert data_api_client.sign_framework_agreement.called is True
-            assert res.status_code == 500
-            assert send_email.called is False
+        assert data_api_client.sign_framework_agreement.called is True
+        assert res.status_code == 500
+        assert send_email.called is False
 
     @mock.patch('dmutils.s3.S3')
     @mock.patch('app.main.views.frameworks.send_email')
     def test_framework_agreement_returned_having_signed_contract_variation_redirects_to_framework_dashboard(
         self, send_email, s3, return_supplier_framework, data_api_client
     ):
-        with self.app.test_client():
-            self.login()
+        self.login()
 
-            framework = get_g_cloud_8()
-            framework['variations'] = {
-                "1": {"createdAt": "2016-06-06T20:01:34.000000Z"}
-            }
-            data_api_client.get_framework.return_value = framework
-            return_supplier_framework.return_value = self.supplier_framework(
-                framework_slug='g-cloud-8',
-                on_framework=True,
-                declaration={
-                    "primaryContact": "contact name",
-                    "primaryContactEmail": "email2@email.com",
-                    "nameOfOrganisation": u"£unicodename"
-                },
-                agreed_variations={
-                    '1': {
-                        "agreedUserId": 2,
-                        "agreedAt": "2016-06-06T00:00:00.000000Z",
-                    }
+        framework = get_g_cloud_8()
+        framework['variations'] = {
+            "1": {"createdAt": "2016-06-06T20:01:34.000000Z"}
+        }
+        data_api_client.get_framework.return_value = framework
+        return_supplier_framework.return_value = self.supplier_framework(
+            framework_slug='g-cloud-8',
+            on_framework=True,
+            declaration={
+                "primaryContact": "contact name",
+                "primaryContactEmail": "email2@email.com",
+                "nameOfOrganisation": u"£unicodename"
+            },
+            agreed_variations={
+                '1': {
+                    "agreedUserId": 2,
+                    "agreedAt": "2016-06-06T00:00:00.000000Z",
                 }
-            )['frameworkInterest']
-            data_api_client.get_framework_agreement.return_value = self.framework_agreement(
-                signed_agreement_details={"signerName": "signer_name", "signerRole": "signer_role"},
-                signed_agreement_path="I/have/returned/my/agreement.pdf"
-            )
-
-            s3.return_value.get_key.return_value = {
-                'last_modified': '2016-07-10T21:18:00.000000Z'
             }
+        )['frameworkInterest']
+        data_api_client.get_framework_agreement.return_value = self.framework_agreement(
+            signed_agreement_details={"signerName": "signer_name", "signerRole": "signer_role"},
+            signed_agreement_path="I/have/returned/my/agreement.pdf"
+        )
 
-            res = self.client.post(
-                "/suppliers/frameworks/g-cloud-8/234/contract-review",
-                data={
-                    'authorisation': 'I have the authority to return this agreement on behalf of company name'
-                }
-            )
+        s3.return_value.get_key.return_value = {
+            'last_modified': '2016-07-10T21:18:00.000000Z'
+        }
 
-            assert res.status_code == 302
-            assert res.location == 'http://localhost/suppliers/frameworks/g-cloud-8'
+        res = self.client.post(
+            "/suppliers/frameworks/g-cloud-8/234/contract-review",
+            data={
+                'authorisation': 'I have the authority to return this agreement on behalf of company name'
+            }
+        )
+
+        assert res.status_code == 302
+        assert res.location == 'http://localhost/suppliers/frameworks/g-cloud-8'
 
     @mock.patch('dmutils.s3.S3')
     @mock.patch('app.main.views.frameworks.send_email')
     def test_framework_agreement_returned_with_feature_flag_off_redirects_to_framework_dashboard(
         self, send_email, s3, return_supplier_framework, data_api_client
     ):
-        with self.app.test_client():
-            self.login()
-            self.app.config['FEATURE_FLAGS_CONTRACT_VARIATION'] = False
+        self.login()
+        self.app.config['FEATURE_FLAGS_CONTRACT_VARIATION'] = False
 
-            framework = get_g_cloud_8()
-            framework['frameworks']['variations'] = {
-                "1": {"createdAt": "2016-06-06T20:01:34.000000Z"}
+        framework = get_g_cloud_8()
+        framework['frameworks']['variations'] = {
+            "1": {"createdAt": "2016-06-06T20:01:34.000000Z"}
+        }
+        data_api_client.get_framework.return_value = framework
+        return_supplier_framework.return_value = self.supplier_framework(
+            framework_slug='g-cloud-8',
+            on_framework=True,
+            declaration={
+                "primaryContact": "contact name",
+                "primaryContactEmail": "email@email.com",
+                "nameOfOrganisation": u"£unicodename"
+            },
+        )['frameworkInterest']
+        data_api_client.get_framework_agreement.return_value = self.framework_agreement(
+            signed_agreement_details={"signerName": "signer_name", "signerRole": "signer_role"},
+            signed_agreement_path="I/have/returned/my/agreement.pdf"
+        )
+
+        s3.return_value.get_key.return_value = {
+            'last_modified': '2016-07-10T21:18:00.000000Z'
+        }
+
+        res = self.client.post(
+            "/suppliers/frameworks/g-cloud-8/234/contract-review",
+            data={
+                'authorisation': 'I have the authority to return this agreement on behalf of company name'
             }
-            data_api_client.get_framework.return_value = framework
-            return_supplier_framework.return_value = self.supplier_framework(
-                framework_slug='g-cloud-8',
-                on_framework=True,
-                declaration={
-                    "primaryContact": "contact name",
-                    "primaryContactEmail": "email@email.com",
-                    "nameOfOrganisation": u"£unicodename"
-                },
-            )['frameworkInterest']
-            data_api_client.get_framework_agreement.return_value = self.framework_agreement(
-                signed_agreement_details={"signerName": "signer_name", "signerRole": "signer_role"},
-                signed_agreement_path="I/have/returned/my/agreement.pdf"
-            )
+        )
 
-            s3.return_value.get_key.return_value = {
-                'last_modified': '2016-07-10T21:18:00.000000Z'
-            }
-
-            res = self.client.post(
-                "/suppliers/frameworks/g-cloud-8/234/contract-review",
-                data={
-                    'authorisation': 'I have the authority to return this agreement on behalf of company name'
-                }
-            )
-
-            assert res.status_code == 302
-            assert res.location == 'http://localhost/suppliers/frameworks/g-cloud-8'
+        assert res.status_code == 302
+        assert res.location == 'http://localhost/suppliers/frameworks/g-cloud-8'
 
     @mock.patch('dmutils.s3.S3')
     @mock.patch('app.main.views.frameworks.send_email')
     def test_framework_agreement_returned_having_not_signed_contract_variation_redirects_to_variation(
         self, send_email, s3, return_supplier_framework, data_api_client
     ):
-        with self.app.test_client():
-            self.login()
+        self.login()
 
-            framework = get_g_cloud_8()
-            framework['frameworks']['variations'] = {
-                "1": {"createdAt": "2016-06-06T20:01:34.000000Z"}
+        framework = get_g_cloud_8()
+        framework['frameworks']['variations'] = {
+            "1": {"createdAt": "2016-06-06T20:01:34.000000Z"}
+        }
+        data_api_client.get_framework.return_value = framework
+        return_supplier_framework.return_value = self.supplier_framework(
+            framework_slug='g-cloud-8',
+            on_framework=True,
+            declaration={
+                "primaryContact": "contact name",
+                "primaryContactEmail": "email2@email.com",
+                "nameOfOrganisation": u"£unicodename"
+            },
+            agreed_variations={}
+        )['frameworkInterest']
+        data_api_client.get_framework_agreement.return_value = self.framework_agreement(
+            signed_agreement_details={"signerName": "signer_name", "signerRole": "signer_role"},
+            signed_agreement_path="I/have/returned/my/agreement.pdf"
+        )
+
+        s3.return_value.get_key.return_value = {
+            'last_modified': '2016-07-10T21:18:00.000000Z'
+        }
+
+        res = self.client.post(
+            "/suppliers/frameworks/g-cloud-8/234/contract-review",
+            data={
+                'authorisation': 'I have the authority to return this agreement on behalf of company name'
             }
-            data_api_client.get_framework.return_value = framework
-            return_supplier_framework.return_value = self.supplier_framework(
-                framework_slug='g-cloud-8',
-                on_framework=True,
-                declaration={
-                    "primaryContact": "contact name",
-                    "primaryContactEmail": "email2@email.com",
-                    "nameOfOrganisation": u"£unicodename"
-                },
-                agreed_variations={}
-            )['frameworkInterest']
-            data_api_client.get_framework_agreement.return_value = self.framework_agreement(
-                signed_agreement_details={"signerName": "signer_name", "signerRole": "signer_role"},
-                signed_agreement_path="I/have/returned/my/agreement.pdf"
-            )
-
-            s3.return_value.get_key.return_value = {
-                'last_modified': '2016-07-10T21:18:00.000000Z'
-            }
-
-            res = self.client.post(
-                "/suppliers/frameworks/g-cloud-8/234/contract-review",
-                data={
-                    'authorisation': 'I have the authority to return this agreement on behalf of company name'
-                }
-            )
-            assert res.status_code == 302
-            assert res.location == 'http://localhost/suppliers/frameworks/g-cloud-8/contract-variation/1'
+        )
+        assert res.status_code == 302
+        assert res.location == 'http://localhost/suppliers/frameworks/g-cloud-8/contract-variation/1'
 
     @mock.patch('dmutils.s3.S3')
     @mock.patch('app.main.views.frameworks.send_email')
     def test_framework_agreement_returned_for_framework_with_no_variations_redirects_to_framework_dashboard(
         self, send_email, s3, return_supplier_framework, data_api_client
     ):
-        with self.app.test_client():
-            self.login()
+        self.login()
 
-            framework = get_g_cloud_8()
-            framework['variations'] = {}
-            data_api_client.get_framework.return_value = framework
+        framework = get_g_cloud_8()
+        framework['variations'] = {}
+        data_api_client.get_framework.return_value = framework
 
-            return_supplier_framework.return_value = self.supplier_framework(
-                framework_slug='g-cloud-8',
-                on_framework=True,
-                declaration={
-                    "primaryContact": "contact name",
-                    "primaryContactEmail": "email@email.com",
-                    "nameOfOrganisation": u"£unicodename"
-                },
-            )['frameworkInterest']
-            data_api_client.get_framework_agreement.return_value = self.framework_agreement(
-                signed_agreement_details={"signerName": "signer_name", "signerRole": "signer_role"},
-                signed_agreement_path="I/have/returned/my/agreement.pdf"
-            )
+        return_supplier_framework.return_value = self.supplier_framework(
+            framework_slug='g-cloud-8',
+            on_framework=True,
+            declaration={
+                "primaryContact": "contact name",
+                "primaryContactEmail": "email@email.com",
+                "nameOfOrganisation": u"£unicodename"
+            },
+        )['frameworkInterest']
+        data_api_client.get_framework_agreement.return_value = self.framework_agreement(
+            signed_agreement_details={"signerName": "signer_name", "signerRole": "signer_role"},
+            signed_agreement_path="I/have/returned/my/agreement.pdf"
+        )
 
-            s3.return_value.get_key.return_value = {
-                'last_modified': '2016-07-10T21:18:00.000000Z'
+        s3.return_value.get_key.return_value = {
+            'last_modified': '2016-07-10T21:18:00.000000Z'
+        }
+
+        res = self.client.post(
+            "/suppliers/frameworks/g-cloud-8/234/contract-review",
+            data={
+                'authorisation': 'I have the authority to return this agreement on behalf of company name'
             }
+        )
 
-            res = self.client.post(
-                "/suppliers/frameworks/g-cloud-8/234/contract-review",
-                data={
-                    'authorisation': 'I have the authority to return this agreement on behalf of company name'
-                }
-            )
-
-            assert res.status_code == 302
-            assert res.location == 'http://localhost/suppliers/frameworks/g-cloud-8'
+        assert res.status_code == 302
+        assert res.location == 'http://localhost/suppliers/frameworks/g-cloud-8'
 
 
 @mock.patch('app.main.views.frameworks.data_api_client', autospec=True)
@@ -5273,8 +5139,7 @@ class TestContractVariation(BaseApplicationTest):
         )
         self.g8_framework['frameworks']['variations'] = {"1": {"createdAt": "2018-08-16"}}
 
-        with self.app.test_client():
-            self.login()
+        self.login()
 
     def test_get_page_renders_if_all_ok(self, data_api_client):
         data_api_client.get_framework.return_value = self.g8_framework
@@ -5487,8 +5352,7 @@ class TestReuseFrameworkSupplierDeclaration(BaseApplicationTest):
 
     def setup_method(self, method):
         super(TestReuseFrameworkSupplierDeclaration, self).setup_method(method)
-        with self.app.test_client():
-            self.login()
+        self.login()
 
     def test_reusable_declaration_framework_slug_param(self, data_api_client):
         """Ensure that when using the param to specify declaration we collect the correct declaration."""
@@ -5511,7 +5375,6 @@ class TestReuseFrameworkSupplierDeclaration(BaseApplicationTest):
         resp = self.client.get(
             '/suppliers/frameworks/g-cloud-9/declaration/reuse?reusable_declaration_framework_slug=g-cloud-8'
         )
-
         # Assert response OK.
         assert resp.status_code == 200
 
@@ -5555,13 +5418,12 @@ class TestReuseFrameworkSupplierDeclaration(BaseApplicationTest):
         )
 
         # Do the get.
-        with self.client:
-            resp = self.client.get(
-                '/suppliers/frameworks/g-cloud-9/declaration/reuse',
-            )
+        resp = self.client.get(
+            '/suppliers/frameworks/g-cloud-9/declaration/reuse',
+        )
 
-            # Assert the redirect
-            assert resp.location.endswith('/suppliers/frameworks/g-cloud-9/declaration')
+        # Assert the redirect
+        assert resp.location.endswith('/suppliers/frameworks/g-cloud-9/declaration')
 
         # Assert expected api calls.
         data_api_client.get_framework.assert_called_once_with('g-cloud-9')
@@ -5640,20 +5502,18 @@ class TestReuseFrameworkSupplierDeclarationPost(BaseApplicationTest):
 
     def setup_method(self, method):
         super(TestReuseFrameworkSupplierDeclarationPost, self).setup_method(method)
-        with self.app.test_client():
-            self.login()
+        self.login()
 
     def test_reuse_false(self, data_api_client):
         """Assert that the redirect happens and the client sets the prefill pref to None."""
         data = {'reuse': 'False', 'old_framework_slug': 'should-not-be-used'}
-        with self.client:
-            resp = self.client.post(
-                '/suppliers/frameworks/g-cloud-9/declaration/reuse',
-                data=data
-            )
+        resp = self.client.post(
+            '/suppliers/frameworks/g-cloud-9/declaration/reuse',
+            data=data
+        )
 
-            # Assert the redirect
-            assert resp.location.endswith('/suppliers/frameworks/g-cloud-9/declaration')
+        # Assert the redirect
+        assert resp.location.endswith('/suppliers/frameworks/g-cloud-9/declaration')
 
         data_api_client.set_supplier_framework_prefill_declaration.assert_called_once_with(
             1234,
@@ -5676,14 +5536,13 @@ class TestReuseFrameworkSupplierDeclarationPost(BaseApplicationTest):
         framework_response = {'frameworks': {'x_field': 'foo', 'allowDeclarationReuse': True}}
         data_api_client.get_framework.return_value = framework_response
 
-        with self.client:
-            resp = self.client.post(
-                '/suppliers/frameworks/g-cloud-9/declaration/reuse',
-                data=data
-            )
+        resp = self.client.post(
+            '/suppliers/frameworks/g-cloud-9/declaration/reuse',
+            data=data
+        )
 
-            # Assert the redirect
-            assert resp.location.endswith('/suppliers/frameworks/g-cloud-9/declaration')
+        # Assert the redirect
+        assert resp.location.endswith('/suppliers/frameworks/g-cloud-9/declaration')
 
         # These api calls need to be made so that we can verify the declaration.
         data_api_client.get_framework.assert_called_once_with('digital-outcomes-and-specialists-2')


### PR DESCRIPTION
These calls are, and always have been as far as I can tell, unnecessary.

I guess they are some sort of copy-paste artefact.

_The only changes in this PR are removing the `with self.app.test_client()` calls and sorting out the indenting_

This makes the test more readable and easier to maintain.