### PR TITLE
Enforce validation on supplier edit contact deatails

### DIFF
--- a/app/main/forms/suppliers.py
+++ b/app/main/forms/suppliers.py
@@ -29,12 +29,15 @@ class EditSupplierForm(Form):
 
 class EditContactInformationForm(Form):
     contactName = StripWhitespaceStringField('Contact name', validators=[
-        InputRequired(message="You must provide a contact name"),
+        InputRequired(message="You must provide a contact name."),
     ])
     email = EmailField('Contact email address', validators=[
-        InputRequired(message="You must provide an email address"),
+        InputRequired(message="You must provide an email address."),
     ])
-    phoneNumber = StripWhitespaceStringField('Contact phone number')
+    phoneNumber = StripWhitespaceStringField('Contact phone number', validators=[
+        InputRequired(message="You must provide a phone number."),
+        Length(max=20, message="You must provide a phone number under 20 characters.")
+    ])
 
 
 class EditRegisteredAddressForm(Form):


### PR DESCRIPTION
To fix this bug: https://trello.com/c/c5wWLrkJ

During supplier creation a phone number is required. It should also be
when editing supplier contact details. Have also added length validation
to remain consistent with the sign up flow.