### PR TITLE
edit_supplier_registration_number view: fix warning log message

### DIFF
--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -243,7 +243,7 @@ def edit_supplier_registration_number():
         else:
             current_app.logger.warning(
                 "supplieredit.fail: has-companies-house-number:{hasnum}, companies-house-number:{chnum}, "
-                "other-registered-company-number:{rnumber}, errors:{errors}",
+                "other-registered-company-number:{rnumber}, errors:{rnumber_errors}",
                 extra={
                     'hasnum': form.has_companies_house_number.data,
                     'chnum': form.companies_house_number.data,


### PR DESCRIPTION
https://trello.com/c/qLOqQYy0/226-unable-to-format-log-message-log-messages-not-particularly-useful

Was referring to a parameter `errors` but providing a parameter `rnumber_errors` instead, causing a confusing error when this is issued.