### PR TITLE
Fix supplier forms validation

### DIFF
--- a/app/main/forms/auth_forms.py
+++ b/app/main/forms/auth_forms.py
@@ -1,38 +1,10 @@
 from flask_wtf import Form
-from wtforms import PasswordField
-from wtforms.validators import DataRequired, Regexp, EqualTo, Length
+from wtforms.validators import InputRequired
 
-from dmutils.forms import StripWhitespaceStringField
-
-
-class LoginForm(Form):
-    email_address = StripWhitespaceStringField('Email address', validators=[
-        DataRequired(message="Email address must be provided"),
-        Regexp("^[^@^\s]+@[^@^\.^\s]+(\.[^@^\.^\s]+)+$",
-               message="Please enter a valid email address")
-    ])
-    password = PasswordField('Password', validators=[
-        DataRequired(message="Please enter your password")
-    ])
+from dmutils.forms import EmailField
 
 
 class EmailAddressForm(Form):
-    email_address = StripWhitespaceStringField('Email address', validators=[
-        DataRequired(message="Email address must be provided"),
-        Regexp("^[^@^\s]+@[^@^\.^\s]+(\.[^@^\.^\s]+)+$",
-               message="Please enter a valid email address")
-    ])
-
-
-class ChangePasswordForm(Form):
-    password = PasswordField('Password', validators=[
-        DataRequired(message="Please enter a new password"),
-        Length(min=10,
-               max=50,
-               message="Passwords must be between 10 and 50 characters"
-               )
-    ])
-    confirm_password = PasswordField('Confirm password', validators=[
-        DataRequired(message="Please confirm your new password"),
-        EqualTo('password', message="The passwords you entered do not match")
+    email_address = EmailField('Email address', validators=[
+        InputRequired(message="Email address must be provided")
     ])

--- a/app/main/forms/suppliers.py
+++ b/app/main/forms/suppliers.py
@@ -30,9 +30,11 @@ class EditSupplierForm(Form):
 class EditContactInformationForm(Form):
     contactName = StripWhitespaceStringField('Contact name', validators=[
         InputRequired(message="You must provide a contact name."),
+        Length(max=255, message="You must provide a contact name under 256 characters."),
     ])
     email = EmailField('Contact email address', validators=[
         InputRequired(message="You must provide an email address."),
+        EmailValidator(message="You must provide a valid email address."),
     ])
     phoneNumber = StripWhitespaceStringField('Contact phone number', validators=[
         InputRequired(message="You must provide a phone number."),

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -5,6 +5,6 @@ Flask==0.10.1
 Flask-Login==0.2.11
 Flask-WTF==0.12
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@34.2.0#egg=digitalmarketplace-utils==34.2.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@35.1.0#egg=digitalmarketplace-utils==35.1.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.2.0#egg=digitalmarketplace-content-loader==4.2.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@15.0.0#egg=digitalmarketplace-apiclient==15.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ Flask==0.10.1
 Flask-Login==0.2.11
 Flask-WTF==0.12
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@34.2.0#egg=digitalmarketplace-utils==34.2.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@35.1.0#egg=digitalmarketplace-utils==35.1.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.2.0#egg=digitalmarketplace-content-loader==4.2.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@15.0.0#egg=digitalmarketplace-apiclient==15.0.0
 


### PR DESCRIPTION
For this tech debt ticket: https://trello.com/c/StDVGuoI
Also, this PR on utils: https://github.com/alphagov/digitalmarketplace-utils/pull/372

### Update validation on ContactInformationForm
Contact name wasn't being validated for length.

The email field can use the EmailValidator we have in utils, with an
updated message.

### Remove unused forms
We no longer use the LoginForm or the ChangePasswordForm. This
functionality has moved to the user app.

Also, the EmailAddressFrom can be refactored to use the common
`EmailField` field from utils. This comes with a free regex validator.