### PR TITLE
Add supplier details to tasklist page

### DIFF
--- a/app/main/helpers/suppliers.py
+++ b/app/main/helpers/suppliers.py
@@ -6,7 +6,7 @@ def load_countries():
     helpers_path = os.path.abspath(os.path.dirname(__file__))
     countryfile = os.path.join(helpers_path, '../../static/location-autocomplete-canonical-list.json')
     with open(countryfile) as f:
-        return (json.load(f))
+        return json.load(f)
 
 
 def get_country_name_from_country_code(country_code):
@@ -27,3 +27,24 @@ def get_country_name_from_country_code(country_code):
 
 
 COUNTRY_TUPLE = load_countries()
+
+
+def supplier_company_details_are_complete(supplier_data):
+    supplier_required_fields = ['dunsNumber', 'name', 'registeredName', 'registrationCountry', 'registrationDate',
+                                'organisationSize', 'tradingStatus']
+    contact_required_fields = ['address1', 'city', 'postcode']
+
+    registration_country = supplier_data['registrationCountry'] if 'registrationCountry' in supplier_data else None
+    if registration_country == 'gb' or registration_country == 'country:GB':
+        supplier_required_fields.append('companiesHouseNumber')
+        supplier_required_fields.append('vatNumber')
+
+    else:
+        supplier_required_fields.append('otherCompanyRegistrationNumber')
+
+    return (
+        all([f in supplier_data and supplier_data[f] for f in supplier_required_fields]) and
+        all([f in supplier_data['contactInformation'][0] and supplier_data['contactInformation'][0][f]
+             for f in
+             contact_required_fields])
+    )

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -34,10 +34,14 @@ from ..helpers.frameworks import (
     return_supplier_framework_info_if_on_framework_or_abort, returned_agreement_email_recipients,
     check_agreement_is_related_to_supplier_framework_or_abort, get_framework_for_reuse,
 )
-from ..helpers.validation import get_validator
+from ..helpers.suppliers import supplier_company_details_are_complete
 from ..helpers.services import (
-    get_signed_document_url, get_drafts, get_lot_drafts, count_unanswered_questions
+    count_unanswered_questions,
+    get_drafts,
+    get_lot_drafts,
+    get_signed_document_url,
 )
+from ..helpers.validation import get_validator
 from ..forms.frameworks import SignerDetailsForm, ContractReviewForm, AcceptAgreementVariationForm, ReuseDeclarationForm
 
 CLARIFICATION_QUESTION_NAME = 'clarification_question'
@@ -73,6 +77,7 @@ def framework_dashboard(framework_slug):
     supplier_framework_info = get_supplier_framework_info(data_api_client, framework_slug)
     declaration_status = get_declaration_status_from_info(supplier_framework_info)
     supplier_is_on_framework = get_supplier_on_framework_from_info(supplier_framework_info)
+    supplier = data_api_client.get_supplier(current_user.supplier_id)['suppliers']
 
     # Do not show a framework dashboard for earlier G-Cloud iterations
     if declaration_status == 'unstarted' and framework['status'] == 'live':
@@ -171,6 +176,7 @@ def framework_dashboard(framework_slug):
         supplier_framework=supplier_framework_info,
         supplier_is_on_framework=supplier_is_on_framework,
         framework_advice=framework_advice,
+        company_details_complete=supplier_company_details_are_complete(supplier),
     ), 200
 
 

--- a/app/templates/frameworks/_framework_actions.html
+++ b/app/templates/frameworks/_framework_actions.html
@@ -25,14 +25,38 @@
 
 {% if framework.status == 'open' %}
 <li class="browse-list-item">
-  {% if declaration_status == 'unstarted' %}
-    <a class="browse-list-item-link" href="{{ url_for('.framework_start_supplier_declaration', framework_slug=framework.slug) }}">
-    <span>Make supplier declaration</span>
-    </a>
+  <a class="browse-list-item-link"
+     href="{{ url_for('.supplier_details') }}">
+    <span>Enter your company details</span>
+  </a>
+  {% if not company_details_complete and counts.complete %}
+  <div class="browse-list-item-status-angry">
+    <p class="browse-list-item-status-title">
+    <strong>No services will be submitted because you haven’t completed your company details</strong>
+    </p>
+  </div>
+  {% elif not company_details_complete %}
+  <div class="browse-list-item-status-quiet">
+    <p class="browse-list-item-status-title">You must add your organisation’s details</p>
+  </div>
   {% else %}
-    <a class="browse-list-item-link" href="{{ url_for('.framework_supplier_declaration_overview', framework_slug=framework.slug) }}">
+  <div class="browse-list-item-status-happy">
+    <p class="browse-list-item-status-title">
+      <strong>Your company details were saved</strong>
+    </p>
+  </div>
+  {% endif %}
+</li>
+
+<li class="browse-list-item">
+  {% if declaration_status == 'unstarted' %}
+  <a class="browse-list-item-link" href="{{ url_for('.framework_start_supplier_declaration', framework_slug=framework.slug) }}">
+    <span>Make supplier declaration</span>
+  </a>
+  {% else %}
+  <a class="browse-list-item-link" href="{{ url_for('.framework_supplier_declaration_overview', framework_slug=framework.slug) }}">
     <span>Edit supplier declaration</span>
-    </a>
+  </a>
   {% endif %}
   <p class="browse-list-item-body">
     Confirm eligibility, agree to the application terms and provide supplier&nbsp;information.
@@ -58,7 +82,7 @@
     </p>
   </div>
   {% elif declaration_status == 'complete' %}
-  <div class="browse-list-item-status-happy">
+  <div class="browse-list-item-status-default">
     <p class="browse-list-item-status-title">
       <strong>You’ve made the supplier declaration</strong>
     </p>
@@ -88,7 +112,7 @@
   {% endif %}
 
   {% if counts.complete %}
-    {% if declaration_status == 'complete' %}
+    {% if declaration_status == 'complete' and company_details_complete %}
       <div class="browse-list-item-status-happy">
         <p class="browse-list-item-status-title">You’re submitting</p>
     {% else %}

--- a/app/templates/frameworks/dashboard.html
+++ b/app/templates/frameworks/dashboard.html
@@ -49,7 +49,7 @@
   {% endwith %}
 
   {# Confidence Banner #}
-  {% if application_made and framework.status == 'open' %}
+  {% if application_made and company_details_complete and framework.status == 'open' %}
     {% with 
       message = "Your application will be submitted at %s. <br> You can edit your declaration and services at any time before the deadline."|safe % framework_dates.framework_close_date|nbsp,
       type="success"

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -7,4 +7,4 @@ Flask-WTF==0.12
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@33.1.0#egg=digitalmarketplace-utils==33.1.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.2.0#egg=digitalmarketplace-content-loader==4.2.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@13.1.0#egg=digitalmarketplace-apiclient==13.1.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@14.4.0#egg=digitalmarketplace-apiclient==14.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ Flask-WTF==0.12
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@33.1.0#egg=digitalmarketplace-utils==33.1.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.2.0#egg=digitalmarketplace-content-loader==4.2.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@13.1.0#egg=digitalmarketplace-apiclient==13.1.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@14.4.0#egg=digitalmarketplace-apiclient==14.4.0
 
 ## The following requirements were added by pip freeze:
 asn1crypto==0.24.0

--- a/tests/app/main/helpers/test_suppliers.py
+++ b/tests/app/main/helpers/test_suppliers.py
@@ -1,8 +1,10 @@
 import pytest
-from app.main.helpers.suppliers import get_country_name_from_country_code
+from app.main.helpers.suppliers import get_country_name_from_country_code, supplier_company_details_are_complete
+
+from dmapiclient.api_stubs import supplier
 
 
-class TestGetCountryNameFromCountryCode():
+class TestGetCountryNameFromCountryCode:
     @pytest.mark.parametrize(
         'code, name',
         (
@@ -15,3 +17,20 @@ class TestGetCountryNameFromCountryCode():
     )
     def test_returns_expected_name_for_different_codes(self, code, name):
         assert get_country_name_from_country_code(code) == name
+
+
+class TestSupplierCompanyDetailsComplete:
+    @pytest.mark.parametrize('supplier_data_from_api, expected_result',
+                             (
+                                 ({}, False),
+                                 ({**supplier()['suppliers'], 'dunsNumber': None}, False),
+                                 ({**supplier()['suppliers'], 'vatNumber': None}, False),
+                                 ({**supplier()['suppliers'], 'companiesHouseNumber': None}, False),
+                                 ({**supplier()['suppliers'], 'contactInformation': [{}]}, False),
+
+                                 (supplier()['suppliers'], True),
+                                 ({**supplier()['suppliers'], 'registrationCountry': 'gb'}, True),
+                                 (supplier(other_company_registration_number=12345)['suppliers'], True),
+                             ))
+    def test_returns_expected_value_for_input(self, supplier_data_from_api, expected_result):
+        assert supplier_company_details_are_complete(supplier_data_from_api) is expected_result


### PR DESCRIPTION
## Summary
Adds a new section to a supplier's framework application tasklist. They
must now check+complete their company details are correct and are
all present. This includes some helper logic to parse the API supplier
data and determine whether or not it's "complete".

Pulls in a new apiclient which contains a supplier fixture.
Tests won't pass until that's been merged.

## Examples
![screen shot 2018-02-19 at 14 23 26](https://user-images.githubusercontent.com/2920760/36382377-93ee6264-1580-11e8-805e-615f7e7569aa.png)
![screen shot 2018-02-19 at 14 23 04](https://user-images.githubusercontent.com/2920760/36382381-96a2f8a8-1580-11e8-9e9d-a076d4abdb38.png)
![screen shot 2018-02-19 at 14 23 58](https://user-images.githubusercontent.com/2920760/36382385-998aeada-1580-11e8-80d9-9cf734cff33f.png)


## Dependencies
https://github.com/alphagov/digitalmarketplace-apiclient/pull/124

## Ticket
https://trello.com/c/8Ahl8YNc/43-supplier-account-add-supplier-details-to-tasklist-page