### PR TITLE
Remove registration date

### DIFF
--- a/app/main/helpers/suppliers.py
+++ b/app/main/helpers/suppliers.py
@@ -30,8 +30,8 @@ COUNTRY_TUPLE = load_countries()
 
 
 def supplier_company_details_are_complete(supplier_data):
-    supplier_required_fields = ['dunsNumber', 'name', 'registeredName', 'registrationCountry', 'registrationDate',
-                                'organisationSize', 'tradingStatus']
+    supplier_required_fields = ['dunsNumber', 'name', 'registeredName', 'registrationCountry', 'organisationSize',
+                                'tradingStatus']
     contact_required_fields = ['address1', 'city', 'postcode']
 
     registration_country = supplier_data['registrationCountry'] if 'registrationCountry' in supplier_data else None

--- a/tests/app/main/test_suppliers.py
+++ b/tests/app/main/test_suppliers.py
@@ -59,7 +59,6 @@ def get_supplier(*args, **kwargs):
         "registeredName": "Official Name Inc",
         "registrationCountry": "country:BZ",
         "otherCompanyRegistrationNumber": "BEL153",
-        "registrationDate": "1973-01-02",
         "vatNumber": "12345678",
         "organisationSize": "small",
         "tradingStatus": "Open for business",


### PR DESCRIPTION
## Summary
Registration date is a field we are no longer interested in, so we should remove all references from it as we will be dropping it from the API shortly.

## Ticket
https://trello.com/c/M2jPJ3kZ/58-purge-registration-date-from-logic-and-data