### PR TITLE
flash messages: port to centralized implementation from frontend toolkit

### DIFF
--- a/app/main/views/login.py
+++ b/app/main/views/login.py
@@ -10,6 +10,9 @@ from ..helpers import login_required
 from ... import data_api_client
 
 
+USER_INVITED_FLASH_MESSAGE = "Contributor invited"
+
+
 @main.route('/invite-user', methods=["GET"])
 @login_required
 def invite_user():
@@ -48,7 +51,7 @@ def send_invite_user():
             data={'invitedEmail': form.email_address.data},
         )
 
-        flash('user_invited', 'success')
+        flash(USER_INVITED_FLASH_MESSAGE, "success")
         return redirect(url_for('.list_users'))
     else:
         return render_template(

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -36,6 +36,14 @@ from ..helpers.suppliers import (
 from ..helpers import login_required
 from .users import get_current_suppliers_users
 
+JOIN_OPEN_FRAMEWORK_NOTIFICATION_MAILING_LIST_SUCCESS_MESSAGE = (
+    "You will receive email notifications to {email_address} when applications are opening."
+)
+JOIN_OPEN_FRAMEWORK_NOTIFICATION_MAILING_LIST_ERROR_MESSAGE = Markup("""
+    The service is unavailable at the moment. If the problem continues please contact
+    <a href="mailto:enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.service.gov.uk</a>
+""")
+
 
 @main.route('')
 @login_required
@@ -750,7 +758,6 @@ def join_open_framework_notification_mailing_list():
                 form.data["email_address"],
             )
 
-            # note we're signalling our flash messages in two separate ways here
             if mc_response not in (True, False,):
                 # success
                 data_api_client.create_audit_event(
@@ -767,17 +774,14 @@ def join_open_framework_notification_mailing_list():
                     },
                 )
 
-                # this message will be consumed by the buyer app which has been converted to display raw "literal"
-                # content from the session
-                flash(Markup(render_template(
-                    "flashmessages/join_open_framework_notification_mailing_list_success.html",
+                flash(JOIN_OPEN_FRAMEWORK_NOTIFICATION_MAILING_LIST_SUCCESS_MESSAGE.format(
                     email_address=form.data["email_address"],
-                )), "success")
+                ), "success")
 
                 return redirect("/")
             else:
                 # failure
-                flash("mailing_list_signup_error", "error")
+                flash(JOIN_OPEN_FRAMEWORK_NOTIFICATION_MAILING_LIST_ERROR_MESSAGE, "error")
                 if mc_response:
                     # this is a case where we think the error is *probably* the user's fault in some way
                     status = 400

--- a/app/main/views/users.py
+++ b/app/main/views/users.py
@@ -6,6 +6,9 @@ from ...main import main
 from ... import data_api_client
 
 
+DEACTIVATED_USER_MESSAGE = "{user_name} ({user_email_address}) has been removed as a contributor."
+
+
 def get_current_suppliers_users():
 
     users = data_api_client.find_users(
@@ -74,9 +77,9 @@ def deactivate_user(user_id):
 
     data_api_client.update_user(user_id=user_to_deactivate['id'], active=False, updater=current_user.email_address)
 
-    flash({
-        'deactivate_user_name': user_to_deactivate['name'],
-        'deactivate_user_email_address': user_to_deactivate['emailAddress']
-    })
+    flash(DEACTIVATED_USER_MESSAGE.format(
+        user_name=user_to_deactivate['name'],
+        user_email_address=user_to_deactivate['emailAddress'],
+    ), "success")
 
     return redirect(url_for('.list_users'))

--- a/app/templates/_base_page.html
+++ b/app/templates/_base_page.html
@@ -29,6 +29,42 @@
   {% block breadcrumb %}{% endblock %}
   <div id="wrapper">
     <main id="content" role="main">
+      {% with messages = get_flashed_messages(with_categories=true) %}
+        {% if messages %}
+          {% for category, message in messages %}
+            {% if category == 'track-page-view' %}
+              <div data-analytics="trackPageView" data-url="{{ message }}"></div>
+            {% elif category == 'flag' %}
+              {# these were originally messages with a function similar to the above "track-page-view" ones (analytics) but #}
+              {# they did not know about their actual virtual page view url, expecting the receiving page to know the       #}
+              {# corresponding url for a particular symbolic "message".                                                     #}
+              {# TODO these can be got rid of as soon as the app generating each flag flash message is converted to using   #}
+              {# new "track-page-view" mechanism                                                                            #}
+              {% if message == "account-created" %}
+                <div data-analytics="trackPageView" data-url="/suppliers?account-created=true"></div>
+              {% endif %}
+              {# else we don't know about this particular flag-message so shouldn't try to do anything about it #}
+            {% elif category != 'must_login' %}  {# skip showing Flask's "Please log in" message #}
+              <div class="flash-message-container {{ 'banner-destructive-without-action' if category == 'error' else 'banner-success-without-action' }}">
+                <p class="banner-message">
+                  {# TODO remove the below special cases, once those two apps have been updated to contain the message. #}
+                  {% if message == 'supplier-role-required' %}  {# set by supplier app #}
+                    You must log in with a supplier account to see this page.
+
+                  {% elif message == 'buyer-role-required' %}  {# set by briefs app #}
+                    You must log in with a buyer account to see this page.
+
+                  {% else %}
+                    {{ message }}
+
+                  {% endif %}
+                </p>
+              </div>
+            {% endif %}
+          {% endfor %}
+        {% endif %}
+      {% endwith %}
+
       {% block main_content %}
       {% endblock %}
     </main>

--- a/app/templates/auth/submit_email_address.html
+++ b/app/templates/auth/submit_email_address.html
@@ -27,28 +27,6 @@
 
 {% block main_content %}
 
-{% with messages = get_flashed_messages(with_categories=true) %}
-{% if messages %}
-{% for category, message in messages %}
-    {% if category == 'error' %}
-      <div class="banner-destructive-without-action">
-    {% elif category == 'success' %}
-      <div class="banner-success-without-action">
-    {% endif %}
-    {% if message == 'user_invited' %}
-    <p class="banner-message">
-        Contributor invited
-    </p>
-    {% elif message == 'user_not_invited' %}
-    <p class="banner-message">
-        Not Invited
-    </p>
-    {% endif %}
-          </div><div class="/sc"></div>
-{% endfor %}
-{% endif %}
-{% endwith %}
-
   {% with
     heading = "Invite a contributor",
     smaller = true

--- a/app/templates/flashmessages/join_open_framework_notification_mailing_list_success.html
+++ b/app/templates/flashmessages/join_open_framework_notification_mailing_list_success.html
@@ -1,1 +1,0 @@
-You will receive email notifications to {{ email_address }} when applications are opening.

--- a/app/templates/frameworks/contract_start.html
+++ b/app/templates/frameworks/contract_start.html
@@ -26,16 +26,6 @@
 
 {% block main_content %}
 
-  {% with messages = get_flashed_messages(with_categories=True) %}
-    {% for category, message in messages %}
-      {% if category == 'declaration_complete' %}
-        <div data-analytics="trackPageView"
-          data-url="{{message}}">
-        </div>
-      {% endif %}
-    {% endfor %}
-  {% endwith %}
-
   <div class="grid-row framework-dashboard">
     <div class="column-two-thirds">
       {% with

--- a/app/templates/frameworks/contract_variation.html
+++ b/app/templates/frameworks/contract_variation.html
@@ -32,21 +32,6 @@
     {% endwith %}
   {% endif %}
 
-  {% with messages = get_flashed_messages(with_categories=true) %}
-    {% for category, message in messages %}
-      {% if message == 'variation_accepted' %}
-        {% set message = variation.confirmation_message %}
-      {% endif %}
-      {%
-        with
-        message = message,
-        type = "destructive" if category == 'error' else "success"
-      %}
-      {% include "toolkit/notification-banner.html" %}
-      {% endwith %}
-    {% endfor %}
-  {% endwith %}
-
     <div class="grid-row">
       <div class="column-one-whole">
         {% if form.errors %}

--- a/app/templates/frameworks/dashboard.html
+++ b/app/templates/frameworks/dashboard.html
@@ -30,24 +30,6 @@
 {% endblock %}
 
 {% block main_content %}
-  {% with messages = get_flashed_messages(with_categories=True) %}
-    {% for category, message in messages %}
-      {% if category == 'declaration_complete' %}
-        <div data-analytics="trackPageView"
-          data-url="{{message}}">
-        </div>
-      {% else %}
-        {%
-          with
-          message = message,
-          type = "destructive" if category == 'error' else "success"
-        %}
-          {% include "toolkit/notification-banner.html" %}
-        {% endwith %}
-      {% endif %}
-    {% endfor %}
-  {% endwith %}
-
   {# Confidence Banner #}
   {% if application_made and company_details_complete and framework.status == 'open' %}
     {% with 

--- a/app/templates/frameworks/services.html
+++ b/app/templates/frameworks/services.html
@@ -31,21 +31,6 @@
 
 {% block main_content %}
 
-  {% with messages = get_flashed_messages(with_categories=True) %}
-    {% for category, message in messages %}
-      <div class="banner-success-without-action">
-        <p class="banner-message">
-          {% if category == 'service_deleted' %}
-            <strong>{{message.service_name}}</strong> was deleted
-          {% elif category == 'service_completed' %}
-            <strong>{{message.service_name}}</strong> was marked as complete
-            <span data-analytics="trackPageView" data-url="{{message.virtual_pageview_url}}"></span>
-          {% endif %}
-        </p>
-      </div>
-    {% endfor %}
-  {% endwith %}
-
   {% include "partials/service_warning.html" %}
 
   {% with

--- a/app/templates/frameworks/submission_lots.html
+++ b/app/templates/frameworks/submission_lots.html
@@ -27,21 +27,6 @@
 
 {% block main_content %}
 
-  {% with messages = get_flashed_messages(with_categories=True) %}
-    {% for category, message in messages %}
-      <div class="banner-success-without-action">
-        <p class="banner-message">
-          {% if category == 'service_deleted' %}
-            <strong>{{message.service_name}}</strong> was deleted
-          {% elif category == 'service_completed' %}
-            <strong>{{message.service_name}}</strong> was marked as complete
-            <span data-analytics="trackPageView" data-url="{{message.virtual_pageview_url}}"></span>
-          {% endif %}
-        </p>
-      </div>
-    {% endfor %}
-  {% endwith %}
-
   {% include "partials/service_warning.html" %}
 
   <div class="grid-row">

--- a/app/templates/frameworks/updates.html
+++ b/app/templates/frameworks/updates.html
@@ -26,25 +26,6 @@
 
 {% block main_content %}
 
-  {% with messages = get_flashed_messages(with_categories=true) %}
-    {% for category, message in messages %}
-      {% if message == 'message_sent' %}
-        {% if framework.clarificationQuestionsOpen %}
-          {% set message = "Your clarification question has been sent. Answers to all clarification questions will be published on this page." %}
-        {% else %}
-          {% set message = "Your question has been sent. You'll get a reply from the Crown Commercial Service soon." %}
-        {% endif %}
-      {% endif %}
-      {%
-        with
-        message = message,
-        type = "destructive" if category == 'error' else "success"
-      %}
-        {% include "toolkit/notification-banner.html" %}
-      {% endwith %}
-    {% endfor %}
-  {% endwith %}
-
   {% if error_message %}
     {%
       with

--- a/app/templates/services/_base_service_page.html
+++ b/app/templates/services/_base_service_page.html
@@ -4,33 +4,6 @@
 
 {% block main_content %}
   <div class="grid-row">
-    {% with messages = get_flashed_messages(with_categories=true) %}
-      {% if messages %}
-        {% for category, message in messages %}
-          {% if category == 'error' %}
-            <div class="banner-destructive-without-action">
-          {% else %}
-            <div class="banner-success-without-action">
-          {% endif %}
-              <p class="banner-message">
-          {% if 'remove_last_attempted' in message %}
-                You must offer one of the {{ message.remove_last_attempted.lower() }} to be eligible.<br>
-                If you don&rsquo;t want to offer {{ (service_data.get('serviceName', service_data['lotName'])).lower() }}, 
-                delete this service.
-                <span data-analytics="trackPageView" data-url="{{message.virtual_pageview_url}}"></span>
-            {% elif category == 'service_deleted' %}
-                <strong>{{message.service_name}}</strong> was deleted
-            {% elif category == 'service_updated' %}
-                You&#x2019;ve edited your service. The changes are now live on the Digital Marketplace.
-            {% else %}
-                {{ message }}
-            {% endif %}
-              </p>
-            </div>
-        {% endfor %}
-      {% endif %}
-    {% endwith %}
-      
     {% if confirm_remove %}
       <form method="post" action='{{ url_for(".remove_subsection", framework_slug=framework.slug, lot_slug=service_data.lot, service_id=service_id, section_id=request.args.get("section_id"), question_slug=confirm_remove, confirm=True) }}'>
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />

--- a/app/templates/services/list_services.html
+++ b/app/templates/services/list_services.html
@@ -21,19 +21,6 @@
 {% endblock %}
 
 {% block main_content %}
-  {% with messages = get_flashed_messages(with_categories=true) %}
-    {% if messages %}
-      {% for category, message in messages %}
-        {% if category == 'remove_service' %}
-          <div class="banner-success-without-action">
-            <p class="banner-message">
-              {{ message.updated_service_name }} has been removed.
-            </p>
-          </div>
-        {% endif %}
-      {% endfor %}
-    {% endif %}
-  {% endwith %}
   <div class="grid-row">
     <div class="column-two-thirds">
       {% set heading %}

--- a/app/templates/suppliers/dashboard.html
+++ b/app/templates/suppliers/dashboard.html
@@ -15,23 +15,8 @@
 {% endblock %}
 
 {% block main_content %}
-  {% with messages = get_flashed_messages(with_categories=true, category_filter=["error", "success"]) %}
-    {% for category, message in messages %}
-      {%
-        with
-        message = message,
-        type = "destructive" if category == 'error' else "success"
-      %}
-        {% include "toolkit/notification-banner.html" %}
-      {% endwith %}
-    {% endfor %}
-  {% endwith %}
 
-  {% if 'account-created' in get_flashed_messages(category_filter=["flag"]) %}
-  <div class="grid-row" data-analytics="trackPageView" data-url="/suppliers?account-created=true">
-  {% else %}
   <div class="grid-row">
-  {% endif %}
     <div class="column-one-whole">
       {% with
         context = current_user.email_address,

--- a/app/templates/suppliers/join_open_framework_notification_mailing_list.html
+++ b/app/templates/suppliers/join_open_framework_notification_mailing_list.html
@@ -17,24 +17,6 @@
 
 {% block main_content %}
 
-{% with messages = get_flashed_messages(with_categories=true) %}
-  {% if messages %}
-    {% for category, message in messages %}
-      {% if category == "error" and message == "mailing_list_signup_error" %}
-        {% set message %}
-          The service is unavailable at the moment. If the problem continues please
-          contact <a href="mailto:enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.service.gov.uk</a>
-        {% endset %}
-        {%
-          with type = "destructive"
-        %}
-          {% include "toolkit/notification-banner.html" %}
-        {% endwith %}
-      {% endif %}
-    {% endfor %}
-  {% endif %}
-{% endwith %}
-
 <div class="grid-row">
   <div class="column-two-thirds">
     {%

--- a/app/templates/users/list_users.html
+++ b/app/templates/users/list_users.html
@@ -22,24 +22,6 @@
 
 {% block main_content %}
   <div class="single-summary-page">
-    {% with messages = get_flashed_messages(with_categories=true) %}
-      {% if messages %}
-        {% for category, message in messages %}
-          {% if message['deactivate_user_name'] and message['deactivate_user_email_address'] %}
-            {% set message = "{} ({}) has been removed as a contributor.".format(message['deactivate_user_name'], message['deactivate_user_email_address']) %}
-          {% elif message == 'user_invited' %}
-            {% set message = "Contributor invited" %}
-          {% endif %}
-          {%
-            with
-            message = message,
-            type = "destructive" if category == 'error' else "success"
-          %}
-            {% include "toolkit/notification-banner.html" %}
-          {% endwith %}
-        {% endfor %}
-      {% endif %}
-    {% endwith %}
     {% with
       context = current_user.email_address,
       heading = "Invite or remove contributors",

--- a/tests/app/helpers.py
+++ b/tests/app/helpers.py
@@ -6,6 +6,7 @@ import re
 from mock import patch
 import pytest
 from werkzeug.http import parse_cookie
+from markupsafe import escape
 
 from dmutils.formats import DATETIME_FORMAT
 
@@ -498,6 +499,10 @@ class BaseApplicationTest(object):
     def assert_no_flashes(self):
         with self.client.session_transaction() as session:
             assert not session.get("_flashes")
+
+    def get_flash_messages(self):
+        with self.client.session_transaction() as session:
+            return tuple((category, escape(message)) for category, message in (session.get("_flashes") or ()))
 
     def assert_single_question_page_validation_errors(self,
                                                       res,

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -3715,10 +3715,12 @@ class TestSendClarificationQuestionEmail(BaseApplicationTest):
         self._assert_application_email(send_email)
 
         assert response.status_code == 200
-        assert self.strip_all_whitespace(
-            '<p class="banner-message">Your question has been sent. You&#39;ll get a reply from ' +
-            'the Crown Commercial Service soon.</p>'
-        ) in self.strip_all_whitespace(response.get_data(as_text=True))
+
+        doc = html.fromstring(response.get_data(as_text=True))
+        assert doc.xpath(
+            "//p[contains(@class, 'banner-message')][normalize-space(string())=$t]",
+            t="Your question has been sent. You’ll get a reply from the Crown Commercial Service soon."
+        )
 
     @pytest.mark.parametrize(
         'invalid_clarification_question',

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -991,10 +991,10 @@ class TestSupplierEditUpdateServiceSection(BaseApplicationTest):
             '1', {'serviceName': 'The service', 'serviceSummary': 'This is the service'},
             'email@email.com')
 
-        self.assert_flashes(
-            {"updated_service_name": "The service"},
-            "service_updated",
-        )
+        assert self.get_flash_messages() == ((
+            "success",
+            "You’ve edited your service. The changes are now live on the Digital Marketplace.",
+        ),)
 
     def test_editing_readonly_section_is_not_allowed(self, data_api_client, s3):
         data_api_client.get_service.return_value = self.empty_service
@@ -1026,10 +1026,10 @@ class TestSupplierEditUpdateServiceSection(BaseApplicationTest):
         data_api_client.update_service.assert_called_once_with(
             '1', dict(), 'email@email.com')
 
-        self.assert_flashes(
-            {"updated_service_name": "Service name 123"},
-            "service_updated",
-        )
+        assert self.get_flash_messages() == ((
+            "success",
+            "You’ve edited your service. The changes are now live on the Digital Marketplace.",
+        ),)
 
     def test_edit_non_existent_service_returns_404(self, data_api_client, s3):
         data_api_client.get_service.return_value = None
@@ -1190,10 +1190,10 @@ class TestSupplierEditUpdateServiceSectionG9(BaseApplicationTest):
             'email@email.com',
         )
 
-        self.assert_flashes(
-            {"updated_service_name": "Service name 321"},
-            "service_updated",
-        )
+        assert self.get_flash_messages() == ((
+            "success",
+            "You’ve edited your service. The changes are now live on the Digital Marketplace.",
+        ),)
 
     def test_file_upload(self, data_api_client, s3):
         data_api_client.get_service.return_value = self.base_service
@@ -2101,15 +2101,11 @@ class TestShowDraftService(BaseApplicationTest):
         data_api_client.get_draft_service.return_value = self.draft_service
         count_unanswered.return_value = 0, 1
         res = self.client.get('/suppliers/frameworks/g-cloud-7/submissions/scs/1')
-        document = html.fromstring(res.get_data(as_text=True))
 
         assert '1 optional question unanswered' in res.get_data(as_text=True)
 
-        submit_button = document.xpath(
-            "//input[@value='Mark as complete']"
-        )[0]
-
-        assert sorted(["submit", "button-save", "Mark as complete"]) == sorted(submit_button.values())
+        doc = html.fromstring(res.get_data(as_text=True))
+        assert doc.xpath("//form//input[@type='submit'][contains('button-save',@class)][@value='Mark as complete']")
 
     @mock.patch('app.main.views.services.count_unanswered_questions')
     def test_no_move_to_complete_button_if_not_open(self, count_unanswered, data_api_client):

--- a/tests/app/main/test_suppliers.py
+++ b/tests/app/main/test_suppliers.py
@@ -2301,9 +2301,8 @@ class TestJoinOpenFrameworkNotificationMailingList(BaseApplicationTest):
         assert response.location == "http://localhost/"
         assert mailchimp_client_instance.subscribe_new_email_to_list.called is True
 
-        self.assert_flashes(
-            "You will receive email notifications to qu&amp;rt@four.pence when applications are opening.",
-            "success",
+        assert self.get_flash_messages() == (
+            ("success", "You will receive email notifications to qu&amp;rt@four.pence when applications are opening.",),
         )
 
 


### PR DESCRIPTION
Trello https://trello.com/c/H7upcsyQ/303-flash-messages-suppliers-app

Depends on https://github.com/alphagov/digitalmarketplace-frontend-toolkit/pull/425/

I *think* I properly converted all of the messages to use the equivalent content that would have been triggered using the previous symbolic messages, though of course it's sometimes hard to know when it comes to inter-app messages.

Added what I think is my preferred way of testing flash messages - `get_flash_messages()` - simple and allows a lot of flexibility for predicates. I like it for similar reasons I like using `Mock`'s `call_args_list`.