### PR TITLE
Email all supplier users

### DIFF
--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -74,7 +74,7 @@ def framework_dashboard(framework_slug):
 
     if request.method == 'POST':
         register_interest_in_framework(data_api_client, framework_slug)
-        supplier_users = data_api_client.find_users(supplier_id=current_user.supplier_id)
+        supplier_users = data_api_client.find_users_iter(supplier_id=current_user.supplier_id)
 
         try:
             email_body = render_template(
@@ -82,7 +82,7 @@ def framework_dashboard(framework_slug):
                 framework=framework)
 
             mandrill_send_email(
-                [user['emailAddress'] for user in supplier_users['users'] if user['active']],
+                [user['emailAddress'] for user in supplier_users if user['active']],
                 email_body,
                 current_app.config['DM_MANDRILL_API_KEY'],
                 'You started a {} application'.format(framework['name']),

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -172,11 +172,11 @@ class TestFrameworksDashboard(BaseApplicationTest):
 
         data_api_client.get_framework.return_value = self.framework(status='open')
         data_api_client.get_supplier_framework_info.return_value = self.supplier_framework()
-        data_api_client.find_users.return_value = {'users': [
+        data_api_client.find_users_iter.return_value = [
             {'emailAddress': 'email1', 'active': True},
             {'emailAddress': 'email2', 'active': True},
             {'emailAddress': 'email3', 'active': False}
-        ]}
+        ]
         res = self.client.post("/suppliers/frameworks/g-cloud-7")
 
         assert res.status_code == 200


### PR DESCRIPTION
 ## Commit 1 - Summary
When a supplier registers interest in applying to join a specific
framework, we email all users associated with that supplier - in theory.
Unfortunately we only emailed the first page of users associated
with that supplier. We now have a supplier with over 100 users, so we
should retrieve all pages of results for users when sending the email
out. This page will become less performant over time and there isn't an
obvious fix beyond increasing the page size or running this task in the
background.

  ## Commit 2 - Summary
Some of the tests for deactivating supplier users incorrectly mocked out
`find_users`, which is not called as part of the view.
`test_cannot_deactivate_nonexistent_id` was missing a mock for
`get_user`, which meant it wasn't really testing the view correctly.
This mock has been added and an assertion included to make sure that the
mock has been called correctly.

 ## Ticket
https://trello.com/c/ZDbIWWbc/464