### PR TITLE
Disable csrf protection on staging for load tests

### DIFF
--- a/config.py
+++ b/config.py
@@ -179,6 +179,7 @@ class Production(Live):
 class Staging(Production):
     FEATURE_FLAGS_CONTRACT_VARIATION = enabled_since('2016-08-22')
     FEATURE_FLAGS_EDIT_SECTIONS = enabled_since('2016-09-14')
+    WTF_CSRF_ENABLED = False
 
 
 configs = {


### PR DESCRIPTION
We want to load test our infrastructure before G-10 applications open.
We're planning to use Gatling to run some scenarios with high user
levels. If we have csrf protection enabled this will prevent the tests
from working.

We _could_ set the tests up to try and parse the csrf token from the body 
of the responses received by Gatling and then include it in the following
POST request. This feels fragile though.