### PR TITLE
Update reporting anchor

### DIFF
--- a/app/templates/frameworks/_guidance_links.html
+++ b/app/templates/frameworks/_guidance_links.html
@@ -124,7 +124,7 @@
   </div>
 {% if communications_files.reporting_template.last_modified %}
   <div>
-  <h2 class="heading-xmedium">Reporting</h2>
+  <h2 id="reporting" class="heading-xmedium">Reporting</h2>
     <p>
       <a href="{{ url_for('.download_supplier_file', filepath=communications_files.reporting_template.filename, framework_slug=framework.slug) }}">
         Download the reporting template

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "hogan.js": "3.0.2",
     "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v28.13.1",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.19.2/jinja_govuk_template-0.19.2.tgz",
-    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#11.5.5"
+    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#11.5.6"
   },
   "scripts": {
     "frontend-build:development": "./node_modules/gulp/bin/gulp.js build:development",

--- a/yarn.lock
+++ b/yarn.lock
@@ -542,9 +542,9 @@ detect-file@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/detect-file/-/detect-file-1.0.0.tgz#f0d66d03672a825cb1b73bdb3fe62310c8e552b7"
 
-"digitalmarketplace-frameworks@https://github.com/alphagov/digitalmarketplace-frameworks.git#11.5.5":
-  version "11.5.5"
-  resolved "https://github.com/alphagov/digitalmarketplace-frameworks.git#a8cd0937a73adfb3498a70ae02135ac2691f8c20"
+"digitalmarketplace-frameworks@https://github.com/alphagov/digitalmarketplace-frameworks.git#11.5.6":
+  version "11.5.6"
+  resolved "https://github.com/alphagov/digitalmarketplace-frameworks.git#e1f8e5c4a1a98d817e1bc9ff90ace85c1a0762c6"
 
 "digitalmarketplace-frontend-toolkit@https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v28.13.1":
   version "28.13.1"


### PR DESCRIPTION
 ## Summary
Pull in latest frameworks which directs a declaration question to
correctly use the #reporting anchor on a framework dashboard.

Also adds the `reporting` element id to the dashboard.

Needs a `yarn install` after frameworks is merged.