### PR TITLE
Update registered address page

### DIFF
--- a/app/main/helpers/suppliers.py
+++ b/app/main/helpers/suppliers.py
@@ -48,3 +48,16 @@ def supplier_company_details_are_complete(supplier_data):
              for f in
              contact_required_fields])
     )
+
+
+def parse_form_errors_for_validation_masthead(forms):
+    form_list = forms if isinstance(forms, (list, tuple)) else [forms]
+
+    errors = []
+    for form in form_list:
+        errors += [{
+            'question': form[field].label.text,
+            'input_name': form[field].name,
+        } for field in form.errors.keys()]
+
+    return errors

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -119,6 +119,7 @@ def edit_registered_address():
     http_status = 200
     registered_address_form = EditRegisteredAddressForm()
     registered_country_form = EditRegisteredCountryForm()
+    form_errors = None
 
     if request.method == 'POST':
         address_valid = registered_address_form.validate_on_submit()
@@ -146,6 +147,18 @@ def edit_registered_address():
 
         http_status = 400
 
+        address_form_errors = [{
+            'question': registered_address_form[field].label.text,
+            'input_name': registered_address_form[field].name,
+        } for field in registered_address_form.errors.keys()]
+
+        country_form_errors = [{
+            'question': registered_country_form[field].label.text,
+            'input_name': registered_country_form[field].name,
+        } for field in registered_country_form.errors.keys()]
+
+        form_errors = address_form_errors + country_form_errors
+
     else:
         registered_address_form.address1.data = supplier['contact'].get('address1')
         registered_address_form.city.data = supplier['contact'].get('city')
@@ -159,6 +172,7 @@ def edit_registered_address():
         countries=COUNTRY_TUPLE,
         registered_address_form=registered_address_form,
         registered_country_form=registered_country_form,
+        form_errors=form_errors,
     ), http_status
 
 

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -116,7 +116,6 @@ def edit_registered_address():
         abort(e.status_code)
     supplier['contact'] = supplier['contactInformation'][0]
 
-    error = None
     http_status = 200
     registered_address_form = EditRegisteredAddressForm()
     registered_country_form = EditRegisteredCountryForm()
@@ -141,10 +140,9 @@ def edit_registered_address():
                 )
 
             except APIError as e:
-                error = e.message
+                abort(e.status_code)
 
-            else:
-                return redirect(url_for(".supplier_details"))
+            return redirect(url_for(".supplier_details"))
 
         http_status = 400
 
@@ -161,7 +159,6 @@ def edit_registered_address():
         countries=COUNTRY_TUPLE,
         registered_address_form=registered_address_form,
         registered_country_form=registered_country_form,
-        error=error,
     ), http_status
 
 

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -27,7 +27,8 @@ from ..forms.suppliers import (
     EmailAddressForm,
 )
 from ..helpers.frameworks import get_frameworks_by_status, get_frameworks_closed_and_open_for_applications
-from ..helpers.suppliers import get_country_name_from_country_code, COUNTRY_TUPLE
+from ..helpers.suppliers import get_country_name_from_country_code, COUNTRY_TUPLE, \
+    parse_form_errors_for_validation_masthead
 from ..helpers import login_required
 from .users import get_current_suppliers_users
 
@@ -119,7 +120,6 @@ def edit_registered_address():
     http_status = 200
     registered_address_form = EditRegisteredAddressForm()
     registered_country_form = EditRegisteredCountryForm()
-    form_errors = None
 
     if request.method == 'POST':
         address_valid = registered_address_form.validate_on_submit()
@@ -147,18 +147,6 @@ def edit_registered_address():
 
         http_status = 400
 
-        address_form_errors = [{
-            'question': registered_address_form[field].label.text,
-            'input_name': registered_address_form[field].name,
-        } for field in registered_address_form.errors.keys()]
-
-        country_form_errors = [{
-            'question': registered_country_form[field].label.text,
-            'input_name': registered_country_form[field].name,
-        } for field in registered_country_form.errors.keys()]
-
-        form_errors = address_form_errors + country_form_errors
-
     else:
         registered_address_form.address1.data = supplier['contact'].get('address1')
         registered_address_form.city.data = supplier['contact'].get('city')
@@ -172,7 +160,7 @@ def edit_registered_address():
         countries=COUNTRY_TUPLE,
         registered_address_form=registered_address_form,
         registered_country_form=registered_country_form,
-        form_errors=form_errors,
+        form_errors=parse_form_errors_for_validation_masthead([registered_address_form, registered_country_form]),
     ), http_status
 
 

--- a/app/templates/suppliers/registered_address.html
+++ b/app/templates/suppliers/registered_address.html
@@ -30,13 +30,6 @@
 
 
 {% block main_content %}
-  {% if error %}
-  <div class="validation-masthead" aria-labelledby="validation-masthead-heading">
-    <h1 class="validation-masthead-heading" id="validation-masthead-heading">
-      {{ error }}
-    </h1>
-  </div>
-  {% endif %}
 
   {% if registered_address_form.errors or registered_country_form.errors %}
       <div class="validation-masthead" aria-labelledby="validation-masthead-heading">

--- a/app/templates/suppliers/registered_address.html
+++ b/app/templates/suppliers/registered_address.html
@@ -31,24 +31,10 @@
 
 {% block main_content %}
 
-  {% if registered_address_form.errors or registered_country_form.errors %}
-      <div class="validation-masthead" aria-labelledby="validation-masthead-heading">
-        <h1 class="validation-masthead-heading" id="validation-masthead-heading">
-            There was a problem with the details you gave for:
-        </h1>
-        <ul>
-          {% for field_name, field_errors in registered_address_form.errors|dictsort %}
-            {% for error in field_errors %}
-              <li><a href="#{{ field_name }}" class="validation-masthead-link">{{ registered_address_form[field_name].label.text }}</a>
-            {% endfor %}
-          {% endfor %}
-          {% for field_name, field_errors in registered_country_form.errors|dictsort %}
-            {% for error in field_errors %}
-              <li><a href="#{{ field_name }}" class="validation-masthead-link">{{ registered_country_form[field_name].label.text }}</a></li>
-            {% endfor %}
-          {% endfor %}
-        </ul>
-      </div>
+  {% if form_errors %}
+  {% with errors = form_errors %}
+    {% include 'toolkit/forms/validation.html' %}
+  {% endwith %}
   {% endif %}
 
   <div class="grid-row">

--- a/app/templates/suppliers/registered_address.html
+++ b/app/templates/suppliers/registered_address.html
@@ -51,7 +51,7 @@
           {% endfor %}
           {% for field_name, field_errors in registered_country_form.errors|dictsort %}
             {% for error in field_errors %}
-              <li><a href="javascript:document.getElementById('location-autocomplete').focus()" class="validation-masthead-link">{{ registered_country_form[field_name].label.text }}</a></li>
+              <li><a href="#{{ field_name }}" class="validation-masthead-link">{{ registered_country_form[field_name].label.text }}</a></li>
             {% endfor %}
           {% endfor %}
         </ul>
@@ -88,7 +88,7 @@
         </style>
       {% endif %}
 
-      <div class="question">
+      <div class="question" id="registrationCountry">
         <span class="question-heading" id="country-label">Country</span>
         {{ forms.field_errors('registrationCountry', errors=registered_country_form.registrationCountry.errors) }}
         <select name="registrationCountry" id="location-autocomplete" class="location-autocomplete-fallback">

--- a/tests/app/main/test_suppliers.py
+++ b/tests/app/main/test_suppliers.py
@@ -1282,16 +1282,19 @@ class TestEditSupplierRegisteredAddress(BaseApplicationTest):
 
     def test_handles_api_errors_when_updating_supplier_or_contact_information(self):
         self.login()
-        self.data_api_client.update_supplier.side_effect = [HTTPError(400, "I'm an error from the API"), None]
-        self.data_api_client.update_contact_information.side_effect = HTTPError(400, "So am I!")
+        self.data_api_client.update_supplier.side_effect = HTTPError(400, "I'm an error from the API")
 
-        for error_message in ["I'm an error from the API", "So am I!"]:
-            status, response = self.post_supplier_address_edit()
-            doc = html.fromstring(response)
+        status, response = self.post_supplier_address_edit()
 
-            assert status == 400
-            assert doc.xpath('normalize-space(//h1[@id="validation-masthead-heading"])') == error_message
-            assert "What is your registered office address?" in doc.xpath('//h1')[-1].text
+        assert status == 503
+
+    def test_handles_api_errors_when_updating_contact_information(self):
+        self.login()
+        self.data_api_client.update_contact_information.side_effect = HTTPError(400, "I'm an error from the API")
+
+        status, response = self.post_supplier_address_edit()
+
+        assert status == 503
 
 
 class TestCreateSupplier(BaseApplicationTest):


### PR DESCRIPTION
Some minor tweaks to the new registered address page, to bring it inline with how we're doing things on other pages. Mostly spurred on my working out why validation masthead links were broken in some cases.

### Remove JavaScript link from validation masthead
There was an issue with the usual links not working so we used
JavaScript instead. I've worked out what the problem was.

The links are actually powered by some other JavaScript from the
frontend toolkit. They look for an element with an ID that matches the
field name, and then target the first input or text area _within_ that.
So if the input itself has the id, or the id isn't used, the link won't
work.

### Abort on APIErrors when updating
As we're validating on the frontend, all errors should be due to
network issues or the like. So any APIErrors can bubble up as 500's.

### Use validation masthead from toolkit
By processing both forms errors in the view and passing them to the
template we can use validation masthead from the toolkit rather than
something custom.