### PR TITLE
Confirm supplier details big green button

### DIFF
--- a/app/main/helpers/suppliers.py
+++ b/app/main/helpers/suppliers.py
@@ -31,14 +31,12 @@ COUNTRY_TUPLE = load_countries()
 
 def supplier_company_details_are_complete(supplier_data):
     supplier_required_fields = ['dunsNumber', 'name', 'registeredName', 'registrationCountry', 'organisationSize',
-                                'tradingStatus']
+                                'tradingStatus', 'vatNumber']
     contact_required_fields = ['address1', 'city', 'postcode']
 
-    registration_country = supplier_data['registrationCountry'] if 'registrationCountry' in supplier_data else None
-    if registration_country == 'gb' or registration_country == 'country:GB':
+    # We require one of either 'companiesHouseNumber' or 'otherCompanyRegistrationNumber'
+    if 'companiesHouseNumber' in supplier_data:
         supplier_required_fields.append('companiesHouseNumber')
-        supplier_required_fields.append('vatNumber')
-
     else:
         supplier_required_fields.append('otherCompanyRegistrationNumber')
 

--- a/app/templates/suppliers/details.html
+++ b/app/templates/suppliers/details.html
@@ -21,8 +21,8 @@
 
 
 {% block main_content %}
-<div class='grid-row'>
-  <div class='column-one-whole padding-bottom-small'>
+  <div class='grid-row'>
+    <div class='column-one-whole padding-bottom-small'>
 {%
   with
     heading = "Company details",
@@ -162,18 +162,22 @@
   {% endif %}
 {% endcall %}
 
-  {% if supplier.dunsNumber %}
-    {% call summary.row() %}
-      {{ summary.field_name('DUNS number') }}
-      {{ summary.text(supplier.dunsNumber) }}
-      {{ summary.edit_link(label="Change", link=url_for(".edit_supplier_duns_number"), hidden_text="DUNS number") }}
-    {% endcall %}
+{% call summary.row() %}
+  {{ summary.field_name('DUNS number') }}
+   {% if supplier.dunsNumber %}
+    {{ summary.text(supplier.dunsNumber) }}
+    {{ summary.edit_link(label="Change", link=url_for(".edit_supplier_duns_number"), hidden_text="DUNS number") }}
+  {% else %}
+    {{ summary.link(link_title="Answer required", link=url_for(".edit_supplier_duns_number"), hidden_text="for DUNS number") }}
+    {{ summary.text("") }}
   {% endif %}
+{% endcall %}
 
 {% endcall %}
 
+    </div>
   </div>
-
+  <div class='grid-row'>
   {% if not supplier.companyDetailsConfirmed %}
     <div class='column-two-thirds'>
       {% if company_details_complete  %}
@@ -195,7 +199,8 @@
       {% endif %}
     </div>
   {% endif %}
-
+  </div>
+  <div class='grid-row'>
     <div class='column-two-thirds'>
   {% if currently_applying_to %}
     {%
@@ -208,5 +213,5 @@
     {% endwith %}
   {% endif %}
     </div>
-</div>
+  </div>
 {% endblock %}

--- a/app/templates/suppliers/details.html
+++ b/app/templates/suppliers/details.html
@@ -21,6 +21,8 @@
 
 
 {% block main_content %}
+<div class='grid-row'>
+  <div class='column-one-whole padding-bottom-small'>
 {%
   with
     heading = "Company details",
@@ -170,16 +172,41 @@
 
 {% endcall %}
 
-{% if currently_applying_to %}
-  <p>You must complete your company details to make an application.</p>
-  {%
-    with
-    url = url_for(".framework_dashboard", framework_slug=currently_applying_to.slug),
-    text = "Return to your {} application".format(currently_applying_to.name),
-    bigger = false
-  %}
-    {% include "toolkit/secondary-action-link.html" %}
-  {% endwith %}
-{% endif %}
+  </div>
 
+  {% if not supplier.companyDetailsConfirmed %}
+    <div class='column-two-thirds'>
+      {% if company_details_complete  %}
+        <form method="POST" action="{{ url_for('.confirm_supplier_details') }}">
+          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+          <p>Once you confirm your information you'll need to contact support to change your:</p>
+          <ul class="list-bullet">
+            <li>registered company name</li>
+            <li>registration number</li>
+            <li>VAT number</li>
+          </ul>
+
+          {% with type = "save", label = "Save and confirm" %}
+            {% include "toolkit/button.html" %}
+          {% endwith %}
+        </form>
+      {% elif currently_applying_to %}
+        <p>You must complete your company details to make an application.</p>
+      {% endif %}
+    </div>
+  {% endif %}
+
+    <div class='column-two-thirds'>
+  {% if currently_applying_to %}
+    {%
+       with
+       url = url_for(".framework_dashboard", framework_slug=currently_applying_to.slug),
+       text = "Return to your {} application".format(currently_applying_to.name),
+       bigger = false
+     %}
+       {% include "toolkit/secondary-action-link.html" %}
+    {% endwith %}
+  {% endif %}
+    </div>
+</div>
 {% endblock %}

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -7,4 +7,4 @@ Flask-WTF==0.12
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@35.2.0#egg=digitalmarketplace-utils==35.2.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.2.0#egg=digitalmarketplace-content-loader==4.2.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@15.0.0#egg=digitalmarketplace-apiclient==15.0.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@15.0.1#egg=digitalmarketplace-apiclient==15.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ Flask-WTF==0.12
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@35.2.0#egg=digitalmarketplace-utils==35.2.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.2.0#egg=digitalmarketplace-content-loader==4.2.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@15.0.0#egg=digitalmarketplace-apiclient==15.0.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@15.0.1#egg=digitalmarketplace-apiclient==15.0.1
 
 ## The following requirements were added by pip freeze:
 asn1crypto==0.24.0

--- a/tests/app/main/helpers/test_suppliers.py
+++ b/tests/app/main/helpers/test_suppliers.py
@@ -1,6 +1,6 @@
 import pytest
 from flask_wtf import Form
-from wtforms import TextField
+from wtforms import StringField
 from wtforms.validators import Length
 from app.main.helpers.suppliers import get_country_name_from_country_code, parse_form_errors_for_validation_masthead, \
     supplier_company_details_are_complete
@@ -42,13 +42,13 @@ class TestSupplierCompanyDetailsComplete:
 
 
 class FormForTest(Form):
-    field_one = TextField('Field one?', validators=[
+    field_one = StringField('Field one?', validators=[
         Length(max=5, message="Field one must be under 5 characters.")
     ])
-    field_two = TextField('Field two?', validators=[
+    field_two = StringField('Field two?', validators=[
         Length(max=5, message="Field two must be under 5 characters.")
     ])
-    field_three = TextField('Field three?', validators=[
+    field_three = StringField('Field three?', validators=[
         Length(max=5, message="Field three must be under 5 characters.")
     ])
 

--- a/tests/app/main/test_suppliers.py
+++ b/tests/app/main/test_suppliers.py
@@ -977,8 +977,16 @@ class TestSupplierDetails(BaseApplicationTest):
             submit_button = document.xpath("//input[@value='Save and confirm']")
             assert submit_button if button_should_be_shown else not submit_button
 
-    def test_post_route_calls_api_and_redirects_when_details_are_complete(self, data_api_client):
-        data_api_client.get_supplier.return_value = get_supplier()
+    @pytest.mark.parametrize(
+        "complete_supplier",
+        (
+            get_supplier(),
+            get_supplier(companiesHouseNumber=None),
+            get_supplier(otherCompanyRegistrationNumber=None),
+        )
+    )
+    def test_post_route_calls_api_and_redirects_when_details_are_complete(self, data_api_client, complete_supplier):
+        data_api_client.get_supplier.return_value = complete_supplier
         with self.app.test_client():
             self.login()
             response = self.client.post("/suppliers/details")
@@ -987,8 +995,16 @@ class TestSupplierDetails(BaseApplicationTest):
                 mock.call(supplier={'companyDetailsConfirmed': True}, supplier_id=1234, user='email@email.com')
             ]
 
-    def test_post_route_does_not_call_api_and_returns_error_if_details_are_incomplete(self, data_api_client):
-        data_api_client.get_supplier.return_value = get_supplier(organisationSize=None)
+    @pytest.mark.parametrize(
+        "incomplete_supplier",
+        (
+            get_supplier(organisationSize=None),
+            get_supplier(vatNumber=None),
+            get_supplier(companiesHouseNumber=None, otherCompanyRegistrationNumber=None),
+        )
+    )
+    def test_post_route_does_not_call_api_and_returns_error_if_incomplete(self, data_api_client, incomplete_supplier):
+        data_api_client.get_supplier.return_value = incomplete_supplier
         with self.app.test_client():
             self.login()
             response = self.client.post("/suppliers/details")

--- a/tests/app/main/test_suppliers.py
+++ b/tests/app/main/test_suppliers.py
@@ -955,6 +955,65 @@ class TestSupplierDetails(BaseApplicationTest):
             document = html.fromstring(page_html)
             assert "Return to your" not in document.text_content()
 
+    @pytest.mark.parametrize(
+        "supplier_details,button_should_be_shown",
+        [
+            (get_supplier(companyDetailsConfirmed=False), True),  # Details complete but not confirmed
+            (get_supplier(companyDetailsConfirmed=True), False),  # Details complete and already confirmed
+            (get_supplier(companyDetailsConfirmed=False, vatNumber=None), False),  # Details not complete or confirmed
+        ]
+    )
+    def test_green_button_is_shown_only_when_details_are_complete_but_not_confirmed(
+            self, data_api_client, supplier_details, button_should_be_shown
+    ):
+        data_api_client.get_supplier.return_value = supplier_details
+        with self.app.test_client():
+            self.login()
+
+            response = self.client.get("/suppliers/details")
+            assert response.status_code == 200
+
+            document = html.fromstring(response.get_data(as_text=True))
+            submit_button = document.xpath("//input[@value='Save and confirm']")
+            assert submit_button if button_should_be_shown else not submit_button
+
+    def test_post_route_calls_api_and_redirects_when_details_are_complete(self, data_api_client):
+        data_api_client.get_supplier.return_value = get_supplier()
+        with self.app.test_client():
+            self.login()
+            response = self.client.post("/suppliers/details")
+            assert response.status_code == 302
+            assert data_api_client.update_supplier.call_args_list == [
+                mock.call(supplier={'companyDetailsConfirmed': True}, supplier_id=1234, user='email@email.com')
+            ]
+
+    def test_post_route_does_not_call_api_and_returns_error_if_details_are_incomplete(self, data_api_client):
+        data_api_client.get_supplier.return_value = get_supplier(organisationSize=None)
+        with self.app.test_client():
+            self.login()
+            response = self.client.post("/suppliers/details")
+            assert response.status_code == 400
+            assert data_api_client.update_supplier.call_args_list == []
+
+    @pytest.mark.parametrize(
+        "current_fwk,expected_destination",
+        [
+            (None, "/suppliers/details"),
+            ("g-things-23", "/suppliers/frameworks/g-things-23"),
+            ("digital-widgets-and-stuff", "/suppliers/frameworks/digital-widgets-and-stuff"),
+        ]
+    )
+    def test_post_green_button_redirects_to_the_correct_place(self, data_api_client, current_fwk, expected_destination):
+        data_api_client.get_supplier.return_value = get_supplier()
+        with self.app.test_client():
+            self.login()
+            if current_fwk:
+                with self.client.session_transaction() as session:
+                    session["currently_applying_to"] = current_fwk
+            response = self.client.post("/suppliers/details")
+            assert response.status_code == 302
+            assert response.location == f"http://localhost{expected_destination}"
+
 
 @mock.patch("app.main.views.suppliers.data_api_client", autospec=True)
 @mock.patch("app.main.views.suppliers.get_current_suppliers_users", autospec=True)


### PR DESCRIPTION
For this ticket: https://trello.com/c/gjl4LXzu/60-confirm-supplier-details-3-the-green-button

Adds in button to confirm supplier details.  The button is shown once all details have been provided, and disappears after it's been clicked once to confirm the details are correct.

It looks like this:
![screen shot 2018-03-15 at 12 36 53](https://user-images.githubusercontent.com/6525554/37463594-a315f060-284d-11e8-893b-68554c353156.png)

I've also reworked the logic of deciding if supplier details are complete - previously we had it contingent on whether country is UK or not whether you need Companies House number or some other registration number, but actually UK suppliers could have an "other" registration number.  So we just require one or the other number, not dependent on the country.