### PR TITLE
Update FROM address for clarification questions

### DIFF
--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -676,7 +676,7 @@ def framework_updates_email_clarification_question(framework_slug):
     if framework['clarificationQuestionsOpen']:
         subject = "{} clarification question".format(framework['name'])
         to_address = current_app.config['DM_CLARIFICATION_QUESTION_EMAIL']
-        from_address = "suppliers+{}@digitalmarketplace.service.gov.uk".format(framework['slug'])
+        from_address = current_app.config['CLARIFICATION_EMAIL_FROM']
         email_body = render_template(
             "emails/clarification_question.html",
             supplier_id=current_user.supplier_id,

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -3654,7 +3654,7 @@ class TestSendClarificationQuestionEmail(BaseApplicationTest):
                 "do-not-reply@digitalmarketplace.service.gov.uk",
                 "Test Framework Supplier",
                 ["clarification-question"],
-                reply_to="suppliers+g-cloud-7@digitalmarketplace.service.gov.uk",
+                reply_to="do-not-reply@digitalmarketplace.service.gov.uk",
             )
         if succeeds:
             send_email.assert_any_call(


### PR DESCRIPTION
For this trello card: https://trello.com/c/UO08QNT9

The process for sending clarification questions doesn't involve replying
to the received email. To avoid any confusion the FROM address is being
changed to 'do-not-reply@...'