### PR TITLE
Change how open framework banner is displayed on dashboard

### DIFF
--- a/app/templates/suppliers/_frameworks_open.html
+++ b/app/templates/suppliers/_frameworks_open.html
@@ -1,41 +1,31 @@
- <div class='grid-row'> 
-  <div class='column-two-thirds'>
+
     {% for framework in frameworks.open %}
       {% if framework.registered_interest %}
-        {%
-          with
-          items = [{
-            "title": "Continue your %s application" | format(framework.name),
-            "link": url_for(".framework_dashboard", framework_slug=framework.slug),
-            "body": framework.deadline,
-          }]
+        {% with
+          headingId = "closed-notice",
+          grid = "column-one-third",
+          main = true,
+          messages = [framework.deadline],
+          link = { "label": "Continue your application", "url": url_for(".framework_dashboard", framework_slug=framework.slug) },
+          heading = "Your {} application".format(framework.name)
         %}
-          {% include "toolkit/browse-list.html" %}
+          {% include "toolkit/temporary-message.html" %}
         {% endwith %}
       {% else %}
         <form action="{{ url_for('.framework_dashboard', framework_slug=framework.slug) }}" method="POST">
-            <div class="summary-item-lede">
-              <h2 class="summary-item-heading">
-                Apply to {{ framework.name }} 
-              </h2>
-              <p>
-                Deadline: {{ framework.dates.framework_close_date }}
-              </p>
-              {%
-              with
-                  type = "save",
-                  label = "Start application"
-              %}
-                  {% include "toolkit/button.html" %}
-              {% endwith %}
-
-              <p>
-                Starting your application means you’ll receive <br>{{ framework.name }} email updates.
-              </p>
-            </div>
-          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+          {% with
+            headingId = "closed-notice",
+            grid = "column-one-third",
+            main = true,
+            messages = [
+              "Starting your application means you’ll receive {} email updates.".format(framework.name)
+            ],
+            button = {"label": "Apply", "type": "save"},
+            heading = "{} is open for applications".format(framework.name)
+          %}
+            {% include "toolkit/temporary-message.html" %}
+          {% endwith %}
         </form>
       {% endif %}
     {% endfor %}
-  </div>
-</div>

--- a/app/templates/suppliers/_frameworks_open.html
+++ b/app/templates/suppliers/_frameworks_open.html
@@ -3,6 +3,7 @@
       {% if framework.registered_interest %}
         {% with
           main = true,
+          header_level = "h2",
           messages = [framework.deadline],
           link = { "label": "Continue your application", "url": url_for(".framework_dashboard", framework_slug=framework.slug) },
           heading = "Your {} application".format(framework.name)
@@ -14,6 +15,7 @@
           <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
           {% with
             main = true,
+            header_level = "h2",
             messages = [
               "Starting your application means you’ll receive {} email updates.".format(framework.name)
             ],

--- a/app/templates/suppliers/_frameworks_open.html
+++ b/app/templates/suppliers/_frameworks_open.html
@@ -2,8 +2,6 @@
     {% for framework in frameworks.open %}
       {% if framework.registered_interest %}
         {% with
-          headingId = "closed-notice",
-          grid = "column-one-third",
           main = true,
           messages = [framework.deadline],
           link = { "label": "Continue your application", "url": url_for(".framework_dashboard", framework_slug=framework.slug) },
@@ -15,8 +13,6 @@
         <form action="{{ url_for('.framework_dashboard', framework_slug=framework.slug) }}" method="POST">
           <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
           {% with
-            headingId = "closed-notice",
-            grid = "column-one-third",
             main = true,
             messages = [
               "Starting your application means you’ll receive {} email updates.".format(framework.name)

--- a/app/templates/suppliers/_frameworks_pending.html
+++ b/app/templates/suppliers/_frameworks_pending.html
@@ -1,15 +1,11 @@
 {% for framework in frameworks.pending %}
   {% if framework.made_application %}
     <div class="summary-item-lede">
-      <div class="grid-row">
-        <div class="column-two-thirds">
-          <h2 class="summary-item-heading">{{ framework.name }} is closed for applications</h2>
-          <p>
-            You submitted {{ framework.complete_drafts_count }} service{{ 's' if framework.complete_drafts_count != 1 }} for consideration
-            <a href="{{ url_for('.framework_dashboard', framework_slug=framework.slug) }}">View your submitted application</a>
-          </p>
-        </div>
-      </div>
+      <h2 class="summary-item-heading">{{ framework.name }} is closed for applications</h2>
+      <p>
+        You submitted {{ framework.complete_drafts_count }} service{{ 's' if framework.complete_drafts_count != 1 }} for consideration
+        <a href="{{ url_for('.framework_dashboard', framework_slug=framework.slug) }}">View your submitted application</a>
+      </p>
     </div>
   {% elif framework.registered_interest %}
     <aside role="complementary" class="temporary-message" aria-labelledby="temporary-message-heading">

--- a/app/templates/suppliers/dashboard.html
+++ b/app/templates/suppliers/dashboard.html
@@ -27,12 +27,6 @@
     {% endfor %}
   {% endwith %}
 
-  {% include 'suppliers/_frameworks_coming.html' %}
-  {% include 'suppliers/_frameworks_open.html' %}
-  {% include 'suppliers/_frameworks_pending.html' %}
-  {% include 'suppliers/_frameworks_standstill.html' %}
-
-
   {% if 'account-created' in get_flashed_messages(category_filter=["flag"]) %}
   <div class="grid-row" data-analytics="trackPageView" data-url="/suppliers?account-created=true">
   {% else %}
@@ -47,10 +41,13 @@
       {% endwith %}
     </div>
   </div>
-  <h2 class="visually-hidden">Your services</h2>
+
   <div class="grid-row">
-    <div class="column-two-thirds dmspeak">
-      {% include 'suppliers/_frameworks_live.html' %}
+    <div class="column-two-thirds">
+    {% include 'suppliers/_frameworks_coming.html' %}
+    {% include 'suppliers/_frameworks_open.html' %}
+    {% include 'suppliers/_frameworks_pending.html' %}
+    {% include 'suppliers/_frameworks_standstill.html' %}
     </div>
     <div class="column-one-third dmspeak">
       <h2 class="heading-xmedium">Your company</h2>
@@ -58,6 +55,13 @@
         <a href="{{ url_for('.supplier_details') }}">Supplier details</a><br/>
         <a href="{{ url_for('.list_users') }}">Contributors</a>
       </p>
+    </div>
+  </div>
+
+  <h2 class="visually-hidden">Your services</h2>
+  <div class="grid-row">
+    <div class="column-two-thirds dmspeak">
+      {% include 'suppliers/_frameworks_live.html' %}
     </div>
   </div>
 {% endblock %}

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "colors": "1.1.2",
     "jquery": "1.12.0",
     "hogan.js": "3.0.2",
-    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v28.7.0",
+    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v28.9.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.19.2/jinja_govuk_template-0.19.2.tgz",
     "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#10.7.2"
   },

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "colors": "1.1.2",
     "jquery": "1.12.0",
     "hogan.js": "3.0.2",
-    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v28.9.0",
+    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v28.10.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.19.2/jinja_govuk_template-0.19.2.tgz",
     "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#10.7.2"
   },

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -2109,7 +2109,7 @@ class TestShowDraftService(BaseApplicationTest):
             "//input[@value='Mark as complete']"
         )[0]
 
-        assert sorted(["submit", "button-save ", "Mark as complete"]) == sorted(submit_button.values())
+        assert sorted(["submit", "button-save", "Mark as complete"]) == sorted(submit_button.values())
 
     @mock.patch('app.main.views.services.count_unanswered_questions')
     def test_no_move_to_complete_button_if_not_open(self, count_unanswered, data_api_client):

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -2101,9 +2101,15 @@ class TestShowDraftService(BaseApplicationTest):
         data_api_client.get_draft_service.return_value = self.draft_service
         count_unanswered.return_value = 0, 1
         res = self.client.get('/suppliers/frameworks/g-cloud-7/submissions/scs/1')
+        document = html.fromstring(res.get_data(as_text=True))
 
-        assert u'1 optional question unanswered' in res.get_data(as_text=True)
-        assert u'<input type="submit" class="button-save"  value="Mark as complete" />' in res.get_data(as_text=True)
+        assert '1 optional question unanswered' in res.get_data(as_text=True)
+
+        submit_button = document.xpath(
+            "//input[@value='Mark as complete']"
+        )[0]
+
+        assert sorted(["submit", "button-save ", "Mark as complete"]) == sorted(submit_button.values())
 
     @mock.patch('app.main.views.services.count_unanswered_questions')
     def test_no_move_to_complete_button_if_not_open(self, count_unanswered, data_api_client):

--- a/tests/app/main/test_suppliers.py
+++ b/tests/app/main/test_suppliers.py
@@ -271,12 +271,16 @@ class TestSuppliersDashboard(BaseApplicationTest):
         with self.app.test_client():
             self.login()
 
-            res = self.client.get("/suppliers")
-            doc = html.fromstring(res.get_data(as_text=True))
+            response = self.client.get("/suppliers")
+            document = html.fromstring(response.get_data(as_text=True))
 
-            assert res.status_code == 200
-            assert 'Apply to G-Cloud 7' in doc.xpath('//h2[@class="summary-item-heading"]/text()')[0]
-            assert doc.xpath('//input[@class="button-save"]/@value')[0] == 'Start application'
+            assert response.status_code == 200
+
+            apply_button = document.xpath(
+                "//h3[normalize-space()='G-Cloud 7 is open for applications']/following::input[1]"
+            )[0]
+
+            assert apply_button.value == "Apply"
 
     def test_shows_gcloud_7_continue_link(self, get_current_suppliers_users, data_api_client):
         data_api_client.get_supplier.side_effect = get_supplier
@@ -290,12 +294,16 @@ class TestSuppliersDashboard(BaseApplicationTest):
         with self.app.test_client():
             self.login()
 
-            res = self.client.get("/suppliers")
-            doc = html.fromstring(res.get_data(as_text=True))
+            response = self.client.get("/suppliers")
+            document = html.fromstring(response.get_data(as_text=True))
 
-            assert res.status_code == 200
-            assert doc.xpath('//a[@href="/suppliers/frameworks/g-cloud-7"]/text()')[0] == \
-                "Continue your G-Cloud 7 application"
+            assert response.status_code == 200
+            continue_link = document.xpath(
+                "//h3[normalize-space()='Your G-Cloud 7 application']"
+                "/following::a[1][normalize-space()='Continue your application']"
+            )
+            assert continue_link
+            assert continue_link[0].values()[0] == "/suppliers/frameworks/g-cloud-7"
 
     def test_shows_gcloud_7_closed_message_if_pending_and_no_interest(self, get_current_suppliers_users, data_api_client):  # noqa
         data_api_client.get_framework.return_value = self.framework('pending')
@@ -669,15 +677,17 @@ class TestSuppliersDashboard(BaseApplicationTest):
         with self.app.test_client():
             self.login()
 
-            res = self.client.get("/suppliers")
-            doc = html.fromstring(res.get_data(as_text=True))
+            response = self.client.get("/suppliers")
+            document = html.fromstring(response.get_data(as_text=True))
 
-            assert res.status_code == 200
+            assert response.status_code == 200
 
-            assert "Apply to Digital Outcomes and Specialists" in doc.xpath(
-                '//div[@class="summary-item-lede"]//h2[@class="summary-item-heading"]/text()'
+            apply_button = document.xpath(
+                "//h3[normalize-space()='Digital Outcomes and Specialists is open for applications']"
+                "/following::input[1]"
             )[0]
-            assert doc.xpath('//div[@class="summary-item-lede"]//input/@value')[0] == "Start application"
+
+            assert apply_button.value == "Apply"
 
     def test_shows_continue_with_dos_link(self, get_current_suppliers_users, data_api_client):
         data_api_client.get_supplier.side_effect = get_supplier
@@ -704,13 +714,16 @@ class TestSuppliersDashboard(BaseApplicationTest):
         with self.app.test_client():
             self.login()
 
-            res = self.client.get("/suppliers")
-            doc = html.fromstring(res.get_data(as_text=True))
+            response = self.client.get("/suppliers")
+            document = html.fromstring(response.get_data(as_text=True))
 
-            assert res.status_code == 200
-            assert "Continue your Digital Outcomes and Specialists application" in doc.xpath(
-                '//a[@class="browse-list-item-link"]/text()'
-            )[0]
+            assert response.status_code == 200
+            continue_link = document.xpath(
+                "//h3[normalize-space()='Your Digital Outcomes and Specialists application']"
+                "/following::a[1][normalize-space()='Continue your application']"
+            )
+            assert continue_link
+            assert continue_link[0].values()[0] == "/suppliers/frameworks/digital-outcomes-and-specialists"
 
 
 @mock.patch("app.main.views.suppliers.data_api_client", autospec=True)

--- a/tests/app/main/test_suppliers.py
+++ b/tests/app/main/test_suppliers.py
@@ -277,7 +277,7 @@ class TestSuppliersDashboard(BaseApplicationTest):
             assert response.status_code == 200
 
             apply_button = document.xpath(
-                "//h3[normalize-space()='G-Cloud 7 is open for applications']/following::input[1]"
+                "//h2[normalize-space()='G-Cloud 7 is open for applications']/following::input[1]"
             )[0]
 
             assert apply_button.value == "Apply"
@@ -299,7 +299,7 @@ class TestSuppliersDashboard(BaseApplicationTest):
 
             assert response.status_code == 200
             continue_link = document.xpath(
-                "//h3[normalize-space()='Your G-Cloud 7 application']"
+                "//h2[normalize-space()='Your G-Cloud 7 application']"
                 "/following::a[1][normalize-space()='Continue your application']"
             )
             assert continue_link
@@ -683,7 +683,7 @@ class TestSuppliersDashboard(BaseApplicationTest):
             assert response.status_code == 200
 
             apply_button = document.xpath(
-                "//h3[normalize-space()='Digital Outcomes and Specialists is open for applications']"
+                "//h2[normalize-space()='Digital Outcomes and Specialists is open for applications']"
                 "/following::input[1]"
             )[0]
 
@@ -719,7 +719,7 @@ class TestSuppliersDashboard(BaseApplicationTest):
 
             assert response.status_code == 200
             continue_link = document.xpath(
-                "//h3[normalize-space()='Your Digital Outcomes and Specialists application']"
+                "//h2[normalize-space()='Your Digital Outcomes and Specialists application']"
                 "/following::a[1][normalize-space()='Continue your application']"
             )
             assert continue_link

--- a/yarn.lock
+++ b/yarn.lock
@@ -546,9 +546,9 @@ detect-file@^1.0.0:
   version "0.0.0"
   resolved "https://github.com/alphagov/digitalmarketplace-frameworks.git#141c5074872247582613887187202abb1dff228f"
 
-"digitalmarketplace-frontend-toolkit@https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v28.7.0":
+"digitalmarketplace-frontend-toolkit@https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v28.10.0":
   version "0.0.1"
-  resolved "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#d52305bf73fcf734335aab8ec8c4834fc02d9585"
+  resolved "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#bd3e5e10988f24966ace029da30e54abaa21567f"
   dependencies:
     del "^2.2.2"
     govuk-elements-sass "3.0.3"


### PR DESCRIPTION
Trello ticket: https://trello.com/c/e1Gk2eTF/12-fix-styling-for-framework-banners-on-account

Everything done as per the screenshot I think except the headers are `h3`, not `h2`,  as changing them would add a layer of complexity (The header element lives in the macro and is used for many different temporary messages across digital marketplace).

## Screenshots: 

### Two started applications:
![screen shot 2018-03-13 at 16 34 10](https://user-images.githubusercontent.com/20957548/37357494-806c51a8-26e0-11e8-9f15-a669191aea38.png)

____

### Started and not started application:
![screen shot 2018-03-13 at 16 34 38](https://user-images.githubusercontent.com/20957548/37357495-808c636c-26e0-11e8-8e29-bd47072d4711.png)

____

### Mobile view:
![screen shot 2018-03-13 at 16 37 03](https://user-images.githubusercontent.com/20957548/37357497-81055934-26e0-11e8-9e20-c0395ed008ca.png)

____

### One framework open:
<img width="704" alt="screen shot 2018-03-13 at 17 29 44" src="https://user-images.githubusercontent.com/20957548/37358942-40deda48-26e4-11e8-9b3b-7dab3e1e4c3c.png">
