### PR TITLE
Check contact details and declaration status for warning banner

### DIFF
--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -35,7 +35,6 @@ from ..helpers.frameworks import (
     check_agreement_is_related_to_supplier_framework_or_abort, get_framework_for_reuse,
     get_supplier_registered_name_from_declaration
 )
-from ..helpers.suppliers import supplier_company_details_are_complete
 from ..helpers.services import (
     count_unanswered_questions,
     get_drafts,
@@ -195,7 +194,7 @@ def framework_dashboard(framework_slug):
         supplier_framework=supplier_framework_info,
         supplier_is_on_framework=supplier_is_on_framework,
         framework_advice=framework_advice,
-        company_details_complete=supplier_company_details_are_complete(supplier),
+        company_details_complete=supplier['companyDetailsConfirmed'],
     ), 200
 
 
@@ -245,7 +244,7 @@ def framework_submission_lots(framework_slug):
         complete_drafts=list(reversed(complete_drafts)),
         drafts=list(reversed(drafts)),
         declaration_status=declaration_status,
-        company_details_complete=supplier_company_details_are_complete(supplier),
+        company_details_complete=supplier['companyDetailsConfirmed'],
         framework=framework,
         lots=lots,
     ), 200
@@ -311,7 +310,7 @@ def framework_submission_services(framework_slug, lot_slug):
         complete_drafts=list(reversed(complete_drafts)),
         drafts=list(reversed(drafts)),
         declaration_status=declaration_status,
-        company_details_complete=supplier_company_details_are_complete(supplier),
+        company_details_complete=supplier['companyDetailsConfirmed'],
         framework=framework,
         lot=lot,
     ), 200

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -16,7 +16,6 @@ from ..helpers.frameworks import (
     get_supplier_framework_info,
     get_framework_or_404,
 )
-from ..helpers.suppliers import supplier_company_details_are_complete
 
 
 # TODO make these more consistent, content-wise
@@ -746,7 +745,7 @@ def list_previous_services(framework_slug, lot_slug):
         previous_services=previous_services_still_to_copy,
         copy_all=copy_all,
         declaration_status=get_declaration_status(data_api_client, framework_slug),
-        company_details_complete=supplier.get('companyDetailsConfirmed', False),
+        company_details_complete=supplier['companyDetailsConfirmed'],
     )
 
 

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -16,6 +16,7 @@ from ..helpers.frameworks import (
     get_supplier_framework_info,
     get_framework_or_404,
 )
+from ..helpers.suppliers import supplier_company_details_are_complete
 
 
 # TODO make these more consistent, content-wise
@@ -735,6 +736,8 @@ def list_previous_services(framework_slug, lot_slug):
     if not previous_services_still_to_copy:
         return redirect(url_for(".framework_submission_services", framework_slug=framework_slug, lot_slug=lot_slug))
 
+    supplier = data_api_client.get_supplier(current_user.supplier_id)['suppliers']
+
     return render_template(
         "services/previous_services.html",
         framework=framework,
@@ -742,6 +745,8 @@ def list_previous_services(framework_slug, lot_slug):
         source_framework=source_framework,
         previous_services=previous_services_still_to_copy,
         copy_all=copy_all,
+        declaration_status=get_declaration_status(data_api_client, framework_slug),
+        company_details_complete=supplier.get('companyDetailsConfirmed', False),
     )
 
 

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -7,4 +7,4 @@ Flask-WTF==0.12
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@36.2.0#egg=digitalmarketplace-utils==36.2.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.10.1#egg=digitalmarketplace-content-loader==4.10.1
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@15.1.1#egg=digitalmarketplace-apiclient==15.1.1
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@15.1.3#egg=digitalmarketplace-apiclient==15.1.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,14 +8,14 @@ Flask-WTF==0.12
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@36.2.0#egg=digitalmarketplace-utils==36.2.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.10.1#egg=digitalmarketplace-content-loader==4.10.1
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@15.1.1#egg=digitalmarketplace-apiclient==15.1.1
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@15.1.3#egg=digitalmarketplace-apiclient==15.1.3
 
 ## The following requirements were added by pip freeze:
 asn1crypto==0.24.0
 backoff==1.0.7
-boto3==1.4.5
+boto3==1.4.4
 botocore==1.5.95
-certifi==2018.1.18
+certifi==2018.4.16
 cffi==1.11.5
 chardet==3.0.4
 contextlib2==0.4.0

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -2410,9 +2410,8 @@ class TestListPreviousServices(BaseApplicationTest):
             ('incomplete', False, True, True, True),
         )
     )
-    @mock.patch('app.main.views.services.supplier_company_details_are_complete')
     def test_shows_service_warning_in_correct_conditions(
-        self, supplier_company_details_are_complete, get_metadata, data_api_client, declaration_status,
+        self, get_metadata, data_api_client, declaration_status,
         company_details_complete, banner_present, declaration_warning, details_warning
     ):
         data_api_client.get_framework.side_effect = [
@@ -2424,7 +2423,7 @@ class TestListPreviousServices(BaseApplicationTest):
         }
         get_metadata.return_value = 'g-cloud-9'
         data_api_client.get_supplier_declaration.return_value = {'declaration': {'status': declaration_status}}
-        supplier_company_details_are_complete.return_value = company_details_complete
+        data_api_client.get_supplier.return_value = {'suppliers': {'companyDetailsConfirmed': company_details_complete}}
 
         res = self.client.get(
             '/suppliers/frameworks/g-cloud-10/submissions/cloud-hosting/previous-services'


### PR DESCRIPTION
Without these variables, the banner would show regardless of the
suppliers state. That is bad.