### PR TITLE
Add edit trading status page

### DIFF
--- a/app/main/forms/suppliers.py
+++ b/app/main/forms/suppliers.py
@@ -142,3 +142,40 @@ class CompanyOrganisationSizeForm(Form):
     organisation_size = RadioField('Organisation size',
                                    validators=[InputRequired(message="You must choose an organisation size.")],
                                    choices=[(o['value'], o['label']) for o in OPTIONS])
+
+
+class CompanyTradingStatusForm(Form):
+    OPTIONS = [
+        {
+            'value': 'limited company (LTD)',
+            'label': 'limited company (LTD)',
+        },
+        {
+            'value': 'limited liability company (LLC)',
+            'label': 'limited liability company (LLC)',
+        },
+        {
+            'value': 'public limited company (PLC)',
+            'label': 'public limited company (PLC)',
+        },
+        {
+            'value': 'limited liability partnership (LLP)',
+            'label': 'limited liability partnership (LLP)',
+        },
+        {
+            'value': 'sole trader',
+            'label': 'sole trader',
+        },
+        {
+            'value': 'public body',
+            'label': 'public body',
+        },
+        {
+            'value': 'other',
+            'label': 'other',
+        },
+    ]
+
+    trading_status = RadioField('Trading status',
+                                validators=[InputRequired(message="You must choose a trading status.")],
+                                choices=[(o['value'], o['label']) for o in OPTIONS])

--- a/app/templates/suppliers/edit_supplier_trading_status.html
+++ b/app/templates/suppliers/edit_supplier_trading_status.html
@@ -1,0 +1,66 @@
+{% extends "_base_page.html" %}
+
+{% block page_title %}Trading status – Digital Marketplace{% endblock %}
+
+{% block breadcrumb %}
+  {% with items = [
+    {
+      "link": "/",
+      "label": "Digital Marketplace"
+    },
+    {
+       "link": url_for('.dashboard'),
+       "label": "Your account"
+    },
+    {
+      "link": url_for('.supplier_details'),
+      "label": "Company details"
+    },
+  ] %}
+    {% include "toolkit/breadcrumb.html" %}
+  {% endwith %}
+{% endblock %}
+
+{% block main_content %}
+
+<div class="single-question-page">
+  <div class="grid-row">
+    {% if form.errors %}
+      {% with errors = [{'question': form.trading_status.label, 'input_name': form.trading_status.name}] %}
+        {% include 'toolkit/forms/validation.html' %}
+      {% endwith %}
+    {% endif %}
+    
+    <div class="column-two-thirds">
+      {% with heading = "What&rsquo;s your trading status?"|safe, smaller = True %}
+        {% include "toolkit/page-heading.html" %}
+      {% endwith %}
+      
+      <form method="POST" action="{{ url_for('.edit_supplier_trading_status') }}">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+        {% set hint %}
+          This information will be used to find out about the types of companies on frameworks.
+        {% endset %}
+        
+        {% with question = "What&rsquo;s your trading status?"|safe,
+                name = "trading_status",
+                value = form.trading_status.data,
+                error = form.trading_status.errors[0],
+                type = "radio",
+                options = form.OPTIONS,
+                hint = hint %}
+          {% include "toolkit/forms/selection-buttons.html" %}
+        {% endwith %}
+        
+        {% with type = "save",
+                label = "Save and continue" %}
+          {% include "toolkit/button.html" %}
+        {% endwith %}
+  
+        <p><a href="{{ url_for('.supplier_details') }}">Return to company details</a></p>
+      </form>
+    </div>
+  </div>
+</div>
+
+{% endblock %}


### PR DESCRIPTION
## Summary
Adds a page for suppliers to edit their trading status.

## Ticket
https://trello.com/c/Wvvtb1yW/52-new-editable-page-trading-status