### PR TITLE
tracing: bump digitalmarketplace-apiclient dependency to 15.0.0

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -7,4 +7,4 @@ Flask-WTF==0.12
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@34.2.0#egg=digitalmarketplace-utils==34.2.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.2.0#egg=digitalmarketplace-content-loader==4.2.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@14.4.0#egg=digitalmarketplace-apiclient==14.4.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@15.0.0#egg=digitalmarketplace-apiclient==15.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ Flask-WTF==0.12
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@34.2.0#egg=digitalmarketplace-utils==34.2.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.2.0#egg=digitalmarketplace-content-loader==4.2.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@14.4.0#egg=digitalmarketplace-apiclient==14.4.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@15.0.0#egg=digitalmarketplace-apiclient==15.0.0
 
 ## The following requirements were added by pip freeze:
 asn1crypto==0.24.0
@@ -39,7 +39,7 @@ notifications-python-client==4.1.0
 odfpy==1.3.6
 pycparser==2.18
 PyJWT==1.6.0
-python-dateutil==2.6.1
+python-dateutil==2.7.0
 python-json-logger==0.1.4
 pytz==2015.4
 PyYAML==3.11


### PR DESCRIPTION
This should bring in support for zipkin span ids

https://trello.com/c/exuNFb7A/357-zipkin-headers-pt2-api-client
https://trello.com/c/UOXf4vZZ/308-make-use-of-zipkin-headers-in-preference-to-request-id