### PR TITLE
Consolidate validation mastheads

### DIFF
--- a/app/main/helpers/suppliers.py
+++ b/app/main/helpers/suppliers.py
@@ -46,16 +46,3 @@ def supplier_company_details_are_complete(supplier_data):
              for f in
              contact_required_fields])
     )
-
-
-def parse_form_errors_for_validation_masthead(forms):
-    form_list = forms if isinstance(forms, (list, tuple)) else [forms]
-
-    errors = []
-    for form in form_list:
-        errors += [{
-            'question': form[field].label.text,
-            'input_name': form[field].name,
-        } for field in form.errors.keys()]
-
-    return errors

--- a/app/main/views/login.py
+++ b/app/main/views/login.py
@@ -3,6 +3,7 @@ from flask_login import current_user
 
 from dmapiclient.audit import AuditTypes
 from dmutils.email import send_user_account_email
+from dmutils.forms import get_errors_from_wtform
 
 from .. import main
 from ..forms.auth_forms import EmailAddressForm
@@ -13,19 +14,9 @@ from ... import data_api_client
 USER_INVITED_FLASH_MESSAGE = "Contributor invited"
 
 
-@main.route('/invite-user', methods=["GET"])
+@main.route('/invite-user', methods=["GET", "POST"])
 @login_required
 def invite_user():
-    form = EmailAddressForm()
-
-    return render_template(
-        "auth/submit_email_address.html",
-        form=form), 200
-
-
-@main.route('/invite-user', methods=["POST"])
-@login_required
-def send_invite_user():
     form = EmailAddressForm()
 
     if form.validate_on_submit():
@@ -53,7 +44,11 @@ def send_invite_user():
 
         flash(USER_INVITED_FLASH_MESSAGE, "success")
         return redirect(url_for('.list_users'))
-    else:
-        return render_template(
-            "auth/submit_email_address.html",
-            form=form), 400
+
+    errors = get_errors_from_wtform(form)
+
+    return render_template(
+        "auth/submit_email_address.html",
+        form=form,
+        errors=errors
+    ), 200 if not errors else 400

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -6,6 +6,7 @@ from dmcontent.content_loader import ContentNotFoundError
 from dmutils import s3
 from dmutils.dates import update_framework_with_formatted_dates
 from dmutils.documents import upload_service_documents
+from dmutils.forms import get_errors_from_wtform
 
 from ... import data_api_client, flask_featureflags
 from ...main import main, content_loader
@@ -784,6 +785,8 @@ def previous_services(framework_slug, lot_slug):
     copy_all = request.args.get('copy_all', None)
     supplier = data_api_client.get_supplier(current_user.supplier_id)['suppliers']
 
+    errors = get_errors_from_wtform(form) if form else {}
+
     return render_template(
         "services/previous_services.html",
         framework=framework,
@@ -794,8 +797,8 @@ def previous_services(framework_slug, lot_slug):
         declaration_status=get_declaration_status(data_api_client, framework_slug),
         company_details_complete=supplier['companyDetailsConfirmed'],
         form=form,
-        form_errors=[{'question': form[key].label.text, 'input_name': key} for key in form.errors] if form else None,
-    )
+        errors=errors
+    ), 200 if not errors else 400
 
 
 @main.route('/frameworks/<framework_slug>/submissions/<lot_slug>/copy-previous-framework-service/<service_id>',

--- a/app/templates/auth/submit_email_address.html
+++ b/app/templates/auth/submit_email_address.html
@@ -26,6 +26,7 @@
 {% endblock %}
 
 {% block main_content %}
+{% include "toolkit/forms/validation.html" %}
 
   {% with
     heading = "Invite a contributor",
@@ -34,7 +35,7 @@
     {% include 'toolkit/page-heading.html' %}
   {% endwith %}
 
-<form autocomplete="off" action="{{ url_for('.send_invite_user') }}" method="POST">
+<form autocomplete="off" action="{{ url_for('.invite_user') }}" method="POST">
 
     <div class="grid-row">
         <div class="column-two-thirds">
@@ -46,7 +47,7 @@
                 name = "email_address",
                 hint = "An invite will be sent asking the recipient to register as a contributor.",
                 value = form.email_address.data,
-                error = form.email_address.errors[0]
+                error = errors.get("email_address", {}).get("message", None)
             %}
             {% include "toolkit/forms/textbox.html" %}
             {% endwith %}

--- a/app/templates/frameworks/contract_review.html
+++ b/app/templates/frameworks/contract_review.html
@@ -24,6 +24,7 @@
 {% endblock %}
 
 {% block main_content %}
+  {% include 'toolkit/forms/validation.html' %}
 
 <div class="grid-row">
   <div class="column-two-thirds">
@@ -36,15 +37,6 @@
     {% endwith %}
   </div>
 </div>
-
-{% if form.errors %}
-  {%
-    with
-      errors = form_errors
-  %}
-    {% include 'toolkit/forms/validation.html' %}
-  {% endwith %}
-{% endif %}
 
 <div>
   {% import "toolkit/summary-table.html" as summary %}
@@ -96,7 +88,7 @@
           options = [{
               "label": form.authorisation.description,
           }],
-          error=form.authorisation.errors[0]
+          error=errors.get("authorisation", {}).get("message", None)
         %}
           {% include "toolkit/forms/selection-buttons.html" %}
         {% endwith %}

--- a/app/templates/frameworks/contract_variation.html
+++ b/app/templates/frameworks/contract_variation.html
@@ -25,18 +25,11 @@
 {% endblock %}
 
 {% block main_content %}
-
-  {% if errors %}
-    {% with errors = errors.values() %}
-      {% include 'toolkit/forms/validation.html' %}
-    {% endwith %}
-  {% endif %}
-
     <div class="grid-row">
       <div class="column-one-whole">
-        {% if form.errors %}
+        {% if errors %}
          {% with 
-            message = "You must <a href=\"#{}\">accept the changes</a> to continue.".format(form_errors[0].input_name)|safe, type = "destructive" %} 
+            message = "You must <a href=\"#{}\">accept the changes</a> to continue.".format(errors.accept_changes.input_name)|safe, type = "destructive" %}
             {% include "toolkit/notification-banner.html" %} 
           {% endwith %}
         {% endif %}
@@ -148,7 +141,7 @@
                   "value": "Yes, I accept the changes"
                 }
                 ],
-                error=form.accept_changes.errors[0]
+                error=errors.get("accept_changes", {}).get("message", None)
               %}
               {% include "toolkit/forms/selection-buttons.html" %}
               {% endwith %}

--- a/app/templates/frameworks/edit_declaration_section.html
+++ b/app/templates/frameworks/edit_declaration_section.html
@@ -29,12 +29,7 @@
 {% endblock %}
 
 {% block main_content %}
-
-  {% if errors %}
-    {% with errors = errors.values() %}
-      {% include 'toolkit/forms/validation.html' %}
-    {% endwith %}
-  {% elif name_of_framework_that_section_has_been_prefilled_from %}
+  {% if name_of_framework_that_section_has_been_prefilled_from %}
     {% with
        message = "Answers on this page are from an earlier declaration and need review.",
        type = "information"

--- a/app/templates/frameworks/reuse_declaration.html
+++ b/app/templates/frameworks/reuse_declaration.html
@@ -28,15 +28,7 @@
 {% endblock %}
 
 {% block main_content %}
-
-  {% if form_errors %}
-    {%
-      with
-      errors = form_errors
-    %}
-      {% include 'toolkit/forms/validation.html' %}
-    {% endwith %}
-  {% endif %}
+  {% include 'toolkit/forms/validation.html' %}
 
   <div class="grid-row">
     <div class="column-two-thirds">
@@ -67,7 +59,7 @@
           question = "Do you want to reuse the answers from your earlier declaration?",
           inline = true,
           type = "boolean",
-          error = form.reuse.errors[0]
+          error = errors.get('reuse', {}).get('message', None)
         %}
           {% include "toolkit/forms/selection-buttons.html" %}
         {% endwith %}

--- a/app/templates/frameworks/signature_upload.html
+++ b/app/templates/frameworks/signature_upload.html
@@ -34,13 +34,12 @@
   {% endwith %}
 
   {% if upload_error %}
-    {%
-      with
-        errors = [{
-          'question': 'Upload your signed signature page',
-          'input_name': 'signature_page'
-        }]
-    %}
+    {% with errors = {
+        "signature_page": {
+          "question": "Upload your signed signature page",
+          "input_name": "signature_page"
+        }
+      } %}
       {% include 'toolkit/forms/validation.html' %}
     {% endwith %}
   {% endif %}

--- a/app/templates/frameworks/signer_details.html
+++ b/app/templates/frameworks/signer_details.html
@@ -24,6 +24,8 @@
 {% endblock %}
 
 {% block main_content %}
+  {% include 'toolkit/forms/validation.html' %}
+
 <div class="grid-row">
   <div class="column-two-thirds">
     {%
@@ -34,15 +36,6 @@
       {% include "toolkit/page-heading.html" %}
     {% endwith %}
 
-    {% if form.errors %}
-      {%
-        with
-          errors = form_errors
-      %}
-        {% include 'toolkit/forms/validation.html' %}
-      {% endwith %}
-    {% endif %}
-
     <form method="POST" action="{{ url_for('.signer_details', framework_slug=framework.slug, agreement_id=agreement['id']) }}">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
         {% for question_key in question_keys %}
@@ -52,7 +45,7 @@
               name = question_key,
               value = form[question_key].data,
               hint = form[question_key].description,
-              error = form[question_key].errors[0]
+              error = errors.get(question_key, {}).get("message", None)
           %}
             {% include "toolkit/forms/textbox.html" %}
           {% endwith %}

--- a/app/templates/frameworks/updates.html
+++ b/app/templates/frameworks/updates.html
@@ -29,12 +29,12 @@
   {% if error_message %}
     {%
       with
-      errors = [
-        {
-            "input_name": clarification_question_name,
-            "question": "Ask a {} clarification question".format(framework.name)
+      errors = {
+        "clarification_question_name": {
+          "input_name": clarification_question_name,
+          "question": "Ask a {} clarification question".format(framework.name)
         }
-    ],
+      },
       lede = "There was a problem with your submitted question"
     %}
       {% include "toolkit/forms/validation.html" %}

--- a/app/templates/services/_base_edit_section_page.html
+++ b/app/templates/services/_base_edit_section_page.html
@@ -5,6 +5,8 @@
 {% block page_title %}{{ section.name }} – Digital Marketplace{% endblock %}
 
 {% block main_content %}
+  {% include 'toolkit/forms/validation.html' %}
+
   <div class="grid-row">
     <div class="column-two-thirds">
 
@@ -23,12 +25,6 @@
 
     </div>
   </div>
-
-  {% if errors %}
-    {% with errors = errors.values() %}
-      {% include 'toolkit/forms/validation.html' %}
-    {% endwith %}
-  {% endif %}
 
   <div>
     <form method="post" enctype="multipart/form-data" action="{{ request.path }}">

--- a/app/templates/services/previous_services.html
+++ b/app/templates/services/previous_services.html
@@ -34,17 +34,8 @@
 {% endblock %}
 
 {% block main_content %}
-
   {% if lot.oneServiceLimit %}
-
-    {% if form_errors %}
-      {%
-        with
-        errors = form_errors
-      %}
-        {% include 'toolkit/forms/validation.html' %}
-      {% endwith %}
-    {% endif %}
+    {% include 'toolkit/forms/validation.html' %}
 
     {% include "partials/service_warning.html" %}
 
@@ -65,7 +56,7 @@
               with
               name = "copy_service",
               type = "boolean",
-              error = form.copy_service.errors[0],
+              error = errors.get("copy_service", {}).get("message", None),
               question_advice = "You still have to review your service and answer any new questions."
             %}
               {% include "toolkit/forms/selection-buttons.html" %}

--- a/app/templates/suppliers/create_company_details.html
+++ b/app/templates/suppliers/create_company_details.html
@@ -24,13 +24,10 @@
 {% endblock %}
 
 {% block main_content %}
-
+  {% include 'toolkit/forms/validation.html' %}
 
 <div class="grid-row">
   <div class="column-one-whole">
-    {% if errors %}
-      {% include 'toolkit/forms/validation.html' %}
-    {% endif %}
 
   </div>
     <div class="column-two-thirds">
@@ -49,7 +46,7 @@
             question = "Company name",
             name = "company_name",
             value = form.company_name.data,
-            error = form.company_name.errors[0],
+            error = errors.get("company_name", {}).get("message", None),
             hint = "This is how buyers will see your company’s name on the Digital&nbsp;Marketplace"|safe
         %}
         {% include "toolkit/forms/textbox.html" %}
@@ -60,7 +57,7 @@
             question = "Contact name",
             name = "contact_name",
             value = form.contact_name.data,
-            error = form.contact_name.errors[0],
+            error = errors.get("contact_name", {}).get("message", None),
             hint = "This can be the name of the person or team you want buyers to contact"
         %}
         {% include "toolkit/forms/textbox.html" %}
@@ -71,7 +68,7 @@
             question = "Contact email address",
             name = "email_address",
             value = form.email_address.data,
-            error = form.email_address.errors[0],
+            error = errors.get("email_address", {}).get("message", None),
             hint = "This is the email buyers will use to contact you"
         %}
         {% include "toolkit/forms/textbox.html" %}
@@ -82,7 +79,7 @@
             question = "Contact phone number",
             name = "phone_number",
             value = form.phone_number.data,
-            error = form.phone_number.errors[0]
+            error = errors.get("phone_number", {}).get("message", None)
         %}
         {% include "toolkit/forms/textbox.html" %}
         {% endwith %}

--- a/app/templates/suppliers/create_duns_number.html
+++ b/app/templates/suppliers/create_duns_number.html
@@ -24,18 +24,15 @@
 {% endblock %}
 
 {% block main_content %}
-
 <div class="grid-row">
-  {% if form.duns_number.errors[0] == 'DUNS number already used' %}
+  {% if errors.get("duns_number", {}).get("message", None) == 'DUNS number already used' %}
     {% with lede = "A supplier account already exists with that DUNS number",
             description = 'If you no longer have your account details, or if you think this may be an error, email <a href="mailto:enquiries@digitalmarketplace.service.gov.uk?subject=DUNS%20number%20question" title="Please contact enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.service.gov.uk</a>'|safe
     %}
       {% include 'toolkit/forms/validation.html' %}
     {% endwith %}
-  {% elif form.duns_number.errors %}
-    {% with errors = [{'question': form.duns_number.label, 'input_name': form.duns_number.name}] %}
-      {% include 'toolkit/forms/validation.html' %}
-    {% endwith %}
+  {% elif errors %}
+    {% include 'toolkit/forms/validation.html' %}
   {% endif %}
   
   <div class="column-two-thirds">
@@ -45,7 +42,7 @@
     {% endwith %}
   
     
-    <form method="POST" action="{{ url_for('.submit_duns_number') }}">
+    <form method="POST" action="{{ url_for('.duns_number') }}">
       <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
       <div class="dmspeak">
         <p>If you registered your business with Companies House, you will automatically have been given a unique
@@ -63,7 +60,7 @@
       {% with question = "DUNS number",
               name = "duns_number",
               value = form.duns_number.data,
-              error = form.duns_number.errors[0],
+              error = errors.get("duns_number", {}).get("message", None),
               question_advice = question_advice,
               hint = "This is a 9 digit number" %}
         {% include "toolkit/forms/textbox.html" %}

--- a/app/templates/suppliers/create_your_account.html
+++ b/app/templates/suppliers/create_your_account.html
@@ -25,6 +25,8 @@
 {% endblock %}
 
 {% block main_content %}
+{% include "toolkit/forms/validation.html" %}
+
 <div class="grid-row">
   <div class="column-two-thirds">
     {% with heading = "Create login", smaller = True %}
@@ -36,14 +38,14 @@
        <p>It won’t be visible on the Digital Marketplace.</p>
        <p>You can add other email addresses to your supplier account later.</p>
     </div>
-    <form method="POST" action="{{ url_for('.submit_create_your_account') }}">
+    <form method="POST" action="{{ url_for('.create_your_account') }}">
       <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
       {%
         with
           question = "Your email address",
           name = "email_address",
           value = email_address,
-          error = form.email_address.errors[0]
+          error = errors.get("email_address", {}).get("message", None)
       %}
         {% include "toolkit/forms/textbox.html" %}
       {% endwith %}

--- a/app/templates/suppliers/edit_company_registration_number.html
+++ b/app/templates/suppliers/edit_company_registration_number.html
@@ -22,20 +22,10 @@
 {% endblock %}
 
 {% block main_content %}
+{% include "toolkit/forms/validation.html" %}
 
 <div class="single-question-page">
   <div class="grid-row">
-    <div class="column-one-whole">
-      {% if form.errors %}
-      {# There can only ever be one error for this form, so take the first (and only) from the errors dict #}
-        {% with field, _ = form.errors.popitem() %}
-          {% with errors = [{'question': form[field].label, 'input_name': form[field].name}] %}
-            {% include 'toolkit/forms/validation.html' %}
-          {% endwith %}
-        {% endwith %}
-      {% endif %}
-    </div>
-
     <div class="column-two-thirds">
       {% with heading = "Are you registered with Companies House?", smaller = True %}
         {% include "toolkit/page-heading.html" %}
@@ -49,7 +39,7 @@
           name = "has_companies_house_number",
           type = "radio",
           value = form.has_companies_house_number.data,
-          error = form.has_companies_house_number.errors[0],
+          error = errors.get("has_companies_house_number", {}).get("message", None),
           options = [
           {
               "label": "Yes",
@@ -58,7 +48,7 @@
                 "question": "Companies House number",
                 "hint": "<a href='https://beta.companieshouse.gov.uk/search/companies'>Find your 8 digit Companies House number</a>"|safe,
                 "value": form.companies_house_number.data,
-                "error": form.companies_house_number.errors[0]
+                "error": errors.get("companies_house_number", {}).get("message", None),
               }
           },
           {
@@ -68,7 +58,7 @@
                 "question": "Enter a number that can be used to identify your business and provide details of the organisation that issued it.",
                 "hint": "For example, ‘0123456789, Unique Taxpayer Reference, HMRC, UK’",
                 "value": form.other_company_registration_number.data,
-                "error": form.other_company_registration_number.errors[0]
+                "error": errors.get("other_company_registration_number", {}).get("message", None),
               }
           }
         ]

--- a/app/templates/suppliers/edit_registered_name.html
+++ b/app/templates/suppliers/edit_registered_name.html
@@ -22,16 +22,9 @@
 {% endblock %}
 
 {% block main_content %}
-
+{% include "toolkit/forms/validation.html" %}
 <div class="single-question-page">
   <div class="grid-row">
-    <div class="column-one-whole">
-      {% if form.errors %}
-        {% with errors = [{'question': form.registered_company_name.label, 'input_name': form.registered_company_name.name}] %}
-          {% include 'toolkit/forms/validation.html' %}
-        {% endwith %}
-      {% endif %}
-    </div>
     <div class="column-two-thirds">
       {% with heading = "Registered company name", smaller = True %}
         {% include "toolkit/page-heading.html" %}
@@ -45,7 +38,7 @@
           name = "registered_company_name",
           question = "Registered company name",
           value = form.registered_company_name.data,
-          error = form.registered_company_name.errors[0],
+          error = errors.get("registered_company_name", {}).get("message", None),
           question_advice = "This could be different to your trading name."
         %}
           {% include "toolkit/forms/textbox.html" %}

--- a/app/templates/suppliers/edit_supplier_organisation_size.html
+++ b/app/templates/suppliers/edit_supplier_organisation_size.html
@@ -22,15 +22,10 @@
 {% endblock %}
 
 {% block main_content %}
+  {% include 'toolkit/forms/validation.html' %}
 
 <div class="single-question-page">
   <div class="grid-row">
-    {% if form.errors %}
-      {% with errors = [{'question': form.organisation_size.label, 'input_name': form.organisation_size.name}] %}
-        {% include 'toolkit/forms/validation.html' %}
-      {% endwith %}
-    {% endif %}
-
     <div class="column-two-thirds">
       {% with heading = "What size is your organisation?", smaller = True %}
         {% include "toolkit/page-heading.html" %}
@@ -46,7 +41,7 @@
         {% with question = "What size is your organisation?",
                 name = "organisation_size",
                 value = form.organisation_size.data,
-                error = form.organisation_size.errors[0],
+                error = errors.get('organisation_size', {}).get('message', None),
                 type = "radio",
                 options = form.OPTIONS,
                 hint = hint %}

--- a/app/templates/suppliers/edit_supplier_trading_status.html
+++ b/app/templates/suppliers/edit_supplier_trading_status.html
@@ -22,15 +22,10 @@
 {% endblock %}
 
 {% block main_content %}
+{% include "toolkit/forms/validation.html" %}
 
 <div class="single-question-page">
   <div class="grid-row">
-    {% if form.errors %}
-      {% with errors = [{'question': form.trading_status.label, 'input_name': form.trading_status.name}] %}
-        {% include 'toolkit/forms/validation.html' %}
-      {% endwith %}
-    {% endif %}
-
     <div class="column-two-thirds">
       {% with heading = "What&rsquo;s your trading status?"|safe, smaller = True %}
         {% include "toolkit/page-heading.html" %}
@@ -45,7 +40,7 @@
         {% with question = "What&rsquo;s your trading status?"|safe,
                 name = "trading_status",
                 value = form.trading_status.data,
-                error = form.trading_status.errors[0],
+                error = errors.get("trading_status", {}).get("message", None),
                 type = "radio",
                 options = form.OPTIONS,
                 hint = hint %}

--- a/app/templates/suppliers/edit_vat_number.html
+++ b/app/templates/suppliers/edit_vat_number.html
@@ -22,12 +22,7 @@
 {% endblock %}
 
 {% block main_content %}
-
-{% if form.errors %}
-  {% with errors = form_errors %}
-    {% include 'toolkit/forms/validation.html' %}
-  {% endwith %}
-{% endif %}
+  {% include 'toolkit/forms/validation.html' %}
 
 <div class="grid-row">
   <div class="column-two-thirds">
@@ -42,7 +37,7 @@
         name = "vat_registered",
         type = "radio",
         value = form.vat_registered.data,
-        error = form.vat_registered.errors[0],
+        error = errors.get('vat_registered', {}).get('message', None),
         options = [
           {
               "label": "Yes",
@@ -50,7 +45,7 @@
                 "name": "vat_number",
                 "question": "What is your VAT number?",
                 "value": form.vat_number.data,
-                "error": form.vat_number.errors[0]
+                "error": errors.get('vat_number', {}).get('message', None)
               }
           },
           {

--- a/app/templates/suppliers/edit_what_buyers_will_see.html
+++ b/app/templates/suppliers/edit_what_buyers_will_see.html
@@ -25,34 +25,7 @@
 {% endblock %}
 
 {% block main_content %}
-{% if supplier_form.errors or contact_form.errors %}
-    <div class="validation-masthead" aria-labelledby="validation-masthead-heading">
-        <h3 class="validation-masthead-heading" id="validation-masthead-heading">
-            There was a problem with the details you gave for:
-        </h3>
-
-        {% if contact_form.errors %}
-        <ul>
-        {% for field_name, field_errors in contact_form.errors|dictsort %}
-          {% for error in field_errors %}
-          <li><a href="#{{ field_name }}" class="validation-masthead-link">{{ contact_form[field_name].label.text }}</a></li>
-          {% endfor %}
-        {% endfor %}
-        </ul>
-        {% endif %}
-
-        {% if supplier_form.errors %}
-        <ul>
-        {% for field_name, field_errors in supplier_form.errors|dictsort %}
-          {% for error in field_errors %}
-            <li><a href="#{{ field_name }}" class="validation-masthead-link">{{ supplier_form[field_name].label.text }}</a>
-          {% endfor %}
-        {% endfor %}
-        </ul>
-        {% endif %}
-
-    </div>
-{% endif %}
+{% include "toolkit/forms/validation.html" %}
 
   <div class="grid-row">
     <div class="column-one-whole">
@@ -72,16 +45,16 @@
   <form action="{{ url_for('.edit_what_buyers_will_see') }}" method="post">
 
   <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
-
+  
   <div class="grid-row">
     <div class="column-two-thirds">
 
-      {{ forms.question_textbox('contactName', 'Contact name', contact_form.contactName.data, 'This can be the name of the person or team you want buyers to contact', errors=contact_form.contactName.errors) }}
-      {{ forms.question_textbox('email', 'Contact email address', contact_form.email.data, 'This is the email buyers will use to contact you', errors=contact_form.email.errors) }}
-      {{ forms.question_textbox('phoneNumber', 'Contact phone number', contact_form.phoneNumber.data, errors=contact_form.phoneNumber.errors) }}
+      {{ forms.question_textbox('contactName', 'Contact name', contact_form.contactName.data, 'This can be the name of the person or team you want buyers to contact', errors=[errors.get("contactName", {}).get("message", None)]) }}
+      {{ forms.question_textbox('email', 'Contact email address', contact_form.email.data, 'This is the email buyers will use to contact you', errors=[errors.get("email", {}).get("message", None)]) }}
+      {{ forms.question_textbox('phoneNumber', 'Contact phone number', contact_form.phoneNumber.data, errors=[errors.get("phoneNumber", {}).get("message", None)]) }}
 
 
-      {{ forms.question_textarea('description', 'Supplier summary', supplier_form.description.data, '50 words maximum', errors=supplier_form.description.errors, max_length_in_words=50) }}
+      {{ forms.question_textarea('description', 'Supplier summary', supplier_form.description.data, '50 words maximum', errors=[errors.get("description", {}).get("message", None)], max_length_in_words=50) }}
     </div>
   </div>
 

--- a/app/templates/suppliers/join_open_framework_notification_mailing_list.html
+++ b/app/templates/suppliers/join_open_framework_notification_mailing_list.html
@@ -16,6 +16,7 @@
 {% endblock %}
 
 {% block main_content %}
+{% include "toolkit/forms/validation.html" %}
 
 <div class="grid-row">
   <div class="column-two-thirds">
@@ -41,7 +42,7 @@
             question = "Your email address",
             name = "email_address",
             value = form.email_address.data,
-            error = form.email_address.errors[0]
+            error = errors.get("email_address", {}).get("message", None)
         %}
           {% include "toolkit/forms/textbox.html" %}
         {% endwith %}

--- a/app/templates/suppliers/registered_address.html
+++ b/app/templates/suppliers/registered_address.html
@@ -30,12 +30,7 @@
 
 
 {% block main_content %}
-
-  {% if form_errors %}
-  {% with errors = form_errors %}
-    {% include 'toolkit/forms/validation.html' %}
-  {% endwith %}
-  {% endif %}
+  {% include 'toolkit/forms/validation.html' %}
 
   <div class="grid-row">
     <div class="column-one-whole">

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "colors": "1.1.2",
     "jquery": "1.12.0",
     "hogan.js": "3.0.2",
-    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v28.15.0",
+    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v29.0.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.19.2/jinja_govuk_template-0.19.2.tgz",
     "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#12.1.0"
   },

--- a/tests/app/helpers.py
+++ b/tests/app/helpers.py
@@ -514,7 +514,7 @@ class BaseApplicationTest(object):
                                                       validation_message=""
                                                       ):
         doc = html.fromstring(res.get_data(as_text=True))
-        masthead_heading = doc.xpath('normalize-space(//h1[@class="validation-masthead-heading"]/text())')
+        masthead_heading = doc.xpath('normalize-space(//h2[@class="validation-masthead-heading"]/text())')
         masthead_link_text = doc.xpath('normalize-space(string(//a[@class="validation-masthead-link"]))')
         validation_text = doc.xpath('normalize-space(//span[@class="validation-message"]/text())')
 

--- a/tests/app/main/helpers/test_suppliers.py
+++ b/tests/app/main/helpers/test_suppliers.py
@@ -2,9 +2,7 @@ import pytest
 from flask_wtf import FlaskForm
 from wtforms import StringField
 from wtforms.validators import Length
-from app.main.helpers.suppliers import get_country_name_from_country_code, parse_form_errors_for_validation_masthead, \
-    supplier_company_details_are_complete
-from ...helpers import BaseApplicationTest
+from app.main.helpers.suppliers import get_country_name_from_country_code, supplier_company_details_are_complete
 
 from dmutils.api_stubs import supplier
 
@@ -51,41 +49,3 @@ class FormForTest(FlaskForm):
     field_three = StringField('Field three?', validators=[
         Length(max=5, message="Field three must be under 5 characters.")
     ])
-
-
-class TestParseFormErrorsForValidationMasthead(BaseApplicationTest):
-    def test_returns_formatted_list_of_errors_for_single_form(self):
-        with self.app.test_request_context():
-            form = FormForTest(field_one='Too long', field_two='Too long', field_three='Good')
-            form.validate()
-
-            masthead_errors = parse_form_errors_for_validation_masthead(form)
-            assert masthead_errors == [
-                {'question': 'Field one?', 'input_name': 'field_one'},
-                {'question': 'Field two?', 'input_name': 'field_two'},
-            ]
-
-    def test_returns_formatted_list_of_errors_for_list_of_forms(self):
-        with self.app.test_request_context():
-            form_one = FormForTest(field_one='Good', field_two='Too long', field_three='Too long')
-            form_two = FormForTest(field_one='Still too long', field_two='Yes!', field_three='Also too long')
-
-            form_one.validate()
-            form_two.validate()
-            masthead_errors = parse_form_errors_for_validation_masthead([form_one, form_two])
-
-            assert masthead_errors == [
-                {'question': 'Field two?', 'input_name': 'field_two'},
-                {'question': 'Field three?', 'input_name': 'field_three'},
-                {'question': 'Field one?', 'input_name': 'field_one'},
-                {'question': 'Field three?', 'input_name': 'field_three'},
-            ]
-
-    def test_returns_falsey_if_no_errors(self):
-        with self.app.test_request_context():
-            form = FormForTest(field_one='Good', field_two='Good', field_three='Good')
-            form.validate()
-
-            masthead_errors = parse_form_errors_for_validation_masthead(form)
-
-            assert not masthead_errors

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -2600,7 +2600,7 @@ class TestPostListPreviousService(BaseApplicationTest):
         )
         doc = html.fromstring(res.get_data(as_text=True))
 
-        assert res.status_code == 200
+        assert res.status_code == 400
         assert "Do you want to reuse your previous digital specialists service?" == doc.xpath(
             "//a[@class='validation-masthead-link']/text()"
         )[0].strip()

--- a/tests/app/main/test_suppliers.py
+++ b/tests/app/main/test_suppliers.py
@@ -2006,7 +2006,7 @@ class TestJoinOpenFrameworkNotificationMailingList(BaseApplicationTest):
         response = self.client.get(
             "/suppliers/mailing-list",
         )
-        assert response.status_code == 200
+        assert response.status_code == 400
         doc = html.fromstring(response.get_data(as_text=True), base_url="/suppliers/mailing-list")
 
         assert not doc.xpath(

--- a/yarn.lock
+++ b/yarn.lock
@@ -546,9 +546,9 @@ detect-file@^1.0.0:
   version "12.1.0"
   resolved "https://github.com/alphagov/digitalmarketplace-frameworks.git#919bdfd04dc6ab41ba3a9d21a4675335e6a0a021"
 
-"digitalmarketplace-frontend-toolkit@https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v28.15.0":
-  version "28.15.0"
-  resolved "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#05167f7a96843fe3e893448a64770ec9dd01684c"
+"digitalmarketplace-frontend-toolkit@https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v29.0.0":
+  version "29.0.0"
+  resolved "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#87b8535689b160c26c0ac53d9d6bb96cde10c277"
   dependencies:
     del "^2.2.2"
     govuk-elements-sass "3.0.3"


### PR DESCRIPTION
 ## Summary
Use validation masthead from the frontend-toolkit consistently.

Also converts most pages over to using the base page from the frontend-toolkit.

The framework clarification question and signature upload pages have not been completely converted as they contains a rather peculiar form and the views are split in a way that doesn't make them trivial to consolidate (in the time I'm willing to spend on this).

 ## Ticket
https://trello.com/c/RSYEM3FL/448