### PR TITLE
Update content in notification banner

### DIFF
--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -184,6 +184,7 @@ def framework_dashboard(framework_slug):
 @login_required
 def framework_submission_lots(framework_slug):
     framework = get_framework_or_404(data_api_client, framework_slug)
+    supplier = data_api_client.get_supplier(current_user.supplier_id)['suppliers']
 
     drafts, complete_drafts = get_drafts(data_api_client, framework_slug)
     declaration_status = get_declaration_status(data_api_client, framework_slug)
@@ -225,6 +226,7 @@ def framework_submission_lots(framework_slug):
         complete_drafts=list(reversed(complete_drafts)),
         drafts=list(reversed(drafts)),
         declaration_status=declaration_status,
+        company_details_complete=supplier_company_details_are_complete(supplier),
         framework=framework,
         lots=lots,
     ), 200
@@ -234,6 +236,7 @@ def framework_submission_lots(framework_slug):
 @login_required
 def framework_submission_services(framework_slug, lot_slug):
     framework, lot = get_framework_and_lot_or_404(data_api_client, framework_slug, lot_slug)
+    supplier = data_api_client.get_supplier(current_user.supplier_id)['suppliers']
 
     drafts, complete_drafts = get_lot_drafts(data_api_client, framework_slug, lot_slug)
     declaration_status = get_declaration_status(data_api_client, framework_slug)
@@ -268,6 +271,7 @@ def framework_submission_services(framework_slug, lot_slug):
         complete_drafts=list(reversed(complete_drafts)),
         drafts=list(reversed(drafts)),
         declaration_status=declaration_status,
+        company_details_complete=supplier_company_details_are_complete(supplier),
         framework=framework,
         lot=lot,
     ), 200

--- a/app/templates/frameworks/services.html
+++ b/app/templates/frameworks/services.html
@@ -46,9 +46,7 @@
     {% endfor %}
   {% endwith %}
 
-  {% if complete_drafts and declaration_status != 'complete' and framework.status == 'open' %}
-    {% include "partials/service_warning.html" %}
-  {% endif %}
+  {% include "partials/service_warning.html" %}
 
   {% with
      heading = lot.name + " services",

--- a/app/templates/frameworks/submission_lots.html
+++ b/app/templates/frameworks/submission_lots.html
@@ -42,9 +42,7 @@
     {% endfor %}
   {% endwith %}
 
-  {% if complete_drafts and declaration_status != 'complete' and framework.status == 'open' %}
-    {% include "partials/service_warning.html" %}
-  {% endif %}
+  {% include "partials/service_warning.html" %}
 
   <div class="grid-row">
     <div class="column-two-thirds">

--- a/app/templates/partials/service_warning.html
+++ b/app/templates/partials/service_warning.html
@@ -1,9 +1,24 @@
-{% with declaration_url = url_for('.framework_start_supplier_declaration' if declaration_status == 'unstarted' else '.framework_supplier_declaration_overview', framework_slug=framework.slug) %}
-  {%
-    with
-    message = 'You need to <a href="'|safe + declaration_url + '">make the supplier&nbsp;declaration</a> before any services can be submitted'|safe,
-    type = 'warning'
-  %}
-    {% include 'toolkit/notification-banner.html' %}
+{% if declaration_status != 'complete' or not company_details_complete %}
+  {% set banner_content %}
+  You still need to:
+  <ul>
+    {% if not company_details_complete %}
+    <li><a href="{{ url_for('.supplier_details') }}">complete your company details</a></li>
+    {% endif %}
+    {% if declaration_status != 'complete' %}
+    <li><a href="{% if declaration_status == 'unstarted' %}{{ url_for('.framework_start_supplier_declaration', framework_slug=framework.slug) }}{% else %}{{ url_for('.framework_supplier_declaration_overview', framework_slug=framework.slug) }}{% endif %}">make your supplier declaration</a></li>
+    {% endif %}
+  </ul>
+  {% endset %}
+
+  {% with declaration_url = url_for('.framework_start_supplier_declaration' if declaration_status == 'unstarted' else '.framework_supplier_declaration_overview', framework_slug=framework.slug) %}
+    {%
+      with
+      heading = "Your application is not complete",
+      banner_content = banner_content|safe,
+      type = 'information'
+    %}
+      {% include 'toolkit/notification-banner.html' %}
+    {% endwith %}
   {% endwith %}
-{% endwith %}
+{% endif %}

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "colors": "1.1.2",
     "jquery": "1.12.0",
     "hogan.js": "3.0.2",
-    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v28.3.0",
+    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v28.5.1",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.19.2/jinja_govuk_template-0.19.2.tgz",
     "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#10.4.3"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -538,9 +538,9 @@ detect-file@^1.0.0:
   version "0.0.0"
   resolved "https://github.com/alphagov/digitalmarketplace-frameworks.git#28dfb10cfbfbd54ee43c2d7d5a3d8c1f07b275d0"
 
-"digitalmarketplace-frontend-toolkit@https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v28.3.0":
+"digitalmarketplace-frontend-toolkit@https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v28.5.1":
   version "0.0.1"
-  resolved "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#d83330311c1a0bb007550c9950e7ded220592c0d"
+  resolved "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#610151c96db1b022f401b448f8cd54e039689a8a"
   dependencies:
     del "^2.2.2"
     govuk-elements-sass "3.0.3"


### PR DESCRIPTION
## Summary
Update copy in the notification banner on service/lots page of supplier application to framework to include links to the company details page and the declaration page

## Example
![screen shot 2018-03-01 at 11 50 14](https://user-images.githubusercontent.com/2920760/36843406-c60221dc-1d46-11e8-9be3-e3d2953068b1.png)



## Associated PR
~https://github.com/alphagov/digitalmarketplace-frontend-toolkit/pull/412~

## Ticket
https://trello.com/c/JVr9gFEC/56-incomplete-application-banner