### PR TITLE
Remove do-not-reply

### DIFF
--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -83,7 +83,7 @@ def framework_dashboard(framework_slug):
                 email_body,
                 current_app.config['DM_MANDRILL_API_KEY'],
                 'You started a {} application'.format(framework['name']),
-                current_app.config['CLARIFICATION_EMAIL_FROM'],
+                current_app.config['DM_ENQUIRIES_EMAIL_ADDRESS'],
                 current_app.config['CLARIFICATION_EMAIL_NAME'],
                 ['{}-application-started'.format(framework_slug)]
             )
@@ -698,7 +698,7 @@ def framework_updates_email_clarification_question(framework_slug):
     if framework['clarificationQuestionsOpen']:
         subject = "{} clarification question".format(framework['name'])
         to_address = current_app.config['DM_CLARIFICATION_QUESTION_EMAIL']
-        from_address = current_app.config['CLARIFICATION_EMAIL_FROM']
+        from_address = current_app.config['DM_ENQUIRIES_EMAIL_ADDRESS']
         email_body = render_template(
             "emails/clarification_question.html",
             supplier_id=current_user.supplier_id,
@@ -723,7 +723,7 @@ def framework_updates_email_clarification_question(framework_slug):
             email_body,
             current_app.config['DM_MANDRILL_API_KEY'],
             subject,
-            current_app.config["DM_GENERIC_NOREPLY_EMAIL"],
+            current_app.config["DM_ENQUIRIES_EMAIL_ADDRESS"],
             "{} Supplier".format(framework['name']),
             tags,
             reply_to=from_address,
@@ -756,7 +756,7 @@ def framework_updates_email_clarification_question(framework_slug):
                 email_body,
                 current_app.config['DM_MANDRILL_API_KEY'],
                 subject,
-                current_app.config['CLARIFICATION_EMAIL_FROM'],
+                current_app.config['DM_ENQUIRIES_EMAIL_ADDRESS'],
                 current_app.config['CLARIFICATION_EMAIL_NAME'],
                 tags
             )
@@ -908,7 +908,7 @@ def upload_framework_agreement(framework_slug):
             email_body,
             current_app.config['DM_MANDRILL_API_KEY'],
             '{} framework agreement'.format(framework['name']),
-            current_app.config["DM_GENERIC_NOREPLY_EMAIL"],
+            current_app.config["DM_ENQUIRIES_EMAIL_ADDRESS"],
             '{} Supplier'.format(framework['name']),
             ['{}-framework-agreement'.format(framework_slug)],
             reply_to=current_user.email_address,
@@ -1114,7 +1114,7 @@ def contract_review(framework_slug, agreement_id):
                     email_body,
                     current_app.config['DM_MANDRILL_API_KEY'],
                     'Your {} signature page has been received'.format(framework['name']),
-                    current_app.config["DM_GENERIC_NOREPLY_EMAIL"],
+                    current_app.config["DM_ENQUIRIES_EMAIL_ADDRESS"],
                     current_app.config["FRAMEWORK_AGREEMENT_RETURNED_NAME"],
                     ['{}-framework-agreement'.format(framework_slug)],
                 )
@@ -1213,7 +1213,7 @@ def view_contract_variation(framework_slug, variation_slug):
                     email_body,
                     current_app.config['DM_MANDRILL_API_KEY'],
                     '{}: you have accepted the proposed contract variation'.format(framework['name']),
-                    current_app.config['CLARIFICATION_EMAIL_FROM'],
+                    current_app.config['DM_ENQUIRIES_EMAIL_ADDRESS'],
                     current_app.config['CLARIFICATION_EMAIL_NAME'],
                     ['{}-variation-accepted'.format(framework_slug)]
                 )

--- a/config.py
+++ b/config.py
@@ -50,13 +50,12 @@ class Config(object):
     INVITE_EMAIL_SUBJECT = 'Your Digital Marketplace invitation'
 
     CLARIFICATION_EMAIL_NAME = 'Digital Marketplace Admin'
-    CLARIFICATION_EMAIL_FROM = 'do-not-reply@digitalmarketplace.service.gov.uk'
     CLARIFICATION_EMAIL_SUBJECT = 'Thanks for your clarification question'
     DM_FOLLOW_UP_EMAIL_TO = 'digitalmarketplace@mailinator.com'
 
     FRAMEWORK_AGREEMENT_RETURNED_NAME = 'Digital Marketplace Admin'
 
-    DM_GENERIC_NOREPLY_EMAIL = 'do-not-reply@digitalmarketplace.service.gov.uk'
+    DM_ENQUIRIES_EMAIL_ADDRESS = 'enquiries@digitalmarketplace.service.gov.uk'
 
     SECRET_KEY = None
     SHARED_EMAIL_KEY = None

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -188,7 +188,7 @@ class TestFrameworksDashboard(BaseApplicationTest):
             mock.ANY,
             'MANDRILL',
             'You started a G-Cloud 7 application',
-            'do-not-reply@digitalmarketplace.service.gov.uk',
+            'enquiries@digitalmarketplace.service.gov.uk',
             'Digital Marketplace Admin',
             ['g-cloud-7-application-started']
         )
@@ -3661,10 +3661,10 @@ class TestSendClarificationQuestionEmail(BaseApplicationTest):
                 FakeMail('Supplier ID:'),
                 "MANDRILL",
                 "Test Framework clarification question",
-                "do-not-reply@digitalmarketplace.service.gov.uk",
+                "enquiries@digitalmarketplace.service.gov.uk",
                 "Test Framework Supplier",
                 ["clarification-question"],
-                reply_to="do-not-reply@digitalmarketplace.service.gov.uk",
+                reply_to="enquiries@digitalmarketplace.service.gov.uk",
             )
         if succeeds:
             send_email.assert_any_call(
@@ -3673,7 +3673,7 @@ class TestSendClarificationQuestionEmail(BaseApplicationTest):
                          'Test&nbsp;Framework updates page'),
                 "MANDRILL",
                 "Thanks for your clarification question",
-                "do-not-reply@digitalmarketplace.service.gov.uk",
+                "enquiries@digitalmarketplace.service.gov.uk",
                 "Digital Marketplace Admin",
                 ["clarification-question-confirm"]
             )
@@ -3691,7 +3691,7 @@ class TestSendClarificationQuestionEmail(BaseApplicationTest):
                 FakeMail('Test Framework question asked'),
                 "MANDRILL",
                 "Test Framework application question",
-                "do-not-reply@digitalmarketplace.service.gov.uk",
+                "enquiries@digitalmarketplace.service.gov.uk",
                 "Test Framework Supplier",
                 ["application-question"],
                 reply_to="email@email.com",
@@ -4843,7 +4843,7 @@ class TestContractReviewPage(BaseApplicationTest):
             mock.ANY,
             'MANDRILL',
             'Your G-Cloud 8 signature page has been received',
-            'do-not-reply@digitalmarketplace.service.gov.uk',
+            'enquiries@digitalmarketplace.service.gov.uk',
             'Digital Marketplace Admin',
             ['g-cloud-8-framework-agreement']
         )
@@ -4884,7 +4884,7 @@ class TestContractReviewPage(BaseApplicationTest):
             mock.ANY,
             'MANDRILL',
             'Your G-Cloud 8 signature page has been received',
-            'do-not-reply@digitalmarketplace.service.gov.uk',
+            'enquiries@digitalmarketplace.service.gov.uk',
             'Digital Marketplace Admin',
             ['g-cloud-8-framework-agreement']
         )
@@ -5299,7 +5299,7 @@ class TestContractVariation(BaseApplicationTest):
             mock.ANY,
             'MANDRILL',
             'G-Cloud 8: you have accepted the proposed contract variation',
-            'do-not-reply@digitalmarketplace.service.gov.uk',
+            'enquiries@digitalmarketplace.service.gov.uk',
             'Digital Marketplace Admin',
             ['g-cloud-8-variation-accepted']
         )
@@ -5320,7 +5320,7 @@ class TestContractVariation(BaseApplicationTest):
             mock.ANY,
             'MANDRILL',
             'G-Cloud 8: you have accepted the proposed contract variation',
-            'do-not-reply@digitalmarketplace.service.gov.uk',
+            'enquiries@digitalmarketplace.service.gov.uk',
             'Digital Marketplace Admin',
             ['g-cloud-8-variation-accepted']
         )


### PR DESCRIPTION
 ## Summary
Some of our emails get sent from `do-not-reply@digitalmarketplace...`.
If a user emails this, they get directed to email enquiries. We should
just directly set the reply-to address as enquiries.

Guidance: https://www.gov.uk/service-manual/technology/how-to-email-your-users#allow-users-to-reply-to-you