### PR TITLE
Add page to edit organisation size

### DIFF
--- a/app/main/forms/suppliers.py
+++ b/app/main/forms/suppliers.py
@@ -1,6 +1,6 @@
 from flask_wtf import Form
-from wtforms import IntegerField
-from wtforms.validators import DataRequired, ValidationError, Length, Optional, Regexp
+from wtforms import IntegerField, RadioField
+from wtforms.validators import DataRequired, ValidationError, Length, Optional, Regexp, InputRequired
 
 from dmutils.forms import StripWhitespaceStringField, EmailField, EmailValidator
 
@@ -82,3 +82,36 @@ class EmailAddressForm(Form):
         DataRequired(message="You must provide an email address."),
         EmailValidator(message="You must provide a valid email address."),
     ])
+
+
+class CompanyOrganisationSizeForm(Form):
+    OPTIONS = [
+        {
+            "value": "micro",
+            "label": "Micro",
+            "description": "Under 10 employees and 2 million euros or less in either annual turnover or balance "
+                           "sheet total",
+        },
+        {
+            "value": "small",
+            "label": "Small",
+            "description": "Under 50 employees and 10 million euros or less in either annual turnover or balance "
+                           "sheet total",
+        },
+        {
+            "value": "medium",
+            "label": "Medium",
+            "description": "Under 250 employees and either 50 million euros or less in either annual turnover or "
+                           "43 million euros or less in annual balance sheet total",
+        },
+        {
+            "value": "large",
+            "label": "Large",
+            "description": "250 or more employees and either over 50 million euros in annual turnover or over 43 "
+                           "million euros in balance sheet total",
+        },
+    ]
+
+    organisation_size = RadioField('Organisation size',
+                                   validators=[InputRequired(message="You must choose an organisation size.")],
+                                   choices=[(o['value'], o['label']) for o in OPTIONS])

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -13,8 +13,14 @@ from dmutils.email.dm_mailchimp import DMMailChimpClient
 from ...main import main, content_loader
 from ... import data_api_client
 from ..forms.suppliers import (
-    EditSupplierForm, EditContactInformationForm, DunsNumberForm, CompaniesHouseNumberForm,
-    CompanyContactDetailsForm, CompanyNameForm, EmailAddressForm
+    CompaniesHouseNumberForm,
+    CompanyContactDetailsForm,
+    CompanyNameForm,
+    CompanyOrganisationSizeForm,
+    DunsNumberForm,
+    EditContactInformationForm,
+    EditSupplierForm,
+    EmailAddressForm,
 )
 from ..helpers.frameworks import get_frameworks_by_status, get_frameworks_closed_and_open_for_applications
 from ..helpers import login_required
@@ -163,6 +169,33 @@ def update_supplier():
                              error=e.message)
 
     return redirect(url_for(".supplier_details"))
+
+
+@main.route('/organisation-size/edit', methods=['GET', 'POST'])
+@login_required
+def edit_supplier_organisation_size():
+    form = CompanyOrganisationSizeForm()
+
+    if request.method == 'POST':
+        if form.validate_on_submit():
+            data_api_client.update_supplier(supplier_id=current_user.supplier_id,
+                                            supplier={"organisationSize": form.organisation_size.data},
+                                            user=current_user.email_address)
+            return redirect(url_for('.supplier_details'))
+
+        current_app.logger.warning(
+            "supplieredit.fail: organisation-size:{osize}, errors:{osize_errors}",
+            extra={
+                'osize': form.organisation_size.data,
+                'osize_errors': ",".join(form.organisation_size.errors)
+            })
+
+        return render_template("suppliers/edit_supplier_organisation_size.html", form=form), 400
+
+    supplier = data_api_client.get_supplier(current_user.supplier_id)['suppliers']
+    form.organisation_size.data = supplier.get('organisationSize', None)
+
+    return render_template('suppliers/edit_supplier_organisation_size.html', form=form)
 
 
 @main.route('/supply', methods=['GET'])

--- a/app/templates/suppliers/become_a_supplier.html
+++ b/app/templates/suppliers/become_a_supplier.html
@@ -16,16 +16,11 @@
 {% endblock %}
 
 {% block main_content %}
-
-  {%
-    with heading = "Become a supplier",
-         smaller = True
-  %}
-    {% include "toolkit/page-heading.html" %}
-  {% endwith %}
-
   <div class="grid-row">
     <div class="column-two-thirds">
+      {% with heading = "Become a supplier", smaller = True %}
+        {% include "toolkit/page-heading.html" %}
+      {% endwith %}
 
       {% if open_fwks or opening_fwks %}
         <div class="dmspeak">

--- a/app/templates/suppliers/companies_house_number.html
+++ b/app/templates/suppliers/companies_house_number.html
@@ -18,16 +18,12 @@
 {% block main_content %}
 
 <div class="single-question-page">
-  {%
-    with
-      heading = "Companies House number (optional)",
-      smaller = True
-  %}
-  {% include "toolkit/page-heading.html" %}
-  {% endwith %}
-
   <div class="grid-row">
     <div class="column-two-thirds">
+      {% with heading = "Companies House number (optional)", smaller = True %}
+        {% include "toolkit/page-heading.html" %}
+      {% endwith %}
+      
       <form method="POST" action="{{ url_for('.submit_companies_house_number') }}">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
         {% set question_advice %}

--- a/app/templates/suppliers/company_contact_details.html
+++ b/app/templates/suppliers/company_contact_details.html
@@ -32,21 +32,16 @@ with items = [
     </div>
 {% endif %}
 
-{%
-with
-    heading = "Company contact details",
-    smaller = True
-%}
-{% include "toolkit/page-heading.html" %}
-{% endwith %}
-
 <div class="grid-row">
-
     <div class="column-two-thirds">
+        {% with heading = "Company contact details", smaller = True %}
+            {% include "toolkit/page-heading.html" %}
+        {% endwith %}
+        
         <p>This information will be visible on the Digital Marketplace.</p>
-
+    
         <p>You can change it at any time.</p>
-
+    
         <form method="POST" action="{{ url_for('.submit_company_contact_details') }}">
             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
             {%
@@ -58,7 +53,7 @@ with
             %}
             {% include "toolkit/forms/textbox.html" %}
             {% endwith %}
-
+    
             {%
                 with
                     question = "Contact email address",
@@ -68,7 +63,7 @@ with
             %}
             {% include "toolkit/forms/textbox.html" %}
             {% endwith %}
-
+    
             {%
                 with
                     question = "Contact phone number",

--- a/app/templates/suppliers/company_name.html
+++ b/app/templates/suppliers/company_name.html
@@ -18,15 +18,12 @@
 {% block main_content %}
 
 <div class="single-question-page">
-  {%
-    with
-      heading = "Company name",
-      smaller = True
-  %}
-  {% include "toolkit/page-heading.html" %}
-  {% endwith %}
   <div class="grid-row">
     <div class="column-two-thirds">
+      {% with heading = "Company name", smaller = True %}
+        {% include "toolkit/page-heading.html" %}
+      {% endwith %}
+      
       <form method="POST" action="{{ url_for('.submit_company_name') }}">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
         {% set question_advice %}

--- a/app/templates/suppliers/create_new_supplier.html
+++ b/app/templates/suppliers/create_new_supplier.html
@@ -22,14 +22,12 @@
 {% block main_content %}
 
 <div class="start-page">
-  {%
-    with heading = "Create a supplier account",
-         smaller = True
-  %}
-    {% include "toolkit/page-heading.html" %}
-  {% endwith %}
   <div class="grid-row">
     <div class="column-two-thirds">
+      {% with heading = "Create a supplier account", smaller = True %}
+        {% include "toolkit/page-heading.html" %}
+      {% endwith %}
+      
       <div class="dmspeak">
         <p>If your company is not <a href="https://beta.companieshouse.gov.uk/" rel="external">registered with Companies House</a>,
            you will need to <a href="https://www.dnb.co.uk/duns-number/lookup/request-a-duns-number.html" rel="external">apply for a DUNS number</a>

--- a/app/templates/suppliers/create_your_account.html
+++ b/app/templates/suppliers/create_your_account.html
@@ -17,17 +17,12 @@
 {% endblock %}
 
 {% block main_content %}
-
-{%
-  with
-    heading = "Create login",
-    smaller = True
-%}
-  {% include "toolkit/page-heading.html" %}
-{% endwith %}
-
 <div class="grid-row">
   <div class="column-two-thirds">
+    {% with heading = "Create login", smaller = True %}
+      {% include "toolkit/page-heading.html" %}
+    {% endwith %}
+    
     <div class="dmspeak">
        <p>You’ll use this to sign in to your company’s supplier account.</p>
        <p>It won’t be visible on the Digital Marketplace.</p>

--- a/app/templates/suppliers/create_your_account_complete.html
+++ b/app/templates/suppliers/create_your_account_complete.html
@@ -16,17 +16,12 @@
 {% endblock %}
 
 {% block main_content %}
-
-  {%
-    with
-      heading = "Activate your account",
-      smaller = True
-  %}
-  {% include "toolkit/page-heading.html" %}
-  {% endwith %}
-
   <div class="grid-row">
     <div class="column-two-thirds">
+      {% with heading = "Create login", smaller = True %}
+        {% include "toolkit/page-heading.html" %}
+      {% endwith %}
+      
       <div class="dmspeak">
         <p>An email has been sent to {{ email_address }}.</p>
         <p>You must click on the link in the email to activate your account.</p>

--- a/app/templates/suppliers/duns_number.html
+++ b/app/templates/suppliers/duns_number.html
@@ -35,44 +35,43 @@
 </div>
 {% endif %}
 
-<div>
-  {% with heading = "Enter your DUNS number",
-          smaller = True %}
-    {% include "toolkit/page-heading.html" %}
-  {% endwith %}
+<div class="grid-row">
+  <div class="column-two-thirds">
+    {% with heading = "Enter your DUNS number",
+            smaller = True %}
+      {% include "toolkit/page-heading.html" %}
+    {% endwith %}
   
-  <div class="grid-row">
-    <div class="column-two-thirds">
-      <form method="POST" action="{{ url_for('.submit_duns_number') }}">
-        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
-        <div class="dmspeak">
-          <p>If you registered your business with Companies House, you will automatically have been given a unique
-            DUNS number.</p>
-          <p>The Digital Marketplace uses this to check if your business already has a supplier account.</p>
-        </div>
-          <p class="lead">You can either:</p>
-          <ul class="list-bullet">
-            <li><a href="https://www.dnb.co.uk/duns-number/lookup.html" rel="external">find your DUNS number</a> on the
-              Dun &amp; Bradstreet website</li>
-            <li><a href="https://www.dnb.co.uk/duns-number/lookup/request-a-duns-number.html" rel="external">apply for
-              a DUNS number</a> if you don&rsquo;t have one</li>
-          </ul>
-        
-        {% with question = "DUNS number",
-                name = "duns_number",
-                value = form.duns_number.data,
-                error = form.duns_number.errors[0],
-                question_advice = question_advice,
-                hint = "This is a 9 digit number" %}
-          {% include "toolkit/forms/textbox.html" %}
-        {% endwith %}
+    
+    <form method="POST" action="{{ url_for('.submit_duns_number') }}">
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+      <div class="dmspeak">
+        <p>If you registered your business with Companies House, you will automatically have been given a unique
+          DUNS number.</p>
+        <p>The Digital Marketplace uses this to check if your business already has a supplier account.</p>
+      </div>
+        <p class="lead">You can either:</p>
+        <ul class="list-bullet">
+          <li><a href="https://www.dnb.co.uk/duns-number/lookup.html" rel="external">find your DUNS number</a> on the
+            Dun &amp; Bradstreet website</li>
+          <li><a href="https://www.dnb.co.uk/duns-number/lookup/request-a-duns-number.html" rel="external">apply for
+            a DUNS number</a> if you don&rsquo;t have one</li>
+        </ul>
+      
+      {% with question = "DUNS number",
+              name = "duns_number",
+              value = form.duns_number.data,
+              error = form.duns_number.errors[0],
+              question_advice = question_advice,
+              hint = "This is a 9 digit number" %}
+        {% include "toolkit/forms/textbox.html" %}
+      {% endwith %}
 
-        {% with type = "save",
-                label = "Save and continue" %}
-          {% include "toolkit/button.html" %}
-        {% endwith %}
-      </form>
-    </div>
+      {% with type = "save",
+              label = "Save and continue" %}
+        {% include "toolkit/button.html" %}
+      {% endwith %}
+    </form>
   </div>
 </div>
 {% endblock %}

--- a/app/templates/suppliers/edit_supplier_organisation_size.html
+++ b/app/templates/suppliers/edit_supplier_organisation_size.html
@@ -24,12 +24,12 @@
 {% block main_content %}
 
 <div class="single-question-page">
-  {% with heading = "What size is your organisation?",
-          smaller = True %}
-    {% include "toolkit/page-heading.html" %}
-  {% endwith %}
   <div class="grid-row">
     <div class="column-two-thirds">
+      {% with heading = "What size is your organisation?", smaller = True %}
+        {% include "toolkit/page-heading.html" %}
+      {% endwith %}
+      
       <form method="POST" action="{{ url_for('.edit_supplier_organisation_size') }}">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
         {% set hint %}

--- a/app/templates/suppliers/edit_supplier_organisation_size.html
+++ b/app/templates/suppliers/edit_supplier_organisation_size.html
@@ -1,0 +1,61 @@
+{% extends "_base_page.html" %}
+
+{% block page_title %}Organisation size – Digital Marketplace{% endblock %}
+
+{% block breadcrumb %}
+  {% with items = [
+    {
+      "link": "/",
+      "label": "Digital Marketplace"
+    },
+    {
+       "link": url_for('.dashboard'),
+       "label": "Your account"
+    },
+    {
+      "link": url_for('.supplier_details'),
+      "label": "Company details"
+    },
+  ] %}
+    {% include "toolkit/breadcrumb.html" %}
+  {% endwith %}
+{% endblock %}
+
+{% block main_content %}
+
+<div class="single-question-page">
+  {% with heading = "What size is your organisation?",
+          smaller = True %}
+    {% include "toolkit/page-heading.html" %}
+  {% endwith %}
+  <div class="grid-row">
+    <div class="column-two-thirds">
+      <form method="POST" action="{{ url_for('.edit_supplier_organisation_size') }}">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+        {% set hint %}
+          This information will be used to report on the number of contracts that go to small and medium sized
+          enterprises (SMEs).
+        {% endset %}
+        
+        {% with question = "What size is your organisation?",
+                name = "organisation_size",
+                value = form.organisation_size.data,
+                error = form.organisation_size.errors[0],
+                type = "radio",
+                options = form.OPTIONS,
+                hint = hint %}
+          {% include "toolkit/forms/selection-buttons.html" %}
+        {% endwith %}
+        
+        {% with type = "save",
+                label = "Save and continue" %}
+          {% include "toolkit/button.html" %}
+        {% endwith %}
+  
+        <p><a href="{{ url_for('.supplier_details') }}">Return to company details</a></p>
+      </form>
+    </div>
+  </div>
+</div>
+
+{% endblock %}


### PR DESCRIPTION
## Summary
Adds a new page to the supplier account that allows a supplier to edit their organisation size. This page hasn't been plumbed up to anything yet - that will be done in a later ticket.

There's no flash message confirming the action the user has taken included as part of this ticket. It feels like it might be good to add this as part of this ticket but I'll need the content (@constancecerf?)

## Examples
![screen shot 2018-02-09 at 14 12 53](https://user-images.githubusercontent.com/2920760/36031692-8445b932-0da3-11e8-8a59-e9963f32e07d.png)
![screen shot 2018-02-09 at 14 13 32](https://user-images.githubusercontent.com/2920760/36031695-8773df26-0da3-11e8-9e09-584e0896eb7d.png)


## Ticket
https://trello.com/c/eB9u3xe7/40-new-editable-page-build-organisation-size-page