### PR TITLE
Remove CSRF token from form data

### DIFF
--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -9,6 +9,7 @@ from dmapiclient.audit import AuditTypes
 from dmcontent.content_loader import ContentNotFoundError
 from dmutils.email import send_user_account_email
 from dmutils.email.dm_mailchimp import DMMailChimpClient
+from dmutils.forms import remove_csrf_token
 
 from ...main import main, content_loader
 from ... import data_api_client
@@ -175,14 +176,14 @@ def edit_registered_address():
             try:
                 data_api_client.update_supplier(
                     current_user.supplier_id,
-                    registered_country_form.data,
+                    remove_csrf_token(registered_country_form.data),
                     current_user.email_address,
                 )
 
                 data_api_client.update_contact_information(
                     current_user.supplier_id,
                     supplier['contact']['id'],
-                    registered_address_form.data,
+                    remove_csrf_token(registered_address_form.data),
                     current_user.email_address
                 )
 
@@ -337,14 +338,14 @@ def edit_what_buyers_will_see():
             try:
                 data_api_client.update_supplier(
                     current_user.supplier_id,
-                    supplier_form.data,
+                    remove_csrf_token(supplier_form.data),
                     current_user.email_address
                 )
 
                 data_api_client.update_contact_information(
                     current_user.supplier_id,
                     supplier['contact']['id'],
-                    contact_form.data,
+                    remove_csrf_token(contact_form.data),
                     current_user.email_address
                 )
             except APIError as e:

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -5,6 +5,6 @@ Flask==0.10.1
 Flask-Login==0.2.11
 Flask-WTF==0.14.2
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@36.0.2#egg=digitalmarketplace-utils==36.0.2
+git+https://github.com/alphagov/digitalmarketplace-utils.git@36.1.0#egg=digitalmarketplace-utils==36.1.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.10.1#egg=digitalmarketplace-content-loader==4.10.1
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@15.1.1#egg=digitalmarketplace-apiclient==15.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ Flask==0.10.1
 Flask-Login==0.2.11
 Flask-WTF==0.14.2
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@36.0.2#egg=digitalmarketplace-utils==36.0.2
+git+https://github.com/alphagov/digitalmarketplace-utils.git@36.1.0#egg=digitalmarketplace-utils==36.1.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.10.1#egg=digitalmarketplace-content-loader==4.10.1
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@15.1.1#egg=digitalmarketplace-apiclient==15.1.1
 


### PR DESCRIPTION
 ## Summary
An update to FlaskWTF now causes `csrf_token` to appear in WTForm's
`form.data`. Our API doesn't like this so we need to strip it out when
we use the entire `form.data` as opposed to `form.<question>.data`. A
small utility in dm-utils will allow us to do this easily if end up
needing it in other apps.