### PR TITLE
Non-breaking space in Companies House

### DIFF
--- a/app/templates/suppliers/create_new_supplier.html
+++ b/app/templates/suppliers/create_new_supplier.html
@@ -39,7 +39,7 @@
         <p>It will take about 5 minutes to create your account.</p>
       </div>
   
-      <h2 class="heading-xmedium">If your company isn’t registered with Companies House</h2>
+      <h2 class="heading-xmedium">If your company isn’t registered with Companies&nbsp;House</h2>
       <div>
         <p>If your company isn’t <a href="https://beta.companieshouse.gov.uk/" rel="external">registered with Companies House</a>,
            you may need to <a href="https://www.dnb.co.uk/duns-number/lookup/request-a-duns-number.html" rel="external">apply for a DUNS number</a>


### PR DESCRIPTION
## Summary
Add a non-breaking space between Companies House to ensure a single word is not left dangling on its own line.

## Before
![screen shot 2018-03-02 at 10 29 58](https://user-images.githubusercontent.com/2920760/36894887-d3a8a9e6-1e04-11e8-92c2-b0b582660c17.png)

## After
![screen shot 2018-03-02 at 10 29 48](https://user-images.githubusercontent.com/2920760/36894892-d672172a-1e04-11e8-8e15-cad2385ee6fb.png)

## Ticket
https://trello.com/c/GgKXHr4V/38-sign-up-flow-update-copy-on-start-page