### PR TITLE
Revert back to eea/odfpy

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -40,7 +40,11 @@ def create_app(config_name):
 
     application.register_blueprint(main_blueprint, url_prefix='/suppliers')
     application.register_blueprint(status_blueprint, url_prefix='/suppliers')
+
+    # Must be registered last so that any routes declared in the app are registered first (i.e. take precedence over
+    # the external NotImplemented routes in the dm-utils external blueprint).
     application.register_blueprint(external_blueprint)
+
     login_manager.login_message_category = "must_login"
     main_blueprint.config = application.config.copy()
 

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -5,7 +5,6 @@ Flask==0.10.1
 Flask-Login==0.2.11
 Flask-WTF==0.12
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@31.1.1#egg=digitalmarketplace-utils==31.1.1
-git+https://github.com/alphagov/odfpy.git@ee4482a#egg=odfpy==1.3.6dev
+git+https://github.com/alphagov/digitalmarketplace-utils.git@33.0.0#egg=digitalmarketplace-utils==33.0.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.2.0#egg=digitalmarketplace-content-loader==4.2.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@13.1.0#egg=digitalmarketplace-apiclient==13.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,8 +6,7 @@ Flask==0.10.1
 Flask-Login==0.2.11
 Flask-WTF==0.12
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@31.1.1#egg=digitalmarketplace-utils==31.1.1
-git+https://github.com/alphagov/odfpy.git@ee4482a#egg=odfpy==1.3.6dev
+git+https://github.com/alphagov/digitalmarketplace-utils.git@33.0.0#egg=digitalmarketplace-utils==33.0.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.2.0#egg=digitalmarketplace-content-loader==4.2.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@13.1.0#egg=digitalmarketplace-apiclient==13.1.0
 
@@ -37,6 +36,7 @@ Markdown==2.6.7
 MarkupSafe==1.0
 monotonic==0.3
 notifications-python-client==4.1.0
+odfpy==1.3.6
 pycparser==2.18
 PyJWT==1.5.3
 python-dateutil==2.6.1

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -103,7 +103,7 @@ class TestFrameworksDashboard(BaseApplicationTest):
             ),
             (
                 'Submitted by',
-                'User email@email.com Sunday 10 July 2016 at 10:20pm'
+                'User email@email.com Sunday 10 July 2016 at 10:20pm BST'
             ),
             (
                 'Countersignature',
@@ -4507,7 +4507,7 @@ class TestContractReviewPage(BaseApplicationTest):
         page = res.get_data(as_text=True)
         assert u'Check the details you’ve given before returning the signature page for £unicodename' in page
         assert (
-            '<tdclass="summary-item-field-first"><span>UploadedSunday10July2016at10:18pm</span></td>'
+            '<tdclass="summary-item-field-first"><span>UploadedSunday10July2016at10:18pmBST</span></td>'
             in self.strip_all_whitespace(page)
         )
 
@@ -4987,7 +4987,9 @@ class TestContractVariation(BaseApplicationTest):
 
         assert res.status_code == 200
         assert len(doc.xpath('//h2[contains(text(), "Contract variation status")]')) == 1
-        assert "<span>William Drăyton<br />agreed@email.com<br />Friday 19 August 2016 at 4:47pm</span>" in page_text
+        assert (
+            "<span>William Drăyton<br />agreed@email.com<br />Friday 19 August 2016 at 4:47pm BST</span>" in page_text
+        )
         assert "<span>Waiting for CCS to countersign</span>" in page_text
         assert len(doc.xpath('//label[contains(text(), "I accept these proposed changes")]')) == 0
         assert len(doc.xpath('//input[@value="I accept"]')) == 0
@@ -5011,7 +5013,9 @@ class TestContractVariation(BaseApplicationTest):
         assert res.status_code == 200
         assert len(doc.xpath('//h1[contains(text(), "G-Cloud 9: proposed contract variation")]')) == 1
         assert len(doc.xpath('//h2[contains(text(), "Contract variation status")]')) == 1
-        assert "<span>William Drăyton<br />agreed@email.com<br />Friday 19 August 2016 at 4:47pm</span>" in page_text
+        assert (
+            "<span>William Drăyton<br />agreed@email.com<br />Friday 19 August 2016 at 4:47pm BST</span>" in page_text
+        )
         assert "<span>Waiting for CCS to countersign</span>" in page_text
         assert "You have accepted the Crown Commercial Service’s changes to the framework agreement" in page_text
         assert "They will come into effect when CCS has countersigned them." in page_text

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -1618,7 +1618,7 @@ class TestEditDraftService(BaseApplicationTest):
 
         s3.return_value.save.assert_called_once_with(
             'g-cloud-7/submissions/1234/1-service-definition-document-2015-01-02-0304.pdf',
-            mock.ANY, acl='private'
+            mock.ANY, acl='bucket-owner-full-control'
         )
 
     def test_file_upload_filters_empty_and_unknown_files(self, data_api_client, s3):


### PR DESCRIPTION
Update utils to use eea/odfpy rather than our interim alphagov/odfpy
fork, which we created to allow us to patch a bug. Now that the bug has
been accepted into the main library as of release 1.3.6
(https://github.com/eea/odfpy/pull/72) we no longer need to support
own our fork.

Also adds a comment when registering the external blueprint from 
dm-utils to ensure it is registered last.