### PR TITLE
Use new api response for copying all lots services

### DIFF
--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -798,7 +798,7 @@ def copy_all_previous_services(framework_slug, lot_slug):
         questions_to_copy = content_loader.get_metadata(framework['slug'], 'copy_services', 'questions_to_copy')
         source_framework_slug = content_loader.get_metadata(framework['slug'], 'copy_services', 'source_framework')
 
-        drafts = data_api_client.copy_published_from_framework(
+        response = data_api_client.copy_published_from_framework(
             framework_slug,
             lot_slug,
             current_user.name,
@@ -809,6 +809,11 @@ def copy_all_previous_services(framework_slug, lot_slug):
             }
         )['services']
 
-        flash(ALL_SERVICES_ADDED_MESSAGE.format(draft_count=len(drafts), framework_name=framework['name']), "success")
+        flash(
+            ALL_SERVICES_ADDED_MESSAGE.format(
+                draft_count=response['draftsCreatedCount'], framework_name=framework['name']
+            ),
+            "success"
+        )
 
         return redirect(url_for(".framework_submission_services", framework_slug=framework_slug, lot_slug=lot_slug))

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -2581,11 +2581,9 @@ class TestCopyAllPreviousServices(CopyingPreviousServicesSetup):
     @mock.patch('app.main.views.services.flash')
     def test_the_correct_flash_message_should_be_set(self, flash):
         self.data_api_client.copy_published_from_framework.return_value = {
-            'services': [
-                {'serviceName': 'service one'},
-                {'serviceName': 'service two'},
-                {'serviceName': 'service three'},
-            ]
+            'services': {
+                'draftsCreatedCount': 3
+            }
         }
         res = self.client.post(
             '/suppliers/frameworks/g-cloud-10/submissions/cloud-hosting/copy-all-previous-framework-services'


### PR DESCRIPTION
See this PR on the API: https://github.com/alphagov/digitalmarketplace-api/pull/773

We're just sending back a count of the drafts created instead of all of
the serialized drafts.