### PR TITLE
Set GA custom dimension for supplier organisation size

### DIFF
--- a/app/templates/_base_page.html
+++ b/app/templates/_base_page.html
@@ -1,7 +1,13 @@
 {% extends "govuk/govuk_template.html" %}
 
 {% block head %}
-  {% include "toolkit/custom-dimensions.html" %}
+    {% with custom_dimensions=[
+          {"data_id": 11, "data_value": current_user.supplier_organisation_size }
+      ] if current_user and current_user.supplier_organisation_size else []
+    %}
+      {% include "toolkit/custom-dimensions.html" %}
+    {% endwith %}
+
   {% include "_stylesheets.html" %}
 {% endblock %}
 

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -5,6 +5,6 @@ Flask==0.10.1
 Flask-Login==0.2.11
 Flask-WTF==0.12
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@34.1.1#egg=digitalmarketplace-utils==34.1.1
+git+https://github.com/alphagov/digitalmarketplace-utils.git@34.2.0#egg=digitalmarketplace-utils==34.2.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.2.0#egg=digitalmarketplace-content-loader==4.2.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@14.4.0#egg=digitalmarketplace-apiclient==14.4.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,5 +12,5 @@ python-coveralls==2.5.0
 requests-mock==0.6.0
 watchdog==0.8.3
 
-git+https://github.com/alphagov/digitalmarketplace-test-utils.git@1.0.0#egg=digitalmarketplace-test-utils==1.0.0
+git+https://github.com/alphagov/digitalmarketplace-test-utils.git@1.1.0#egg=digitalmarketplace-test-utils==1.1.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ Flask==0.10.1
 Flask-Login==0.2.11
 Flask-WTF==0.12
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@34.1.1#egg=digitalmarketplace-utils==34.1.1
+git+https://github.com/alphagov/digitalmarketplace-utils.git@34.2.0#egg=digitalmarketplace-utils==34.2.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.2.0#egg=digitalmarketplace-content-loader==4.2.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@14.4.0#egg=digitalmarketplace-apiclient==14.4.0
 

--- a/tests/app/helpers.py
+++ b/tests/app/helpers.py
@@ -258,7 +258,7 @@ class BaseApplicationTest(object):
 
     @staticmethod
     def user(id, email_address, supplier_id, supplier_name, name,
-             is_token_valid=True, locked=False, active=True, role='buyer'):
+             is_token_valid=True, locked=False, active=True, role='buyer', supplier_organisation_size=None):
 
         hours_offset = -1 if is_token_valid else 1
         date = datetime.utcnow() + timedelta(hours=hours_offset)
@@ -279,6 +279,8 @@ class BaseApplicationTest(object):
                 "supplierId": supplier_id,
                 "name": supplier_name,
             }
+            if supplier_organisation_size:
+                supplier['organisationSize'] = supplier_organisation_size
             user['role'] = 'supplier'
             user['supplier'] = supplier
         return {
@@ -440,13 +442,15 @@ class BaseApplicationTest(object):
 
     def login(self):
         with patch('app.main.views.login.data_api_client') as login_api_client:
-            login_api_client.authenticate_user.return_value = self.user(
-                123, "email@email.com", 1234, u'Supplier NĀme', u'Năme')
+            supplier_user_json = self.user(
+                123, "email@email.com", 1234, u'Supplier NĀme', u'Năme', supplier_organisation_size="small"
+            )
+            login_api_client.authenticate_user.return_value = supplier_user_json
 
             self.get_user_patch = patch.object(
                 data_api_client,
                 'get_user',
-                return_value=self.user(123, "email@email.com", 1234, u'Supplier NĀme', u'Năme')
+                return_value=supplier_user_json
             )
             self.get_user_patch.start()
 

--- a/tests/app/helpers.py
+++ b/tests/app/helpers.py
@@ -440,10 +440,11 @@ class BaseApplicationTest(object):
         if self.get_user_patch is not None:
             self.get_user_patch.stop()
 
-    def login(self):
+    def login(self, supplier_organisation_size="small"):
         with patch('app.main.views.login.data_api_client') as login_api_client:
             supplier_user_json = self.user(
-                123, "email@email.com", 1234, u'Supplier NĀme', u'Năme', supplier_organisation_size="small"
+                123, "email@email.com", 1234, u'Supplier NĀme', u'Năme',
+                supplier_organisation_size=supplier_organisation_size
             )
             login_api_client.authenticate_user.return_value = supplier_user_json
 

--- a/tests/app/main/test_suppliers.py
+++ b/tests/app/main/test_suppliers.py
@@ -955,6 +955,33 @@ class TestSupplierDashboardLogin(BaseApplicationTest):
             assert len(doc.xpath('//meta[@data-value="supplier"]')) == 1
             assert len(doc.xpath('//meta[@data-value="small"]')) == 1
 
+    @mock.patch("app.main.views.suppliers.data_api_client")
+    @mock.patch("app.main.views.suppliers.get_current_suppliers_users")
+    def test_custom_dimension_supplier_organisation_size_not_set_if_size_is_null(
+        self, get_current_suppliers_users, data_api_client
+    ):
+        get_current_suppliers_users.side_effect = get_user
+        data_api_client.find_frameworks.return_value = find_frameworks_return_value
+        data_api_client.get_supplier.side_effect = get_supplier
+
+        with self.app.test_client():
+            self.login(supplier_organisation_size=None)
+            res = self.client.get('/suppliers')
+
+            doc = html.fromstring(res.get_data(as_text=True))
+            # The default supplier details from self.login() should available as attributes of current_user
+            assert len(doc.xpath('//meta[@data-value="supplier"]')) == 1
+            assert len(doc.xpath('//meta[@data-value="small"]')) == 0
+
+    def test_custom_dimension_supplier_role_and_organisation_size_not_set_if_supplier_logged_out(self):
+        with self.app.test_client():
+            # View that does not require login
+            res = self.client.get('/suppliers/create')
+
+            doc = html.fromstring(res.get_data(as_text=True))
+            assert len(doc.xpath('//meta[@data-id="10"]')) == 0
+            assert len(doc.xpath('//meta[@data-id="11"]')) == 0
+
 
 @mock.patch("app.main.views.suppliers.data_api_client")
 class TestSupplierUpdate(BaseApplicationTest):


### PR DESCRIPTION
Trello: https://trello.com/c/PZyZdMtG/337-custom-dimension-to-capture-size-of-supplier

- Adds in extra context for the custom dimensions template to set the organisation size for a supplier.
- Updates test helpers to include the supplier organisation size in the test user JSON.
