### PR TITLE
digitalmarketplace-utils dependency: bump to 36.2.1

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -5,6 +5,6 @@ Flask==0.10.1
 Flask-Login==0.2.11
 Flask-WTF==0.12
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@36.2.0#egg=digitalmarketplace-utils==36.2.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@36.2.1#egg=digitalmarketplace-utils==36.2.1
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.10.1#egg=digitalmarketplace-content-loader==4.10.1
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@15.1.3#egg=digitalmarketplace-apiclient==15.1.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,15 +6,15 @@ Flask==0.10.1
 Flask-Login==0.2.11
 Flask-WTF==0.12
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@36.2.0#egg=digitalmarketplace-utils==36.2.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@36.2.1#egg=digitalmarketplace-utils==36.2.1
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.10.1#egg=digitalmarketplace-content-loader==4.10.1
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@15.1.3#egg=digitalmarketplace-apiclient==15.1.3
 
 ## The following requirements were added by pip freeze:
 asn1crypto==0.24.0
 backoff==1.0.7
-boto3==1.4.4
-botocore==1.5.95
+boto3==1.4.8
+botocore==1.8.50
 certifi==2018.4.16
 cffi==1.11.5
 chardet==3.0.4


### PR DESCRIPTION
This includes a security fix for https://snyk.io/vuln/SNYK-PYTHON-BOTO3-40617