### PR TITLE
Add validation masthead to declaration

### DIFF
--- a/app/templates/frameworks/edit_declaration_section.html
+++ b/app/templates/frameworks/edit_declaration_section.html
@@ -29,6 +29,8 @@
 {% endblock %}
 
 {% block main_content %}
+  {% include "toolkit/forms/validation.html" %}
+
   {% if name_of_framework_that_section_has_been_prefilled_from %}
     {% with
        message = "Answers on this page are from an earlier declaration and need review.",


### PR DESCRIPTION
 ## Summary
QA noticed that validation is missing from declaration pages. This adds
it back.

 ## Ticket
https://trello.com/c/RSYEM3FL/448