### PR TITLE
Return 404 if no service found when editing

### DIFF
--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -60,6 +60,9 @@ def list_services(framework_slug):
 @login_required
 def edit_service(framework_slug, service_id):
     service = data_api_client.get_service(service_id)
+    if not service:
+        abort(404)
+
     service_unavailability_information = service.get('serviceMadeUnavailableAuditEvent')
     service = service.get('services')
 

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -376,7 +376,7 @@ class _BaseTestSupplierEditRemoveService(BaseApplicationTest):
         }
 
 
-class SupplierEditServiceTestsSharedAcrossFrameworks(_BaseTestSupplierEditRemoveService):
+class _BaseSupplierEditServiceTestsSharedAcrossFrameworks(_BaseTestSupplierEditRemoveService):
     """Tests shared by both DOS and GCloud frameworks for editing a service e.g. /suppliers/services/123"""
 
     @pytest.mark.parametrize("fwk_status,expected_code", [
@@ -480,7 +480,7 @@ class SupplierEditServiceTestsSharedAcrossFrameworks(_BaseTestSupplierEditRemove
 
 
 @mock.patch('app.main.views.services.data_api_client')
-class TestSupplierEditGCloudService(SupplierEditServiceTestsSharedAcrossFrameworks):
+class TestSupplierEditGCloudService(_BaseSupplierEditServiceTestsSharedAcrossFrameworks):
     framework_kwargs = {
         "framework_slug": "g-cloud-9",
         "framework_framework": "g-cloud",
@@ -609,7 +609,7 @@ class TestSupplierEditGCloudService(SupplierEditServiceTestsSharedAcrossFramewor
 
 
 @mock.patch('app.main.views.services.data_api_client')
-class TestSupplierEditDosServices(SupplierEditServiceTestsSharedAcrossFrameworks):
+class TestSupplierEditDosServices(_BaseSupplierEditServiceTestsSharedAcrossFrameworks):
     """Although the route tested is the edit service page, DOS services are not editable or removable and are only
     viewable at the moment"""
     framework_kwargs = {

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -407,6 +407,14 @@ class SupplierEditServiceTestsSharedAcrossFrameworks(_BaseTestSupplierEditRemove
             "Unexpected response {} for {} framework state".format(res.status_code, fwk_status)
         )
 
+    def test_edit_page_returns_404_if_service_not_found(self, data_api_client):
+        self.login()
+        data_api_client.get_service.return_value = None
+
+        res = self.client.get("/suppliers/frameworks/{}/services/123".format(self.framework_kwargs["framework_slug"]))
+
+        assert res.status_code == 404
+
     def test_should_not_view_other_suppliers_services(self, data_api_client):
         self.login()
         self._setup_service(


### PR DESCRIPTION
See this 2nd line ticket: https://trello.com/c/zb8Ee7EW

We currently don't check that a service has been found when a supplier
edits it. If one isn't returned from the api we end up getting a 500.