### PR TITLE
Only add padding to top grid row if there are rows below

### DIFF
--- a/app/templates/suppliers/details.html
+++ b/app/templates/suppliers/details.html
@@ -22,7 +22,11 @@
 
 {% block main_content %}
   <div class='grid-row'>
+  {% if currently_applying_to or (company_details_complete and not supplier.companyDetailsConfirmed) %}
     <div class='column-one-whole padding-bottom-small'>
+  {% else %}
+    <div class='column-one-whole'>
+  {% endif %}
 {%
   with
     heading = "Company details",


### PR DESCRIPTION
Visual regression tests identified some extra spacing introduced here at the bottom of the page when there was no button or wording to show.

Including the padding on the first grid-row only when there's something to put in them should fix the issue.