### PR TITLE
Use flash_messages toolkit template to render flash messages

### DIFF
--- a/app/templates/_base_page.html
+++ b/app/templates/_base_page.html
@@ -29,41 +29,7 @@
   {% block breadcrumb %}{% endblock %}
   <div id="wrapper">
     <main id="content" role="main">
-      {% with messages = get_flashed_messages(with_categories=true) %}
-        {% if messages %}
-          {% for category, message in messages %}
-            {% if category == 'track-page-view' %}
-              <div data-analytics="trackPageView" data-url="{{ message }}"></div>
-            {% elif category == 'flag' %}
-              {# these were originally messages with a function similar to the above "track-page-view" ones (analytics) but #}
-              {# they did not know about their actual virtual page view url, expecting the receiving page to know the       #}
-              {# corresponding url for a particular symbolic "message".                                                     #}
-              {# TODO these can be got rid of as soon as the app generating each flag flash message is converted to using   #}
-              {# new "track-page-view" mechanism                                                                            #}
-              {% if message == "account-created" %}
-                <div data-analytics="trackPageView" data-url="/suppliers?account-created=true"></div>
-              {% endif %}
-              {# else we don't know about this particular flag-message so shouldn't try to do anything about it #}
-            {% elif category != 'must_login' %}  {# skip showing Flask's "Please log in" message #}
-              <div class="flash-message-container {{ 'banner-destructive-without-action' if category == 'error' else 'banner-success-without-action' }}">
-                <p class="banner-message">
-                  {# TODO remove the below special cases, once those two apps have been updated to contain the message. #}
-                  {% if message == 'supplier-role-required' %}  {# set by supplier app #}
-                    You must log in with a supplier account to see this page.
-
-                  {% elif message == 'buyer-role-required' %}  {# set by briefs app #}
-                    You must log in with a buyer account to see this page.
-
-                  {% else %}
-                    {{ message }}
-
-                  {% endif %}
-                </p>
-              </div>
-            {% endif %}
-          {% endfor %}
-        {% endif %}
-      {% endwith %}
+      {% include "toolkit/flash_messages.html" %}
 
       {% block main_content %}
       {% endblock %}

--- a/tests/app/main/test_suppliers.py
+++ b/tests/app/main/test_suppliers.py
@@ -117,7 +117,7 @@ class TestSuppliersDashboard(BaseApplicationTest):
             session['_flashes'] = [
                 ('error', 'This is an error'),
                 ('success', 'This is a success'),
-                ('flag', 'account-created')
+                ('track-page-view', '/suppliers?account-created=true')
             ]
 
         data_api_client.get_framework.return_value = self.framework('open')
@@ -140,7 +140,7 @@ class TestSuppliersDashboard(BaseApplicationTest):
         self, get_current_suppliers_users, data_api_client
     ):
         with self.client.session_transaction() as session:
-            session['_flashes'] = [('flag', 'account-created')]
+            session['_flashes'] = [('track-page-view', '/suppliers?account-created=true')]
 
         with self.app.test_client():
             self.login()


### PR DESCRIPTION
Trello: https://trello.com/c/H7upcsyQ/303-flash-messages-suppliers-app

Cleanup of the remaining `flag` type of flash messages. 

Once the User FE app is deployed with the changes in https://github.com/alphagov/digitalmarketplace-user-frontend/pull/50, the `flag` message won't be needed and we can use the generic toolkit `flash_messages.html` instead.