### PR TITLE
Allow editing until confirmation

### DIFF
--- a/app/main/forms/suppliers.py
+++ b/app/main/forms/suppliers.py
@@ -226,6 +226,8 @@ class CompanyTradingStatusForm(Form):
 
 
 class VatNumberForm(Form):
+    NOT_VAT_REGISTERED_TEXT = "Not VAT registered"
+
     def stop_validation_if_not_registered(form, field):
         # If a user is not registered for VAT we don't care about validating something they have entered in the
         # VAT number input field. If a value for `vat_registered` is not sent in the POST request, WTForms sets the


### PR DESCRIPTION
## Summary
Allow suppliers to edit some company details (vat number, registration
number, registration name) until they specifically confirm they are all
correct. In the theoretically impossible situation where a supplier has
confirmed their details but one/more of these pieces of information are
missing, they will still be able to provide it as a one-off.

## Related PRs
* https://github.com/alphagov/digitalmarketplace-api/pull/762

## Example: Company details not confirmed
![unconfirmed-account](https://user-images.githubusercontent.com/2920760/37391279-9efc93f8-2762-11e8-8d36-94f70ad083e7.gif)


## Example: Company details confirmed
![confirmed-account](https://user-images.githubusercontent.com/2920760/37391383-ee0a4b5c-2762-11e8-86c0-163c4c0989a6.gif)



## Ticket
https://trello.com/c/NaNjMOHc/61-confirm-supplier-details-2-frontend-logic-changes