### PR TITLE
Update content for DUNS number

### DIFF
--- a/app/templates/suppliers/create_new_supplier.html
+++ b/app/templates/suppliers/create_new_supplier.html
@@ -8,6 +8,10 @@
       {
         "link": "/",
         "label": "Digital Marketplace"
+      },
+      {
+        "link": url_for('.become_a_supplier'),
+        "label": "Become a supplier"
       }
     ]
   %}

--- a/app/templates/suppliers/duns_number.html
+++ b/app/templates/suppliers/duns_number.html
@@ -8,6 +8,14 @@
     {
       "link": "/",
       "label": "Digital Marketplace"
+    },
+    {
+      "link": url_for('.become_a_supplier'),
+      "label": "Become a supplier"
+    },
+    {
+      "link": url_for('.create_new_supplier'),
+      "label": "Create an account"
     }
   ]
 %}
@@ -16,55 +24,53 @@
 {% endblock %}
 
 {% block main_content %}
-
 {% if form.duns_number.errors[0] == 'DUNS number already used' %}
 <div class="validation-masthead" role="group" aria-labelledby="validation-masthead-heading">
-    <h1 class="validation-masthead-heading" id="validation-masthead-heading">
-        A supplier account already exists with that DUNS number
-    </h1>
-    <p class="validation-masthead-description">
-        If you no longer have your account details, or if you think this may be an error, email <a href="mailto:enquiries@digitalmarketplace.service.gov.uk?subject=DUNS%20number%20question" title="Please contact enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.service.gov.uk</a>
-    </p>
+  <h1 class="validation-masthead-heading" id="validation-masthead-heading">
+      A supplier account already exists with that DUNS number
+  </h1>
+  <p class="validation-masthead-description">
+      If you no longer have your account details, or if you think this may be an error, email <a href="mailto:enquiries@digitalmarketplace.service.gov.uk?subject=DUNS%20number%20question" title="Please contact enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.service.gov.uk</a>
+  </p>
 </div>
 {% endif %}
 
-<div class="single-question-page">
-  {%
-  with
-      heading = "DUNS number",
-      smaller = True
-  %}
-  {% include "toolkit/page-heading.html" %}
+<div>
+  {% with heading = "Enter your DUNS number",
+          smaller = True %}
+    {% include "toolkit/page-heading.html" %}
   {% endwith %}
-
+  
   <div class="grid-row">
     <div class="column-two-thirds">
       <form method="POST" action="{{ url_for('.submit_duns_number') }}">
-          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
-          {% set question_advice %}
-            <p>If you registered your business with Companies House, you will automatically have been given a unique DUNS number.</p>
-            <p>The Digital Marketplace uses this to check if your business already has a supplier account.</p>
-            <p><a href="https://www.dnb.co.uk/duns-number/lookup.html" rel="external">Find your DUNS number</a> on the Dun &amp; Bradstreet website.</p>
-            <p>You can <a href="https://www.dnb.co.uk/duns-number/lookup/request-a-duns-number.html" rel="external">apply for a DUNS number</a> if you don’t have one.</p>
-          {% endset %}
-          {%
-            with
-              question = "DUNS number",
-              name = "duns_number",
-              value = form.duns_number.data,
-              error = form.duns_number.errors[0],
-              question_advice = question_advice
-          %}
-            {% include "toolkit/forms/textbox.html" %}
-          {% endwith %}
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+        <div class="dmspeak">
+          <p>If you registered your business with Companies House, you will automatically have been given a unique
+            DUNS number.</p>
+          <p>The Digital Marketplace uses this to check if your business already has a supplier account.</p>
+        </div>
+          <p class="lead">You can either:</p>
+          <ul class="list-bullet">
+            <li><a href="https://www.dnb.co.uk/duns-number/lookup.html" rel="external">find your DUNS number</a> on the
+              Dun &amp; Bradstreet website</li>
+            <li><a href="https://www.dnb.co.uk/duns-number/lookup/request-a-duns-number.html" rel="external">apply for
+              a DUNS number</a> if you don&rsquo;t have one</li>
+          </ul>
+        
+        {% with question = "DUNS number",
+                name = "duns_number",
+                value = form.duns_number.data,
+                error = form.duns_number.errors[0],
+                question_advice = question_advice,
+                hint = "This is a 9 digit number" %}
+          {% include "toolkit/forms/textbox.html" %}
+        {% endwith %}
 
-          {%
-            with
-              type = "save",
-              label = "Continue"
-          %}
+        {% with type = "save",
+                label = "Continue" %}
           {% include "toolkit/button.html" %}
-          {% endwith %}
+        {% endwith %}
       </form>
     </div>
   </div>


### PR DESCRIPTION
## Summary
Update the content when asking suppliers for their DUNS number. Also add breadcrumbs to the DUNS number page and the 'create new supplier' page, which doesn't have the breadcrumb it ought to (according to the prototype). We've had to change from `single-question-page` to `dmspeak` on the top-level div for two reasons.
1) `single-question-page` hides the "DUNS number" header above the hint text.
2) `dmspeak` adds some padding around the paragraphs, which are otherwise too tightly packed.

## Before
![screen shot 2018-02-08 at 12 55 24](https://user-images.githubusercontent.com/2920760/35974005-61ca7f2a-0ccf-11e8-8514-5211cd5f27fa.png)


## After
![screen shot 2018-02-08 at 14 08 08](https://user-images.githubusercontent.com/2920760/35976935-8ca3f262-0cd9-11e8-8a45-fc2f521039d7.png)


## Ticket
https://trello.com/c/ae5UzOAn/39-sign-up-flow-update-copy-on-duns-number-page