### PR TITLE
Add error page for 400s

### DIFF
--- a/app/main/errors.py
+++ b/app/main/errors.py
@@ -32,6 +32,11 @@ def page_unauthorized(e):
         return redirect('/user/login')
 
 
+@main.app_errorhandler(400)
+def bad_request(e):
+    return _render_error_page(400, e.description or None)
+
+
 @main.app_errorhandler(404)
 def page_not_found(e):
     return _render_error_page(404)
@@ -47,13 +52,16 @@ def service_unavailable(e):
     return _render_error_page(503)
 
 
-def _render_error_page(status_code):
+def _render_error_page(status_code, error_message=None):
     template_map = {
-        400: "errors/500.html",
+        400: "errors/400.html",
         404: "errors/404.html",
         500: "errors/500.html",
         503: "errors/500.html",
     }
     if status_code not in template_map:
         status_code = 500
-    return render_template(template_map[status_code]), status_code
+    return render_template(
+        template_map[status_code],
+        error_message=error_message,
+    ), status_code

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -756,7 +756,7 @@ def previous_services(framework_slug, lot_slug):
             # Don't copy a service if the lot has a one service limit and the supplier already has a draft for that lot
             drafts, complete_drafts = get_lot_drafts(data_api_client, framework_slug, lot_slug)
             if drafts or complete_drafts:
-                abort(400)
+                abort(400, f"You already have a draft {lot['name'].lower()} service.")
             if form.validate_on_submit():
                 if form.copy_service.data is True:
                     copy_service_from_previous_framework(

--- a/app/templates/errors/400.html
+++ b/app/templates/errors/400.html
@@ -1,0 +1,20 @@
+{% extends "_base_page.html" %}
+
+{% block page_title %}Bad request - Digital Marketplace{% endblock %}
+
+{% block main_content %}
+
+<div class="error-page">
+    <header class="page-heading-smaller">
+      <h1>Sorry, there was a problem with your request</h1>
+    </header>
+    <p>
+      {% if error_message %}
+        {{ error_message }}
+      {% else %}
+        Please do not attempt the same request again.
+      {% endif %}
+    </p>
+</div>
+
+{% endblock %}


### PR DESCRIPTION
Unlike the buyer or user frontends, the supplier frontend didn't have a
custom error page, or even any error handling at all, for 400s. This
meant that any time `abort(400)` was being called the user would get
a janky horrible error page.

This allows a custom error message to also be passed through which wil
be displayed to the user.

### Before
<img width="1440" alt="screen shot 2018-06-06 at 14 32 15" src="https://user-images.githubusercontent.com/13836290/41041250-78ea0256-6996-11e8-9657-5fb4f223fb56.png">

### After
<img width="1440" alt="screen shot 2018-06-06 at 14 29 21" src="https://user-images.githubusercontent.com/13836290/41041261-7f0b1c2e-6996-11e8-8f4d-2a97f961caad.png">

