### PR TITLE
Remove "company" from "company registration number"

### DIFF
--- a/app/main/forms/suppliers.py
+++ b/app/main/forms/suppliers.py
@@ -88,7 +88,7 @@ class AddCompanyRegistrationNumberForm(Form):
         default='',
         validators=[
             Optional(),
-            Length(max=255, message="You must provide a company registration number under 256 characters.")
+            Length(max=255, message="You must provide a registration number under 256 characters.")
         ]
     )
 

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -207,7 +207,7 @@ def edit_supplier_registration_number():
         return (
             render_template(
                 "suppliers/already_completed.html",
-                completed_data_description="company registration number"
+                completed_data_description="registration number"
             ),
             200 if request.method == 'GET' else 400
         )

--- a/tests/app/main/test_suppliers.py
+++ b/tests/app/main/test_suppliers.py
@@ -2388,7 +2388,7 @@ class TestSupplierAddRegistrationNumber(BaseApplicationTest):
                  'other_company_registration_number': 'a' * 256
                  },
                 'Other company registration number',
-                'You must provide a company registration number under 256 characters.'
+                'You must provide a registration number under 256 characters.'
             )
         )
     )
@@ -2478,7 +2478,7 @@ class TestSupplierAddRegistrationNumber(BaseApplicationTest):
             page_heading = doc.xpath('//h1')
 
             assert res.status_code == 200
-            assert page_heading[0].text.strip() == "Change your company registration number"
+            assert page_heading[0].text.strip() == "Change your registration number"
             assert data_api_client.update_supplier.call_args_list == []
 
     def test_post_shows_already_entered_page_and_api_not_called_if_data_already_entered(self, data_api_client):
@@ -2495,7 +2495,7 @@ class TestSupplierAddRegistrationNumber(BaseApplicationTest):
             page_heading = doc.xpath('//h1')
 
             assert res.status_code == 400
-            assert page_heading[0].text.strip() == "Change your company registration number"
+            assert page_heading[0].text.strip() == "Change your registration number"
             assert data_api_client.update_supplier.call_args_list == []
 
 


### PR DESCRIPTION
Final piece of QA follow-up for this ticket: https://trello.com/c/nToxBmYI/48-new-one-time-page-build-registered-with-companies-house-page

The heading on the "contact support" page should match the text in the bullet point, which is just "registration number".