### PR TITLE
Accessibility fixes for summary table Edit links

### DIFF
--- a/app/templates/frameworks/contract_review.html
+++ b/app/templates/frameworks/contract_review.html
@@ -62,7 +62,7 @@
       {% call summary.field() %}
         <p>{{ agreement.signedAgreementDetails.signerName }}</p><p>{{ agreement.signedAgreementDetails.signerRole }}</p>
       {% endcall %}
-      {{ summary.edit_link("Edit", url_for('.signer_details', framework_slug=framework.slug, agreement_id=agreement.id)) }}
+      {{ summary.edit_link("Edit", url_for('.signer_details', framework_slug=framework.slug, agreement_id=agreement.id), hidden_text="person who signed") }}
     {% endcall %}
     {% call summary.row() %}
       {{ summary.field_name('Signature page') }}
@@ -71,7 +71,7 @@
       {% else %}
         {{ summary.field_name( "Uploaded {}".format(signature_page.last_modified|datetimeformat) if signature_page else None) }}
       {% endif %}
-      {{ summary.edit_link("Change", url_for('.signature_upload', framework_slug=framework.slug, agreement_id=agreement.id)) }}
+      {{ summary.edit_link("Change", url_for('.signature_upload', framework_slug=framework.slug, agreement_id=agreement.id), hidden_text="signature") }}
     {% endcall %}
   {% endcall %}
 </div>

--- a/app/templates/frameworks/declaration_overview.html
+++ b/app/templates/frameworks/declaration_overview.html
@@ -80,7 +80,7 @@
         {{ summary.heading(section.name, id=section.slug) }}
         {% if section.editable %}
           {% if framework.status == 'open' %}
-            {{ summary.top_link("Edit", url_for(".framework_supplier_declaration_edit", framework_slug=framework.slug, section_id=section.id)) }}
+            {{ summary.top_link("Edit", url_for(".framework_supplier_declaration_edit", framework_slug=framework.slug, section_id=section.id), hidden_text=section.name) }}
           {% endif %}
         {% endif %}
         {% if section.summary_page_description %}

--- a/app/templates/services/service.html
+++ b/app/templates/services/service.html
@@ -90,7 +90,7 @@
 
 {% block edit_link %}
   {% if 'EDIT_SECTIONS' is active_feature %}
-    {{ summary.top_link("Edit", url_for(".edit_section", framework_slug=service_data["frameworkSlug"], service_id=service_id, section_id=section.id)) }}
+    {{ summary.top_link("Edit", url_for(".edit_section", framework_slug=service_data["frameworkSlug"], service_id=service_id, section_id=section.id, hidden_text=section.name)) }}
   {% endif %}
 {% endblock %}
 

--- a/app/templates/services/service_submission.html
+++ b/app/templates/services/service_submission.html
@@ -127,7 +127,7 @@
 
 {% block edit_link %}
   {% if framework.status == 'open' %}
-    {{ summary.top_link("Edit", url_for(".edit_service_submission", framework_slug=framework.slug, lot_slug=service_data.lot, service_id=service_id, section_id=section.id)) }}
+    {{ summary.top_link("Edit", url_for(".edit_service_submission", framework_slug=framework.slug, lot_slug=service_data.lot, service_id=service_id, section_id=section.id, hidden_text=section.name)) }}
   {% endif %}
 {% endblock %}
 

--- a/app/templates/suppliers/company_summary.html
+++ b/app/templates/suppliers/company_summary.html
@@ -49,27 +49,27 @@
   {% call summary.row(complete=session.get("duns_number", None)) %}
   {{ summary.field_name("DUNS number") }}
   {{ summary.text(session.get("duns_number", "You must answer this question.")) }}
-  {{ summary.edit_link("Edit", url_for(".duns_number")) }}
+  {{ summary.edit_link("Edit", url_for(".duns_number"), hidden_text="DUNS number") }}
   {% endcall %}
   {% call summary.row(complete=session.get("company_name", None)) %}
   {{ summary.field_name("Company name") }}
   {{ summary.text(session.get("company_name", "You must answer this question.")) }}
-  {{ summary.edit_link("Edit", url_for(".company_name")) }}
+  {{ summary.edit_link("Edit", url_for(".company_name"), hidden_text="company name") }}
   {% endcall %}
   {% call summary.row(complete=session.get("contact_name", None)) %}
   {{ summary.field_name("Contact name") }}
   {{ summary.text(session.get("contact_name", "You must answer this question.")) }}
-  {{ summary.edit_link("Edit", url_for(".company_contact_details")) }}
+  {{ summary.edit_link("Edit", url_for(".company_contact_details"), hidden_text="contact name") }}
   {% endcall %}
-  {% call summary.row(complete=session.get("phone_number", None)) %}
+  {% call summary.row(complete=session.get("email_address", None)) %}
   {{ summary.field_name("Contact email") }}
   {{ summary.text(session.get("email_address", "You must answer this question.")) }}
-  {{ summary.edit_link("Edit", url_for(".company_contact_details")) }}
+  {{ summary.edit_link("Edit", url_for(".company_contact_details"), hidden_text="contact email") }}
   {% endcall %}
   {% call summary.row(complete=session.get("phone_number", None)) %}
   {{ summary.field_name("Contact phone number") }}
   {{ summary.text(session.get("phone_number", "You must answer this question.")) }}
-  {{ summary.edit_link("Edit", url_for(".company_contact_details")) }}
+  {{ summary.edit_link("Edit", url_for(".company_contact_details"), hidden_text="contact phone number") }}
   {% endcall %}
   {% endcall %}
 
@@ -85,7 +85,7 @@
     {% call summary.row(complete=session.get("account_email_address", None)) %}
     {{ summary.field_name("Email address") }}
     {{ summary.text(session.get("account_email_address", "You must answer this question.")) }}
-    {{ summary.edit_link("Edit", url_for(".create_your_account")) }}
+    {{ summary.edit_link("Edit", url_for(".create_your_account"), hidden_text="email address") }}
     {% endcall %}
   {% endcall %}
 </div>


### PR DESCRIPTION
Trello: https://trello.com/c/sYJYKnK9/58-how-summary-tables-handle-their-links-means-pages-can-contain-multiple-links-with-duplicate-text

Summary tables with multiple 'Edit' or 'Change' links are unhelpful for screenreader users who may not know which section the link refers to. 

v28.1.0 of the FE toolkit adds in a 'hidden_text' param to the `summary.top_link` macro (similar to the existing `summary.edit_link`) so we can make the link text less ambiguous for screen reader users. 

For example:
```
<a href="...">Edit</a>
```
becomes
```
<a href="...">Edit<span class="visually-hidden"> supplier details</span></a>
```

NB: I've guessed at the content for some of the links where there isn't an existing `section.name` to use. These will need a content designer to review (@constancecerf @karlchillmaid ?). 

See also: Brief Responses FE https://github.com/alphagov/digitalmarketplace-brief-responses-frontend/pull/32