### PR TITLE
add banner to account page

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -18,6 +18,7 @@
 //= require ../../../node_modules/govuk_frontend_toolkit/javascripts/govuk/stop-scrolling-at-footer.js
 //= require ../../../node_modules/digitalmarketplace-frontend-toolkit/toolkit/javascripts/shim-links-with-button-role.js
 //= require ../../../node_modules/digitalmarketplace-frontend-toolkit/toolkit/javascripts/show-hide-content.js
+//= require ../../../node_modules/digitalmarketplace-frontend-toolkit/toolkit/javascripts/user-research-consent-banner.js
 //= require _analytics.js
 //= require _selection-buttons.js
 //= require _stick-at-top-when-scrolling.js

--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -37,6 +37,7 @@ $path: "/suppliers/static/images/";
 @import "toolkit/_service-id.scss";
 @import "toolkit/_temporary-message.scss";
 @import "toolkit/_text-diff.scss";
+@import "toolkit/_user-research-consent-banner.scss";
 @import "toolkit/forms/_combinations.scss";
 @import "toolkit/forms/_checkbox-tree.scss";  // Has to be imported after _combinations.scss, which defines the
                                               // $border-width variable that _checkbox-tree.scss relies upon. :sad:

--- a/app/templates/suppliers/dashboard.html
+++ b/app/templates/suppliers/dashboard.html
@@ -14,6 +14,29 @@
   {% endwith %}
 {% endblock %}
 
+{% block head %}
+  {{ super() }}
+  {% if not current_user.user_research_opted_in and not 'seen_user_research_message' in request.cookies %}
+    {%
+      with
+      custom_dimensions = [
+        {
+          "data_id": 12,
+          "data_value": "User research banner"
+        }
+      ]
+    %}
+      {% include "toolkit/custom-dimensions.html" %}
+    {% endwith %}
+  {% endif %}
+{% endblock %}
+
+{% block after_header %}
+  {% if not current_user.user_research_opted_in and not 'seen_user_research_message' in request.cookies %}
+    {% include "toolkit/user-research-consent-banner.html" %}
+  {% endif %}
+{% endblock %}
+
 {% block main_content %}
 
   <div class="grid-row">
@@ -33,6 +56,10 @@
     {% include 'suppliers/_frameworks_open.html' %}
     {% include 'suppliers/_frameworks_pending.html' %}
     {% include 'suppliers/_frameworks_standstill.html' %}
+    <h2 class="visually-hidden">Your services</h2>
+    <div class="dmspeak">
+      {% include 'suppliers/_frameworks_live.html' %}
+    </div>
     </div>
     <div class="column-one-third dmspeak">
       <h2 class="heading-xmedium">Your company</h2>
@@ -40,13 +67,24 @@
         <a href="{{ url_for('.supplier_details') }}">Supplier details</a><br/>
         <a href="{{ url_for('.list_users') }}">Contributors</a>
       </p>
+      <h2 class="heading-xmedium">Account settings</h2>
+      <p>
+        <a 
+          href="{{ url_for('external.user_research_consent') }}"
+          data-analytics="trackEvent"
+          data-analytics-category="user-research"
+          data-analytics-action="account-settings-link"
+        >
+          {% if not current_user.user_research_opted_in %}
+            Join the user research mailing list
+          {% else %}
+            Unsubscribe from the user research mailing list
+          {% endif %}
+        </a>
+      </p>
     </div>
   </div>
 
-  <h2 class="visually-hidden">Your services</h2>
-  <div class="grid-row">
-    <div class="column-two-thirds dmspeak">
-      {% include 'suppliers/_frameworks_live.html' %}
-    </div>
-  </div>
+  
+
 {% endblock %}

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "colors": "1.1.2",
     "jquery": "1.12.0",
     "hogan.js": "3.0.2",
-    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v28.10.0",
+    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v28.10.1",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.19.2/jinja_govuk_template-0.19.2.tgz",
     "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#10.7.2"
   },

--- a/tests/app/helpers.py
+++ b/tests/app/helpers.py
@@ -259,7 +259,8 @@ class BaseApplicationTest(object):
 
     @staticmethod
     def user(id, email_address, supplier_id, supplier_name, name,
-             is_token_valid=True, locked=False, active=True, role='buyer', supplier_organisation_size=None):
+             is_token_valid=True, locked=False, active=True, role='buyer', supplier_organisation_size=None,
+             userResearchOptedIn=True):
 
         hours_offset = -1 if is_token_valid else 1
         date = datetime.utcnow() + timedelta(hours=hours_offset)
@@ -271,8 +272,9 @@ class BaseApplicationTest(object):
             "name": name,
             "role": role,
             "locked": locked,
-            'active': active,
-            'passwordChangedAt': password_changed_at
+            "active": active,
+            "passwordChangedAt": password_changed_at,
+            "userResearchOptedIn": userResearchOptedIn
         }
 
         if supplier_id:
@@ -441,11 +443,11 @@ class BaseApplicationTest(object):
         if self.get_user_patch is not None:
             self.get_user_patch.stop()
 
-    def login(self, supplier_organisation_size="small"):
+    def login(self, supplier_organisation_size="small", user_researh_opted_in=True):
         with patch('app.main.views.login.data_api_client') as login_api_client:
             supplier_user_json = self.user(
                 123, "email@email.com", 1234, u'Supplier NĀme', u'Năme',
-                supplier_organisation_size=supplier_organisation_size
+                supplier_organisation_size=supplier_organisation_size, userResearchOptedIn=user_researh_opted_in
             )
             login_api_client.authenticate_user.return_value = supplier_user_json
 

--- a/tests/app/main/test_notifications.py
+++ b/tests/app/main/test_notifications.py
@@ -1,0 +1,55 @@
+from ..helpers import BaseApplicationTest
+import mock
+
+
+@mock.patch("app.main.views.suppliers.data_api_client")
+@mock.patch("app.main.views.suppliers.get_current_suppliers_users")
+class TestUserResearch(BaseApplicationTest):
+    def setup_method(self, method):
+        super(TestUserResearch, self).setup_method(method)
+
+    def test_should_see_banner_if_not_subscribed(
+        self, get_current_suppliers_users, data_api_client
+    ):
+        with self.app.test_client():
+            self.login(supplier_organisation_size=None, user_researh_opted_in=False)
+            res = self.client.get('/suppliers')
+            assert res.status_code == 200
+            assert 'Help us improve the Digital Marketplace' in res.get_data(as_text=True)
+            assert 'Sign up to be a potential user research participant' in res.get_data(as_text=True)
+            assert 'class="user-research-banner-close-btn"' in res.get_data(as_text=True)
+            cookie_value = self.get_cookie_by_name(res, 'seen_user_research_message')
+            assert cookie_value is None
+
+    def test_should_not_see_banner_if_subscribed(
+        self, get_current_suppliers_users, data_api_client
+    ):
+        with self.app.test_client():
+            self.login(supplier_organisation_size=None, user_researh_opted_in=True)
+            res = self.client.get('/suppliers')
+            assert res.status_code == 200
+            assert 'Help us improve the Digital Marketplace' not in res.get_data(as_text=True)
+            assert 'Sign up to be a potential user research participant' not in res.get_data(as_text=True)
+            assert 'class="user-research-banner-close-btn"' not in res.get_data(as_text=True)
+
+    def test_should_see_subscribed_link_if_not_subscribed(
+        self, get_current_suppliers_users, data_api_client
+    ):
+        with self.app.test_client():
+            self.login(supplier_organisation_size=None, user_researh_opted_in=False)
+            res = self.client.get('/suppliers')
+            assert res.status_code == 200
+            assert "href=\"/user/notifications/user-research\"" in res.get_data(as_text=True)
+            assert "Join the user research mailing list" in res.get_data(as_text=True)
+            assert "Unsubscribe from the user research mailing list" not in res.get_data(as_text=True)
+
+    def test_should_see_unsubscribed_link_if_subscribed(
+        self, get_current_suppliers_users, data_api_client
+    ):
+        with self.app.test_client():
+            self.login(supplier_organisation_size=None, user_researh_opted_in=True)
+            res = self.client.get('/suppliers')
+            assert res.status_code == 200
+            assert "href=\"/user/notifications/user-research\"" in res.get_data(as_text=True)
+            assert "Join the user research mailing list" not in res.get_data(as_text=True)
+            assert "Unsubscribe from the user research mailing list" in res.get_data(as_text=True)

--- a/yarn.lock
+++ b/yarn.lock
@@ -546,9 +546,9 @@ detect-file@^1.0.0:
   version "0.0.0"
   resolved "https://github.com/alphagov/digitalmarketplace-frameworks.git#141c5074872247582613887187202abb1dff228f"
 
-"digitalmarketplace-frontend-toolkit@https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v28.10.0":
+"digitalmarketplace-frontend-toolkit@https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v28.10.1":
   version "0.0.1"
-  resolved "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#bd3e5e10988f24966ace029da30e54abaa21567f"
+  resolved "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#f7fa5abe9c4d7c3025c8f2b91995304e0610a168"
   dependencies:
     del "^2.2.2"
     govuk-elements-sass "3.0.3"


### PR DESCRIPTION
PRE REQUISITE:  https://github.com/alphagov/digitalmarketplace-user-frontend/pull/43

Add the user research banner to the account page using the existing GOV.uk pattern. Allow for links to 'sign up to mailing list' page

As a user I should be presented with the banner to sign up to the user research mailing list when I log in if: I have not already closed it and I have not already signed up for this.
This is the first point of contact for getting users to sign up to the mailing list.

The close link should set a cookie value of 'seen_this_banner_thing' to true so we don't show it again
The sign up link should link to the new sign up page.

https://trello.com/c/OJ9lFk1M/129-add-banner-to-account-page

<img width="1001" alt="screen shot 2018-03-13 at 14 43 21" src="https://user-images.githubusercontent.com/4599889/37348886-1366e72a-26cd-11e8-967e-bbf3f756a3cf.png">
