### PR TITLE
Update application started email

### DIFF
--- a/app/templates/emails/g-cloud-10_application_started.html
+++ b/app/templates/emails/g-cloud-10_application_started.html
@@ -4,6 +4,34 @@
    <meta charset="UTF-8">
 </head>
 <body>
-    PLACEHOLDER EMAIL TEXT
+    Dear supplier,
+    <br/><br/>
+    You, or one of your team, started an application to become a G-Cloud&nbsp;10 supplier.
+    All contributors on your Digital Marketplace account will now receive email updates.
+    The deadline for completing your application is 5pm BST on Wednesday 23 May 2018.
+    <br/><br/>
+    You must ask any clarification questions you have through your Digital Marketplace account before
+    5pm BST on Wednesday 9 May 2018.
+    <br/><br/>
+    To complete your application, you must:
+    <ul>
+      <li>complete your company details</li>
+      <li>make the supplier declaration</li>
+      <li>provide information about the services you offer, and mark each service as complete</li>
+    </ul>
+    <br/><br/>
+    To understand if your services are suitable for G-Cloud&nbsp;10, read this guidance:
+    <br/>
+    <a href="https://www.gov.uk/guidance/g-cloud-suppliers-guide">https://www.gov.uk/guidance/g-cloud-suppliers-guide</a>
+    <br/><br/>
+    The G-Cloud&nbsp;10 application section of your Digital Marketplace account helps you:
+    <ul>
+      <li>find all the legal documents and guidance</li>
+      <li>ask clarification questions</li>
+      <li>read responses to all supplier questions</li>
+    </ul>
+    Thanks,
+    <br/>
+    The Digital Marketplace team
 </body>
 </html>


### PR DESCRIPTION
 ## Summary
Adds the correct content for the G-Cloud 10 application started email
which is sent to suppliers when they begin their application.

## Ticket
https://trello.com/c/y3NrHfy5/39-content-requiring-final-dates-1-you-have-started-an-application-email