### PR TITLE
Fix deprecation warnings

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -2,7 +2,7 @@ import re
 
 from flask import Flask, request, redirect, session, abort
 from flask_login import LoginManager
-from flask_wtf.csrf import CsrfProtect
+from flask_wtf.csrf import CsrfProtect, CSRFError
 
 import dmapiclient
 from dmutils import init_app, flask_featureflags
@@ -50,7 +50,7 @@ def create_app(config_name):
 
     csrf.init_app(application)
 
-    @csrf.error_handler
+    @application.errorhandler(CSRFError)
     def csrf_handler(reason):
         if 'user_id' not in session:
             application.logger.info(

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -2,7 +2,7 @@ import re
 
 from flask import Flask, request, redirect, session, abort
 from flask_login import LoginManager
-from flask_wtf.csrf import CsrfProtect, CSRFError
+from flask_wtf.csrf import CSRFProtect, CSRFError
 
 import dmapiclient
 from dmutils import init_app, flask_featureflags
@@ -14,7 +14,7 @@ from config import configs
 data_api_client = dmapiclient.DataAPIClient()
 login_manager = LoginManager()
 feature_flags = flask_featureflags.FeatureFlag()
-csrf = CsrfProtect()
+csrf = CSRFProtect()
 
 
 from app.main.helpers.services import parse_document_upload_time

--- a/app/main/forms/auth_forms.py
+++ b/app/main/forms/auth_forms.py
@@ -1,10 +1,10 @@
-from flask_wtf import Form
+from flask_wtf import FlaskForm
 from wtforms.validators import InputRequired
 
 from dmutils.forms import EmailField
 
 
-class EmailAddressForm(Form):
+class EmailAddressForm(FlaskForm):
     email_address = EmailField('Email address', validators=[
         InputRequired(message="Email address must be provided")
     ])

--- a/app/main/forms/frameworks.py
+++ b/app/main/forms/frameworks.py
@@ -1,11 +1,11 @@
-from flask_wtf import Form
+from flask_wtf import FlaskForm
 from wtforms import BooleanField, HiddenField
 from wtforms.validators import DataRequired, InputRequired, Length
 
 from dmutils.forms import StripWhitespaceStringField
 
 
-class SignerDetailsForm(Form):
+class SignerDetailsForm(FlaskForm):
     signerName = StripWhitespaceStringField('Full name', validators=[
         DataRequired(message="You must provide the full name of the person signing on behalf of the company."),
         Length(max=255, message="You must provide a name under 256 characters.")
@@ -21,14 +21,14 @@ class SignerDetailsForm(Form):
     )
 
 
-class ContractReviewForm(Form):
+class ContractReviewForm(FlaskForm):
     authorisation = BooleanField(
         'Authorisation',
         validators=[DataRequired(message="You must confirm you have the authority to return the agreement.")]
     )
 
 
-class AcceptAgreementVariationForm(Form):
+class AcceptAgreementVariationForm(FlaskForm):
     accept_changes = BooleanField(
         'I accept these changes',
         validators=[
@@ -37,7 +37,7 @@ class AcceptAgreementVariationForm(Form):
     )
 
 
-class ReuseDeclarationForm(Form):
+class ReuseDeclarationForm(FlaskForm):
     """Form for the reuse declaration page. One yes no question.
 
     `reuse` is a yes no whether they want to reuse a framework.

--- a/app/main/forms/suppliers.py
+++ b/app/main/forms/suppliers.py
@@ -1,5 +1,5 @@
 import re
-from flask_wtf import Form
+from flask_wtf import FlaskForm
 from wtforms import RadioField, StringField
 from wtforms.validators import AnyOf, InputRequired, Length, Optional, Regexp, StopValidation, ValidationError
 
@@ -21,13 +21,13 @@ def word_length(limit=None, message=None):
     return _length
 
 
-class EditSupplierForm(Form):
+class EditSupplierForm(FlaskForm):
     description = StripWhitespaceStringField('Supplier summary', validators=[
         word_length(50, 'Your summary must not be more than %d words')
     ])
 
 
-class EditContactInformationForm(Form):
+class EditContactInformationForm(FlaskForm):
     contactName = StripWhitespaceStringField('Contact name', validators=[
         InputRequired(message="You must provide a contact name."),
         Length(max=255, message="You must provide a contact name under 256 characters."),
@@ -42,7 +42,7 @@ class EditContactInformationForm(Form):
     ])
 
 
-class EditRegisteredAddressForm(Form):
+class EditRegisteredAddressForm(FlaskForm):
     address1 = StripWhitespaceStringField('Building and street', validators=[
         InputRequired(message="You need to enter the street address."),
         Length(max=255, message="You must provide a building and street name under 256 characters."),
@@ -57,7 +57,7 @@ class EditRegisteredAddressForm(Form):
     ])
 
 
-class EditRegisteredCountryForm(Form):
+class EditRegisteredCountryForm(FlaskForm):
     registrationCountry = StripWhitespaceStringField('Country', validators=[
         InputRequired(message="You need to enter a country."),
         AnyOf(values=[country[1] for country in COUNTRY_TUPLE], message="You must enter a valid country."),
@@ -65,14 +65,14 @@ class EditRegisteredCountryForm(Form):
 
 
 # "Add" rather than "Edit" because this information can only be set once by a supplier
-class AddCompanyRegisteredNameForm(Form):
+class AddCompanyRegisteredNameForm(FlaskForm):
     registered_company_name = StripWhitespaceStringField('Registered company name', validators=[
         InputRequired(message="You must provide a registered company name."),
         Length(max=255, message="You must provide a registered company name under 256 characters.")
     ])
 
 
-class AddCompanyRegistrationNumberForm(Form):
+class AddCompanyRegistrationNumberForm(FlaskForm):
     has_companies_house_number = RadioField(
         "Are you registered with Companies House?",
         validators=[InputRequired(message="You need to answer this question.")],
@@ -124,7 +124,7 @@ class AddCompanyRegistrationNumberForm(Form):
         return valid
 
 
-class CompanyPublicContactInformationForm(Form):
+class CompanyPublicContactInformationForm(FlaskForm):
     company_name = StripWhitespaceStringField('Company name', validators=[
         InputRequired(message="You must provide a company name."),
         Length(max=255, message="You must provide a company name under 256 characters.")
@@ -143,21 +143,21 @@ class CompanyPublicContactInformationForm(Form):
     ])
 
 
-class DunsNumberForm(Form):
+class DunsNumberForm(FlaskForm):
     duns_number = StripWhitespaceStringField('DUNS Number', validators=[
         InputRequired(message="You must enter a DUNS number with 9 digits."),
         Regexp(r'^\d{9}$', message="You must enter a DUNS number with 9 digits."),
     ])
 
 
-class EmailAddressForm(Form):
+class EmailAddressForm(FlaskForm):
     email_address = StripWhitespaceStringField('Email address', validators=[
         InputRequired(message="You must provide an email address."),
         EmailValidator(message="You must provide a valid email address."),
     ])
 
 
-class CompanyOrganisationSizeForm(Form):
+class CompanyOrganisationSizeForm(FlaskForm):
     OPTIONS = [
         {
             "value": "micro",
@@ -190,7 +190,7 @@ class CompanyOrganisationSizeForm(Form):
                                    choices=[(o['value'], o['label']) for o in OPTIONS])
 
 
-class CompanyTradingStatusForm(Form):
+class CompanyTradingStatusForm(FlaskForm):
     OPTIONS = [
         {
             'value': 'limited company (LTD)',
@@ -227,7 +227,7 @@ class CompanyTradingStatusForm(Form):
                                 choices=[(o['value'], o['label']) for o in OPTIONS])
 
 
-class VatNumberForm(Form):
+class VatNumberForm(FlaskForm):
     NOT_VAT_REGISTERED_TEXT = "Not VAT registered"
 
     def stop_validation_if_not_registered(form, field):

--- a/tests/app/main/helpers/test_suppliers.py
+++ b/tests/app/main/helpers/test_suppliers.py
@@ -1,5 +1,5 @@
 import pytest
-from flask_wtf import Form
+from flask_wtf import FlaskForm
 from wtforms import StringField
 from wtforms.validators import Length
 from app.main.helpers.suppliers import get_country_name_from_country_code, parse_form_errors_for_validation_masthead, \
@@ -41,7 +41,7 @@ class TestSupplierCompanyDetailsComplete:
         assert supplier_company_details_are_complete(supplier_data_from_api) is expected_result
 
 
-class FormForTest(Form):
+class FormForTest(FlaskForm):
     field_one = StringField('Field one?', validators=[
         Length(max=5, message="Field one must be under 5 characters.")
     ])


### PR DESCRIPTION
The latest dependency bumps introduced a delightful 900+ deprecation warnings 😸 Thankfully these are easily fixed.

- Rename `CsrfProtect` to `CSRFProtect`
- Rename `flask_wtf.Form` to `flask_wtf.FlaskForm`
- Use `@application.errorhandler(CSRFError)` instead of `@csrf.error_handler`