### PR TITLE
apiclient dependency: bump to v17.1.0

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -7,4 +7,4 @@ Flask-WTF==0.14.2
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@39.3.0#egg=digitalmarketplace-utils==39.3.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.10.1#egg=digitalmarketplace-content-loader==4.10.1
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@16.0.0#egg=digitalmarketplace-apiclient==16.0.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@17.1.0#egg=digitalmarketplace-apiclient==17.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ Flask-WTF==0.14.2
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@39.3.0#egg=digitalmarketplace-utils==39.3.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.10.1#egg=digitalmarketplace-content-loader==4.10.1
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@16.0.0#egg=digitalmarketplace-apiclient==16.0.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@17.1.0#egg=digitalmarketplace-apiclient==17.1.0
 
 ## The following requirements were added by pip freeze:
 asn1crypto==0.24.0


### PR DESCRIPTION
This brings in `childSpanId` logging.