### PR TITLE
Increase allowed postcode length to 15 characters

### DIFF
--- a/app/main/forms/suppliers.py
+++ b/app/main/forms/suppliers.py
@@ -53,7 +53,7 @@ class EditRegisteredAddressForm(FlaskForm):
     ])
     postcode = StripWhitespaceStringField('Postcode', validators=[
         InputRequired(message="You need to enter the postcode."),
-        Length(max=10, message="You must provide a valid postcode under 10 characters."),
+        Length(max=15, message="You must provide a valid postcode under 15 characters."),
     ])
 
 

--- a/tests/app/main/test_suppliers.py
+++ b/tests/app/main/test_suppliers.py
@@ -1415,7 +1415,7 @@ class TestEditSupplierRegisteredAddress(BaseApplicationTest):
         status, response = self.post_supplier_address_edit({
             "address1": "A" * length,
             "city": "C" * length,
-            "postcode": "P" * (length - 245),
+            "postcode": "P" * (length - 240),
             "registrationCountry": "country:GB",
         })
 
@@ -1424,7 +1424,7 @@ class TestEditSupplierRegisteredAddress(BaseApplicationTest):
         validation_messages = [
             "You must provide a building and street name under 256 characters.",
             "You must provide a town or city name under 256 characters.",
-            "You must provide a valid postcode under 10 characters.",
+            "You must provide a valid postcode under 15 characters.",
         ]
         for message in validation_messages:
             assert (message in response) == validation_error_returned
@@ -1435,7 +1435,7 @@ class TestEditSupplierRegisteredAddress(BaseApplicationTest):
         data_values = [
             f"value=\"{'A' * length}\"",
             f"value=\"{'C' * length}\"",
-            f"value=\"{'P' * (length - 245)}\"",
+            f"value=\"{'P' * (length - 240)}\"",
         ]
         for value in data_values:
             assert (value in response) == validation_error_returned


### PR DESCRIPTION
This is because we found out that some US postcodes have as much
as 13 characters

Trello ticket: https://trello.com/c/kOGpfxcw/475-supplier-fe-postcode-field-validation-is-more-lax-than-api-and-varies-between-two-forms

API pull request: https://github.com/alphagov/digitalmarketplace-api/pull/812