### PR TITLE
Improve documentation around custom form macros found in this app

### DIFF
--- a/app/main/helpers/frameworks.py
+++ b/app/main/helpers/frameworks.py
@@ -154,6 +154,16 @@ def return_supplier_framework_info_if_on_framework_or_abort(data_api_client, fra
 
 
 def question_references(data, get_question):
+    """
+    Replace placeholders for question references with the number of the referenced question
+
+    e.g. "This is my question hint which references question [[anotherQuestion]]" becomes
+    "This is my question hint which references question 7"
+
+    :param data: Object to have placeholders replaced for example a string or Markup object
+    :param get_question: ContentManifest.get_question function
+    :return: Object with same type of original `data` object but with question references replaced
+    """
     if not data:
         return data
     references = re.sub(

--- a/app/templates/macros/toolkit_forms.html
+++ b/app/templates/macros/toolkit_forms.html
@@ -22,7 +22,6 @@
   {{ upstream_forms.list(question_content, service_data, errors,
     error=errors.get(question_content.id)['message']|question_references(kwargs.get_question),
     hint=(question_content.hint or '')|question_references(kwargs.get_question),
-    number_of_items=10,
     question=question_content.question|question_references(kwargs.get_question),
     **kwargs
   ) }}

--- a/app/templates/macros/toolkit_forms.html
+++ b/app/templates/macros/toolkit_forms.html
@@ -40,7 +40,6 @@
   {{ upstream_forms.radios(question_content, service_data, errors,
     error=errors.get(question_content.id)['message']|question_references(kwargs.get_question),
     hint=(question_content.hint or '')|question_references(kwargs.get_question),
-    hint_underneath=(question_content.hint_underneath or False),
     question=question_content.question|question_references(kwargs.get_question),
     **kwargs
   ) }}

--- a/app/templates/macros/toolkit_forms.html
+++ b/app/templates/macros/toolkit_forms.html
@@ -1,3 +1,18 @@
+{#
+The following form macros extend on top of of the macros found in the front end toolkit so we can support additional
+functionality needed for forms for applying for a framework.
+
+Because questions for the supplier framework declaration form have hints, questions and errors that are supposed to
+reference the numbers of other questions, after we get the manifest (which allows us to know the number for each
+question) from the content loader, we must replace the placeholders for question references with their corresponding
+question number. This is done using the `question_references` helper. This behaviour does not seem to be needed for any
+of our other forms. Note, it may be an idea in the future to move this functionality into the content loader as it
+doesn't feel quite right being at the templating level.
+
+So we can format the value of a form upload to be a 'pretty' datetime string for file uploads for editing a service, we
+set a custom filter on its value.
+#}
+
 {% import "toolkit/forms/macros/forms.html" as upstream_forms %}
 
 {% macro text(question_content, service_data, errors) -%}

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -3,6 +3,7 @@ try:
     from StringIO import StringIO
 except ImportError:
     from io import BytesIO as StringIO
+from datetime import datetime
 
 from dmapiclient import HTTPError
 import copy
@@ -12,6 +13,7 @@ import pytest
 from lxml import html
 from freezegun import freeze_time
 
+from app.main.helpers.services import parse_document_upload_time
 from tests.app.helpers import BaseApplicationTest, empty_g7_draft_service, empty_g9_draft_service
 
 
@@ -2279,3 +2281,9 @@ class TestSubmissionDocuments(BaseApplicationTest):
         )
 
         assert res.status_code == 404
+
+
+class TestParseDocumentUploadTime(BaseApplicationTest):
+    def test_parses_document_upload_time(self):
+        file_url = "http://www.address.com/g-cloud-9/submissions/92352/70419-terms-and-conditions-2018-01-23-1103.pdf"
+        assert parse_document_upload_time(file_url) == datetime(2018, 1, 23, 11, 3)


### PR DESCRIPTION
https://trello.com/c/iaRQlj6y/87-toolkit-forms-macros-are-different-in-all-of-the-apps

I originally was hoping to remove the custom `toolkit_forms` macros file from this repo so that instead it could just use the the macros found in the FE toolkit so we had consistency between the apps. However upon on review, we have functionality in this app that relies on these custom macros (question references being parsed for declaration questions and nice date values on file uploads for service editing).

There were however a few small things that I could tidy up
- removed two lines of code from the toolkit_forms macros that were having no effects
- Improved documentation
- Added test coverage

Current behaviour for upload time:
![image](https://user-images.githubusercontent.com/7228605/35279916-6b70bf02-0046-11e8-8abd-c55c39080903.png)

Behaviour that would have been changed if we used the toolkit macros rather than the app macros.
![image](https://user-images.githubusercontent.com/7228605/35279907-64c1f13a-0046-11e8-956f-7f319a8e9fbd.png)

