### PR TITLE
Revert "Bump Flask-WTF to match utils requirement"

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -2,7 +2,7 @@ import re
 
 from flask import Flask, request, redirect, session, abort
 from flask_login import LoginManager
-from flask_wtf.csrf import CSRFProtect, CSRFError
+from flask_wtf.csrf import CsrfProtect
 
 import dmapiclient
 from dmutils import init_app, flask_featureflags
@@ -14,7 +14,7 @@ from config import configs
 data_api_client = dmapiclient.DataAPIClient()
 login_manager = LoginManager()
 feature_flags = flask_featureflags.FeatureFlag()
-csrf = CSRFProtect()
+csrf = CsrfProtect()
 
 
 from app.main.helpers.services import parse_document_upload_time
@@ -50,7 +50,7 @@ def create_app(config_name):
 
     csrf.init_app(application)
 
-    @application.errorhandler(CSRFError)
+    @csrf.error_handler
     def csrf_handler(reason):
         if 'user_id' not in session:
             application.logger.info(

--- a/app/main/forms/auth_forms.py
+++ b/app/main/forms/auth_forms.py
@@ -1,10 +1,10 @@
-from flask_wtf import FlaskForm
+from flask_wtf import Form
 from wtforms.validators import InputRequired
 
 from dmutils.forms import EmailField
 
 
-class EmailAddressForm(FlaskForm):
+class EmailAddressForm(Form):
     email_address = EmailField('Email address', validators=[
         InputRequired(message="Email address must be provided")
     ])

--- a/app/main/forms/frameworks.py
+++ b/app/main/forms/frameworks.py
@@ -1,11 +1,11 @@
-from flask_wtf import FlaskForm
+from flask_wtf import Form
 from wtforms import BooleanField, HiddenField
 from wtforms.validators import DataRequired, InputRequired, Length
 
 from dmutils.forms import StripWhitespaceStringField
 
 
-class SignerDetailsForm(FlaskForm):
+class SignerDetailsForm(Form):
     signerName = StripWhitespaceStringField('Full name', validators=[
         DataRequired(message="You must provide the full name of the person signing on behalf of the company."),
         Length(max=255, message="You must provide a name under 256 characters.")
@@ -21,14 +21,14 @@ class SignerDetailsForm(FlaskForm):
     )
 
 
-class ContractReviewForm(FlaskForm):
+class ContractReviewForm(Form):
     authorisation = BooleanField(
         'Authorisation',
         validators=[DataRequired(message="You must confirm you have the authority to return the agreement.")]
     )
 
 
-class AcceptAgreementVariationForm(FlaskForm):
+class AcceptAgreementVariationForm(Form):
     accept_changes = BooleanField(
         'I accept these changes',
         validators=[
@@ -37,7 +37,7 @@ class AcceptAgreementVariationForm(FlaskForm):
     )
 
 
-class ReuseDeclarationForm(FlaskForm):
+class ReuseDeclarationForm(Form):
     """Form for the reuse declaration page. One yes no question.
 
     `reuse` is a yes no whether they want to reuse a framework.

--- a/app/main/forms/suppliers.py
+++ b/app/main/forms/suppliers.py
@@ -1,5 +1,5 @@
 import re
-from flask_wtf import FlaskForm
+from flask_wtf import Form
 from wtforms import RadioField, StringField
 from wtforms.validators import AnyOf, InputRequired, Length, Optional, Regexp, StopValidation, ValidationError
 
@@ -21,13 +21,13 @@ def word_length(limit=None, message=None):
     return _length
 
 
-class EditSupplierForm(FlaskForm):
+class EditSupplierForm(Form):
     description = StripWhitespaceStringField('Supplier summary', validators=[
         word_length(50, 'Your summary must not be more than %d words')
     ])
 
 
-class EditContactInformationForm(FlaskForm):
+class EditContactInformationForm(Form):
     contactName = StripWhitespaceStringField('Contact name', validators=[
         InputRequired(message="You must provide a contact name."),
         Length(max=255, message="You must provide a contact name under 256 characters."),
@@ -42,7 +42,7 @@ class EditContactInformationForm(FlaskForm):
     ])
 
 
-class EditRegisteredAddressForm(FlaskForm):
+class EditRegisteredAddressForm(Form):
     address1 = StripWhitespaceStringField('Building and street', validators=[
         InputRequired(message="You need to enter the street address."),
         Length(max=255, message="You must provide a building and street name under 256 characters."),
@@ -57,7 +57,7 @@ class EditRegisteredAddressForm(FlaskForm):
     ])
 
 
-class EditRegisteredCountryForm(FlaskForm):
+class EditRegisteredCountryForm(Form):
     registrationCountry = StripWhitespaceStringField('Country', validators=[
         InputRequired(message="You need to enter a country."),
         AnyOf(values=[country[1] for country in COUNTRY_TUPLE], message="You must enter a valid country."),
@@ -65,14 +65,14 @@ class EditRegisteredCountryForm(FlaskForm):
 
 
 # "Add" rather than "Edit" because this information can only be set once by a supplier
-class AddCompanyRegisteredNameForm(FlaskForm):
+class AddCompanyRegisteredNameForm(Form):
     registered_company_name = StripWhitespaceStringField('Registered company name', validators=[
         InputRequired(message="You must provide a registered company name."),
         Length(max=255, message="You must provide a registered company name under 256 characters.")
     ])
 
 
-class AddCompanyRegistrationNumberForm(FlaskForm):
+class AddCompanyRegistrationNumberForm(Form):
     has_companies_house_number = RadioField(
         "Are you registered with Companies House?",
         validators=[InputRequired(message="You need to answer this question.")],
@@ -124,7 +124,7 @@ class AddCompanyRegistrationNumberForm(FlaskForm):
         return valid
 
 
-class CompanyPublicContactInformationForm(FlaskForm):
+class CompanyPublicContactInformationForm(Form):
     company_name = StripWhitespaceStringField('Company name', validators=[
         InputRequired(message="You must provide a company name."),
         Length(max=255, message="You must provide a company name under 256 characters.")
@@ -143,21 +143,21 @@ class CompanyPublicContactInformationForm(FlaskForm):
     ])
 
 
-class DunsNumberForm(FlaskForm):
+class DunsNumberForm(Form):
     duns_number = StripWhitespaceStringField('DUNS Number', validators=[
         InputRequired(message="You must enter a DUNS number with 9 digits."),
         Regexp(r'^\d{9}$', message="You must enter a DUNS number with 9 digits."),
     ])
 
 
-class EmailAddressForm(FlaskForm):
+class EmailAddressForm(Form):
     email_address = StripWhitespaceStringField('Email address', validators=[
         InputRequired(message="You must provide an email address."),
         EmailValidator(message="You must provide a valid email address."),
     ])
 
 
-class CompanyOrganisationSizeForm(FlaskForm):
+class CompanyOrganisationSizeForm(Form):
     OPTIONS = [
         {
             "value": "micro",
@@ -190,7 +190,7 @@ class CompanyOrganisationSizeForm(FlaskForm):
                                    choices=[(o['value'], o['label']) for o in OPTIONS])
 
 
-class CompanyTradingStatusForm(FlaskForm):
+class CompanyTradingStatusForm(Form):
     OPTIONS = [
         {
             'value': 'limited company (LTD)',
@@ -227,7 +227,7 @@ class CompanyTradingStatusForm(FlaskForm):
                                 choices=[(o['value'], o['label']) for o in OPTIONS])
 
 
-class VatNumberForm(FlaskForm):
+class VatNumberForm(Form):
     NOT_VAT_REGISTERED_TEXT = "Not VAT registered"
 
     def stop_validation_if_not_registered(form, field):

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -3,7 +3,7 @@
 
 Flask==0.10.1
 Flask-Login==0.2.11
-Flask-WTF==0.14.2
+Flask-WTF==0.12
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@36.1.0#egg=digitalmarketplace-utils==36.1.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.10.1#egg=digitalmarketplace-content-loader==4.10.1

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -5,6 +5,6 @@ Flask==0.10.1
 Flask-Login==0.2.11
 Flask-WTF==0.12
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@36.1.0#egg=digitalmarketplace-utils==36.1.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@36.2.0#egg=digitalmarketplace-utils==36.2.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.10.1#egg=digitalmarketplace-content-loader==4.10.1
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@15.1.1#egg=digitalmarketplace-apiclient==15.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ Flask==0.10.1
 Flask-Login==0.2.11
 Flask-WTF==0.12
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@36.1.0#egg=digitalmarketplace-utils==36.1.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@36.2.0#egg=digitalmarketplace-utils==36.2.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.10.1#egg=digitalmarketplace-content-loader==4.10.1
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@15.1.1#egg=digitalmarketplace-apiclient==15.1.1
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 
 Flask==0.10.1
 Flask-Login==0.2.11
-Flask-WTF==0.14.2
+Flask-WTF==0.12
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@36.1.0#egg=digitalmarketplace-utils==36.1.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.10.1#egg=digitalmarketplace-content-loader==4.10.1

--- a/tests/app/main/helpers/test_suppliers.py
+++ b/tests/app/main/helpers/test_suppliers.py
@@ -1,5 +1,5 @@
 import pytest
-from flask_wtf import FlaskForm
+from flask_wtf import Form
 from wtforms import StringField
 from wtforms.validators import Length
 from app.main.helpers.suppliers import get_country_name_from_country_code, parse_form_errors_for_validation_masthead, \
@@ -41,7 +41,7 @@ class TestSupplierCompanyDetailsComplete:
         assert supplier_company_details_are_complete(supplier_data_from_api) is expected_result
 
 
-class FormForTest(FlaskForm):
+class FormForTest(Form):
     field_one = StringField('Field one?', validators=[
         Length(max=5, message="Field one must be under 5 characters.")
     ])


### PR DESCRIPTION
## Summary
This reverts commit bc2df3289545cbb16cebb628fb1a821b13792d72.

We are going back to Flask-WTF==0.12 to keep our CSRF tokens compatible across apps until we can work out how to smoothly upgrade.

Will need to freeze-reqs after the utils PR goes in: https://github.com/alphagov/digitalmarketplace-utils/pull/382