### PR TITLE
Pull in latest utils

### DIFF
--- a/app/main/__init__.py
+++ b/app/main/__init__.py
@@ -1,4 +1,5 @@
 from flask import Blueprint
+
 from dmcontent.content_loader import ContentLoader
 
 main = Blueprint('main', __name__)

--- a/app/main/errors.py
+++ b/app/main/errors.py
@@ -1,12 +1,12 @@
-try:
-    from urllib import quote_plus
-except ImportError:
-    from urllib.parse import quote_plus
+from urllib.parse import quote_plus
+
 from flask import redirect, render_template, request
-from app.main import main
+
 from dmapiclient import APIError
-from dmutils.s3 import S3ResponseError
 from dmcontent.content_loader import QuestionNotFoundError
+from dmutils.s3 import S3ResponseError
+
+from app.main import main
 
 
 @main.app_errorhandler(APIError)

--- a/app/main/forms/auth_forms.py
+++ b/app/main/forms/auth_forms.py
@@ -1,6 +1,7 @@
 from flask.ext.wtf import Form
 from wtforms import PasswordField
 from wtforms.validators import DataRequired, Regexp, EqualTo, Length
+
 from dmutils.forms import StripWhitespaceStringField
 
 

--- a/app/main/forms/auth_forms.py
+++ b/app/main/forms/auth_forms.py
@@ -1,4 +1,4 @@
-from flask.ext.wtf import Form
+from flask_wtf import Form
 from wtforms import PasswordField
 from wtforms.validators import DataRequired, Regexp, EqualTo, Length
 

--- a/app/main/forms/frameworks.py
+++ b/app/main/forms/frameworks.py
@@ -1,6 +1,7 @@
 from flask.ext.wtf import Form
 from wtforms import BooleanField, HiddenField
 from wtforms.validators import DataRequired, InputRequired, Length
+
 from dmutils.forms import StripWhitespaceStringField
 
 

--- a/app/main/forms/frameworks.py
+++ b/app/main/forms/frameworks.py
@@ -1,4 +1,4 @@
-from flask.ext.wtf import Form
+from flask_wtf import Form
 from wtforms import BooleanField, HiddenField
 from wtforms.validators import DataRequired, InputRequired, Length
 

--- a/app/main/forms/suppliers.py
+++ b/app/main/forms/suppliers.py
@@ -1,6 +1,7 @@
 from flask.ext.wtf import Form
 from wtforms import IntegerField
 from wtforms.validators import DataRequired, ValidationError, Length, Optional, Regexp
+
 from dmutils.forms import StripWhitespaceStringField, EmailField, EmailValidator
 
 

--- a/app/main/forms/suppliers.py
+++ b/app/main/forms/suppliers.py
@@ -1,4 +1,4 @@
-from flask.ext.wtf import Form
+from flask_wtf import Form
 from wtforms import IntegerField
 from wtforms.validators import DataRequired, ValidationError, Length, Optional, Regexp
 

--- a/app/main/helpers/__init__.py
+++ b/app/main/helpers/__init__.py
@@ -1,10 +1,10 @@
 import base64
-import hashlib
-import flask_login
-
 from datetime import datetime
 from functools import wraps
+import hashlib
+
 from flask import current_app, flash
+import flask_login
 
 
 def login_required(func):

--- a/app/main/helpers/frameworks.py
+++ b/app/main/helpers/frameworks.py
@@ -1,12 +1,13 @@
 # -*- coding: utf-8 -*-
-import re
 from datetime import datetime
 from itertools import chain, islice, groupby
+import re
 
-from dmutils.formats import DATETIME_FORMAT
 from flask import abort
 from flask_login import current_user
+
 from dmapiclient import APIError
+from dmutils.formats import DATETIME_FORMAT
 
 
 def get_framework_or_404(client, framework_slug, allowed_statuses=None):

--- a/app/main/helpers/frameworks.py
+++ b/app/main/helpers/frameworks.py
@@ -59,12 +59,13 @@ def register_interest_in_framework(client, framework_slug):
 
 def get_last_modified_from_first_matching_file(key_list, framework_slug, prefix):
     """
-    Takes a list of file keys and a string.
-    Returns the 'last_modified' timestamp for first file whose path starts with the passed-in string,
+    Takes a list of file keys, a framework slug and a string that is a whole or start of a filename.
+    Returns the 'last_modified' timestamp for first file whose path starts with the framework slug and passed-in string,
     or None if no matching file is found.
 
     :param key_list: list of file keys (from an s3 bucket)
-    :param path_starts_with: check for file paths which start with this string
+    :param framework_slug: the framework that we're looking up a document for (this is the first part of the file path)
+    :param prefix: the first part of the filename to match (this could also be the complete filename for an exact match)
     :return: the timestamp of the first matching file key or None
     """
     path_starts_with = '{}/{}'.format(framework_slug, prefix)

--- a/app/main/helpers/services.py
+++ b/app/main/helpers/services.py
@@ -1,14 +1,11 @@
-import re
 from datetime import datetime
+import re
+import urllib.parse as urlparse
+
 from flask import abort, current_app
 from flask_login import current_user
 
 from dmapiclient import APIError
-
-try:
-    import urlparse
-except ImportError:
-    import urllib.parse as urlparse
 
 
 def get_drafts(apiclient, framework_slug):

--- a/app/main/helpers/validation.py
+++ b/app/main/helpers/validation.py
@@ -1,6 +1,7 @@
 from functools import reduce
 from operator import add
 import re
+
 from werkzeug.datastructures import ImmutableOrderedMultiDict
 
 EMAIL_REGEX = r'^[^@^\s]+@[^@^\.^\s]+(\.[^@^\.^\s]+)+$'

--- a/app/main/helpers/validation.py
+++ b/app/main/helpers/validation.py
@@ -1,7 +1,6 @@
 from functools import reduce
 from operator import add
 import re
-import six
 from werkzeug.datastructures import ImmutableOrderedMultiDict
 
 EMAIL_REGEX = r'^[^@^\s]+@[^@^\.^\s]+(\.[^@^\.^\s]+)+$'
@@ -67,7 +66,7 @@ class DeclarationValidator(object):
 
     def fields_with_values(self):
         return set(key for key, value in self.answers.items()
-                   if value is not None and (not isinstance(value, six.string_types) or len(value) > 0))
+                   if value is not None and (not isinstance(value, str) or len(value) > 0))
 
     def errors(self):
         errors_map = {}

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -7,7 +7,6 @@ from dmapiclient import HTTPError
 from flask import render_template, request, abort, flash, redirect, url_for, current_app, session
 from flask_login import current_user
 import flask_featureflags as feature
-import six
 
 from dmapiclient import APIError
 from dmapiclient.audit import AuditTypes
@@ -67,7 +66,7 @@ def framework_dashboard(framework_slug):
         except EmailError as e:
             current_app.logger.error(
                 "Application started email failed to send: {error}, supplier_id: {supplier_id}",
-                extra={'error': six.text_type(e), 'supplier_id': current_user.supplier_id}
+                extra={'error': str(e), 'supplier_id': current_user.supplier_id}
             )
 
     drafts, complete_drafts = get_drafts(data_api_client, framework_slug)
@@ -148,7 +147,7 @@ def framework_dashboard(framework_slug):
                 d["path"] + d.get("filename", ""),
             ),
         )
-        for label, d in six.iteritems(base_communications_files)
+        for label, d in base_communications_files.items()
     }
 
     return render_template(
@@ -686,7 +685,7 @@ def framework_updates_email_clarification_question(framework_slug):
         current_app.logger.error(
             "{framework} clarification question email failed to send. "
             "error {error} supplier_id {supplier_id} email_hash {email_hash}",
-            extra={'error': six.text_type(e),
+            extra={'error': str(e),
                    'framework': framework['slug'],
                    'supplier_id': current_user.supplier_id,
                    'email_hash': hash_string(current_user.email_address)})
@@ -718,7 +717,7 @@ def framework_updates_email_clarification_question(framework_slug):
             current_app.logger.error(
                 "{framework} clarification question confirmation email failed to send. "
                 "error {error} supplier_id {supplier_id} email_hash {email_hash}",
-                extra={'error': six.text_type(e),
+                extra={'error': str(e),
                        'framework': framework['slug'],
                        'supplier_id': current_user.supplier_id,
                        'email_hash': hash_string(current_user.email_address)})
@@ -867,7 +866,7 @@ def upload_framework_agreement(framework_slug):
         current_app.logger.error(
             "Framework agreement email failed to send. "
             "error {error} supplier_id {supplier_id} email_hash {email_hash}",
-            extra={'error': six.text_type(e),
+            extra={'error': str(e),
                    'supplier_id': current_user.supplier_id,
                    'email_hash': hash_string(current_user.email_address)})
         abort(503, "Framework agreement email failed to send")
@@ -1071,7 +1070,7 @@ def contract_review(framework_slug, agreement_id):
                 current_app.logger.error(
                     "Framework agreement email failed to send. "
                     "error {error} supplier_id {supplier_id} email_hash {email_hash}",
-                    extra={'error': six.text_type(e),
+                    extra={'error': str(e),
                            'supplier_id': current_user.supplier_id,
                            'email_hash': hash_string(current_user.email_address)})
                 abort(503, "Framework agreement email failed to send")
@@ -1166,7 +1165,7 @@ def view_contract_variation(framework_slug, variation_slug):
             except EmailError as e:
                 current_app.logger.error(
                     "Variation agreed email failed to send: {error}, supplier_id: {supplier_id}",
-                    extra={'error': six.text_type(e), 'supplier_id': current_user.supplier_id}
+                    extra={'error': str(e), 'supplier_id': current_user.supplier_id}
                 )
             flash('variation_accepted')
             return redirect(url_for(".view_contract_variation",

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -3,20 +3,15 @@ from collections import OrderedDict
 from itertools import chain
 
 from dateutil.parser import parse as date_parse
-from dmapiclient import HTTPError
 from flask import render_template, request, abort, flash, redirect, url_for, current_app, session
 from flask_login import current_user
 import flask_featureflags as feature
 
-from dmapiclient import APIError
+from dmapiclient import APIError, HTTPError
 from dmapiclient.audit import AuditTypes
-from dmutils.email import send_email
-from dmutils.email.exceptions import EmailError
-from dmutils.email.helpers import hash_string
 from dmcontent.formats import format_service_price
 from dmcontent.questions import ContentQuestion
 from dmcontent.errors import ContentNotFoundError
-from dmutils.formats import datetimeformat
 from dmutils import s3
 from dmutils.documents import (
     RESULT_LETTER_FILENAME, AGREEMENT_FILENAME, SIGNED_AGREEMENT_PREFIX, SIGNED_SIGNATURE_PAGE_PREFIX,
@@ -24,6 +19,10 @@ from dmutils.documents import (
     degenerate_document_path_and_return_doc_name, get_signed_url, get_extension, file_is_less_than_5mb,
     file_is_empty, file_is_image, file_is_pdf, sanitise_supplier_name
 )
+from dmutils.email import send_email
+from dmutils.email.exceptions import EmailError
+from dmutils.email.helpers import hash_string
+from dmutils.formats import datetimeformat
 
 from ... import data_api_client, flask_featureflags
 from ...main import main, content_loader

--- a/app/main/views/login.py
+++ b/app/main/views/login.py
@@ -1,6 +1,5 @@
-from __future__ import absolute_import
-from flask_login import current_user
 from flask import flash, redirect, render_template, url_for, current_app
+from flask_login import current_user
 
 from dmapiclient.audit import AuditTypes
 from dmutils.email import send_user_account_email

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -1,5 +1,10 @@
-from flask_login import current_user
 from flask import render_template, request, redirect, url_for, abort, flash, current_app
+from flask_login import current_user
+
+from dmapiclient import HTTPError
+from dmcontent.content_loader import ContentNotFoundError
+from dmutils import s3
+from dmutils.documents import upload_service_documents
 
 from ... import data_api_client, flask_featureflags
 from ...main import main, content_loader
@@ -11,11 +16,6 @@ from ..helpers.frameworks import (
     get_supplier_framework_info,
     get_framework_or_404,
 )
-
-from dmcontent.content_loader import ContentNotFoundError
-from dmapiclient import HTTPError
-from dmutils import s3
-from dmutils.documents import upload_service_documents
 
 
 @main.route("/frameworks/<string:framework_slug>/services")

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -1,5 +1,4 @@
 # coding=utf-8
-
 from itertools import chain
 
 from flask import render_template, request, redirect, url_for, abort, session, Markup, flash
@@ -7,9 +6,9 @@ from flask_login import current_user, current_app
 
 from dmapiclient import APIError
 from dmapiclient.audit import AuditTypes
+from dmcontent.content_loader import ContentNotFoundError
 from dmutils.email import send_user_account_email
 from dmutils.email.dm_mailchimp import DMMailChimpClient
-from dmcontent.content_loader import ContentNotFoundError
 
 from ...main import main, content_loader
 from ... import data_api_client

--- a/app/main/views/users.py
+++ b/app/main/views/users.py
@@ -1,5 +1,5 @@
-from flask_login import current_user
 from flask import render_template, abort, flash, url_for, redirect, current_app
+from flask_login import current_user
 
 from ..helpers import login_required
 from ...main import main

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -5,6 +5,7 @@ Flask==0.10.1
 Flask-Login==0.2.11
 Flask-WTF==0.12
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@31.1.0#egg=digitalmarketplace-utils==31.1.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@31.1.1#egg=digitalmarketplace-utils==31.1.1
+git+https://github.com/alphagov/odfpy.git@ee4482a#egg=odfpy==1.3.6dev
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.2.0#egg=digitalmarketplace-content-loader==4.2.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@13.1.0#egg=digitalmarketplace-apiclient==13.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,17 +6,18 @@ Flask==0.10.1
 Flask-Login==0.2.11
 Flask-WTF==0.12
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@31.1.0#egg=digitalmarketplace-utils==31.1.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@31.1.1#egg=digitalmarketplace-utils==31.1.1
+git+https://github.com/alphagov/odfpy.git@ee4482a#egg=odfpy==1.3.6dev
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.2.0#egg=digitalmarketplace-content-loader==4.2.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@13.1.0#egg=digitalmarketplace-apiclient==13.1.0
 
 ## The following requirements were added by pip freeze:
-asn1crypto==0.23.0
+asn1crypto==0.24.0
 backoff==1.0.7
 boto3==1.4.4
 botocore==1.5.95
-certifi==2017.11.5
-cffi==1.11.2
+certifi==2018.1.18
+cffi==1.11.4
 chardet==3.0.4
 contextlib2==0.4.0
 cryptography==1.9
@@ -36,7 +37,6 @@ Markdown==2.6.7
 MarkupSafe==1.0
 monotonic==0.3
 notifications-python-client==4.1.0
-odfpy==1.3.3
 pycparser==2.18
 PyJWT==1.5.3
 python-dateutil==2.6.1
@@ -48,6 +48,6 @@ s3transfer==0.1.12
 six==1.9.0
 unicodecsv==0.14.1
 urllib3==1.22
-Werkzeug==0.12.2
+Werkzeug==0.14.1
 workdays==1.4
 WTForms==2.1

--- a/tests/app/helpers.py
+++ b/tests/app/helpers.py
@@ -1,13 +1,15 @@
 # -*- coding: utf-8 -*-
-import re
-from mock import patch
-from app import create_app
-from tests import login_for_tests
-from werkzeug.http import parse_cookie
-from app import data_api_client
 from datetime import datetime, timedelta
-from dmutils.formats import DATETIME_FORMAT
+import re
+
+from mock import patch
 import pytest
+from werkzeug.http import parse_cookie
+
+from dmutils.formats import DATETIME_FORMAT
+
+from app import create_app, data_api_client
+from tests import login_for_tests
 
 
 # intended to be used as a mock's side_effect

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -4283,6 +4283,30 @@ class TestSignatureUploadPage(BaseApplicationTest):
 
     @mock.patch('dmutils.s3.S3')
     @mock.patch('app.main.views.frameworks.file_is_empty')
+    def test_signature_upload_returns_400_if_no_file_is_chosen(
+        self, file_is_empty, s3, return_supplier_framework, data_api_client
+    ):
+        self.login()
+
+        data_api_client.get_framework.return_value = get_g_cloud_8()
+        data_api_client.get_framework_agreement.return_value = self.framework_agreement()
+        return_supplier_framework.return_value = self.supplier_framework(
+            framework_slug='g-cloud-8',
+            on_framework=True
+        )['frameworkInterest']
+        s3.return_value.get_key.return_value = None
+        file_is_empty.return_value = True
+
+        res = self.client.post(
+            '/suppliers/frameworks/g-cloud-8/234/signature-upload',
+            data={}
+        )
+
+        assert res.status_code == 400
+        assert 'You must choose a file to upload' in res.get_data(as_text=True)
+
+    @mock.patch('dmutils.s3.S3')
+    @mock.patch('app.main.views.frameworks.file_is_empty')
     def test_signature_upload_returns_400_if_file_is_empty(
         self, file_is_empty, s3, return_supplier_framework, data_api_client
     ):

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -1,23 +1,19 @@
 # -*- coding: utf-8 -*-
-from collections import OrderedDict
-from itertools import chain
-
-from dmapiclient import HTTPError
-from werkzeug.datastructures import MultiDict
-
-from app.main.forms.frameworks import ReuseDeclarationForm
-
 import mock
 import pytest
-from six.moves.urllib.parse import urljoin
-
+from collections import OrderedDict
 from io import BytesIO
+from itertools import chain
 from lxml import html
-from dmapiclient import APIError
+from urllib.parse import urljoin
+from werkzeug.datastructures import MultiDict
+
+from dmapiclient import APIError, HTTPError
 from dmapiclient.audit import AuditTypes
 from dmutils.email.exceptions import EmailError
 from dmutils.s3 import S3ResponseError
 
+from app.main.forms.frameworks import ReuseDeclarationForm
 from ..helpers import (
     BaseApplicationTest,
     FULL_G7_SUBMISSION,

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -7,14 +7,11 @@ from werkzeug.datastructures import MultiDict
 
 from app.main.forms.frameworks import ReuseDeclarationForm
 
-try:
-    from StringIO import StringIO
-except ImportError:
-    from io import BytesIO as StringIO
 import mock
 import pytest
 from six.moves.urllib.parse import urljoin
 
+from io import BytesIO
 from lxml import html
 from dmapiclient import APIError
 from dmapiclient.audit import AuditTypes
@@ -1791,7 +1788,7 @@ class TestFrameworkAgreementUpload(BaseApplicationTest):
 
         res = self.client.post(
             '/suppliers/frameworks/g-cloud-7/agreement',
-            data={'agreement': (StringIO(b'doc'), 'test.pdf')}
+            data={'agreement': (BytesIO(b'doc'), 'test.pdf')}
         )
 
         assert res.status_code == 404
@@ -1805,7 +1802,7 @@ class TestFrameworkAgreementUpload(BaseApplicationTest):
 
         res = self.client.post(
             '/suppliers/frameworks/g-cloud-7/agreement',
-            data={'agreement': (StringIO(b'doc'), 'test.pdf')}
+            data={'agreement': (BytesIO(b'doc'), 'test.pdf')}
         )
 
         assert res.status_code == 404
@@ -1821,7 +1818,7 @@ class TestFrameworkAgreementUpload(BaseApplicationTest):
 
         res = self.client.post(
             '/suppliers/frameworks/g-cloud-7/agreement',
-            data={'agreement': (StringIO(b'doc'), 'test.pdf')}
+            data={'agreement': (BytesIO(b'doc'), 'test.pdf')}
         )
 
         assert res.status_code == 400
@@ -1838,7 +1835,7 @@ class TestFrameworkAgreementUpload(BaseApplicationTest):
 
         res = self.client.post(
             '/suppliers/frameworks/g-cloud-7/agreement',
-            data={'agreement': (StringIO(b''), 'test.pdf')}
+            data={'agreement': (BytesIO(b''), 'test.pdf')}
         )
 
         assert res.status_code == 400
@@ -1861,7 +1858,7 @@ class TestFrameworkAgreementUpload(BaseApplicationTest):
 
         res = self.client.post(
             '/suppliers/frameworks/g-cloud-7/agreement',
-            data={'agreement': (StringIO(b'doc'), 'test.pdf')}
+            data={'agreement': (BytesIO(b'doc'), 'test.pdf')}
         )
 
         assert res.status_code == 503
@@ -1890,7 +1887,7 @@ class TestFrameworkAgreementUpload(BaseApplicationTest):
 
         res = self.client.post(
             '/suppliers/frameworks/g-cloud-7/agreement',
-            data={'agreement': (StringIO(b'doc'), 'test.pdf')}
+            data={'agreement': (BytesIO(b'doc'), 'test.pdf')}
         )
 
         assert res.status_code == 500
@@ -1912,7 +1909,7 @@ class TestFrameworkAgreementUpload(BaseApplicationTest):
 
         res = self.client.post(
             '/suppliers/frameworks/g-cloud-7/agreement',
-            data={'agreement': (StringIO(b'doc'), 'test.pdf')}
+            data={'agreement': (BytesIO(b'doc'), 'test.pdf')}
         )
 
         assert res.status_code == 500
@@ -1934,7 +1931,7 @@ class TestFrameworkAgreementUpload(BaseApplicationTest):
 
         res = self.client.post(
             '/suppliers/frameworks/g-cloud-7/agreement',
-            data={'agreement': (StringIO(b'doc'), 'test.pdf')}
+            data={'agreement': (BytesIO(b'doc'), 'test.pdf')}
         )
 
         assert res.status_code == 500
@@ -1957,7 +1954,7 @@ class TestFrameworkAgreementUpload(BaseApplicationTest):
 
         res = self.client.post(
             '/suppliers/frameworks/g-cloud-7/agreement',
-            data={'agreement': (StringIO(b'doc'), 'test.pdf')}
+            data={'agreement': (BytesIO(b'doc'), 'test.pdf')}
         )
 
         assert res.status_code == 503
@@ -1977,7 +1974,7 @@ class TestFrameworkAgreementUpload(BaseApplicationTest):
 
         res = self.client.post(
             '/suppliers/frameworks/g-cloud-7/agreement',
-            data={'agreement': (StringIO(b'doc'), 'test.pdf')}
+            data={'agreement': (BytesIO(b'doc'), 'test.pdf')}
         )
 
         generate_timestamped_document_upload_path.assert_called_once_with(
@@ -2015,7 +2012,7 @@ class TestFrameworkAgreementUpload(BaseApplicationTest):
 
         res = self.client.post(
             '/suppliers/frameworks/g-cloud-7/agreement',
-            data={'agreement': (StringIO(b'doc'), 'test.jpg')}
+            data={'agreement': (BytesIO(b'doc'), 'test.jpg')}
         )
 
         s3.return_value.save.assert_called_with(
@@ -4257,7 +4254,7 @@ class TestSignatureUploadPage(BaseApplicationTest):
 
         res = self.client.post(
             '/suppliers/frameworks/g-cloud-8/234/signature-upload',
-            data={'signature_page': (StringIO(b'asdf'), 'test.jpg')}
+            data={'signature_page': (BytesIO(b'asdf'), 'test.jpg')}
         )
 
         generate_timestamped_document_upload_path.assert_called_once_with(
@@ -4302,7 +4299,7 @@ class TestSignatureUploadPage(BaseApplicationTest):
 
         res = self.client.post(
             '/suppliers/frameworks/g-cloud-8/234/signature-upload',
-            data={'signature_page': (StringIO(b''), 'test.pdf')}
+            data={'signature_page': (BytesIO(b''), 'test.pdf')}
         )
 
         assert res.status_code == 400
@@ -4326,7 +4323,7 @@ class TestSignatureUploadPage(BaseApplicationTest):
 
         res = self.client.post(
             '/suppliers/frameworks/g-cloud-8/234/signature-upload',
-            data={'signature_page': (StringIO(b'asdf'), 'test.txt')}
+            data={'signature_page': (BytesIO(b'asdf'), 'test.txt')}
         )
 
         assert res.status_code == 400
@@ -4350,7 +4347,7 @@ class TestSignatureUploadPage(BaseApplicationTest):
 
         res = self.client.post(
             '/suppliers/frameworks/g-cloud-8/234/signature-upload',
-            data={'signature_page': (StringIO(b'asdf'), 'test.jpg')}
+            data={'signature_page': (BytesIO(b'asdf'), 'test.jpg')}
         )
 
         assert res.status_code == 400
@@ -4421,7 +4418,7 @@ class TestSignatureUploadPage(BaseApplicationTest):
         self.login()
         res = self.client.post(
             '/suppliers/frameworks/g-cloud-8/234/signature-upload',
-            data={'signature_page': (StringIO(b''), '')}
+            data={'signature_page': (BytesIO(b''), '')}
         )
         s3.return_value.get_key.assert_called_with('already/uploaded/file/path.pdf')
         assert res.status_code == 302

--- a/tests/app/main/test_login.py
+++ b/tests/app/main/test_login.py
@@ -1,13 +1,11 @@
 # coding: utf-8
-from __future__ import unicode_literals
-
 from flask import current_app
+import mock
 
 from dmapiclient.audit import AuditTypes
 from dmutils.email.exceptions import EmailError
 
 from ..helpers import BaseApplicationTest
-import mock
 
 EMAIL_EMPTY_ERROR = "Email address must be provided"
 EMAIL_INVALID_ERROR = "Please enter a valid email address"

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -1,17 +1,15 @@
 # -*- coding: utf-8 -*-
-try:
-    from StringIO import StringIO
-except ImportError:
-    from io import BytesIO as StringIO
-from datetime import datetime
-
-from dmapiclient import HTTPError
 import copy
+from datetime import datetime
 from functools import partial
+from io import BytesIO
+
+from freezegun import freeze_time
+from lxml import html
 import mock
 import pytest
-from lxml import html
-from freezegun import freeze_time
+
+from dmapiclient import HTTPError
 
 from app.main.helpers.services import parse_document_upload_time
 from tests.app.helpers import BaseApplicationTest, empty_g7_draft_service, empty_g9_draft_service
@@ -1204,7 +1202,7 @@ class TestSupplierEditUpdateServiceSectionG9(BaseApplicationTest):
             res = self.client.post(
                 '/suppliers/frameworks/g-cloud-9/services/321/edit/documents',
                 data={
-                    'serviceDefinitionDocumentURL': (StringIO(b'doc'), 'document.pdf'),
+                    'serviceDefinitionDocumentURL': (BytesIO(b'doc'), 'document.pdf'),
                 }
             )
 
@@ -1242,8 +1240,8 @@ class TestSupplierEditUpdateServiceSectionG9(BaseApplicationTest):
         res = self.client.post(
             '/suppliers/frameworks/g-cloud-9/services/321/edit/documents',
             data={
-                'serviceDefinitionDocumentURL': (StringIO(b''), 'document.pdf'),
-                'unknownDocumentURL': (StringIO(b'doc'), 'document.pdf'),
+                'serviceDefinitionDocumentURL': (BytesIO(b''), 'document.pdf'),
+                'unknownDocumentURL': (BytesIO(b'doc'), 'document.pdf'),
             })
 
         assert res.status_code == 302
@@ -1606,7 +1604,7 @@ class TestEditDraftService(BaseApplicationTest):
             res = self.client.post(
                 '/suppliers/frameworks/g-cloud-7/submissions/scs/1/edit/service-definition',
                 data={
-                    'serviceDefinitionDocumentURL': (StringIO(b'doc'), 'document.pdf'),
+                    'serviceDefinitionDocumentURL': (BytesIO(b'doc'), 'document.pdf'),
                 }
             )
 
@@ -1629,9 +1627,9 @@ class TestEditDraftService(BaseApplicationTest):
         res = self.client.post(
             '/suppliers/frameworks/g-cloud-7/submissions/scs/1/edit/service-definition',
             data={
-                'serviceDefinitionDocumentURL': (StringIO(b''), 'document.pdf'),
-                'unknownDocumentURL': (StringIO(b'doc'), 'document.pdf'),
-                'pricingDocumentURL': (StringIO(b'doc'), 'document.pdf'),
+                'serviceDefinitionDocumentURL': (BytesIO(b''), 'document.pdf'),
+                'unknownDocumentURL': (BytesIO(b'doc'), 'document.pdf'),
+                'pricingDocumentURL': (BytesIO(b'doc'), 'document.pdf'),
             })
 
         assert res.status_code == 302

--- a/tests/app/main/test_suppliers.py
+++ b/tests/app/main/test_suppliers.py
@@ -3,7 +3,7 @@ from flask import session, current_app
 from lxml import html
 import mock
 import pytest
-from six.moves.urllib.parse import urlparse
+from urllib.parse import urlparse
 
 from dmapiclient import HTTPError
 from dmapiclient.audit import AuditTypes

--- a/tests/app/main/test_suppliers.py
+++ b/tests/app/main/test_suppliers.py
@@ -1,9 +1,10 @@
 # coding=utf-8
+from urllib.parse import urlparse
+
 from flask import session, current_app
 from lxml import html
 import mock
 import pytest
-from urllib.parse import urlparse
 
 from dmapiclient import HTTPError
 from dmapiclient.audit import AuditTypes

--- a/tests/app/test_application.py
+++ b/tests/app/test_application.py
@@ -1,9 +1,10 @@
 # coding=utf-8
-
 import mock
-from .helpers import BaseApplicationTest
+
 from dmapiclient.errors import HTTPError
+
 from app.main.helpers.frameworks import question_references
+from .helpers import BaseApplicationTest
 
 
 class TestApplication(BaseApplicationTest):


### PR DESCRIPTION
This fixes the S3 files-not-showing-if-no-timestamp bug: 
https://trello.com/c/qBiGn3bP/9-legal-documents-files-not-appearing-on-framework-application-dashboard

## Update

The (unintentional) updating of Werkzeuz caused a test to fail (and, it turns out, the app to break) - see my commit message on new commit, copied here for ease of reference:
```
Running `make freeze-requirements` has, as well as adding utils and ODFPy
updates, pulled in a newer version of Werkzeug (it's gone from 0.12.2 to
0.14.1).  This dependency comes from the Flask libraries specification of
`required: >=0.7`, but pip pulls in the latest available at the time it
runs.

The new version has new behaviour for file uploads. Previously, if no file
 was uploaded Werkzeug would pass an empty FileStorage object to the route
 under the `signature_page` key, but new behaviour is for that key not to
 exist at all under `request.files`.

 The changes here mean that the page will not break if a user submits the
 page with no new file chosen.
```