### PR TITLE
Add permanent redirect for /suppliers/create route

### DIFF
--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -525,6 +525,12 @@ def become_a_supplier():
     ), 200
 
 
+# Redirect added 23rd March 2018 - can probably remove it in 6 months or so
+@main.route('/create', methods=['GET'])
+def redirect_to_create_new_supplier():
+    return redirect(url_for(".create_new_supplier")), 301
+
+
 @main.route('/create/start', methods=['GET'])
 def create_new_supplier():
     return render_template(

--- a/tests/app/main/test_suppliers.py
+++ b/tests/app/main/test_suppliers.py
@@ -1622,6 +1622,23 @@ class TestEditSupplierRegisteredAddress(BaseApplicationTest):
 
 
 class TestCreateSupplier(BaseApplicationTest):
+    def test_old_create_start_page_redirects_to_new_start_page(self):
+        res = self.client.get("/suppliers/create")
+        assert res.status_code == 301
+        assert res.location == "http://localhost/suppliers/create/start"
+
+    def test_create_start_page_get_ok(self):
+        res = self.client.get("/suppliers/create/start")
+        assert res.status_code == 200
+
+    def test_create_duns_number_page_get_ok(self):
+        res = self.client.get("/suppliers/create/duns-number")
+        assert res.status_code == 200
+
+    def test_create_company_details_page_get_ok(self):
+        res = self.client.get("/suppliers/create/company-details")
+        assert res.status_code == 200
+
     @pytest.mark.parametrize('duns_number', [None, 'invalid', '12345678', '1234567890'])
     def test_should_be_an_error_if_missing_or_invalid_duns_number(self, duns_number):
         """Ensures that validation on duns number prevents submission of:


### PR DESCRIPTION
This changed recently to /suppliers/create/start - we should have redirected the old URL when we did that.

Also adds some additional tests for the sign-up flow pages that should have been there but weren't.