### PR TITLE
 Show a back to framework application link if framework application info in session

### DIFF
--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -51,6 +51,9 @@ CLARIFICATION_QUESTION_NAME = 'clarification_question'
 @login_required
 def framework_dashboard(framework_slug):
     framework = get_framework_or_404(data_api_client, framework_slug)
+    if framework["status"] == "open":
+        session["currently_applying_to"] = framework_slug
+
     if request.method == 'POST':
         register_interest_in_framework(data_api_client, framework_slug)
         supplier_users = data_api_client.find_users(supplier_id=current_user.supplier_id)

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -99,10 +99,15 @@ def supplier_details():
     supplier['contact'] = supplier['contactInformation'][0]
     country_name = get_country_name_from_country_code(supplier.get('registrationCountry'))
 
+    framework = None
+
+    if "currently_applying_to" in session:
+        framework = data_api_client.get_framework(session["currently_applying_to"])["frameworks"]
     return render_template(
         "suppliers/details.html",
         supplier=supplier,
         country_name=country_name,
+        currently_applying_to=framework,
     ), 200
 
 

--- a/app/templates/suppliers/details.html
+++ b/app/templates/suppliers/details.html
@@ -169,4 +169,17 @@
   {% endif %}
 
 {% endcall %}
+
+{% if currently_applying_to %}
+  <p>You must complete your company details to make an application.</p>
+  {%
+    with
+    url = url_for(".framework_dashboard", framework_slug=currently_applying_to.slug),
+    text = "Return to your {} application".format(currently_applying_to.name),
+    bigger = false
+  %}
+    {% include "toolkit/secondary-action-link.html" %}
+  {% endwith %}
+{% endif %}
+
 {% endblock %}

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -5,7 +5,6 @@ from io import BytesIO
 from itertools import chain
 from urllib.parse import urljoin
 
-from flask import session
 from lxml import html
 import pytest
 from werkzeug.datastructures import MultiDict
@@ -1635,9 +1634,9 @@ class TestFrameworksDashboard(BaseApplicationTest):
         )
         data_api_client.get_supplier_framework_info.return_value = self.supplier_framework()
 
-        res = self.client.get("/suppliers/frameworks/g-cloud-9")
+        response = self.client.get("/suppliers/frameworks/g-cloud-9")
 
-        assert res.status_code == 200
+        assert response.status_code == 200
         with self.client.session_transaction() as session:
             assert session["currently_applying_to"] == "g-cloud-9"
 
@@ -1657,7 +1656,7 @@ class TestFrameworksDashboard(BaseApplicationTest):
         )
         data_api_client.get_supplier_framework_info.return_value = self.supplier_framework()
 
-        res = self.client.get("/suppliers/frameworks/g-cloud-9")
+        self.client.get("/suppliers/frameworks/g-cloud-9")
 
         with self.client.session_transaction() as session:
             assert "currently_applying_to" not in session


### PR DESCRIPTION
Trello ticket: https://trello.com/c/l2xh4cR3/63-confirm-supplier-details-4-return-to-your-framework-application-link

The link and hint text:
![screen shot 2018-03-09 at 16 49 03](https://user-images.githubusercontent.com/20957548/37218939-d5dc131e-23b9-11e8-83a2-72afb4a01967.png)
