### PR TITLE
Fix links on "What buyers will see" validation banner

### DIFF
--- a/app/templates/suppliers/details.html
+++ b/app/templates/suppliers/details.html
@@ -59,7 +59,9 @@
     {{ summary.field_name('Summary') }}
     {{ summary.text(supplier.description) }}
     {% call summary.field(action=True) %}
-      Optional
+      {% if not supplier.description %}
+        Optional
+      {% endif %}
     {% endcall %}
   {% endcall %}
 {% endcall %}

--- a/app/templates/suppliers/edit_what_buyers_will_see.html
+++ b/app/templates/suppliers/edit_what_buyers_will_see.html
@@ -35,7 +35,7 @@
         <ul>
         {% for field_name, field_errors in contact_form.errors|dictsort %}
           {% for error in field_errors %}
-          <li><a href="#contact_{{ field_name }}" class="validation-masthead-link">{{ contact_form[field_name].label.text }}</a></li>
+          <li><a href="#{{ field_name }}" class="validation-masthead-link">{{ contact_form[field_name].label.text }}</a></li>
           {% endfor %}
         {% endfor %}
         </ul>


### PR DESCRIPTION
Also make "Optional" only appear when the summary is empty.