### PR TITLE
Add tracking to copying services

### DIFF
--- a/app/assets/javascripts/analytics/_events.js
+++ b/app/assets/javascripts/analytics/_events.js
@@ -144,11 +144,32 @@
       );
     },
     'ScrollTracker': ScrollTracker,
+    trackEvent: function (e) {
+      var $target = $(e.target);
+      var category = $target.attr('data-analytics-category');
+      var action = $target.attr('data-analytics-action');
+      var label = $target.attr('data-analytics-label');
+      var href = $target.attr('href');
+      var text = $target.text();
+
+      if ( !label && text ) label = text;
+      else if ( !label && !text && href ) label = href;
+
+      GOVUK.GDM.analytics.events.sendEvent(category, action, label);
+
+    },
+    sendEvent: function (category, action, label) {
+      GOVUK.analytics.trackEvent(category, action, {
+        'label': label,
+        'transport': 'beacon'
+      });
+    },
     'init': function () {
 
       $('body')
         .on('click', 'a', this.registerLinkClick)
-        .on('click', 'input[type=submit]', this.registerSubmitButtonClick);
+        .on('click', 'input[type=submit]', this.registerSubmitButtonClick)
+        .on('click', '[data-analytics=trackEvent]', this.trackEvent);
       var scrollTracker = new this.ScrollTracker(CONFIG);
 
     }

--- a/app/templates/services/previous_services.html
+++ b/app/templates/services/previous_services.html
@@ -42,7 +42,10 @@
         with
         message = "Are you sure you want to add all your {} services?".format(lot.name|lower),
         type = "success",
-        action = '<button type="submit" class="button-save banner-action">Yes, add all services'|safe
+        action = '<button type="submit" class="button-save banner-action" data-analytics="trackEvent"
+          data-analytics-category="Copy services"
+          data-analytics-action="Copy all"
+          data-analytics-label="Count: {}">Yes, add all services'.format(previous_services|length)|safe
       %}
         {% include "toolkit/notification-banner.html" %}
       {% endwith %}
@@ -74,7 +77,11 @@
       {{ summary.service_link(service.serviceName,
                               url_for(".edit_service", framework_slug=source_framework.slug, service_id=service.id)) }}
       {{ summary.button(text="Add to " + framework.name,
-                         action=url_for('.copy_previous_service', framework_slug=framework.slug, lot_slug=service.lot, service_id=service.id)) }}
+                        action=url_for('.copy_previous_service', framework_slug=framework.slug, lot_slug=service.lot, service_id=service.id),
+                        analytics="trackEvent",
+                        analytics_category="Copy services",
+                        analytics_action="Copy individual",
+                        analytics_label="ID: {}".format(service.id)) }}
 
     {% endcall %}
   {% endcall %}

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "colors": "1.1.2",
     "jquery": "1.12.0",
     "hogan.js": "3.0.2",
-    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v28.10.1",
+    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v28.13.1",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.19.2/jinja_govuk_template-0.19.2.tgz",
     "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#11.5.5"
   },

--- a/spec/javascripts/manifest.js
+++ b/spec/javascripts/manifest.js
@@ -7,6 +7,7 @@ var manifest = {
     '../../../node_modules/digitalmarketplace-frontend-toolkit/toolkit/javascripts/analytics/_register.js',
     '../../../node_modules/digitalmarketplace-frontend-toolkit/toolkit/javascripts/analytics/_pageViews.js',
     '../../../node_modules/digitalmarketplace-frontend-toolkit/toolkit/javascripts/analytics/_virtualPageViews.js',
+    '../../../node_modules/digitalmarketplace-frontend-toolkit/toolkit/javascripts/analytics/_trackExternalLinks.js',
     '../../../node_modules/digitalmarketplace-frontend-toolkit/toolkit/javascripts/analytics/_init.js',
     '../../../app/assets/javascripts/analytics/_events.js',
   ],

--- a/spec/javascripts/unit/AnalyticsSpec.js
+++ b/spec/javascripts/unit/AnalyticsSpec.js
@@ -91,6 +91,18 @@ describe("GOVUK.Analytics", function () {
         'eventAction': 'Download guidance and legal documentation (.zip)'
       }]);
     });
+    it('sends an event requested via html attributes on example of copying service', function() {
+      $(document.body).append('<button id="copy-button" type="submit" class="button-secondary" data-analytics="trackEvent" data-analytics-category="Copy services" data-analytics-action="Copy individual" data-analytics-label="2000000000">Add to G-Cloud 10</button>');
+      GOVUK.GDM.analytics.events.init();
+      $('#copy-button').click();
+      expect(window.ga.calls.first().args).toEqual(['send', {
+        'hitType': 'event',
+        'eventCategory': "Copy services",
+        'eventAction': "Copy individual",
+        'eventLabel': "2000000000",
+        'transport': 'beacon'
+      }]);
+    });
   });
 
   describe('button tracking', function () {

--- a/yarn.lock
+++ b/yarn.lock
@@ -546,9 +546,9 @@ detect-file@^1.0.0:
   version "11.5.5"
   resolved "https://github.com/alphagov/digitalmarketplace-frameworks.git#a8cd0937a73adfb3498a70ae02135ac2691f8c20"
 
-"digitalmarketplace-frontend-toolkit@https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v28.10.1":
-  version "0.0.1"
-  resolved "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#f7fa5abe9c4d7c3025c8f2b91995304e0610a168"
+"digitalmarketplace-frontend-toolkit@https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v28.13.1":
+  version "28.13.1"
+  resolved "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#dcd6713536a989bdc891b5e16789db4d21550295"
   dependencies:
     del "^2.2.2"
     govuk-elements-sass "3.0.3"


### PR DESCRIPTION
### Add event tracking to analytics js

This has been ported over the buyer app so we can track service copying
when G-10 opens. Ideally this code should be in a shared place, the
frontend-toolkit. This is on Dilwoars list of things to do.

To make it more complicated we intentionally don't share apps
`_events.js` files. See here:
https://github.com/alphagov/digitalmarketplace-frontend-toolkit/commit/1d88cb8c6454c23fe89f96d901320f5935948504