### PR TITLE
Handle suppliers with no `registrationCountry` key

### DIFF
--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -94,7 +94,7 @@ def supplier_details():
     except APIError as e:
         abort(e.status_code)
     supplier['contact'] = supplier['contactInformation'][0]
-    country_name = get_country_name_from_country_code(supplier['registrationCountry'])
+    country_name = get_country_name_from_country_code(supplier.get('registrationCountry'))
 
     return render_template(
         "suppliers/details.html",

--- a/tests/app/main/test_suppliers.py
+++ b/tests/app/main/test_suppliers.py
@@ -788,6 +788,17 @@ class TestSupplierDetails(BaseApplicationTest):
             document = html.fromstring(page_html)
             assert document.xpath("//*[normalize-space(string())='United Kingdom']")  # Country United Kingdom is shown
 
+    def test_handles_supplier_with_no_registration_country_key(self, data_api_client):
+        supplier = get_supplier()
+        del supplier['suppliers']['registrationCountry']
+        data_api_client.get_supplier.return_value = supplier
+
+        with self.app.test_client():
+            self.login()
+
+            res = self.client.get("/suppliers/details")
+            assert res.status_code == 200
+
 
 @mock.patch("app.main.views.suppliers.data_api_client", autospec=True)
 @mock.patch("app.main.views.suppliers.get_current_suppliers_users", autospec=True)


### PR DESCRIPTION
When suppliers are serialized by the api any `None` value keys are
dropped before being returned in the response.

The `registrationCountry` field in the suppliers table is a nullable
field. Whilst in practice in production we don't have any null values in
this field (it's either an empty string or 'gb' at the time of writing),
we should cover this case just in case.

This issue was picked up by the functional tests on preview. The
suppliers generated by the functional tests have null values for
`registrationCountry`. This may also need looking at.