### PR TITLE
Update start page copy

### DIFF
--- a/app/templates/suppliers/create_new_supplier.html
+++ b/app/templates/suppliers/create_new_supplier.html
@@ -23,15 +23,27 @@
 
 <div class="start-page">
   <div class="grid-row">
-    <div class="column-two-thirds">
+    <div class="column-two-thirds dmspeak">
       {% with heading = "Create a supplier account", smaller = True %}
         {% include "toolkit/page-heading.html" %}
       {% endwith %}
-      
-      <div class="dmspeak">
-        <p>If your company is not <a href="https://beta.companieshouse.gov.uk/" rel="external">registered with Companies House</a>,
-           you will need to <a href="https://www.dnb.co.uk/duns-number/lookup/request-a-duns-number.html" rel="external">apply for a DUNS number</a>
-           before you create a supplier account.
+  
+      <div>
+        <p class="lead">You must provide:</p>
+    
+        <ul class="list-bullet">
+          <li>a company name and company details that buyers may use to contact you</li>
+          <li>your own details to create a login</li>
+        </ul>
+        
+        <p>It will take about 5 minutes to create your account.</p>
+      </div>
+  
+      <h2 class="heading-xmedium">If your company isn’t registered with Companies House</h2>
+      <div>
+        <p>If your company isn’t <a href="https://beta.companieshouse.gov.uk/" rel="external">registered with Companies House</a>,
+           you may need to <a href="https://www.dnb.co.uk/duns-number/lookup/request-a-duns-number.html" rel="external">apply for a DUNS number</a>
+           before you can create a supplier account.
         </p>
 
         <p>


### PR DESCRIPTION
## Summary
Update the copy on the supplier create account start page to clarify what users will need before starting

## Let's see it then
![screen shot 2018-02-27 at 15 39 15](https://user-images.githubusercontent.com/2920760/36738030-6c09c842-1bd4-11e8-8ab0-a5174d378892.png)



## Ticket
https://trello.com/c/GgKXHr4V/38-sign-up-flow-update-copy-on-start-page