### PR TITLE
Remove Company House Number page from supplier sign up flow

### DIFF
--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -233,7 +233,7 @@ def submit_duns_number():
                 form=form
             ), 400
         session[form.duns_number.name] = form.duns_number.data
-        return redirect(url_for(".companies_house_number"))
+        return redirect(url_for(".company_name"))
     else:
         current_app.logger.warning(
             "suppliercreate.fail: duns:{duns} {duns_errors}",
@@ -265,10 +265,11 @@ def submit_companies_house_number():
 
     if form.validate_on_submit():
         if form.companies_house_number.data:
+            # TODO: below should be a statement updating database with Company House Number
             session[form.companies_house_number.name] = form.companies_house_number.data
         else:
             session.pop(form.companies_house_number.name, None)
-        return redirect(url_for(".company_name"))
+        return redirect(url_for(".supplier_details"))
     else:
         current_app.logger.warning(
             "suppliercreate.fail: duns:{duns} {duns_errors}",
@@ -418,9 +419,6 @@ def submit_company_summary():
                 "contactName": session["contact_name"]
             }]
         }
-
-        if session.get("companies_house_number", None):
-            supplier["companiesHouseNumber"] = session.get("companies_house_number")
 
         account_email_address = session.get("account_email_address", None)
 

--- a/app/templates/suppliers/company_summary.html
+++ b/app/templates/suppliers/company_summary.html
@@ -51,11 +51,6 @@
   {{ summary.text(session.get("duns_number", "You must answer this question.")) }}
   {{ summary.edit_link("Edit", url_for(".duns_number")) }}
   {% endcall %}
-  {% call summary.row() %}
-  {{ summary.field_name("Companies House number") }}
-  {{ summary.text(session["companies_house_number"]) }}
-  {{ summary.edit_link("Edit", url_for(".companies_house_number")) }}
-  {% endcall %}
   {% call summary.row(complete=session.get("company_name", None)) %}
   {{ summary.field_name("Company name") }}
   {{ summary.text(session.get("company_name", "You must answer this question.")) }}

--- a/tests/app/main/test_suppliers.py
+++ b/tests/app/main/test_suppliers.py
@@ -1121,7 +1121,7 @@ class TestCreateSupplier(BaseApplicationTest):
             }
         )
         assert res.status_code == 302
-        assert res.location == 'http://localhost/suppliers/companies-house-number'
+        assert res.location == 'http://localhost/suppliers/company-name'
 
     @mock.patch("app.main.suppliers.data_api_client")
     def test_should_allow_duns_numbers_that_start_with_zero(self, data_api_client):
@@ -1133,7 +1133,7 @@ class TestCreateSupplier(BaseApplicationTest):
             }
         )
         assert res.status_code == 302
-        assert res.location == 'http://localhost/suppliers/companies-house-number'
+        assert res.location == 'http://localhost/suppliers/company-name'
 
     @mock.patch("app.main.suppliers.data_api_client")
     def test_should_strip_whitespace_surrounding_duns_number_field(self, data_api_client):
@@ -1154,7 +1154,7 @@ class TestCreateSupplier(BaseApplicationTest):
             data={}
         )
         assert res.status_code == 302
-        assert res.location == 'http://localhost/suppliers/company-name'
+        assert res.location == 'http://localhost/suppliers/details'
 
     def test_should_be_an_error_if_companies_house_number_is_not_8_characters_short(self):
         res = self.client.post(
@@ -1204,7 +1204,7 @@ class TestCreateSupplier(BaseApplicationTest):
                 }
             )
             assert res.status_code == 302
-            assert res.location == 'http://localhost/suppliers/company-name'
+            assert res.location == 'http://localhost/suppliers/details'
 
     def test_should_strip_whitespace_surrounding_companies_house_number_field(self):
         with self.client as c:
@@ -1226,7 +1226,7 @@ class TestCreateSupplier(BaseApplicationTest):
                 }
             )
             assert res.status_code == 302
-            assert res.location == 'http://localhost/suppliers/company-name'
+            assert res.location == 'http://localhost/suppliers/details'
             assert "companies_house_number" not in session
 
     def test_should_allow_valid_company_name(self):
@@ -1436,7 +1436,6 @@ class TestCreateSupplier(BaseApplicationTest):
                 sess['contact_name'] = "contact_name"
                 sess['duns_number'] = "duns_number"
                 sess['company_name'] = "company_name"
-                sess['companies_house_number'] = "companies_house_number"
                 sess['account_email_address'] = "valid@email.com"
 
             data_api_client.create_supplier.return_value = self.supplier()
@@ -1451,14 +1450,12 @@ class TestCreateSupplier(BaseApplicationTest):
                 }],
                 "dunsNumber": "duns_number",
                 "name": "company_name",
-                "companiesHouseNumber": "companies_house_number",
             })
             assert 'email_address' not in session
             assert 'phone_number' not in session
             assert 'contact_name' not in session
             assert 'duns_number' not in session
             assert 'company_name' not in session
-            assert 'companies_house_number' not in session
             assert session['email_supplier_id'] == 12345
             assert session['email_company_name'] == 'Supplier Name'
 


### PR DESCRIPTION
This has been done as this number is optional and now we will
let suppliers add it on the 'company details' page.

Related pull request for Functional Tests: https://github.com/alphagov/digitalmarketplace-functional-tests/pull/463

Trello ticket:
https://trello.com/c/coCrPhFZ/25-remove-companies-house-page-from-sign-up-journey