### PR TITLE
BUGFIX: nameOfOrganisation key doesn't exist for newer frameworks

### DIFF
--- a/app/main/helpers/frameworks.py
+++ b/app/main/helpers/frameworks.py
@@ -346,3 +346,10 @@ def get_frameworks_closed_and_open_for_applications(frameworks):
             key=lambda fw_groupby: fw_groupby["framework"],
         )
     ))
+
+
+def get_supplier_registered_name_from_declaration(declaration):
+    return(
+        declaration.get('supplierRegisteredName')  # G-Cloud 10 and later declaration key
+        or declaration.get('nameOfOrganisation')  # G-Cloud 9 and earlier declaration key
+    )

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -33,6 +33,7 @@ from ..helpers.frameworks import (
     get_framework_or_404, get_framework_and_lot_or_404, count_drafts_by_lot, get_statuses_for_lot,
     return_supplier_framework_info_if_on_framework_or_abort, returned_agreement_email_recipients,
     check_agreement_is_related_to_supplier_framework_or_abort, get_framework_for_reuse,
+    get_supplier_registered_name_from_declaration
 )
 from ..helpers.suppliers import supplier_company_details_are_complete
 from ..helpers.services import (
@@ -802,6 +803,7 @@ def framework_agreement(framework_slug):
                 'result': lot_results[lot['slug']]
             } for lot in framework['lots']],
             supplier_framework=supplier_framework,
+            supplier_registered_name=get_supplier_registered_name_from_declaration(supplier_framework['declaration']),
         ), 200
 
     return render_template(
@@ -971,6 +973,7 @@ def signer_details(framework_slug, agreement_id):
         framework=framework,
         question_keys=question_keys,
         supplier_framework=supplier_framework,
+        supplier_registered_name=get_supplier_registered_name_from_declaration(supplier_framework['declaration']),
     ), 400 if form_errors else 200
 
 
@@ -1124,7 +1127,7 @@ def contract_review(framework_slug, agreement_id):
             ]
 
     form.authorisation.description = u"I have the authority to return this agreement on behalf of {}.".format(
-        supplier_framework['declaration']['nameOfOrganisation']
+        get_supplier_registered_name_from_declaration(supplier_framework['declaration'])
     )
 
     return render_template(
@@ -1135,6 +1138,7 @@ def contract_review(framework_slug, agreement_id):
         framework=framework,
         signature_page=signature_page,
         supplier_framework=supplier_framework,
+        supplier_registered_name=get_supplier_registered_name_from_declaration(supplier_framework['declaration']),
     ), 400 if form_errors else 200
 
 
@@ -1160,7 +1164,7 @@ def view_contract_variation(framework_slug, variation_slug):
     form = AcceptAgreementVariationForm()
     form_errors = None
 
-    supplier_name = supplier_framework['declaration']['nameOfOrganisation']
+    supplier_name = get_supplier_registered_name_from_declaration(supplier_framework['declaration'])
     variation_content = content_loader.get_message(framework_slug, variation_content_name).filter(
         {'supplier_name': supplier_name}
     )

--- a/app/templates/frameworks/contract_review.html
+++ b/app/templates/frameworks/contract_review.html
@@ -29,7 +29,7 @@
   <div class="column-two-thirds">
     {%
       with
-      heading = "Check the details you’ve given before returning the signature page for %s" | format(supplier_framework.declaration.nameOfOrganisation),
+      heading = "Check the details you’ve given before returning the signature page for %s" | format(supplier_registered_name),
       smaller = True
     %}
       {% include "toolkit/page-heading.html" %}

--- a/app/templates/frameworks/contract_start.html
+++ b/app/templates/frameworks/contract_start.html
@@ -42,7 +42,7 @@
       </div>
 
       <div>
-        {{ summary.heading(supplier_framework.declaration.nameOfOrganisation) }}
+        {{ summary.heading(supplier_registered_name) }}
         {% call(item) summary.list_table(
           lots,
           caption="Lot application status table",

--- a/app/templates/frameworks/signer_details.html
+++ b/app/templates/frameworks/signer_details.html
@@ -28,7 +28,7 @@
   <div class="column-two-thirds">
     {%
     with
-      heading = "Details of the person who is signing on behalf of %s" | format(supplier_framework.declaration.nameOfOrganisation),
+      heading = "Details of the person who is signing on behalf of %s" | format(supplier_registered_name),
       smaller = True
     %}
       {% include "toolkit/page-heading.html" %}

--- a/tests/app/main/helpers/test_frameworks.py
+++ b/tests/app/main/helpers/test_frameworks.py
@@ -8,7 +8,7 @@ from werkzeug.exceptions import HTTPException
 from app.main.helpers.frameworks import (
     check_agreement_is_related_to_supplier_framework_or_abort, get_framework_for_reuse, get_statuses_for_lot,
     return_supplier_framework_info_if_on_framework_or_abort, order_frameworks_for_reuse,
-    get_frameworks_closed_and_open_for_applications)
+    get_frameworks_closed_and_open_for_applications, get_supplier_registered_name_from_declaration)
 
 
 def get_lot_status_examples():
@@ -560,3 +560,17 @@ def test_get_frameworks_closed_and_open_for_applications():
     for case in cases:
         displayed_frameworks = get_frameworks_closed_and_open_for_applications(case["frameworks"])
         assert displayed_frameworks == case["expected"], "ERROR ON CASE {}".format(case)
+
+
+@pytest.mark.parametrize('name_of_org, supplier_reg_name, expected_result', [
+    ('G-Cloud 9 supplier', None, 'G-Cloud 9 supplier'),
+    (None, 'G-Cloud 10 supplier', 'G-Cloud 10 supplier'),
+    ('G-9 supplier', 'G-10 supplier', 'G-10 supplier'),  # Favour newer key, but in reality should NEVER exist with both
+])
+def test_get_supplier_registered_name_from_declaration(name_of_org, supplier_reg_name, expected_result):
+    declaration = {}
+    if name_of_org:
+        declaration['nameOfOrganisation'] = name_of_org
+    if supplier_reg_name:
+        declaration['supplierRegisteredName'] = supplier_reg_name
+    assert get_supplier_registered_name_from_declaration(declaration) == expected_result


### PR DESCRIPTION
As of G-Cloud 10 we are using the new key `supplierRegisteredName` to hold the same data that `nameOfOrganisation` previously held.

This updates the frontend to be happy with either of the keys, so we can handle both G-Cloud 9 and G-Cloud 10 flows concurrently.