### PR TITLE
request id handling: bump digitalmarketplace-utils dependency to 34.1.1

### DIFF
--- a/config.py
+++ b/config.py
@@ -82,7 +82,6 @@ class Config(object):
     DM_PLAIN_TEXT_LOGS = False
     DM_LOG_PATH = None
     DM_APP_NAME = 'supplier-frontend'
-    DM_DOWNSTREAM_REQUEST_ID_HEADER = 'X-Amz-Cf-Id'
 
     @staticmethod
     def init_app(app):

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -5,6 +5,6 @@ Flask==0.10.1
 Flask-Login==0.2.11
 Flask-WTF==0.12
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@33.1.0#egg=digitalmarketplace-utils==33.1.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@34.1.1#egg=digitalmarketplace-utils==34.1.1
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.2.0#egg=digitalmarketplace-content-loader==4.2.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@14.4.0#egg=digitalmarketplace-apiclient==14.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ Flask==0.10.1
 Flask-Login==0.2.11
 Flask-WTF==0.12
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@33.1.0#egg=digitalmarketplace-utils==33.1.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@34.1.1#egg=digitalmarketplace-utils==34.1.1
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.2.0#egg=digitalmarketplace-content-loader==4.2.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@14.4.0#egg=digitalmarketplace-apiclient==14.4.0
 
@@ -16,7 +16,7 @@ backoff==1.0.7
 boto3==1.4.4
 botocore==1.5.95
 certifi==2018.1.18
-cffi==1.11.4
+cffi==1.11.5
 chardet==3.0.4
 contextlib2==0.4.0
 cryptography==1.9
@@ -38,7 +38,7 @@ monotonic==0.3
 notifications-python-client==4.1.0
 odfpy==1.3.6
 pycparser==2.18
-PyJWT==1.5.3
+PyJWT==1.6.0
 python-dateutil==2.6.1
 python-json-logger==0.1.4
 pytz==2015.4


### PR DESCRIPTION
...and re-freeze requirements.txt. this should bring in the new request id header handling.

Trello https://trello.com/c/dlbLmRDB/343-make-use-of-zipkin-headers-in-preference-to-request-id-pt-1