### PR TITLE
Add one time vat page

### DIFF
--- a/app/main/forms/suppliers.py
+++ b/app/main/forms/suppliers.py
@@ -1,3 +1,4 @@
+from re import IGNORECASE
 from flask_wtf import Form
 from wtforms import RadioField
 from wtforms.validators import AnyOf, InputRequired, Length, Optional, Regexp, StopValidation, ValidationError
@@ -218,11 +219,12 @@ class VatNumberForm(Form):
             raise StopValidation()
 
     vat_registered = RadioField("VAT registered",
-                                validators=[InputRequired(message="You must provide an answer.")],
+                                validators=[InputRequired(message="You need to answer this question.")],
                                 choices=[('Yes', 'Yes'), ('No', 'No')])
     vat_number = StripWhitespaceStringField('VAT number', default="", validators=[
         stop_validation_if_not_registered,
         InputRequired(message="You must provide a VAT number."),
-        Regexp(r'^([GB])*(([1-9]\d{8})|([1-9]\d{11})|((GD|HA)[1-9]\d{2}))$',
-               message="You must provide a valid VAT number.")
+        Regexp(r'^([GB])*((\d{9})|(\d{12})|((GD|HA)\d{3}))$',
+               flags=IGNORECASE,
+               message="You must provide a valid VAT number, they are usually either 9 or 12 digits.")
     ])

--- a/app/templates/suppliers/edit_vat_number.html
+++ b/app/templates/suppliers/edit_vat_number.html
@@ -1,0 +1,72 @@
+{% extends "_base_page.html" %}
+
+{% block page_title %}VAT number – Digital Marketplace{% endblock %}
+
+{% block breadcrumb %}
+  {% with items = [
+    {
+      "link": "/",
+      "label": "Digital Marketplace"
+    },
+    {
+       "link": url_for('.dashboard'),
+       "label": "Your account"
+    },
+    {
+      "link": url_for('.supplier_details'),
+      "label": "Company details"
+    },
+  ] %}
+    {% include "toolkit/breadcrumb.html" %}
+  {% endwith %}
+{% endblock %}
+
+{% block main_content %}
+
+{% if form.errors %}
+  {% with errors = form_errors %}
+    {% include 'toolkit/forms/validation.html' %}
+  {% endwith %}
+{% endif %}
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+    {% with heading = "Are you registered for VAT?", smaller = True %}
+      {% include "toolkit/page-heading.html" %}
+    {% endwith %}
+
+    <form method="POST" action="{{ url_for('.edit_supplier_vat_number') }}">
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+      {%
+        with
+        name = "vat_registered",
+        type = "radio",
+        value = form.vat_registered.data,
+        error = form.vat_registered.errors[0],
+        options = [
+          {
+              "label": "Yes",
+              "reveal": {
+                "name": "vat_number",
+                "question": "What is your VAT number?",
+                "value": form.vat_number.data,
+                "error": form.vat_number.errors[0]
+              }
+          },
+          {
+              "label": "No"
+          }
+        ]
+      %}
+        {% include "toolkit/forms/selection-buttons.html" %}
+      {% endwith %}
+
+      {% with type = "save",
+              label = "Save and continue" %}
+        {% include "toolkit/button.html" %}
+      {% endwith %}
+      <p><a href="{{ url_for('.supplier_details') }}">Return to company details</a></p>
+    </form>
+  </div>
+</div>
+{% endblock %}

--- a/tests/app/main/test_suppliers.py
+++ b/tests/app/main/test_suppliers.py
@@ -84,7 +84,9 @@ def get_supplier(*args, **kwargs):
         }
     }
     supplier_info.update(kwargs)
-    return {"suppliers": supplier_info}
+    return {"suppliers": dict(
+        filter(lambda x: x[1] is not None, supplier_info.items())
+    )}
 
 
 def get_user():
@@ -2496,3 +2498,148 @@ class TestSupplierAddRegistrationNumber(BaseApplicationTest):
             assert res.status_code == 400
             assert page_heading[0].text.strip() == "Change your company registration number"
             assert data_api_client.update_supplier.call_args_list == []
+
+
+class TestEditSupplierVatNumber(BaseApplicationTest):
+    def setup_method(self, method):
+        super().setup_method(method)
+        self.data_api_client_patch = mock.patch("app.main.views.suppliers.data_api_client", autospec=True)
+        self.data_api_client = self.data_api_client_patch.start()
+        self.data_api_client.get_supplier.return_value = get_supplier(vatNumber=None)
+        self.login()
+
+    def teardown_method(self, method):
+        super().setup_method(method)
+        self.data_api_client_patch.stop()
+
+    def test_loads_page_for_supplier_with_no_vat_number(self):
+        with self.app.test_client():
+            res = self.client.get("/suppliers/vat-number/edit")
+            doc = html.fromstring(res.get_data(as_text=True))
+
+            assert res.status_code == 200
+            assert doc.xpath("//h1[normalize-space(string())='Are you registered for VAT?']")
+
+    @pytest.mark.parametrize('method, status_code', (('get', 200), ('post', 400)))
+    def test_get_and_post_load_already_completed_page_and_do_not_update_supplier_with_vat_number(
+        self, method, status_code
+    ):
+        with self.app.test_client():
+            self.data_api_client.get_supplier.return_value = get_supplier()
+
+            res = getattr(self.client, method)("/suppliers/vat-number/edit")
+            doc = html.fromstring(res.get_data(as_text=True))
+
+            assert res.status_code == status_code
+            assert doc.xpath("//h1[normalize-space(string())='Change your VAT number']")
+            assert not self.data_api_client.update_supplier.called
+
+    def test_posting_valid_vat_code_updates_supplier(self):
+        with self.app.test_client():
+            res = self.client.post(
+                "/suppliers/vat-number/edit",
+                data={
+                    "vat_registered": "Yes",
+                    "vat_number": "GB123456789",
+                }
+            )
+
+            assert res.status_code == 302
+            assert res.location == "http://localhost/suppliers/details"
+            self.data_api_client.update_supplier.assert_called_once_with(
+                supplier_id=1234,
+                supplier={"vatNumber": "GB123456789"},
+                user="email@email.com"
+            )
+
+    @pytest.mark.parametrize('vat_number', ("", "Not a VAT number"))
+    def test_posting_not_vat_registered_correctly_updates_supplier(self, vat_number):
+        with self.app.test_client():
+            res = self.client.post(
+                "/suppliers/vat-number/edit",
+                data={
+                    "vat_registered": "No",
+                    "vat_number": vat_number,
+                }
+            )
+
+            assert res.status_code == 302
+            assert res.location == "http://localhost/suppliers/details"
+            self.data_api_client.update_supplier.assert_called_once_with(
+                supplier_id=1234,
+                supplier={"vatNumber": "Not VAT registered"},
+                user="email@email.com",
+            )
+
+    @pytest.mark.parametrize("vat_number, message, masthead", (
+        ("GB123456789", None, None),
+        ("gb123456789012", None, None),
+        ("gBGD123", None, None),
+        ("gbHA456", None, None),
+        ("123456789", None, None),
+        ("123456789012", None, None),
+        ("GD123", None, None),
+        ("Ha456", None, None),
+        ("NOTVALID", "You must provide a valid VAT number, they are usually either 9 or 12 digits.", "VAT number"),
+        ("", "You must provide a VAT number.", "VAT number")
+    ))
+    def test_validation_of_tax_number(self, vat_number, message, masthead):
+        with self.app.test_client():
+            res = self.client.post(
+                "/suppliers/vat-number/edit",
+                data={
+                    "vat_registered": "Yes",
+                    "vat_number": vat_number,
+                }
+            )
+            doc = html.fromstring(res.get_data(as_text=True))
+
+            if message:
+                self.assert_single_question_page_validation_errors(
+                    res,
+                    question_name=masthead,
+                    validation_message=message,
+                )
+                assert not self.data_api_client.update_supplier.called
+            else:
+                assert res.status_code == 302
+                self.data_api_client.update_supplier.assert_called_once_with(
+                    supplier_id=1234,
+                    supplier={"vatNumber": vat_number},
+                    user="email@email.com",
+                )
+
+    def test_validation_of_vat_registered(self):
+        with self.app.test_client():
+            res = self.client.post(
+                "/suppliers/vat-number/edit",
+                data={
+                    "vat_number": "",
+                }
+            )
+            doc = html.fromstring(res.get_data(as_text=True))
+
+            assert res.status_code == 400
+            assert doc.xpath(
+                "//div[@class='validation-masthead'][normalize-space(string())=$masthead]",
+                masthead="There was a problem with your answer to: VAT registered"
+            )
+            assert doc.xpath(
+                "//span[@class='validation-message'][normalize-space(string())=$message]",
+                message="You need to answer this question."
+            )
+            assert not self.data_api_client.update_supplier.called
+
+    def test_post_response_fails_if_api_error(self):
+        with self.app.test_client():
+            self.data_api_client.update_supplier.side_effect = APIError(mock.Mock(status_code=504))
+
+            res = self.client.post(
+                "/suppliers/vat-number/edit",
+                data={
+                    "vat_registered": "Yes",
+                    "vat_number": "GB123456789",
+                }
+            )
+
+            assert res.status_code == 504

--- a/yarn.lock
+++ b/yarn.lock
@@ -229,9 +229,9 @@ brace-expansion@^1.0.0, brace-expansion@^1.1.7:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
-braces@^2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/braces/-/braces-2.3.0.tgz#a46941cb5fb492156b3d6a656e06c35364e3e66e"
+braces@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/braces/-/braces-2.3.1.tgz#7086c913b4e5a08dbe37ac0ee6a2500c4ba691bb"
   dependencies:
     arr-flatten "^1.1.0"
     array-unique "^0.3.2"
@@ -239,6 +239,7 @@ braces@^2.3.0:
     extend-shallow "^2.0.1"
     fill-range "^4.0.0"
     isobject "^3.0.1"
+    kind-of "^6.0.2"
     repeat-element "^1.1.2"
     snapdragon "^0.8.1"
     snapdragon-node "^2.0.1"
@@ -495,6 +496,13 @@ define-property@^1.0.0:
   dependencies:
     is-descriptor "^1.0.0"
 
+define-property@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/define-property/-/define-property-2.0.2.tgz#d459689e8d654ba77e02a817f8710d702cb16e9d"
+  dependencies:
+    is-descriptor "^1.0.2"
+    isobject "^3.0.1"
+
 del@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/del/-/del-1.2.0.tgz#3241336ead45a66c8f97215ae223c7e7947401c8"
@@ -628,7 +636,7 @@ extend-shallow@^2.0.1:
   dependencies:
     is-extendable "^0.1.0"
 
-extend-shallow@^3.0.0:
+extend-shallow@^3.0.0, extend-shallow@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/extend-shallow/-/extend-shallow-3.0.2.tgz#26a71aaf073b39fb2127172746131c2704028db8"
   dependencies:
@@ -639,7 +647,7 @@ extend@^3.0.0, extend@~3.0.0, extend@~3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.1.tgz#a755ea7bc1adfcc5a31ce7e762dbaadc5e636444"
 
-extglob@^2.0.2:
+extglob@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/extglob/-/extglob-2.0.4.tgz#ad00fe4dc612a9232e8718711dc5cb5ab0285543"
   dependencies:
@@ -669,8 +677,8 @@ fancy-log@^1.0.0, fancy-log@^1.1.0:
     time-stamp "^1.0.0"
 
 fast-deep-equal@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz#96256a3bc975595eb36d82e9929d060d893439ff"
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz#c053477817c86b51daa853c81e059b733d023614"
 
 fast-json-stable-stringify@^2.0.0:
   version "2.0.0"
@@ -1238,8 +1246,8 @@ hoek@2.x.x:
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-2.16.3.tgz#20bb7403d3cea398e91dc4710a8ff1b8274a25ed"
 
 hoek@4.x.x:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/hoek/-/hoek-4.2.0.tgz#72d9d0754f7fe25ca2d01ad8f8f9a9449a89526d"
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/hoek/-/hoek-4.2.1.tgz#9634502aa12c445dd5a7c5734b572bb8738aacbb"
 
 hogan.js@3.0.2:
   version "3.0.2"
@@ -1364,7 +1372,7 @@ is-descriptor@^0.1.0:
     is-data-descriptor "^0.1.4"
     kind-of "^5.0.0"
 
-is-descriptor@^1.0.0:
+is-descriptor@^1.0.0, is-descriptor@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-descriptor/-/is-descriptor-1.0.2.tgz#3b159746a66604b04f8c81524ba365c5f14d86ec"
   dependencies:
@@ -1424,11 +1432,15 @@ is-number@^3.0.0:
   dependencies:
     kind-of "^3.0.2"
 
-is-odd@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/is-odd/-/is-odd-1.0.0.tgz#3b8a932eb028b3775c39bb09e91767accdb69088"
+is-number@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/is-number/-/is-number-4.0.0.tgz#0026e37f5454d73e356dfe6564699867c6a7f0ff"
+
+is-odd@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-odd/-/is-odd-2.0.0.tgz#7646624671fd7ea558ccd9a2795182f2958f1b24"
   dependencies:
-    is-number "^3.0.0"
+    is-number "^4.0.0"
 
 is-path-cwd@^1.0.0:
   version "1.0.0"
@@ -1476,7 +1488,7 @@ is-utf8@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
 
-is-windows@^1.0.1:
+is-windows@^1.0.1, is-windows@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
 
@@ -1575,7 +1587,7 @@ kind-of@^4.0.0:
   dependencies:
     is-buffer "^1.1.5"
 
-kind-of@^5.0.0, kind-of@^5.0.2:
+kind-of@^5.0.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-5.1.0.tgz#729c91e2d857b7a419a1f9aa65685c4c33f5845d"
 
@@ -1884,32 +1896,32 @@ meow@^3.3.0, meow@^3.7.0:
     trim-newlines "^1.0.0"
 
 micromatch@^3.0.4:
-  version "3.1.5"
-  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-3.1.5.tgz#d05e168c206472dfbca985bfef4f57797b4cd4ba"
+  version "3.1.9"
+  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-3.1.9.tgz#15dc93175ae39e52e93087847096effc73efcf89"
   dependencies:
     arr-diff "^4.0.0"
     array-unique "^0.3.2"
-    braces "^2.3.0"
-    define-property "^1.0.0"
-    extend-shallow "^2.0.1"
-    extglob "^2.0.2"
+    braces "^2.3.1"
+    define-property "^2.0.2"
+    extend-shallow "^3.0.2"
+    extglob "^2.0.4"
     fragment-cache "^0.2.1"
-    kind-of "^6.0.0"
-    nanomatch "^1.2.5"
+    kind-of "^6.0.2"
+    nanomatch "^1.2.9"
     object.pick "^1.3.0"
     regex-not "^1.0.0"
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
-mime-db@~1.30.0:
-  version "1.30.0"
-  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.30.0.tgz#74c643da2dd9d6a45399963465b26d5ca7d71f01"
+mime-db@~1.33.0:
+  version "1.33.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.33.0.tgz#a3492050a5cb9b63450541e39d9788d2272783db"
 
 mime-types@^2.1.12, mime-types@~2.1.17, mime-types@~2.1.7:
-  version "2.1.17"
-  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.17.tgz#09d7a393f03e995a79f8af857b70a9e0ab16557a"
+  version "2.1.18"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.18.tgz#6f323f60a83d11146f831ff11fd66e2fe5503bb8"
   dependencies:
-    mime-db "~1.30.0"
+    mime-db "~1.33.0"
 
 minimatch@0.3:
   version "0.3.0"
@@ -1977,20 +1989,21 @@ multipipe@^0.1.0, multipipe@^0.1.2:
     duplexer2 "0.0.2"
 
 nan@^2.3.2:
-  version "2.8.0"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.8.0.tgz#ed715f3fe9de02b57a5e6252d90a96675e1f085a"
+  version "2.9.2"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.9.2.tgz#f564d75f5f8f36a6d9456cca7a6c4fe488ab7866"
 
-nanomatch@^1.2.5:
-  version "1.2.7"
-  resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.7.tgz#53cd4aa109ff68b7f869591fdc9d10daeeea3e79"
+nanomatch@^1.2.9:
+  version "1.2.9"
+  resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.9.tgz#879f7150cb2dab7a471259066c104eee6e0fa7c2"
   dependencies:
     arr-diff "^4.0.0"
     array-unique "^0.3.2"
-    define-property "^1.0.0"
-    extend-shallow "^2.0.1"
+    define-property "^2.0.2"
+    extend-shallow "^3.0.2"
     fragment-cache "^0.2.1"
-    is-odd "^1.0.0"
-    kind-of "^5.0.2"
+    is-odd "^2.0.0"
+    is-windows "^1.0.2"
+    kind-of "^6.0.2"
     object.pick "^1.3.0"
     regex-not "^1.0.0"
     snapdragon "^0.8.1"
@@ -2184,8 +2197,8 @@ os-tmpdir@^1.0.0:
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
 
 osenv@0:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/osenv/-/osenv-0.1.4.tgz#42fe6d5953df06c8064be6f176c3d05aaaa34644"
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/osenv/-/osenv-0.1.5.tgz#85cdfafaeb28e8677f416e287592b5f3f49ea410"
   dependencies:
     os-homedir "^1.0.0"
     os-tmpdir "^1.0.0"
@@ -2362,11 +2375,12 @@ redent@^1.0.0:
     indent-string "^2.1.0"
     strip-indent "^1.0.1"
 
-regex-not@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/regex-not/-/regex-not-1.0.0.tgz#42f83e39771622df826b02af176525d6a5f157f9"
+regex-not@^1.0.0, regex-not@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/regex-not/-/regex-not-1.0.2.tgz#1f4ece27e00b0b65e0247a6810e6a85d83a5752c"
   dependencies:
-    extend-shallow "^2.0.1"
+    extend-shallow "^3.0.2"
+    safe-regex "^1.1.0"
 
 repeat-element@^1.1.2:
   version "1.1.2"
@@ -2463,6 +2477,10 @@ resolve@^1.1.6, resolve@^1.1.7:
   dependencies:
     path-parse "^1.0.5"
 
+ret@~0.1.10:
+  version "0.1.15"
+  resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
+
 right-align@^0.1.1:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/right-align/-/right-align-0.1.3.tgz#61339b722fe6a3515689210d24e14c96148613ef"
@@ -2478,6 +2496,12 @@ rimraf@2, rimraf@^2.2.8:
 safe-buffer@^5.0.1, safe-buffer@^5.1.1, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
+
+safe-regex@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/safe-regex/-/safe-regex-1.1.0.tgz#40a3669f3b077d1e943d44629e157dd48023bf2e"
+  dependencies:
+    ret "~0.1.10"
 
 sass-graph@^2.2.4:
   version "2.2.4"
@@ -2632,19 +2656,38 @@ sparkles@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/sparkles/-/sparkles-1.0.0.tgz#1acbbfb592436d10bbe8f785b7cc6f82815012c3"
 
-spdx-correct@~1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/spdx-correct/-/spdx-correct-1.0.2.tgz#4b3073d933ff51f3912f03ac5519498a4150db40"
+spdx-correct@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/spdx-correct/-/spdx-correct-2.0.4.tgz#d1652ad2ebc516f656f66ea93398558065f1b4a4"
   dependencies:
-    spdx-license-ids "^1.0.2"
+    spdx-expression-parse "^2.0.1"
+    spdx-license-ids "^2.0.1"
 
-spdx-expression-parse@~1.0.0:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz#9bdf2f20e1f40ed447fbe273266191fced51626c"
+spdx-exceptions@^2.0.0, spdx-exceptions@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz#2c7ae61056c714a5b9b9b2b2af7d311ef5c78fe9"
 
-spdx-license-ids@^1.0.2:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz#c9df7a3424594ade6bd11900d596696dc06bac57"
+spdx-expression-parse@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/spdx-expression-parse/-/spdx-expression-parse-2.0.2.tgz#e2e0f229c057eac704c5a6d1c687eed66aca034b"
+  dependencies:
+    spdx-exceptions "^2.0.0"
+    spdx-license-ids "^2.0.1"
+
+spdx-expression-parse@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz#99e119b7a5da00e05491c9fa338b7904823b41d0"
+  dependencies:
+    spdx-exceptions "^2.1.0"
+    spdx-license-ids "^3.0.0"
+
+spdx-license-ids@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-2.0.1.tgz#02017bcc3534ee4ffef6d58d20e7d3e9a1c3c8ec"
+
+spdx-license-ids@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz#7a7cd28470cc6d3a1cfe6d66886f6bc430d3ac87"
 
 split-string@^3.0.1, split-string@^3.0.2:
   version "3.1.0"
@@ -2813,16 +2856,17 @@ to-regex-range@^2.1.0:
     repeat-string "^1.6.1"
 
 to-regex@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/to-regex/-/to-regex-3.0.1.tgz#15358bee4a2c83bd76377ba1dc049d0f18837aae"
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/to-regex/-/to-regex-3.0.2.tgz#13cfdd9b336552f30b51f33a8ae1b42a7a7599ce"
   dependencies:
-    define-property "^0.2.5"
-    extend-shallow "^2.0.1"
-    regex-not "^1.0.0"
+    define-property "^2.0.2"
+    extend-shallow "^3.0.2"
+    regex-not "^1.0.2"
+    safe-regex "^1.1.0"
 
 tough-cookie@~2.3.0, tough-cookie@~2.3.3:
-  version "2.3.3"
-  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.3.3.tgz#0b618a5565b6dea90bf3425d04d55edc475a7561"
+  version "2.3.4"
+  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.3.4.tgz#ec60cee38ac675063ffc97a5c18970578ee83655"
   dependencies:
     punycode "^1.4.1"
 
@@ -2930,11 +2974,11 @@ v8flags@^2.0.2:
     user-home "^1.1.1"
 
 validate-npm-package-license@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz#2804babe712ad3379459acfbe24746ab2c303fbc"
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.2.tgz#ec39d030e27d1ee714515162c547f66356e49f41"
   dependencies:
-    spdx-correct "~1.0.0"
-    spdx-expression-parse "~1.0.0"
+    spdx-correct "^2.0.4"
+    spdx-expression-parse "^3.0.0"
 
 verror@1.10.0:
   version "1.10.0"


### PR DESCRIPTION
Trello ticket here: https://trello.com/c/NFRFA2K5

The tests won't go green until the [related PR](https://github.com/alphagov/digitalmarketplace-frontend-toolkit/pull/409) on the frontend-toolkit goes in. It's been approved, it's just waiting for Laurence to give it a thumbs up.

~~The validation messages may also be updated; Constance is reviewing them so they may change.~~
Constance has reviewed the validation messages.

### Add VatNumberForm
We need only validate the VAT number entered if the user has stated that
they are registered. We can't use the `Optional` validator for this in
case the user has started typing something in the input field and then
changed their mind.

The regex used for the VAT number covers 9 and 12 digit VAT codes, both
with the optional 'GB' prefix. It also supports the lesser used but
still valid GD and HA vat numbers which are used for government
departments and health authorities. Again, with the optional 'GB'
prefix.

### Pull in verision 28.2.0 of the frontend toolkit
It includes patterns for conditionally reveling inputs with
radiobuttons.

### Screen capture:

![new_vat](https://user-images.githubusercontent.com/13836290/36606605-211a8a30-18bc-11e8-8f26-b756105b3f89.gif)
