### PR TITLE
Refactor Supplier FE tests (part 2)

### DIFF
--- a/tests/app/helpers.py
+++ b/tests/app/helpers.py
@@ -444,11 +444,13 @@ class BaseApplicationTest(object):
         if self.get_user_patch is not None:
             self.get_user_patch.stop()
 
-    def login(self, supplier_organisation_size="small", user_researh_opted_in=True):
+    def login(self, supplier_organisation_size="small", user_research_opted_in=True, active=True):
         with patch('app.main.views.login.data_api_client') as login_api_client:
             supplier_user_json = self.user(
                 123, "email@email.com", 1234, u'Supplier NĀme', u'Năme',
-                supplier_organisation_size=supplier_organisation_size, userResearchOptedIn=user_researh_opted_in
+                supplier_organisation_size=supplier_organisation_size,
+                userResearchOptedIn=user_research_opted_in,
+                active=active
             )
             login_api_client.authenticate_user.return_value = supplier_user_json
 

--- a/tests/app/main/test_notifications.py
+++ b/tests/app/main/test_notifications.py
@@ -13,7 +13,7 @@ class TestUserResearch(BaseApplicationTest):
         super().teardown_method(method)
 
     def test_should_see_banner_if_not_subscribed(self):
-        self.login(supplier_organisation_size=None, user_researh_opted_in=False)
+        self.login(user_research_opted_in=False)
         res = self.client.get('/suppliers')
         assert res.status_code == 200
         assert 'Help us improve the Digital Marketplace' in res.get_data(as_text=True)
@@ -23,7 +23,7 @@ class TestUserResearch(BaseApplicationTest):
         assert cookie_value is None
 
     def test_should_not_see_banner_if_subscribed(self):
-        self.login(supplier_organisation_size=None, user_researh_opted_in=True)
+        self.login(user_research_opted_in=True)
         res = self.client.get('/suppliers')
         assert res.status_code == 200
         assert 'Help us improve the Digital Marketplace' not in res.get_data(as_text=True)
@@ -31,7 +31,7 @@ class TestUserResearch(BaseApplicationTest):
         assert 'class="user-research-banner-close-btn"' not in res.get_data(as_text=True)
 
     def test_should_see_subscribed_link_if_not_subscribed(self):
-        self.login(supplier_organisation_size=None, user_researh_opted_in=False)
+        self.login(user_research_opted_in=False)
         res = self.client.get('/suppliers')
         assert res.status_code == 200
         assert "href=\"/user/notifications/user-research\"" in res.get_data(as_text=True)
@@ -39,7 +39,7 @@ class TestUserResearch(BaseApplicationTest):
         assert "Unsubscribe from the user research mailing list" not in res.get_data(as_text=True)
 
     def test_should_see_unsubscribed_link_if_subscribed(self):
-        self.login(supplier_organisation_size=None, user_researh_opted_in=True)
+        self.login(user_research_opted_in=True)
         res = self.client.get('/suppliers')
         assert res.status_code == 200
         assert "href=\"/user/notifications/user-research\"" in res.get_data(as_text=True)


### PR DESCRIPTION
See part 1: https://github.com/alphagov/digitalmarketplace-supplier-frontend/pull/894

- Move `data_api_client` patching to setup methods
- Remove unnecessary `app.app_context` and `self.app.test_client` context managers
- Organise `helpers/test_frameworks` into classes (and use consistent api patching)
- Whitespace tidying

Also fixes a typo in a test helper method param: 
`user_researh_opted_in` --> `user_research_opted_in`