### PR TITLE
Update content for become a supplier messages

### DIFF
--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -507,7 +507,7 @@ def become_a_supplier():
     try:
         frameworks = sorted(
             data_api_client.find_frameworks().get('frameworks'),
-            key=lambda framework: framework['slug'],
+            key=lambda framework: framework['id'],
             reverse=True
         )
         displayed_frameworks = get_frameworks_closed_and_open_for_applications(frameworks)

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "hogan.js": "3.0.2",
     "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v28.15.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.19.2/jinja_govuk_template-0.19.2.tgz",
-    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#12.0.0"
+    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#12.0.1"
   },
   "scripts": {
     "frontend-build:development": "./node_modules/gulp/bin/gulp.js build:development",

--- a/yarn.lock
+++ b/yarn.lock
@@ -542,9 +542,9 @@ detect-file@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/detect-file/-/detect-file-1.0.0.tgz#f0d66d03672a825cb1b73bdb3fe62310c8e552b7"
 
-"digitalmarketplace-frameworks@https://github.com/alphagov/digitalmarketplace-frameworks.git#12.0.0":
-  version "12.0.0"
-  resolved "https://github.com/alphagov/digitalmarketplace-frameworks.git#908c2bca2624c4d3a0f5085587ba90a953f7d08c"
+"digitalmarketplace-frameworks@https://github.com/alphagov/digitalmarketplace-frameworks.git#12.0.1":
+  version "12.0.1"
+  resolved "https://github.com/alphagov/digitalmarketplace-frameworks.git#3dafa57114e463caa97c58d60be7b0b63766a4ef"
 
 "digitalmarketplace-frontend-toolkit@https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v28.15.0":
   version "28.15.0"


### PR DESCRIPTION
For this trello ticket: [https://trello.com/c/7P1cRFqt](https://trello.com/c/7P1cRFqt)

### Pull in updated content for `become a supplier` page

The content was wrong and needed changing. This has been done in a separate PR on the frameworks repo and is already [merged](https://github.com/alphagov/digitalmarketplace-frameworks/pull/522)


### Fix framework ordering bug on `become_a_supplier`

We were ordering frameworks by their slug and then reversing. This was
so that they were ordered by family, newest first. This broke down
when we got to g-cloud-10 as lexicographically before g-cloud-9.

Ordering first by framework, then by id has the desired effect.

Screenshot of new content

<img width="643" alt="screen shot 2018-05-25 at 12 40 37" src="https://user-images.githubusercontent.com/13836290/40542648-ddb7e7e8-6018-11e8-82af-249ca444176e.png">
