### PR TITLE
Confirm company details every application

### DIFF
--- a/app/main/helpers/frameworks.py
+++ b/app/main/helpers/frameworks.py
@@ -215,7 +215,6 @@ def get_statuses_for_lot(
     unit,
     unit_plural
 ):
-
     if not drafts_count and not complete_drafts_count:
         return []
 
@@ -283,7 +282,6 @@ def get_status_for_one_service_lot(
 def get_status_for_multi_service_lot_and_service_type(
     count, services_status, framework_is_open, declaration_complete, unit, unit_plural
 ):
-
     singular = (1 == count)
     description_of_services = u'{} {} {}'.format(
         count, services_status, unit if singular else unit_plural
@@ -365,7 +363,7 @@ def get_frameworks_closed_and_open_for_applications(frameworks):
 
 
 def get_supplier_registered_name_from_declaration(declaration):
-    return(
+    return (
         declaration.get('supplierRegisteredName')  # G-Cloud 10 and later declaration key
         or declaration.get('nameOfOrganisation')  # G-Cloud 9 and earlier declaration key
     )

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -30,12 +30,22 @@ from ... import data_api_client
 from ...main import main, content_loader
 from ..helpers import login_required
 from ..helpers.frameworks import (
-    get_declaration_status, get_last_modified_from_first_matching_file, register_interest_in_framework,
-    get_supplier_on_framework_from_info, get_declaration_status_from_info, get_supplier_framework_info,
-    get_framework_or_404, get_framework_and_lot_or_404, get_framework_or_500, count_drafts_by_lot, get_statuses_for_lot,
-    return_supplier_framework_info_if_on_framework_or_abort, returned_agreement_email_recipients,
-    check_agreement_is_related_to_supplier_framework_or_abort, get_framework_for_reuse,
-    get_supplier_registered_name_from_declaration
+    check_agreement_is_related_to_supplier_framework_or_abort,
+    count_drafts_by_lot,
+    get_declaration_status,
+    get_declaration_status_from_info,
+    get_framework_and_lot_or_404,
+    get_framework_for_reuse,
+    get_framework_or_404,
+    get_framework_or_500,
+    get_last_modified_from_first_matching_file,
+    get_statuses_for_lot,
+    get_supplier_framework_info,
+    get_supplier_on_framework_from_info,
+    get_supplier_registered_name_from_declaration,
+    register_interest_in_framework,
+    return_supplier_framework_info_if_on_framework_or_abort,
+    returned_agreement_email_recipients,
 )
 from ..helpers.services import (
     count_unanswered_questions,

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -32,6 +32,7 @@ from ..helpers import login_required
 from ..helpers.frameworks import (
     check_agreement_is_related_to_supplier_framework_or_abort,
     count_drafts_by_lot,
+    EnsureApplicationCompanyDetailsHaveBeenConfirmed,
     get_declaration_status,
     get_declaration_status_from_info,
     get_framework_and_lot_or_404,
@@ -53,6 +54,7 @@ from ..helpers.services import (
     get_lot_drafts,
     get_signed_document_url,
 )
+from ..helpers.suppliers import supplier_company_details_are_complete
 from ..helpers.validation import get_validator
 from ..forms.frameworks import SignerDetailsForm, ContractReviewForm, AcceptAgreementVariationForm, ReuseDeclarationForm
 
@@ -117,7 +119,16 @@ def framework_dashboard(framework_slug):
     if declaration_status == 'unstarted' and framework['status'] == 'live':
         abort(404)
 
-    application_made = supplier_is_on_framework or (len(complete_drafts) > 0 and declaration_status == 'complete')
+    application_company_details_confirmed = (
+        supplier_framework_info and supplier_framework_info['applicationCompanyDetailsConfirmed']
+    )
+    application_made = (
+        supplier_is_on_framework or (
+            len(complete_drafts) > 0
+            and declaration_status == 'complete'
+            and application_company_details_confirmed
+        )
+    )
     lots_with_completed_drafts = [lot for lot in framework['lots'] if count_drafts_by_lot(complete_drafts, lot['slug'])]
 
     try:
@@ -206,15 +217,16 @@ def framework_dashboard(framework_slug):
         supplier_framework=supplier_framework_info,
         supplier_is_on_framework=supplier_is_on_framework,
         framework_advice=framework_advice,
-        company_details_complete=supplier['companyDetailsConfirmed'],
+        supplier_company_details_complete=supplier_company_details_are_complete(supplier),
+        application_company_details_confirmed=application_company_details_confirmed,
     ), 200
 
 
 @main.route('/frameworks/<framework_slug>/submissions', methods=['GET'])
 @login_required
+@EnsureApplicationCompanyDetailsHaveBeenConfirmed(data_api_client)
 def framework_submission_lots(framework_slug):
     framework = get_framework_or_404(data_api_client, framework_slug)
-    supplier = data_api_client.get_supplier(current_user.supplier_id)['suppliers']
 
     drafts, complete_drafts = get_drafts(data_api_client, framework_slug)
     declaration_status = get_declaration_status(data_api_client, framework_slug)
@@ -256,7 +268,6 @@ def framework_submission_lots(framework_slug):
         complete_drafts=list(reversed(complete_drafts)),
         drafts=list(reversed(drafts)),
         declaration_status=declaration_status,
-        company_details_complete=supplier['companyDetailsConfirmed'],
         framework=framework,
         lots=lots,
     ), 200
@@ -264,9 +275,9 @@ def framework_submission_lots(framework_slug):
 
 @main.route('/frameworks/<framework_slug>/submissions/<lot_slug>', methods=['GET'])
 @login_required
+@EnsureApplicationCompanyDetailsHaveBeenConfirmed(data_api_client)
 def framework_submission_services(framework_slug, lot_slug):
     framework, lot = get_framework_and_lot_or_404(data_api_client, framework_slug, lot_slug)
-    supplier = data_api_client.get_supplier(current_user.supplier_id)['suppliers']
 
     drafts, complete_drafts = get_lot_drafts(data_api_client, framework_slug, lot_slug)
     declaration_status = get_declaration_status(data_api_client, framework_slug)
@@ -327,7 +338,6 @@ def framework_submission_services(framework_slug, lot_slug):
         complete_drafts=list(reversed(complete_drafts)),
         drafts=list(reversed(drafts)),
         declaration_status=declaration_status,
-        company_details_complete=supplier['companyDetailsConfirmed'],
         framework=framework,
         lot=lot,
     ), 200
@@ -335,6 +345,7 @@ def framework_submission_services(framework_slug, lot_slug):
 
 @main.route('/frameworks/<framework_slug>/declaration/start', methods=['GET'])
 @login_required
+@EnsureApplicationCompanyDetailsHaveBeenConfirmed(data_api_client)
 def framework_start_supplier_declaration(framework_slug):
     framework = get_framework_or_404(data_api_client, framework_slug, allowed_statuses=['open'])
     update_framework_with_formatted_dates(framework)
@@ -345,6 +356,7 @@ def framework_start_supplier_declaration(framework_slug):
 
 @main.route('/frameworks/<framework_slug>/declaration/reuse', methods=['GET'])
 @login_required
+@EnsureApplicationCompanyDetailsHaveBeenConfirmed(data_api_client)
 def reuse_framework_supplier_declaration(framework_slug):
     """Attempt to find a supplier framework declaration that we can reuse.
 
@@ -391,6 +403,7 @@ def reuse_framework_supplier_declaration(framework_slug):
 
 @main.route('/frameworks/<framework_slug>/declaration/reuse', methods=['POST'])
 @login_required
+@EnsureApplicationCompanyDetailsHaveBeenConfirmed(data_api_client)
 def reuse_framework_supplier_declaration_post(framework_slug):
     """Set the prefill preference if a reusable framework slug is provided and redirect to declaration."""
 
@@ -450,6 +463,7 @@ def reuse_framework_supplier_declaration_post(framework_slug):
 
 @main.route('/frameworks/<framework_slug>/declaration', methods=['GET'])
 @login_required
+@EnsureApplicationCompanyDetailsHaveBeenConfirmed(data_api_client)
 def framework_supplier_declaration_overview(framework_slug):
     framework = get_framework_or_404(data_api_client, framework_slug, allowed_statuses=[
         "open",
@@ -503,6 +517,7 @@ def framework_supplier_declaration_overview(framework_slug):
 
 @main.route('/frameworks/<framework_slug>/declaration', methods=['POST'])
 @login_required
+@EnsureApplicationCompanyDetailsHaveBeenConfirmed(data_api_client)
 def framework_supplier_declaration_submit(framework_slug):
     framework = get_framework_or_404(data_api_client, framework_slug, allowed_statuses=['open'])
 
@@ -539,6 +554,7 @@ def framework_supplier_declaration_submit(framework_slug):
 
 @main.route('/frameworks/<framework_slug>/declaration/edit/<string:section_id>', methods=['GET', 'POST'])
 @login_required
+@EnsureApplicationCompanyDetailsHaveBeenConfirmed(data_api_client)
 def framework_supplier_declaration_edit(framework_slug, section_id):
     framework = get_framework_or_404(data_api_client, framework_slug, allowed_statuses=['open'])
 

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -24,6 +24,7 @@ from ..helpers.frameworks import (
     get_supplier_framework_info,
     get_framework_or_404,
     get_framework_or_500,
+    EnsureApplicationCompanyDetailsHaveBeenConfirmed,
 )
 from ..forms.frameworks import OneServiceLimitCopyServiceForm
 
@@ -289,6 +290,7 @@ def redirect_direct_service_urls(service_id, trailing_path):
 
 @main.route('/frameworks/<framework_slug>/submissions/<lot_slug>/create', methods=['GET', 'POST'])
 @login_required
+@EnsureApplicationCompanyDetailsHaveBeenConfirmed(data_api_client)
 def start_new_draft_service(framework_slug, lot_slug):
     """Page to kick off creation of a new service."""
 
@@ -351,6 +353,7 @@ def start_new_draft_service(framework_slug, lot_slug):
 
 @main.route('/frameworks/<framework_slug>/submissions/<lot_slug>/<service_id>/copy', methods=['POST'])
 @login_required
+@EnsureApplicationCompanyDetailsHaveBeenConfirmed(data_api_client)
 def copy_draft_service(framework_slug, lot_slug, service_id):
     framework, lot = get_framework_and_lot_or_404(data_api_client, framework_slug, lot_slug, allowed_statuses=['open'])
 
@@ -397,6 +400,7 @@ def copy_draft_service(framework_slug, lot_slug, service_id):
 
 @main.route('/frameworks/<framework_slug>/submissions/<lot_slug>/<service_id>/complete', methods=['POST'])
 @login_required
+@EnsureApplicationCompanyDetailsHaveBeenConfirmed(data_api_client)
 def complete_draft_service(framework_slug, lot_slug, service_id):
     framework, lot = get_framework_and_lot_or_404(data_api_client, framework_slug, lot_slug, allowed_statuses=['open'])
 
@@ -435,6 +439,7 @@ def complete_draft_service(framework_slug, lot_slug, service_id):
 
 @main.route('/frameworks/<framework_slug>/submissions/<lot_slug>/<service_id>/delete', methods=['POST'])
 @login_required
+@EnsureApplicationCompanyDetailsHaveBeenConfirmed(data_api_client)
 def delete_draft_service(framework_slug, lot_slug, service_id):
     framework, lot = get_framework_and_lot_or_404(data_api_client, framework_slug, lot_slug, allowed_statuses=['open'])
 
@@ -473,6 +478,7 @@ def delete_draft_service(framework_slug, lot_slug, service_id):
 
 @main.route('/assets/<framework_slug>/submissions/<int:supplier_id>/<document_name>', methods=['GET'])
 @login_required
+@EnsureApplicationCompanyDetailsHaveBeenConfirmed(data_api_client)
 def service_submission_document(framework_slug, supplier_id, document_name):
     if current_user.supplier_id != supplier_id:
         abort(404)
@@ -488,6 +494,7 @@ def service_submission_document(framework_slug, supplier_id, document_name):
 
 @main.route('/frameworks/<framework_slug>/submissions/<lot_slug>/<service_id>', methods=['GET'])
 @login_required
+@EnsureApplicationCompanyDetailsHaveBeenConfirmed(data_api_client)
 def view_service_submission(framework_slug, lot_slug, service_id):
     framework, lot = get_framework_and_lot_or_404(data_api_client, framework_slug, lot_slug)
     update_framework_with_formatted_dates(framework)
@@ -533,6 +540,7 @@ def view_service_submission(framework_slug, lot_slug, service_id):
 @main.route('/frameworks/<framework_slug>/submissions/<lot_slug>/<service_id>/edit/<section_id>/<question_slug>',
             methods=('GET', 'POST',))
 @login_required
+@EnsureApplicationCompanyDetailsHaveBeenConfirmed(data_api_client)
 def edit_service_submission(framework_slug, lot_slug, service_id, section_id, question_slug=None):
     """
         Also accepts URL parameter `force_continue_button` which will allow rendering of a 'Save and continue' button,
@@ -637,6 +645,7 @@ def edit_service_submission(framework_slug, lot_slug, service_id, section_id, qu
 @main.route('/frameworks/<framework_slug>/submissions/<lot_slug>/<service_id>/remove/<section_id>/<question_slug>',
             methods=['GET', 'POST'])
 @login_required
+@EnsureApplicationCompanyDetailsHaveBeenConfirmed(data_api_client)
 def remove_subsection(framework_slug, lot_slug, service_id, section_id, question_slug):
     # Suppliers must have registered interest in a framework before they can edit draft services
     if not get_supplier_framework_info(data_api_client, framework_slug):
@@ -727,6 +736,7 @@ def remove_subsection(framework_slug, lot_slug, service_id, section_id, question
 
 @main.route('/frameworks/<framework_slug>/submissions/<lot_slug>/previous-services', methods=['GET', 'POST'])
 @login_required
+@EnsureApplicationCompanyDetailsHaveBeenConfirmed(data_api_client)
 def previous_services(framework_slug, lot_slug):
     framework, lot = get_framework_and_lot_or_404(data_api_client, framework_slug, lot_slug)
     if framework['status'] != 'open':
@@ -781,7 +791,6 @@ def previous_services(framework_slug, lot_slug):
             abort(400)
 
     copy_all = request.args.get('copy_all', None)
-    supplier = data_api_client.get_supplier(current_user.supplier_id)['suppliers']
 
     errors = get_errors_from_wtform(form) if form else {}
 
@@ -793,7 +802,6 @@ def previous_services(framework_slug, lot_slug):
         previous_services_still_to_copy=previous_services_still_to_copy,
         copy_all=copy_all,
         declaration_status=get_declaration_status(data_api_client, framework_slug),
-        company_details_complete=supplier['companyDetailsConfirmed'],
         form=form,
         errors=errors
     ), 200 if not errors else 400
@@ -802,6 +810,7 @@ def previous_services(framework_slug, lot_slug):
 @main.route('/frameworks/<framework_slug>/submissions/<lot_slug>/copy-previous-framework-service/<service_id>',
             methods=['POST'])
 @login_required
+@EnsureApplicationCompanyDetailsHaveBeenConfirmed(data_api_client)
 def copy_previous_service(framework_slug, lot_slug, service_id):
     framework, lot = get_framework_and_lot_or_404(
         data_api_client, framework_slug, lot_slug, allowed_statuses=['open']
@@ -815,6 +824,7 @@ def copy_previous_service(framework_slug, lot_slug, service_id):
 @main.route('/frameworks/<framework_slug>/submissions/<lot_slug>/copy-all-previous-framework-services',
             methods=['POST'])
 @login_required
+@EnsureApplicationCompanyDetailsHaveBeenConfirmed(data_api_client)
 def copy_all_previous_services(framework_slug, lot_slug):
         framework, lot = get_framework_and_lot_or_404(
             data_api_client, framework_slug, lot_slug, allowed_statuses=['open']

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -113,17 +113,21 @@ def supplier_details():
     supplier['contact'] = supplier['contactInformation'][0]
     country_name = get_country_name_from_country_code(supplier.get('registrationCountry'))
 
-    framework = None
+    supplier_company_details_confirmed = supplier['companyDetailsConfirmed']
 
-    if "currently_applying_to" in session:
-        framework = data_api_client.get_framework(session["currently_applying_to"])["frameworks"]
+    currently_applying_to_framework = (
+        data_api_client.get_framework(session["currently_applying_to"])['frameworks']
+        if "currently_applying_to" in session else
+        None
+    )
+
     return render_template(
         "suppliers/details.html",
         supplier=supplier,
         country_name=country_name,
-        currently_applying_to=framework,
-        company_details_complete=supplier_company_details_are_complete(supplier),
-        supplier_company_details_confirmed=supplier['companyDetailsConfirmed'],
+        currently_applying_to=currently_applying_to_framework,
+        supplier_company_details_complete=supplier_company_details_are_complete(supplier),
+        supplier_company_details_confirmed=supplier_company_details_confirmed,
     ), 200
 
 

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -28,7 +28,10 @@ from ..forms.suppliers import (
     EmailAddressForm,
     VatNumberForm,
 )
-from ..helpers.frameworks import get_frameworks_by_status, get_frameworks_closed_and_open_for_applications
+from ..helpers.frameworks import (
+    get_frameworks_by_status,
+    get_frameworks_closed_and_open_for_applications,
+)
 from ..helpers.suppliers import (
     COUNTRY_TUPLE,
     get_country_name_from_country_code,

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -85,6 +85,9 @@ def dashboard():
             )
         })
 
+    if "currently_applying_to" in session:
+        del session["currently_applying_to"]
+
     return render_template(
         "suppliers/dashboard.html",
         supplier=supplier,

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -117,6 +117,7 @@ def supplier_details():
         country_name=country_name,
         currently_applying_to=framework,
         company_details_complete=supplier_company_details_are_complete(supplier),
+        supplier_company_details_confirmed=supplier['companyDetailsConfirmed'],
     ), 200
 
 

--- a/app/templates/frameworks/_framework_actions.html
+++ b/app/templates/frameworks/_framework_actions.html
@@ -27,17 +27,11 @@
 <li class="browse-list-item">
   <a class="browse-list-item-link"
      href="{{ url_for('.supplier_details') }}">
-    <span>Enter your company details</span>
+    <h2>1. Enter your company details</h2>
   </a>
-  {% if not company_details_complete and counts.complete %}
-  <div class="browse-list-item-status-angry">
-    <p class="browse-list-item-status-title">
-    <strong>No services will be submitted because you haven’t completed your company details</strong>
-    </p>
-  </div>
-  {% elif not company_details_complete %}
+  {% if not application_company_details_confirmed %}
   <div class="browse-list-item-status-quiet">
-    <p class="browse-list-item-status-title">You must add your organisation’s details</p>
+    <p class="browse-list-item-status-title">You must {% if supplier_company_details_complete %}confirm{% else %}add{% endif %} your organisation’s details</p>
   </div>
   {% else %}
   {% if declaration_status == 'complete' and counts.complete %}
@@ -53,96 +47,105 @@
 </li>
 
 <li class="browse-list-item">
-  {% if declaration_status == 'unstarted' %}
-  <a class="browse-list-item-link" href="{{ url_for('.framework_start_supplier_declaration', framework_slug=framework.slug) }}">
-    <span>Make supplier declaration</span>
-  </a>
+  {% if not application_company_details_confirmed %}
+    <h2>2. Make supplier declaration</h2>
+    <p class="instruction-list-item-box inactive">Can't start yet</p>
   {% else %}
-  <a class="browse-list-item-link" href="{{ url_for('.framework_supplier_declaration_overview', framework_slug=framework.slug) }}">
-    <span>Edit supplier declaration</span>
-  </a>
-  {% endif %}
-  <p class="browse-list-item-body">
-    Confirm eligibility, agree to the application terms and provide supplier&nbsp;information.
-  </p>
-  {% if declaration_status == 'unstarted' and not counts.complete %}
-  <div class="browse-list-item-status-quiet">
-    <p class="browse-list-item-status-title">You need to make the supplier declaration</p>
-  </div>
-  {% elif declaration_status == 'started' and not counts.complete %}
-  <div class="browse-list-item-status-quiet">
-    <p class="browse-list-item-status-title">You need to finish making the supplier declaration</p>
-  </div>
-  {% elif declaration_status == 'unstarted' and counts.complete %}
-  <div class="browse-list-item-status-angry">
-    <p class="browse-list-item-status-title">
-      <strong>No services will be submitted because you haven’t made the supplier declaration</strong>
+    {% if declaration_status == 'unstarted' %}
+    <a class="browse-list-item-link" href="{{ url_for('.framework_start_supplier_declaration', framework_slug=framework.slug) }}">
+      <h2>2. Make supplier declaration</h2>
+    </a>
+    {% else %}
+    <a class="browse-list-item-link" href="{{ url_for('.framework_supplier_declaration_overview', framework_slug=framework.slug) }}">
+      <h2>2. Edit supplier declaration</h2>
+    </a>
+    {% endif %}
+    <p class="browse-list-item-body">
+      Confirm eligibility, agree to the application terms and provide supplier&nbsp;information.
     </p>
-  </div>
-  {% elif declaration_status == 'started' and counts.complete %}
-  <div class="browse-list-item-status-angry">
-    <p class="browse-list-item-status-title">
-      <strong>No services will be submitted because you haven’t finished making the supplier declaration</strong>
-    </p>
-  </div>
-  {% elif declaration_status == 'complete' %}
-  {% if counts.complete and company_details_complete %}
-  <div class="browse-list-item-status-happy">
-  {% else %}
-    <div class="browse-list-item-status-default">
-  {% endif %}
-    <p class="browse-list-item-status-title">
-      <strong>You’ve made the supplier declaration</strong>
-    </p>
-  </div>
+    {% if declaration_status == 'unstarted' and not counts.complete %}
+      <div class="browse-list-item-status-quiet">
+        <p class="browse-list-item-status-title">You need to make the supplier declaration</p>
+      </div>
+    {% elif declaration_status == 'started' and not counts.complete %}
+      <div class="browse-list-item-status-quiet">
+        <p class="browse-list-item-status-title">You need to finish making the supplier declaration</p>
+      </div>
+    {% elif declaration_status == 'unstarted' and counts.complete %}
+      <div class="browse-list-item-status-angry">
+        <p class="browse-list-item-status-title">
+          <strong>No services will be submitted because you haven’t made the supplier declaration</strong>
+        </p>
+      </div>
+    {% elif declaration_status == 'started' and counts.complete %}
+      <div class="browse-list-item-status-angry">
+        <p class="browse-list-item-status-title">
+          <strong>No services will be submitted because you haven’t finished making the supplier declaration</strong>
+        </p>
+      </div>
+    {% elif declaration_status == 'complete' %}
+      {% if counts.complete and application_company_details_confirmed %}
+        <div class="browse-list-item-status-happy">
+      {% else %}
+        <div class="browse-list-item-status-default">
+      {% endif %}
+        <p class="browse-list-item-status-title">
+          <strong>You’ve made the supplier declaration</strong>
+        </p>
+      </div>
+    {% endif %}
   {% endif %}
 </li>
 
 <li class="browse-list-item">
-  <a class="browse-list-item-link" href="{{ url_for('.framework_submission_lots', framework_slug=framework.slug) }}">
-    <span>Add, edit and complete services</span>
-  </a>
-  {% if framework_advice.use_of_service_data %}
-    <div class="browse-list-item-body">
+  {% if not application_company_details_confirmed %}
+    <h2>3. Add, edit and complete services</h2>
+    <p class="instruction-list-item-box inactive">Can't start yet</p>
+  {% else %}
+    <a class="browse-list-item-link" href="{{ url_for('.framework_submission_lots', framework_slug=framework.slug) }}">
+      <h2>3. Add, edit and complete services</h2>
+    </a>
+    {% if framework_advice.use_of_service_data %}
+    <div class="browse-list-item-body use-of-service-data">
       {{ framework_advice.use_of_service_data }}
     </div>
-  {% endif %}
-  {% if not counts.complete and not counts.draft %}
-  <div class="browse-list-item-status-quiet">
-    <p class="browse-list-item-status-title">You need to add and complete services</p>
-  </div>
-  {% endif %}
-
-  {% if counts.draft and not counts.complete %}
-  <div class="browse-list-item-status-quiet">
-    <p class="browse-list-item-status-title">No services marked as complete</p>
-  </div>
-  {% endif %}
-
-  {% if counts.complete %}
-    {% if declaration_status == 'complete' and company_details_complete %}
-      <div class="browse-list-item-status-happy">
-        <p class="browse-list-item-status-title">You’re submitting</p>
+    {% endif %}
+  
+    {% if not counts.complete %}
+      {% if not counts.draft %}
+    <div class="browse-list-item-status-quiet">
+      <p class="browse-list-item-status-title">You need to add and complete services</p>
+    </div>
+      {% else %}
+    <div class="browse-list-item-status-quiet">
+      <p class="browse-list-item-status-title">No services marked as complete</p>
+    </div>
+      {% endif %}
     {% else %}
-      <div class="browse-list-item-status-default">
-        <p class="browse-list-item-status-title">You’ve completed:</p>
+      {% if declaration_status == 'complete' %}
+    <div class="browse-list-item-status-happy">
+      <p class="browse-list-item-status-title">You’re submitting</p>
+      {% else %}
+    <div class="browse-list-item-status-default">
+      <p class="browse-list-item-status-title">You’ve completed:</p>
+      {% endif %}
+      <ul class="browse-list-item-status-list">
+        {% for lot in completed_lots %}
+          {% if lot.one_service_limit %}
+        <li>
+            {{lot.name|lower}}
+        </li>
+          {% else %}
+        <li>
+          {{ lot.complete_count }}
+          {{ lot.unitSingular if (1 == lot.complete_count) else lot.unitPlural }} in
+          {{ lot.name|lower }}
+        </li>
+          {% endif %}
+        {% endfor %}
+      </ul>
+    </div>
     {% endif %}
-        <ul class="browse-list-item-status-list">
-          {% for lot in completed_lots %}
-            {% if lot.one_service_limit %}
-            <li>
-              {{lot.name|lower}}
-            </li>
-            {% else %}
-            <li>
-              {{ lot.complete_count }}
-              {{ lot.unitSingular if (1 == lot.complete_count) else lot.unitPlural }} in
-              {{ lot.name|lower }}
-            </li>
-            {% endif %}
-          {% endfor %}
-        </ul>
-      </div>
-    {% endif %}
+  {% endif %}
 </li>
 {% endif %}

--- a/app/templates/frameworks/dashboard.html
+++ b/app/templates/frameworks/dashboard.html
@@ -31,7 +31,7 @@
 
 {% block main_content %}
   {# Confidence Banner #}
-  {% if application_made and company_details_complete and framework.status == 'open' %}
+  {% if application_made and framework.status == 'open' %}
     {% with 
       message = "Your application will be submitted at %s. <br> You can edit your declaration and services at any time before the deadline."|safe % (framework.applicationsCloseAt | nbsp),
       type="success"

--- a/app/templates/partials/service_warning.html
+++ b/app/templates/partials/service_warning.html
@@ -1,14 +1,6 @@
-{% if declaration_status != 'complete' or not company_details_complete %}
+{% if declaration_status != 'complete' %}
   {% set banner_content %}
-  You still need to:
-  <ul>
-    {% if not company_details_complete %}
-    <li><a href="{{ url_for('.supplier_details') }}">complete your company details</a></li>
-    {% endif %}
-    {% if declaration_status != 'complete' %}
-    <li><a href="{% if declaration_status == 'unstarted' %}{{ url_for('.framework_start_supplier_declaration', framework_slug=framework.slug) }}{% else %}{{ url_for('.framework_supplier_declaration_overview', framework_slug=framework.slug) }}{% endif %}">make your supplier declaration</a></li>
-    {% endif %}
-  </ul>
+  You still need to <a href="{% if declaration_status == 'unstarted' %}{{ url_for('.framework_start_supplier_declaration', framework_slug=framework.slug) }}{% else %}{{ url_for('.framework_supplier_declaration_overview', framework_slug=framework.slug) }}{% endif %}">make your supplier declaration</a>.
   {% endset %}
 
   {% with declaration_url = url_for('.framework_start_supplier_declaration' if declaration_status == 'unstarted' else '.framework_supplier_declaration_overview', framework_slug=framework.slug) %}

--- a/app/templates/suppliers/already_completed.html
+++ b/app/templates/suppliers/already_completed.html
@@ -40,7 +40,7 @@
         <li>VAT number</li>
         <li>DUNS number</li>
       </ul>
-      <p>If you want to change your {{ completed_data_description }}, you must <a href="{{ url_for('.create_new_supplier') }}">create a new supplier account</a>.</p>
+      <p>If you want to change your {{ completed_data_description }}, you must <a href="{{ url_for('.create_new_supplier') }}">create a new supplier account</a> using a different login email address.</p>
       </div>
 
       {%

--- a/app/templates/suppliers/details.html
+++ b/app/templates/suppliers/details.html
@@ -22,11 +22,7 @@
 
 {% block main_content %}
   <div class='grid-row'>
-  {% if currently_applying_to or (company_details_complete and not supplier.companyDetailsConfirmed) %}
-    <div class='column-one-whole padding-bottom-small'>
-  {% else %}
-    <div class='column-one-whole'>
-  {% endif %}
+    <div class='column-one-whole{% if currently_applying_to or (company_details_complete and not supplier_company_details_confirmed) %} padding-bottom-small{% endif %}'>
 {%
   with
     heading = "Company details",
@@ -86,7 +82,7 @@
   {{ summary.field_name('Registered company name') }}
   {% if supplier.registeredName %}
     {{ summary.text(supplier.registeredName) }}
-    {{ summary.edit_link(label="Correct a mistake", link=url_for(".edit_supplier_registered_name"), hidden_text="Registered company name") }}
+    {{ summary.edit_link(label="Correct a mistake" if supplier_company_details_confirmed else "Change", link=url_for(".edit_supplier_registered_name"), hidden_text="Registered company name") }}
   {% else %}
     {{ summary.link(link_title="Answer required", link=url_for(".edit_supplier_registered_name"), hidden_text="for registered company name") }}
     {{ summary.text("") }}
@@ -112,7 +108,7 @@
         {% include "toolkit/contact-details.html" %}
       {% endwith %}
     {% endcall %}
-    {{ summary.edit_link(label="Correct a mistake", link=url_for(".edit_registered_address"), hidden_text="Registered company address") }}
+    {{ summary.edit_link(label="Change", link=url_for(".edit_registered_address"), hidden_text="Registered company address") }}
   {% else %}
     {{ summary.link(link_title="Answer required", link=url_for(".edit_registered_address"), hidden_text=" for registered company address") }}
     {{ summary.text("") }}
@@ -123,10 +119,10 @@
   {{ summary.field_name('Registration number') }}
   {% if supplier.companiesHouseNumber %}
     {{ summary.text(supplier.companiesHouseNumber) }}
-    {{ summary.edit_link(label="Correct a mistake", link=url_for(".edit_supplier_registration_number"), hidden_text="Registration number") }}
+    {{ summary.edit_link(label="Correct a mistake" if supplier_company_details_confirmed else "Change", link=url_for(".edit_supplier_registration_number"), hidden_text="Registration number") }}
   {% elif supplier.otherCompanyRegistrationNumber %}
     {{ summary.text(supplier.otherCompanyRegistrationNumber) }}
-    {{ summary.edit_link(label="Correct a mistake", link=url_for(".edit_supplier_registration_number"), hidden_text="Registration number") }}
+    {{ summary.edit_link(label="Correct a mistake" if supplier_company_details_confirmed else "Change", link=url_for(".edit_supplier_registration_number"), hidden_text="Registration number") }}
   {% else %}
     {{ summary.link(link_title="Answer required", link=url_for(".edit_supplier_registration_number"), hidden_text="for registration number") }}
     {{ summary.text("") }}
@@ -137,7 +133,7 @@
   {{ summary.field_name('Trading status') }}
   {% if supplier.tradingStatus %}
     {{ summary.text(supplier.tradingStatus|capitalize_first) }}
-    {{ summary.edit_link(label="Correct a mistake", link=url_for(".edit_supplier_trading_status"), hidden_text="Trading status") }}
+    {{ summary.edit_link(label="Change", link=url_for(".edit_supplier_trading_status"), hidden_text="Trading status") }}
   {% else %}
     {{ summary.link(link_title="Answer required", link=url_for(".edit_supplier_trading_status"), hidden_text="for trading status") }}
     {{ summary.text("") }}
@@ -148,7 +144,7 @@
   {{ summary.field_name('Company size') }}
   {% if supplier.organisationSize %}
     {{ summary.text(supplier.organisationSize|capitalize_first) }}
-    {{ summary.edit_link(label="Correct a mistake", link=url_for(".edit_supplier_organisation_size"), hidden_text="Company size") }}
+    {{ summary.edit_link(label="Change", link=url_for(".edit_supplier_organisation_size"), hidden_text="Company size") }}
   {% else %}
     {{ summary.link(link_title="Answer required", link=url_for(".edit_supplier_organisation_size"), hidden_text="for company size") }}
     {{ summary.text("") }}
@@ -159,7 +155,7 @@
   {{ summary.field_name('VAT number') }}
   {% if supplier.vatNumber %}
     {{ summary.text(supplier.vatNumber) }}
-    {{ summary.edit_link(label="Correct a mistake", link=url_for(".edit_supplier_vat_number"), hidden_text="VAT number") }}
+    {{ summary.edit_link(label="Correct a mistake" if supplier_company_details_confirmed else "Change", link=url_for(".edit_supplier_vat_number"), hidden_text="VAT number") }}
   {% else %}
     {{ summary.link(link_title="Answer required", link=url_for(".edit_supplier_vat_number"), hidden_text="for VAT number") }}
     {{ summary.text("") }}
@@ -182,12 +178,13 @@
     </div>
   </div>
 
-  {% if not supplier.companyDetailsConfirmed %}
+  {% if supplier_company_details_confirmed == False %}
     {% if company_details_complete  %}
     <div class='grid-row'>
       <div class='column-two-thirds'>
         <form method="POST" action="{{ url_for('.confirm_supplier_details') }}">
           <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+          {% if supplier_company_details_confirmed == False %}
           <p>Once you confirm your information you'll need to contact support to correct a mistake in your:</p>
           <ul class="list-bullet">
             <li>registered company name</li>
@@ -195,6 +192,7 @@
             <li>VAT number</li>
             <li>DUNS number</li>
           </ul>
+          {% endif %}
 
           {% with type = "save", label = "Save and confirm" %}
             {% include "toolkit/button.html" %}

--- a/app/templates/suppliers/details.html
+++ b/app/templates/suppliers/details.html
@@ -178,7 +178,7 @@
     </div>
   </div>
 
-  {% if supplier_company_details_confirmed == False %}
+  {% if supplier_company_details_confirmed == False or unconfirmed_open_supplier_framework_names|length > 0 %}
     {% if supplier_company_details_complete %}
     <br>
     <div class='grid-row'>
@@ -193,6 +193,9 @@
             <li>VAT number</li>
             <li>DUNS number</li>
           </ul>
+          {% else %}
+          <p>You must confirm that your company details are correct for your {{ pluralize(unconfirmed_open_supplier_framework_names|length, 'application', 'applications') }} to {{
+            unconfirmed_open_supplier_framework_names|smartjoin }}.</p>
           {% endif %}
 
           {% with type = "save", label = "Save and confirm" %}

--- a/app/templates/suppliers/details.html
+++ b/app/templates/suppliers/details.html
@@ -22,7 +22,7 @@
 
 {% block main_content %}
   <div class='grid-row'>
-    <div class='column-one-whole{% if currently_applying_to or (company_details_complete and not supplier_company_details_confirmed) %} padding-bottom-small{% endif %}'>
+    <div class='column-one-whole{% if currently_applying_to or (supplier_company_details_complete and not supplier_company_details_confirmed) %} padding-bottom-small{% endif %}'>
 {%
   with
     heading = "Company details",
@@ -179,7 +179,8 @@
   </div>
 
   {% if supplier_company_details_confirmed == False %}
-    {% if company_details_complete  %}
+    {% if supplier_company_details_complete %}
+    <br>
     <div class='grid-row'>
       <div class='column-two-thirds'>
         <form method="POST" action="{{ url_for('.confirm_supplier_details') }}">

--- a/application.py
+++ b/application.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python
 
 import os
+
+# import jinja2
+
 from app import create_app
 from dmutils import init_manager
 
@@ -12,6 +15,9 @@ application.jinja_options = {
         'jinja2.ext.with_'
     ]
 }
+
+# Sadly can't enable this yet, but we should work towards it...
+# application.jinja_env.undefined = jinja2.StrictUndefined
 
 manager = init_manager(application, 5003, ['./app/content/frameworks'])
 

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -5,6 +5,6 @@ Flask==0.10.1
 Flask-Login==0.2.11
 Flask-WTF==0.14.2
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@39.3.0#egg=digitalmarketplace-utils==39.3.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@39.4.1#egg=digitalmarketplace-utils==39.4.1
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.10.1#egg=digitalmarketplace-content-loader==4.10.1
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@17.1.0#egg=digitalmarketplace-apiclient==17.1.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@17.2.0#egg=digitalmarketplace-apiclient==17.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,9 +6,9 @@ Flask==0.10.1
 Flask-Login==0.2.11
 Flask-WTF==0.14.2
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@39.3.0#egg=digitalmarketplace-utils==39.3.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@39.4.1#egg=digitalmarketplace-utils==39.4.1
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.10.1#egg=digitalmarketplace-content-loader==4.10.1
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@17.1.0#egg=digitalmarketplace-apiclient==17.1.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@17.2.0#egg=digitalmarketplace-apiclient==17.2.0
 
 ## The following requirements were added by pip freeze:
 asn1crypto==0.24.0

--- a/tests/app/main/helpers/test_frameworks.py
+++ b/tests/app/main/helpers/test_frameworks.py
@@ -649,8 +649,6 @@ class TestEnsureApplicationCompanyDetailsHaveBeenConfirmed(BaseApplicationTest):
 
         from app import data_api_client
         self.data_api_client_mock = mock.Mock(spec_set=data_api_client)
-        self.decorator = EnsureApplicationCompanyDetailsHaveBeenConfirmed(self.data_api_client_mock)
-        # self.login()
 
     def test_validator_raises_500_if_framework_slug_missing(self):
         @EnsureApplicationCompanyDetailsHaveBeenConfirmed(self.data_api_client_mock)
@@ -698,15 +696,6 @@ class TestEnsureApplicationCompanyDetailsHaveBeenConfirmed(BaseApplicationTest):
             current_user_patch.supplier_id.return_value = 1
 
             assert decorator.validator(framework_slug='g-cloud-10') is True
-
-    def test_validator_can_be_reassigned(self):
-        def raise_successful_override():
-            return 'overriden'
-
-        decorator = EnsureApplicationCompanyDetailsHaveBeenConfirmed(self.data_api_client_mock)
-
-        with mock.patch.object(decorator, 'validator', raise_successful_override):
-            assert decorator.validator() == 'overriden'
 
     def test_only_known_decorated_views_are_protected(self):
         """This checks _all_ registered routes and asserts that the views listed in `decorated_views`, below, are all

--- a/tests/app/main/test_suppliers.py
+++ b/tests/app/main/test_suppliers.py
@@ -715,31 +715,73 @@ class TestSupplierDetails(BaseApplicationTest):
         assert answer_required_link[0].values()[0] == link_address
 
     @pytest.mark.parametrize(
-        "question,filled_in_attribute,link_address",
+        "question,filled_in_attribute,link_address,expected_link_text",
         [
             (
-                "Registered company name",
-                {"registeredName": "Digital Ponies"},
-                "/suppliers/registered-company-name/edit"
-            ),
-            ("Registered company address", {"registrationCountry": "country:GB"}, "/suppliers/registered-address/edit"),
-            (
-                "Registration number",
-                {"companiesHouseNumber": "CH123456", "otherCompanyRegistrationNumber": None},
-                "/suppliers/registration-number/edit"
+                "Registered company name", {"companyDetailsConfirmed": True, "registeredName": "Digital Ponies"},
+                "/suppliers/registered-company-name/edit", 'Correct a mistake',
             ),
             (
-                "Registration number",
-                {"companiesHouseNumber": None, "otherCompanyRegistrationNumber": "EQ789"},
-                "/suppliers/registration-number/edit"
+                "Registered company name", {"companyDetailsConfirmed": False, "registeredName": "Digital Ponies"},
+                "/suppliers/registered-company-name/edit", 'Change',
             ),
-            ("Trading status", {"tradingStatus": "limited company (LTD)"}, "/suppliers/trading-status/edit"),
-            ("Company size", {"organisationSize": "small"}, "/suppliers/organisation-size/edit"),
-            ("VAT number", {"vatNumber": "VAT654321"}, "/suppliers/vat-number/edit"),
-            ("DUNS number", {"dunsNumber": "123456789"}, "/suppliers/duns-number/edit"),
+            ("Registered company address", {"companyDetailsConfirmed": True, "registrationCountry": "country:GB"},
+             "/suppliers/registered-address/edit", 'Change',),
+            ("Registered company address", {"companyDetailsConfirmed": False, "registrationCountry": "country:GB"},
+             "/suppliers/registered-address/edit", 'Change',),
+            (
+                "Registration number",
+                {
+                    "companyDetailsConfirmed": True, "companiesHouseNumber": "CH123456",
+                    "otherCompanyRegistrationNumber": None
+                },
+                "/suppliers/registration-number/edit",
+                'Correct a mistake',
+            ),
+            (
+                "Registration number",
+                {
+                    "companyDetailsConfirmed": False, "companiesHouseNumber": "CH123456",
+                    "otherCompanyRegistrationNumber": None
+                },
+                "/suppliers/registration-number/edit",
+                'Change',
+            ),
+            (
+                "Registration number",
+                {
+                    "companyDetailsConfirmed": True, "companiesHouseNumber": None,
+                    "otherCompanyRegistrationNumber": "EQ789"
+                },
+                "/suppliers/registration-number/edit",
+                'Correct a mistake',
+            ),
+            (
+                "Registration number",
+                {
+                    "companyDetailsConfirmed": False, "companiesHouseNumber": None,
+                    "otherCompanyRegistrationNumber": "EQ789"
+                },
+                "/suppliers/registration-number/edit",
+                'Change',
+            ),
+            ("Trading status", {"companyDetailsConfirmed": False, "tradingStatus": "limited company (LTD)"},
+             "/suppliers/trading-status/edit", "Change"),
+            ("Company size", {"companyDetailsConfirmed": False, "organisationSize": "small"},
+             "/suppliers/organisation-size/edit", "Change"),
+            ("VAT number", {"companyDetailsConfirmed": True, "vatNumber": "VAT654321"},
+             "/suppliers/vat-number/edit", 'Correct a mistake',),
+            ("VAT number", {"companyDetailsConfirmed": False, "vatNumber": "VAT654321"},
+             "/suppliers/vat-number/edit", 'Change',),
+            ("DUNS number", {"companyDetailsConfirmed": True, "dunsNumber": "123456789"},
+             "/suppliers/duns-number/edit", 'Correct a mistake',),
+            ("DUNS number", {"companyDetailsConfirmed": False, "dunsNumber": "123456789"},
+             "/suppliers/duns-number/edit", 'Correct a mistake',),
         ]
     )
-    def test_filled_in_question_field_has_a_correct_a_mistake_link(self, question, filled_in_attribute, link_address):
+    def test_filled_in_question_field_has_a_change_or_correct_a_mistake_link(
+        self, question, filled_in_attribute, link_address, expected_link_text
+    ):
         self.data_api_client.get_supplier.return_value = get_supplier(**filled_in_attribute)
 
         self.login()
@@ -749,7 +791,7 @@ class TestSupplierDetails(BaseApplicationTest):
         page_html = response.get_data(as_text=True)
         document = html.fromstring(page_html)
         answer_required_link = document.xpath(
-            "//span[text()='{}']/following::td[2]/span/a[text()='Correct a mistake']".format(question)
+            "//span[text()='{}']/following::td[2]/span/a[text()='{}']".format(question, expected_link_text)
         )
 
         assert answer_required_link

--- a/tests/app/main/test_suppliers.py
+++ b/tests/app/main/test_suppliers.py
@@ -861,6 +861,23 @@ class TestSupplierDetails(BaseApplicationTest):
         document = html.fromstring(page_html)
         assert "Return to your" not in document.text_content()
 
+    def test_currently_applying_to_removed_from_session_after_account_dashboard_visit(self):
+        self.data_api_client.get_supplier.return_value = get_supplier()
+
+        self.login()
+
+        with self.client.session_transaction() as session:
+            session["currently_applying_to"] = 'g-bork-2'
+
+        with self.client.session_transaction() as session:
+            assert "currently_applying_to" in session
+
+        response = self.client.get("/suppliers")
+        assert response.status_code == 200
+
+        with self.client.session_transaction() as session:
+            assert "currently_applying_to" not in session
+
     @pytest.mark.parametrize(
         "supplier_details,button_should_be_shown",
         [


### PR DESCRIPTION
 ## Summary
Suppliers need to confirm that the company details they've declared in
their account remain accurate over time as they apply to new iterations
of frameworks on the Digital Marketplace.

When suppliers first set up their account, they confirm that some
immutable attributes are correct: registered name, company registration
number, VAT number and DUNS number. Once these have been confirmed as
correct, they are locked down in the account and cannot be edited
without talking to support. Generally, these will only be updated by
support if there has been a mistake in entering the details. If the
details have legitimately changed, the supplier will need to create a
new supplier account on the Marketplace to complete their application.

After confirming their details are correct at the account level, they
must also confirm the details are correct at the framework application
level. Until they do this, they cannot progress their application
(complete the declaration or add services). This is to prevent the
supplier from putting time into these labour-intensive tasks before
realising that their supplier account no longer accurately represents
their company.

 ## Notes
It might be easiest to review this on a per-commit basis, as some of them are refactoring/small tweaks which dilute the intention of the ticket.

 ## Ticket
https://trello.com/c/V0FSdOCJ/188