### PR TITLE
Add registered name page

### DIFF
--- a/app/main/forms/suppliers.py
+++ b/app/main/forms/suppliers.py
@@ -63,6 +63,14 @@ class EditRegisteredCountryForm(Form):
     ])
 
 
+# "Add" rather than "Edit" because this information can only be set once by a supplier
+class AddCompanyRegisteredNameForm(Form):
+    registered_company_name = StripWhitespaceStringField('Registered company name', validators=[
+        InputRequired(message="You must provide a registered company name."),
+        Length(max=255, message="You must provide a registered company name under 256 characters.")
+    ])
+
+
 class DunsNumberForm(Form):
     duns_number = StripWhitespaceStringField('DUNS Number', validators=[
         InputRequired(message="You must enter a DUNS number with 9 digits."),

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -174,29 +174,25 @@ def edit_supplier_registered_name():
             render_template("suppliers/already_completed.html", completed_data_description="registered company name"),
             200 if request.method == 'GET' else 400
         )
+
     if request.method == 'POST':
         if form.validate_on_submit():
             try:
                 data_api_client.update_supplier(supplier_id=current_user.supplier_id,
                                                 supplier={"registeredName": form.registered_company_name.data},
                                                 user=current_user.email_address)
-            except APIError as e:
-                api_error = e.message
-                form.registered_company_name.errors.append(api_error)
-                current_app.logger.warning("supplieredit.fail: api error:{api_error}", extra={"api_error": api_error})
-            else:
                 return redirect(url_for('.supplier_details'))
+            except APIError as e:
+                abort(e.status_code)
+        else:
+            current_app.logger.warning(
+                "supplieredit.fail: registered-name:{rname}, errors:{rname_errors}",
+                extra={
+                    'rname': form.registered_company_name.data,
+                    'rname_errors': ",".join(form.registered_company_name.errors)
+                })
 
-        current_app.logger.warning(
-            "supplieredit.fail: registered-name:{rname}, errors:{rname_errors}",
-            extra={
-                'rname': form.registered_company_name.data,
-                'rname_errors': ",".join(form.registered_company_name.errors)
-            })
-
-        return render_template("suppliers/edit_registered_name.html", form=form), 400
-
-    form.registered_company_name.data = supplier.get("registeredName", "")
+            return render_template("suppliers/edit_registered_name.html", form=form), 400
 
     return render_template('suppliers/edit_registered_name.html', form=form)
 

--- a/app/templates/suppliers/already_completed.html
+++ b/app/templates/suppliers/already_completed.html
@@ -1,0 +1,48 @@
+{% extends "_base_page.html" %}
+
+{% block page_title %}Change your {{ completed_data_description }} – Digital Marketplace{% endblock %}
+
+{% block breadcrumb %}
+  {% with items = [
+    {
+      "link": "/",
+      "label": "Digital Marketplace"
+    },
+    {
+       "link": url_for('.dashboard'),
+       "label": "Your account"
+    },
+    {
+      "link": url_for('.supplier_details'),
+      "label": "Company details"
+    },
+  ] %}
+    {% include "toolkit/breadcrumb.html" %}
+  {% endwith %}
+{% endblock %}
+
+{% block main_content %}
+
+<div class="single-question-page">
+  <div class="grid-row">
+
+    <div class="column-two-thirds dmspeak">
+      {% with heading = "Change your {}".format(completed_data_description), smaller = True %}
+        {% include "toolkit/page-heading.html" %}
+      {% endwith %}
+
+      <p>Contact <a href="mailto:cloud_digital@crowncommercial.gov.uk">cloud_digital@crowncommercial.gov.uk</a> to make changes to your:</p>
+
+      <ul class="list-bullet">
+        <li>registered company name</li>
+        <li>registration number</li>
+        <li>VAT number</li>
+        <li>DUNS number</li>
+      </ul>
+
+      <p><a href="{{ url_for('.supplier_details') }}">Return to company details</a></p>
+    </div>
+  </div>
+</div>
+
+{% endblock %}

--- a/app/templates/suppliers/already_completed.html
+++ b/app/templates/suppliers/already_completed.html
@@ -31,7 +31,8 @@
         {% include "toolkit/page-heading.html" %}
       {% endwith %}
 
-      <p>Contact <a href="mailto:cloud_digital@crowncommercial.gov.uk">cloud_digital@crowncommercial.gov.uk</a> to make changes to your:</p>
+      <div class="explanation-list">
+      <p class="lead">Contact <a href="mailto:cloud_digital@crowncommercial.gov.uk">cloud_digital@crowncommercial.gov.uk</a> to make changes to your:</p>
 
       <ul class="list-bullet">
         <li>registered company name</li>
@@ -39,8 +40,16 @@
         <li>VAT number</li>
         <li>DUNS number</li>
       </ul>
+      </div>
 
-      <p><a href="{{ url_for('.supplier_details') }}">Return to company details</a></p>
+      {%
+        with
+        url = url_for('.supplier_details'),
+        text = "Return to company details"
+      %}
+        {% include "toolkit/secondary-action-link.html" %}
+      {% endwith %}
+
     </div>
   </div>
 </div>

--- a/app/templates/suppliers/edit_registered_name.html
+++ b/app/templates/suppliers/edit_registered_name.html
@@ -1,0 +1,65 @@
+{% extends "_base_page.html" %}
+
+{% block page_title %}Registered company name – Digital Marketplace{% endblock %}
+
+{% block breadcrumb %}
+  {% with items = [
+    {
+      "link": "/",
+      "label": "Digital Marketplace"
+    },
+    {
+       "link": url_for('.dashboard'),
+       "label": "Your account"
+    },
+    {
+      "link": url_for('.supplier_details'),
+      "label": "Company details"
+    },
+  ] %}
+    {% include "toolkit/breadcrumb.html" %}
+  {% endwith %}
+{% endblock %}
+
+{% block main_content %}
+
+<div class="single-question-page">
+  <div class="grid-row">
+
+      {% if form.errors %}
+        {% with errors = [{'question': form.registered_company_name.label, 'input_name': form.registered_company_name.name}] %}
+          {% include 'toolkit/forms/validation.html' %}
+        {% endwith %}
+      {% endif %}
+
+    <div class="column-two-thirds">
+      {% with heading = "Registered company name", smaller = True %}
+        {% include "toolkit/page-heading.html" %}
+      {% endwith %}
+
+      <form method="POST" action="{{ url_for('.edit_supplier_registered_name') }}">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+
+        {%
+          with
+          name = "registered_company_name",
+          question = "Registered company name",
+          value = form.registered_company_name.data,
+          error = form.registered_company_name.errors[0],
+          question_advice = "This could be different to your trading name."
+        %}
+          {% include "toolkit/forms/textbox.html" %}
+        {% endwith %}
+
+        {% with type = "save",
+                label = "Save and continue" %}
+          {% include "toolkit/button.html" %}
+        {% endwith %}
+
+        <p><a href="{{ url_for('.supplier_details') }}">Return to company details</a></p>
+      </form>
+    </div>
+  </div>
+</div>
+
+{% endblock %}

--- a/app/templates/suppliers/edit_registered_name.html
+++ b/app/templates/suppliers/edit_registered_name.html
@@ -25,13 +25,13 @@
 
 <div class="single-question-page">
   <div class="grid-row">
-
+    <div class="column-one-whole">
       {% if form.errors %}
         {% with errors = [{'question': form.registered_company_name.label, 'input_name': form.registered_company_name.name}] %}
           {% include 'toolkit/forms/validation.html' %}
         {% endwith %}
       {% endif %}
-
+    </div>
     <div class="column-two-thirds">
       {% with heading = "Registered company name", smaller = True %}
         {% include "toolkit/page-heading.html" %}

--- a/tests/app/helpers.py
+++ b/tests/app/helpers.py
@@ -494,10 +494,21 @@ class BaseApplicationTest(object):
         with self.client.session_transaction() as session:
             assert not session.get("_flashes")
 
-    def assert_validation_masthead(self, res, title="There was a problem with your answer to:"):
+    def assert_single_question_page_validation_errors(self,
+                                                      res,
+                                                      title="There was a problem with your answer to:",
+                                                      question_name="",
+                                                      validation_message=""
+                                                      ):
         doc = html.fromstring(res.get_data(as_text=True))
-        masthead_text = doc.xpath('//h1[@class="validation-masthead-heading"]/text()')
-        assert masthead_text and title in masthead_text[0]
+        masthead_heading = doc.xpath('normalize-space(//h1[@class="validation-masthead-heading"]/text())')
+        masthead_link_text = doc.xpath('normalize-space(string(//a[@class="validation-masthead-link"]))')
+        validation_text = doc.xpath('normalize-space(//span[@class="validation-message"]/text())')
+
+        assert res.status_code == 400
+        assert masthead_heading and title == masthead_heading
+        assert masthead_link_text and question_name == masthead_link_text
+        assert validation_text and validation_message == validation_text
 
 
 class FakeMail(object):

--- a/tests/app/main/test_suppliers.py
+++ b/tests/app/main/test_suppliers.py
@@ -2288,19 +2288,13 @@ class TestSupplierAddRegisteredCompanyName(BaseApplicationTest):
                 mock.call(supplier_id=1234, supplier={'registeredName': "K-Inc"}, user='email@email.com')
             ], 'update_supplier was called with the wrong arguments'
 
-    def test_post_response_shows_error_message_on_api_failure(self, data_api_client):
+    def test_fails_if_api_update_fails(self, data_api_client):
         with self.app.test_client():
             self.login()
-            error_message = "You broke it"
             data_api_client.get_supplier.return_value = get_supplier(registeredName=None)
-            data_api_client.update_supplier.side_effect = APIError(mock.Mock(status_code=504), error_message)
+            data_api_client.update_supplier.side_effect = APIError(mock.Mock(status_code=504))
             res = self.client.post("/suppliers/registered-company-name/edit", data={'registered_company_name': "K-Inc"})
-            doc = html.fromstring(res.get_data(as_text=True))
-            validation_wrap = doc.xpath('//span[@class="validation-message"]')
-
-            assert res.status_code == 400
-            assert len(validation_wrap) == 1, 'Only one validation message should be shown.'
-            assert validation_wrap[0].text.strip() == error_message, 'The validation message is not as expected.'
+            assert res.status_code == 504
 
     def test_get_shows_already_entered_page_and_api_not_called_update_if_data_already_entered(self, data_api_client):
         with self.app.test_client():

--- a/tests/app/main/test_suppliers.py
+++ b/tests/app/main/test_suppliers.py
@@ -2282,11 +2282,13 @@ class TestSupplierAddRegisteredCompanyName(BaseApplicationTest):
             self.login()
             data_api_client.get_supplier.return_value = get_supplier(registeredName=None)
 
-            self.client.post("/suppliers/registered-company-name/edit", data={'registered_company_name': "K-Inc"})
+            res = self.client.post("/suppliers/registered-company-name/edit", data={'registered_company_name': "K-Inc"})
 
             assert data_api_client.update_supplier.call_args_list == [
                 mock.call(supplier_id=1234, supplier={'registeredName': "K-Inc"}, user='email@email.com')
             ], 'update_supplier was called with the wrong arguments'
+            assert res.status_code == 302
+            assert res.location == 'http://localhost/suppliers/details'
 
     def test_fails_if_api_update_fails(self, data_api_client):
         with self.app.test_client():


### PR DESCRIPTION
For this ticket: https://trello.com/c/Q5N2RVEj/47-new-one-time-page-build-registered-company-name-page

Adds a new page where suppliers can add their registered name.

# Unfilled
![screen shot 2018-02-21 at 13 07 43](https://user-images.githubusercontent.com/6525554/36481653-612db526-1708-11e8-9f82-2b41ce471cac.png)


# Validation error
![screen shot 2018-02-21 at 15 56 21](https://user-images.githubusercontent.com/6525554/36490304-e0f4753a-171f-11e8-9ebe-b24e22bd7e6f.png)



# Already filled
![screen shot 2018-02-21 at 15 55 50](https://user-images.githubusercontent.com/6525554/36490301-dd7bee10-171f-11e8-89cb-cf6f63970601.png)


