### PR TITLE
Rearrange Supplier Details page elements and change headers

### DIFF
--- a/app/main/forms/suppliers.py
+++ b/app/main/forms/suppliers.py
@@ -1,5 +1,5 @@
 from flask_wtf import Form
-from wtforms import IntegerField, RadioField
+from wtforms import RadioField
 from wtforms.validators import AnyOf, InputRequired, Length, Optional, Regexp, ValidationError
 
 from dmutils.forms import StripWhitespaceStringField, EmailField, EmailValidator
@@ -27,7 +27,6 @@ class EditSupplierForm(Form):
 
 
 class EditContactInformationForm(Form):
-    id = IntegerField()
     contactName = StripWhitespaceStringField('Contact name', validators=[
         InputRequired(message="You must provide a contact name"),
     ])

--- a/app/main/forms/suppliers.py
+++ b/app/main/forms/suppliers.py
@@ -35,10 +35,6 @@ class EditContactInformationForm(Form):
         InputRequired(message="You must provide an email address"),
     ])
     phoneNumber = StripWhitespaceStringField('Contact phone number')
-    # TODO: remove these fields when address is removed from the supplier details edit page
-    address1 = StripWhitespaceStringField('Building and street')
-    city = StripWhitespaceStringField('Town or city')
-    postcode = StripWhitespaceStringField('Postcode')
 
 
 class EditRegisteredAddressForm(Form):

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -215,7 +215,6 @@ def edit_what_buyers_will_see():
         abort(e.status_code)
 
     supplier['contact'] = supplier['contactInformation'][0]
-    error = None
     http_status = 200
 
     supplier_form = EditSupplierForm()
@@ -240,7 +239,7 @@ def edit_what_buyers_will_see():
                     current_user.email_address
                 )
             except APIError as e:
-                error = e.message
+                abort(e.status_code)
             else:
                 return redirect(url_for(".supplier_details"))
 
@@ -254,7 +253,6 @@ def edit_what_buyers_will_see():
 
     return render_template(
         "suppliers/edit_what_buyers_will_see.html",
-        error=error,
         supplier_form=supplier_form,
         contact_form=contact_form
     ), http_status

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -204,9 +204,9 @@ def edit_supplier_redirect():
     return redirect(url_for('.edit_supplier'), 302)
 
 
-@main.route('/details/edit', methods=['GET'])
+@main.route('/details/edit', methods=['GET', 'POST'])
 @login_required
-def edit_supplier(supplier_form=None, contact_form=None, error=None):
+def edit_supplier():
     try:
         supplier = data_api_client.get_supplier(
             current_user.supplier_id
@@ -214,60 +214,50 @@ def edit_supplier(supplier_form=None, contact_form=None, error=None):
     except APIError as e:
         abort(e.status_code)
 
-    if supplier_form is None:
-        supplier_form = EditSupplierForm(
-            description=supplier.get('description', None),
-            clients=supplier.get('clients', None)
-        )
-        contact_form = EditContactInformationForm(
-            prefix='contact_',
-            **supplier['contactInformation'][0]
-        )
+    supplier['contact'] = supplier['contactInformation'][0]
+    error = None
+    http_status = 200
+
+    supplier_form = EditSupplierForm()
+    contact_form = EditContactInformationForm()
+
+    if request.method == 'POST':
+        supplier_info_valid = supplier_form.validate_on_submit()
+        contact_info_valid = contact_form.validate_on_submit()
+
+        if supplier_info_valid and contact_info_valid:
+            try:
+                data_api_client.update_supplier(
+                    current_user.supplier_id,
+                    supplier_form.data,
+                    current_user.email_address
+                )
+
+                data_api_client.update_contact_information(
+                    current_user.supplier_id,
+                    supplier['contact']['id'],
+                    contact_form.data,
+                    current_user.email_address
+                )
+            except APIError as e:
+                error = e.message
+            else:
+                return redirect(url_for(".supplier_details"))
+
+        http_status = 400
+
+    else:
+        supplier_form.description.data = supplier.get('description', None)
+        contact_form.contactName.data = supplier['contact'].get('contactName')
+        contact_form.phoneNumber.data = supplier['contact'].get('phoneNumber')
+        contact_form.email.data = supplier['contact'].get('email')
 
     return render_template(
         "suppliers/edit_supplier.html",
         error=error,
         supplier_form=supplier_form,
         contact_form=contact_form
-    ), 200
-
-
-@main.route('/details/edit', methods=['POST'])
-@login_required
-def update_supplier():
-    # FieldList expects post parameter keys to have number suffixes
-    # (eg client-0, client-1 ...), which is incompatible with how
-    # JS list-entry plugin generates input names. So instead of letting
-    # the form search for request keys we pass in the values directly as data
-    supplier_form = EditSupplierForm(
-        formdata=None,
-        description=request.form['description'],
-    )
-
-    contact_form = EditContactInformationForm(prefix='contact_')
-
-    if not (supplier_form.validate_on_submit() and contact_form.validate_on_submit()):
-        return edit_supplier(supplier_form=supplier_form, contact_form=contact_form)
-
-    try:
-        data_api_client.update_supplier(
-            current_user.supplier_id,
-            supplier_form.data,
-            current_user.email_address
-        )
-
-        data_api_client.update_contact_information(
-            current_user.supplier_id,
-            contact_form.id.data,
-            contact_form.data,
-            current_user.email_address
-        )
-    except APIError as e:
-        return edit_supplier(supplier_form=supplier_form,
-                             contact_form=contact_form,
-                             error=e.message)
-
-    return redirect(url_for(".supplier_details"))
+    ), http_status
 
 
 @main.route('/organisation-size/edit', methods=['GET', 'POST'])

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -199,14 +199,14 @@ def edit_supplier_registered_name():
 
 @main.route('/edit', methods=['GET'])
 @login_required
-def edit_supplier_redirect():
+def edit_what_buyers_will_see_redirect():
     # redirect old route for this view
-    return redirect(url_for('.edit_supplier'), 302)
+    return redirect(url_for('.edit_what_buyers_will_see'), 302)
 
 
-@main.route('/details/edit', methods=['GET', 'POST'])
+@main.route('/what-buyers-will-see/edit', methods=['GET', 'POST'])
 @login_required
-def edit_supplier():
+def edit_what_buyers_will_see():
     try:
         supplier = data_api_client.get_supplier(
             current_user.supplier_id
@@ -253,7 +253,7 @@ def edit_supplier():
         contact_form.email.data = supplier['contact'].get('email')
 
     return render_template(
-        "suppliers/edit_supplier.html",
+        "suppliers/edit_what_buyers_will_see.html",
         error=error,
         supplier_form=supplier_form,
         contact_form=contact_form

--- a/app/templates/suppliers/details.html
+++ b/app/templates/suppliers/details.html
@@ -23,57 +23,48 @@
 {% block main_content %}
 {%
   with
-    heading = "Supplier details",
+    heading = "Company details",
     smaller = true
 %}
   {% include "toolkit/page-heading.html" %}
 {% endwith %}
 
-
-{{ summary.top_link('Edit', url_for('.edit_supplier')) }}
+{{ summary.heading("What buyers will see", id="what_buyers_will_see") }}
+{{ summary.top_link('Change', url_for('.edit_supplier')) }}
 {% call(item) summary.mapping_table(
-  caption='Supplier details',
+  caption='What buyers will see',
   field_headings=[
     'Label',
-    'Value'
+    'Value',
+    'Optional'
   ],
   field_headings_visible=False
 ) %}
   {% call summary.row() %}
     {{ summary.field_name('Contact name') }}
     {{ summary.text(supplier.contact.contactName) }}
+    {{ summary.text("") }}
   {% endcall %}
   {% call summary.row() %}
     {{ summary.field_name('Contact email') }}
     {{ summary.text(supplier.contact.email) }}
+    {{ summary.text("") }}
   {% endcall %}
   {% call summary.row() %}
     {{ summary.field_name('Contact phone number') }}
     {{ summary.text(supplier.contact.phoneNumber) }}
+    {{ summary.text("") }}
   {% endcall %}
   {% call summary.row() %}
-    {{ summary.field_name('Registered office address') }}
-    {% call summary.field() %}
-      {%
-        with
-        without_spacing = true,
-        postcode = supplier.contact.get("postcode"),
-        street_address = True,
-        street_address_line_1 = supplier.contact.get("address1"),
-        locality = supplier.contact.get("city")
-      %}
-        {% include "toolkit/contact-details.html" %}
-      {% endwith %}
-    {% endcall %}
-  {% endcall %}
-  {% call summary.row() %}
-    {{ summary.field_name('Supplier summary') }}
+    {{ summary.field_name('Summary') }}
     {{ summary.text(supplier.description) }}
+    {% call summary.field(action=True) %}
+      Optional
+    {% endcall %}
   {% endcall %}
 {% endcall %}
 
-{{ summary.heading("Registration information", id="registration_information") }}
-{{ summary.description("This is used to process your applications and manage your participation on frameworks.") }}
+{{ summary.heading("Company details for your framework applications", id="registration_information") }}
 {% call(item) summary.mapping_table(
   caption='Registration information',
   field_headings=[
@@ -82,13 +73,34 @@
   ],
   field_headings_visible=False
 ) %}
-
-  {% if supplier.registeredName %}
-    {% call summary.row() %}
-      {{ summary.field_name('Registered company name') }}
+{% if supplier.registeredName %}
+  {% call summary.row() %}
+    {{ summary.field_name('Registered company name') }}
       {{ summary.text(supplier.registeredName) }}
+  {% endcall %}
+{% endif %}
+
+{% set postcode = supplier.contact.get("postcode") %}
+{% set street_address_line_1 = supplier.contact.get("address1") %}
+{% set locality = supplier.contact.get("city") %}
+{% if postcode or street_address_line_1 or locality or supplier.registrationCountry %}
+  {% call summary.row() %}
+    {{ summary.field_name('Registered company address') }}
+    {% call summary.field() %}
+      {%
+        with
+        without_spacing = true,
+        postcode = postcode,
+        street_address = True,
+        street_address_line_1 = street_address_line_1,
+        locality = locality,
+        country = country_name
+      %}
+        {% include "toolkit/contact-details.html" %}
+      {% endwith %}
     {% endcall %}
-  {% endif %}
+  {% endcall %}
+{% endif %}
 
   {% if supplier.companiesHouseNumber %}
     {% call summary.row() %}
@@ -97,24 +109,10 @@
     {% endcall %}
   {% endif %}
 
-  {% if supplier.registrationCountry and not supplier.companiesHouseNumber %}
-    {% call summary.row() %}
-      {{ summary.field_name('Where your business was established') }}
-      {{ summary.text(country_name) }}
-    {% endcall %}
-  {% endif %}
-
   {% if supplier.otherCompanyRegistrationNumber and not supplier.companiesHouseNumber and country_name != 'United Kingdom' %}
     {% call summary.row() %}
       {{ summary.field_name('Registration number') }}
       {{ summary.text(supplier.otherCompanyRegistrationNumber) }}
-    {% endcall %}
-  {% endif %}
-
-  {% if supplier.dunsNumber %}
-    {% call summary.row() %}
-      {{ summary.field_name('DUNS number') }}
-      {{ summary.text(supplier.dunsNumber) }}
     {% endcall %}
   {% endif %}
 
@@ -136,6 +134,13 @@
     {% call summary.row() %}
       {{ summary.field_name('Company size') }}
       {{ summary.text(supplier.organisationSize|capitalize_first) }}
+    {% endcall %}
+  {% endif %}
+
+  {% if supplier.dunsNumber %}
+    {% call summary.row() %}
+      {{ summary.field_name('DUNS number') }}
+      {{ summary.text(supplier.dunsNumber) }}
     {% endcall %}
   {% endif %}
 

--- a/app/templates/suppliers/details.html
+++ b/app/templates/suppliers/details.html
@@ -30,7 +30,7 @@
 {% endwith %}
 
 {{ summary.heading("What buyers will see", id="what_buyers_will_see") }}
-{{ summary.top_link('Change', url_for('.edit_supplier')) }}
+{{ summary.top_link('Change', url_for('.edit_what_buyers_will_see')) }}
 {% call(item) summary.mapping_table(
   caption='What buyers will see',
   field_headings=[

--- a/app/templates/suppliers/edit_supplier.html
+++ b/app/templates/suppliers/edit_supplier.html
@@ -75,17 +75,16 @@
       </div>
   {% endif %}
 
-  <form action="{{ url_for('.update_supplier') }}" method="post" enctype="multipart/form-data">
+  <form action="{{ url_for('.edit_supplier') }}" method="post" enctype="multipart/form-data">
 
   <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
 
   <div class="grid-row">
     <div class="column-two-thirds">
 
-      {{ forms.question_textbox('contact_contactName', 'Contact name', contact_form.contactName.data, 'Primary contact', errors=contact_form.contactName.errors) }}
-      {{ forms.question_textbox('contact_email', 'Contact email', contact_form.email.data, errors=contact_form.email.errors) }}
-      {{ forms.question_textbox('contact_phoneNumber', 'Contact phone number', contact_form.phoneNumber.data, errors=contact_form.phoneNumber.errors) }}
-      {{ forms.input('contact_id', contact_form.id.data, type='hidden') }}
+      {{ forms.question_textbox('contactName', 'Contact name', contact_form.contactName.data, 'Primary contact', errors=contact_form.contactName.errors) }}
+      {{ forms.question_textbox('email', 'Contact email', contact_form.email.data, errors=contact_form.email.errors) }}
+      {{ forms.question_textbox('phoneNumber', 'Contact phone number', contact_form.phoneNumber.data, errors=contact_form.phoneNumber.errors) }}
 
 
       {{ forms.question_textarea('description', 'Supplier summary', supplier_form.description.data, '50 words max', errors=supplier_form.description.errors, max_length_in_words=50) }}

--- a/app/templates/suppliers/edit_supplier.html
+++ b/app/templates/suppliers/edit_supplier.html
@@ -80,19 +80,8 @@
       {{ forms.question_textbox('contact_contactName', 'Contact name', contact_form.contactName.data, 'Primary contact', errors=contact_form.contactName.errors) }}
       {{ forms.question_textbox('contact_email', 'Contact email', contact_form.email.data, errors=contact_form.email.errors) }}
       {{ forms.question_textbox('contact_phoneNumber', 'Contact phone number', contact_form.phoneNumber.data, errors=contact_form.phoneNumber.errors) }}
+      {{ forms.input('contact_id', contact_form.id.data, type='hidden') }}
 
-      <div class="question">
-        <label class="question-heading">
-          Registered office address
-        </label>
-        {{ forms.input('contact_id', contact_form.id.data, type='hidden') }}
-        <div class="box-label" id="address1-label">Building and street</div>
-        {{ forms.input('contact_address1', contact_form.address1.data, errors=contact_form.address1.errors) }}
-        <div class="box-label" id="city-label">Town or city</div>
-        {{ forms.input('contact_city', contact_form.city.data, errors=contact_form.city.errors) }}
-        <div class="box-label" id="postcode-label">Postcode</div>
-        {{ forms.input('contact_postcode', contact_form.postcode.data, errors=contact_form.postcode.errors) }}
-      </div>
 
       {{ forms.question_textarea('description', 'Supplier summary', supplier_form.description.data, '50 words max', errors=supplier_form.description.errors, max_length_in_words=50) }}
     </div>

--- a/app/templates/suppliers/edit_supplier.html
+++ b/app/templates/suppliers/edit_supplier.html
@@ -25,6 +25,41 @@
 {% endblock %}
 
 {% block main_content %}
+
+{% if error %}
+<div class="validation-masthead" aria-labelledby="validation-masthead-heading">
+  <h3 class="validation-masthead-heading" id="validation-masthead-heading">
+    {{ error }}
+  </h3>
+</div>
+{% endif %}
+{% if supplier_form.errors or contact_form.errors %}
+    <div class="validation-masthead" aria-labelledby="validation-masthead-heading">
+        <h3 class="validation-masthead-heading" id="validation-masthead-heading">
+            There was a problem with the details you gave for:
+        </h3>
+        {% if supplier_form.errors %}
+        <ul>
+        {% for field_name, field_errors in supplier_form.errors|dictsort %}
+          {% for error in field_errors %}
+            <li><a href="#{{ field_name }}" class="validation-masthead-link">{{ supplier_form[field_name].label.text }}</a>
+          {% endfor %}
+        {% endfor %}
+        </ul>
+        {% endif %}
+
+        {% if contact_form.errors %}
+        <ul>
+        {% for field_name, field_errors in contact_form.errors|dictsort %}
+          {% for error in field_errors %}
+          <li><a href="#contact_{{ field_name }}" class="validation-masthead-link">{{ contact_form[field_name].label.text }}</a></li>
+          {% endfor %}
+        {% endfor %}
+        </ul>
+        {% endif %}
+    </div>
+{% endif %}
+
   <div class="grid-row">
     <div class="column-one-whole">
       {% with
@@ -39,41 +74,6 @@
       </div>
     </div>
   </div>
-
-
-  {% if error %}
-  <div class="validation-masthead" aria-labelledby="validation-masthead-heading">
-    <h3 class="validation-masthead-heading" id="validation-masthead-heading">
-      {{ error }}
-    </h3>
-  </div>
-  {% endif %}
-  {% if supplier_form.errors or contact_form.errors %}
-      <div class="validation-masthead" aria-labelledby="validation-masthead-heading">
-          <h3 class="validation-masthead-heading" id="validation-masthead-heading">
-              There was a problem with the details you gave for:
-          </h3>
-          {% if supplier_form.errors %}
-          <ul>
-          {% for field_name, field_errors in supplier_form.errors|dictsort %}
-            {% for error in field_errors %}
-              <li><a href="#{{ field_name }}" class="validation-masthead-link">{{ supplier_form[field_name].label.text }}</a>
-            {% endfor %}
-          {% endfor %}
-          </ul>
-          {% endif %}
-
-          {% if contact_form.errors %}
-          <ul>
-          {% for field_name, field_errors in contact_form.errors|dictsort %}
-            {% for error in field_errors %}
-            <li><a href="#contact_{{ field_name }}" class="validation-masthead-link">{{ contact_form[field_name].label.text }}</a></li>
-            {% endfor %}
-          {% endfor %}
-          </ul>
-          {% endif %}
-      </div>
-  {% endif %}
 
   <form action="{{ url_for('.edit_supplier') }}" method="post" enctype="multipart/form-data">
 

--- a/app/templates/suppliers/edit_supplier.html
+++ b/app/templates/suppliers/edit_supplier.html
@@ -1,7 +1,7 @@
 {% extends "_base_page.html" %}
 {% import "toolkit/forms/macros/forms.html" as forms %}
 
-{% block page_title %}Edit supplier – Digital Marketplace{% endblock %}
+{% block page_title %}What buyers will see – Digital Marketplace{% endblock %}
 
 {% block breadcrumb %}
   {%
@@ -16,7 +16,7 @@
       },
       {
         "link": url_for(".supplier_details"),
-        "label": "Supplier details"
+        "label": "Company details"
       }
     ]
   %}
@@ -28,13 +28,18 @@
   <div class="grid-row">
     <div class="column-one-whole">
       {% with
-        context = "Edit supplier information",
-        heading = current_user.supplier_name
+        heading = "What buyers will see"
       %}
         {% include 'toolkit/page-heading.html' %}
       {% endwith %}
+
+      <div class="dmspeak">
+        <p>This information will be visible on the Digital Marketplace.</p>
+        <p>You can change it at any time.</p>
+      </div>
     </div>
   </div>
+
 
   {% if error %}
   <div class="validation-masthead" aria-labelledby="validation-masthead-heading">

--- a/app/templates/suppliers/edit_what_buyers_will_see.html
+++ b/app/templates/suppliers/edit_what_buyers_will_see.html
@@ -75,7 +75,7 @@
     </div>
   </div>
 
-  <form action="{{ url_for('.edit_supplier') }}" method="post" enctype="multipart/form-data">
+  <form action="{{ url_for('.edit_what_buyers_will_see') }}" method="post" enctype="multipart/form-data">
 
   <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
 

--- a/app/templates/suppliers/edit_what_buyers_will_see.html
+++ b/app/templates/suppliers/edit_what_buyers_will_see.html
@@ -25,28 +25,11 @@
 {% endblock %}
 
 {% block main_content %}
-
-{% if error %}
-<div class="validation-masthead" aria-labelledby="validation-masthead-heading">
-  <h3 class="validation-masthead-heading" id="validation-masthead-heading">
-    {{ error }}
-  </h3>
-</div>
-{% endif %}
 {% if supplier_form.errors or contact_form.errors %}
     <div class="validation-masthead" aria-labelledby="validation-masthead-heading">
         <h3 class="validation-masthead-heading" id="validation-masthead-heading">
             There was a problem with the details you gave for:
         </h3>
-        {% if supplier_form.errors %}
-        <ul>
-        {% for field_name, field_errors in supplier_form.errors|dictsort %}
-          {% for error in field_errors %}
-            <li><a href="#{{ field_name }}" class="validation-masthead-link">{{ supplier_form[field_name].label.text }}</a>
-          {% endfor %}
-        {% endfor %}
-        </ul>
-        {% endif %}
 
         {% if contact_form.errors %}
         <ul>
@@ -57,6 +40,17 @@
         {% endfor %}
         </ul>
         {% endif %}
+
+        {% if supplier_form.errors %}
+        <ul>
+        {% for field_name, field_errors in supplier_form.errors|dictsort %}
+          {% for error in field_errors %}
+            <li><a href="#{{ field_name }}" class="validation-masthead-link">{{ supplier_form[field_name].label.text }}</a>
+          {% endfor %}
+        {% endfor %}
+        </ul>
+        {% endif %}
+
     </div>
 {% endif %}
 
@@ -75,31 +69,31 @@
     </div>
   </div>
 
-  <form action="{{ url_for('.edit_what_buyers_will_see') }}" method="post" enctype="multipart/form-data">
+  <form action="{{ url_for('.edit_what_buyers_will_see') }}" method="post">
 
   <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
 
   <div class="grid-row">
     <div class="column-two-thirds">
 
-      {{ forms.question_textbox('contactName', 'Contact name', contact_form.contactName.data, 'Primary contact', errors=contact_form.contactName.errors) }}
-      {{ forms.question_textbox('email', 'Contact email', contact_form.email.data, errors=contact_form.email.errors) }}
+      {{ forms.question_textbox('contactName', 'Contact name', contact_form.contactName.data, 'This can be the name of the person or team you want buyers to contact', errors=contact_form.contactName.errors) }}
+      {{ forms.question_textbox('email', 'Contact email address', contact_form.email.data, 'This is the email buyers will use to contact you', errors=contact_form.email.errors) }}
       {{ forms.question_textbox('phoneNumber', 'Contact phone number', contact_form.phoneNumber.data, errors=contact_form.phoneNumber.errors) }}
 
 
-      {{ forms.question_textarea('description', 'Supplier summary', supplier_form.description.data, '50 words max', errors=supplier_form.description.errors, max_length_in_words=50) }}
+      {{ forms.question_textarea('description', 'Supplier summary', supplier_form.description.data, '50 words maximum', errors=supplier_form.description.errors, max_length_in_words=50) }}
     </div>
   </div>
 
   {%
     with
     type = "save",
-    label = "Save and return"
+    label = "Save and continue"
   %}
     {% include "toolkit/button.html" %}
   {% endwith %}
   <p>
-    <a href="{{ url_for('.supplier_details') }}">Return without saving</a>
+    <a href="{{ url_for('.supplier_details') }}">Return to company details</a>
   </p>
   </form>
 

--- a/tests/app/main/test_suppliers.py
+++ b/tests/app/main/test_suppliers.py
@@ -720,7 +720,7 @@ class TestSupplierDetails(BaseApplicationTest):
             assert document.xpath(
                 "//a[normalize-space(string())=$t][@href=$u][contains(@class, $c)]",
                 t="Change",
-                u="/suppliers/details/edit",
+                u="/suppliers/what-buyers-will-see/edit",
                 c="summary-change-link",
             )
 
@@ -943,7 +943,7 @@ class TestSupplierUpdate(BaseApplicationTest):
                 "phoneNumber": "0800123123",
             }
         data.update(kwargs)
-        res = self.client.post("/suppliers/details/edit", data=data)
+        res = self.client.post("/suppliers/what-buyers-will-see/edit", data=data)
         return res.status_code, res.get_data(as_text=True)
 
     def test_should_render_edit_page_with_minimum_data(self, data_api_client):
@@ -968,7 +968,7 @@ class TestSupplierUpdate(BaseApplicationTest):
 
         data_api_client.get_supplier.side_effect = limited_supplier
 
-        response = self.client.get("/suppliers/details/edit")
+        response = self.client.get("/suppliers/what-buyers-will-see/edit")
         assert response.status_code == 200
 
     def test_update_all_supplier_fields(self, data_api_client):
@@ -1071,9 +1071,9 @@ class TestSupplierUpdate(BaseApplicationTest):
         assert data_api_client.update_contact_information.called is False
 
     def test_should_redirect_to_login_if_not_logged_in(self, data_api_client):
-        res = self.client.get("/suppliers/details/edit")
+        res = self.client.get("/suppliers/what-buyers-will-see/edit")
         assert res.status_code == 302
-        assert res.location == "http://localhost/user/login?next=%2Fsuppliers%2Fdetails%2Fedit"
+        assert res.location == "http://localhost/user/login?next=%2Fsuppliers%2Fwhat-buyers-will-see%2Fedit"
 
 
 class TestEditSupplierRegisteredAddress(BaseApplicationTest):

--- a/tests/app/main/test_suppliers.py
+++ b/tests/app/main/test_suppliers.py
@@ -942,9 +942,6 @@ class TestSupplierUpdate(BaseApplicationTest):
                 "contact_email": "supplier@user.dmdev",
                 "contact_contactName": "Supplier Person",
                 "contact_phoneNumber": "0800123123",
-                "contact_address1": "1 Street",
-                "contact_city": "Supplierville",
-                "contact_postcode": "11 AB",
             }
         data.update(kwargs)
         res = self.client.post("/suppliers/details/edit", data=data)
@@ -992,11 +989,8 @@ class TestSupplierUpdate(BaseApplicationTest):
         data_api_client.update_contact_information.assert_called_once_with(
             1234, 2,
             {
-                'city': u'Supplierville',
-                'address1': u'1 Street',
                 'email': u'supplier@user.dmdev',
                 'phoneNumber': u'0800123123',
-                'postcode': u'11 AB',
                 'contactName': u'Supplier Person',
                 'id': 2
             },
@@ -1012,9 +1006,6 @@ class TestSupplierUpdate(BaseApplicationTest):
             "contact_email": "  supplier@user.dmdev  ",
             "contact_contactName": "  Supplier Person  ",
             "contact_phoneNumber": "  0800123123  ",
-            "contact_address1": "  1 Street  ",
-            "contact_city": "  Supplierville  ",
-            "contact_postcode": "  11 AB  "
         }
 
         status, _ = self.post_supplier_edit(data=data)
@@ -1031,11 +1022,8 @@ class TestSupplierUpdate(BaseApplicationTest):
         data_api_client.update_contact_information.assert_called_once_with(
             1234, 2,
             {
-                'city': u'Supplierville',
-                'address1': u'1 Street',
                 'email': u'supplier@user.dmdev',
                 'phoneNumber': u'0800123123',
-                'postcode': u'11 AB',
                 'contactName': u'Supplier Person',
                 'id': 2
             },
@@ -1045,29 +1033,23 @@ class TestSupplierUpdate(BaseApplicationTest):
     def test_missing_required_supplier_fields(self, data_api_client):
         self.login()
 
-        status, resp = self.post_supplier_edit({
+        status, response = self.post_supplier_edit({
             "description": "New Description",
             "contact_id": 2,
             "contact_contactName": "Supplier Person",
             "contact_phoneNumber": "0800123123",
-            "contact_address1": "1 Street",
-            "contact_city": "Supplierville",
-            "contact_postcode": "11 AB",
         })
 
         assert status == 200
-        assert 'You must provide an email address' in resp
+        assert 'You must provide an email address' in response
 
         assert data_api_client.update_supplier.called is False
         assert data_api_client.update_contact_information.called is False
 
-        assert "New Description" in resp
-        assert 'value="2"' in resp
-        assert 'value="Supplier Person"' in resp
-        assert 'value="0800123123"' in resp
-        assert 'value="1 Street"' in resp
-        assert 'value="Supplierville"' in resp
-        assert 'value="11 AB"' in resp
+        assert "New Description" in response
+        assert 'value="2"' in response
+        assert 'value="Supplier Person"' in response
+        assert 'value="0800123123"' in response
 
     def test_description_below_word_length(self, data_api_client):
         self.login()

--- a/tests/app/main/test_suppliers.py
+++ b/tests/app/main/test_suppliers.py
@@ -743,7 +743,7 @@ class TestSupplierDetails(BaseApplicationTest):
             ):
                 assert document.xpath("//*[normalize-space(string())=$t]", t=property_str), property_str
 
-            # Registration nnumber not shown if Companies House ID exists
+            # Registration number not shown if Companies House ID exists
             assert "BEL153" not in page_html
 
             data_api_client.get_supplier.assert_called_once_with(1234)

--- a/tests/app/main/test_suppliers.py
+++ b/tests/app/main/test_suppliers.py
@@ -938,10 +938,9 @@ class TestSupplierUpdate(BaseApplicationTest):
         if data is None:
             data = {
                 "description": "New Description",
-                "contact_id": 2,
-                "contact_email": "supplier@user.dmdev",
-                "contact_contactName": "Supplier Person",
-                "contact_phoneNumber": "0800123123",
+                "email": "supplier@user.dmdev",
+                "contactName": "Supplier Person",
+                "phoneNumber": "0800123123",
             }
         data.update(kwargs)
         res = self.client.post("/suppliers/details/edit", data=data)
@@ -974,7 +973,7 @@ class TestSupplierUpdate(BaseApplicationTest):
 
     def test_update_all_supplier_fields(self, data_api_client):
         self.login()
-
+        data_api_client.get_supplier.side_effect = get_supplier
         status, _ = self.post_supplier_edit()
 
         assert status == 302
@@ -992,20 +991,18 @@ class TestSupplierUpdate(BaseApplicationTest):
                 'email': u'supplier@user.dmdev',
                 'phoneNumber': u'0800123123',
                 'contactName': u'Supplier Person',
-                'id': 2
             },
             'email@email.com'
         )
 
     def test_should_strip_whitespace_surrounding_supplier_update_all_fields(self, data_api_client):
         self.login()
-
+        data_api_client.get_supplier.side_effect = get_supplier
         data = {
             "description": "  New Description  ",
-            "contact_id": 2,
-            "contact_email": "  supplier@user.dmdev  ",
-            "contact_contactName": "  Supplier Person  ",
-            "contact_phoneNumber": "  0800123123  ",
+            "email": "  supplier@user.dmdev  ",
+            "contactName": "  Supplier Person  ",
+            "phoneNumber": "  0800123123  ",
         }
 
         status, _ = self.post_supplier_edit(data=data)
@@ -1025,7 +1022,6 @@ class TestSupplierUpdate(BaseApplicationTest):
                 'email': u'supplier@user.dmdev',
                 'phoneNumber': u'0800123123',
                 'contactName': u'Supplier Person',
-                'id': 2
             },
             'email@email.com'
         )
@@ -1035,19 +1031,17 @@ class TestSupplierUpdate(BaseApplicationTest):
 
         status, response = self.post_supplier_edit({
             "description": "New Description",
-            "contact_id": 2,
-            "contact_contactName": "Supplier Person",
-            "contact_phoneNumber": "0800123123",
+            "contactName": "Supplier Person",
+            "phoneNumber": "0800123123",
         })
 
-        assert status == 200
+        assert status == 400
         assert 'You must provide an email address' in response
 
         assert data_api_client.update_supplier.called is False
         assert data_api_client.update_contact_information.called is False
 
         assert "New Description" in response
-        assert 'value="2"' in response
         assert 'value="Supplier Person"' in response
         assert 'value="0800123123"' in response
 
@@ -1070,7 +1064,7 @@ class TestSupplierUpdate(BaseApplicationTest):
             description="DESCR " * 51
         )
 
-        assert status == 200
+        assert status == 400
         assert 'must not be more than 50' in resp
 
         assert data_api_client.update_supplier.called is False


### PR DESCRIPTION
Trello ticket: https://trello.com/c/VF5yc1pd/50-supplier-account-1-update-supplier-details-page
- rename headers
- rename 'Edit' to 'Change' link
- add 'Optional' next to summary field
- Move address field to second section of the page and add registration country to it
- remove 'Registration Country' as a separate question
- write a test for address field
- adjust existing tests

Also 2nd Trello ticket: https://trello.com/c/A3ovgHlk/51-remove-address-from-edit-supplier-details-page

- Delete address details from "Edit supplier" page
- Change header and breadcrumb for 'What buyers will see' page
- Move validation errors banner above the page header
-  Rename route/page from 'edit_supplier' to 'edit_what_buyers_will_see' 

ADDITIONALLY:
- unite GET and POST routes for edit_supplier contact information

Screenshot of the updated "Supplier details" page:
![screen shot 2018-02-20 at 14 36 03](https://user-images.githubusercontent.com/20957548/36430060-26f4fc6e-164c-11e8-8de1-c8d3c5634cd5.png)


____



Screenshot of the updated  "What buyers will see"page (content checked with @constancecerf ):
![screen shot 2018-02-26 at 14 49 41](https://user-images.githubusercontent.com/20957548/36676709-56db5b50-1b04-11e8-9a5c-5a7da371da93.png)
