### PR TITLE
Delete templates

### DIFF
--- a/app/templates/macros/forms.html
+++ b/app/templates/macros/forms.html
@@ -24,15 +24,6 @@
 {%- endmacro %}
 
 
-{% macro question_list_entry(id, question, value='', hint='', errors=None, item_name='', number_of_items=10) -%}
-  {% with
-    values=value,
-    error=errors[0]
-  %}
-    {% include "toolkit/forms/list-entry.html" %}
-  {% endwith %}
-{%- endmacro %}
-
 
 {% macro field_errors(name, errors=None) -%}
   {% if errors %}


### PR DESCRIPTION
https://trello.com/c/40CAgE62/256-remove-old-html-macros-supplier-front-end

I have reviewed all the templates and macros in the supplier app.

The only thing I could find that isn't being used was one small macro.