### PR TITLE
'Change' company details

### DIFF
--- a/app/templates/suppliers/already_completed.html
+++ b/app/templates/suppliers/already_completed.html
@@ -40,7 +40,9 @@
         <li>VAT number</li>
         <li>DUNS number</li>
       </ul>
-      <p>If you want to change your {{ completed_data_description }}, you must <a href="{{ url_for('.create_new_supplier') }}">create a new supplier account</a> using a different login email address.</p>
+      <h2 class="heading-xmedium">If you have a new {{ completed_data_description }}</h2>
+      <p>You must <a href="{{ url_for('.create_new_supplier') }}">create a new supplier account</a> using a different login email address
+        if you want to change your {{ completed_data_description }}.</p>
       </div>
 
       {%

--- a/app/templates/suppliers/details.html
+++ b/app/templates/suppliers/details.html
@@ -82,7 +82,7 @@
   {{ summary.field_name('Registered company name') }}
   {% if supplier.registeredName %}
     {{ summary.text(supplier.registeredName) }}
-    {{ summary.edit_link(label="Correct a mistake" if supplier_company_details_confirmed else "Change", link=url_for(".edit_supplier_registered_name"), hidden_text="Registered company name") }}
+    {{ summary.edit_link(label="Change", link=url_for(".edit_supplier_registered_name"), hidden_text="Registered company name") }}
   {% else %}
     {{ summary.link(link_title="Answer required", link=url_for(".edit_supplier_registered_name"), hidden_text="for registered company name") }}
     {{ summary.text("") }}
@@ -119,10 +119,10 @@
   {{ summary.field_name('Registration number') }}
   {% if supplier.companiesHouseNumber %}
     {{ summary.text(supplier.companiesHouseNumber) }}
-    {{ summary.edit_link(label="Correct a mistake" if supplier_company_details_confirmed else "Change", link=url_for(".edit_supplier_registration_number"), hidden_text="Registration number") }}
+    {{ summary.edit_link(label="Change", link=url_for(".edit_supplier_registration_number"), hidden_text="Registration number") }}
   {% elif supplier.otherCompanyRegistrationNumber %}
     {{ summary.text(supplier.otherCompanyRegistrationNumber) }}
-    {{ summary.edit_link(label="Correct a mistake" if supplier_company_details_confirmed else "Change", link=url_for(".edit_supplier_registration_number"), hidden_text="Registration number") }}
+    {{ summary.edit_link(label="Change", link=url_for(".edit_supplier_registration_number"), hidden_text="Registration number") }}
   {% else %}
     {{ summary.link(link_title="Answer required", link=url_for(".edit_supplier_registration_number"), hidden_text="for registration number") }}
     {{ summary.text("") }}
@@ -155,7 +155,7 @@
   {{ summary.field_name('VAT number') }}
   {% if supplier.vatNumber %}
     {{ summary.text(supplier.vatNumber) }}
-    {{ summary.edit_link(label="Correct a mistake" if supplier_company_details_confirmed else "Change", link=url_for(".edit_supplier_vat_number"), hidden_text="VAT number") }}
+    {{ summary.edit_link(label="Change", link=url_for(".edit_supplier_vat_number"), hidden_text="VAT number") }}
   {% else %}
     {{ summary.link(link_title="Answer required", link=url_for(".edit_supplier_vat_number"), hidden_text="for VAT number") }}
     {{ summary.text("") }}
@@ -166,7 +166,7 @@
   {{ summary.field_name('DUNS number') }}
    {% if supplier.dunsNumber %}
     {{ summary.text(supplier.dunsNumber) }}
-    {{ summary.edit_link(label="Correct a mistake", link=url_for(".edit_supplier_duns_number"), hidden_text="DUNS number") }}
+    {{ summary.edit_link(label="Change", link=url_for(".edit_supplier_duns_number"), hidden_text="DUNS number") }}
   {% else %}
     {{ summary.link(link_title="Answer required", link=url_for(".edit_supplier_duns_number"), hidden_text="for DUNS number") }}
     {{ summary.text("") }}

--- a/tests/app/main/test_suppliers.py
+++ b/tests/app/main/test_suppliers.py
@@ -716,20 +716,20 @@ class TestSupplierDetails(BaseApplicationTest):
         assert answer_required_link[0].values()[0] == link_address
 
     @pytest.mark.parametrize(
-        "question,filled_in_attribute,link_address,expected_link_text",
+        "question,filled_in_attribute,link_address",
         [
             (
                 "Registered company name", {"companyDetailsConfirmed": True, "registeredName": "Digital Ponies"},
-                "/suppliers/registered-company-name/edit", 'Correct a mistake',
+                "/suppliers/registered-company-name/edit",
             ),
             (
                 "Registered company name", {"companyDetailsConfirmed": False, "registeredName": "Digital Ponies"},
-                "/suppliers/registered-company-name/edit", 'Change',
+                "/suppliers/registered-company-name/edit",
             ),
             ("Registered company address", {"companyDetailsConfirmed": True, "registrationCountry": "country:GB"},
-             "/suppliers/registered-address/edit", 'Change',),
+             "/suppliers/registered-address/edit",),
             ("Registered company address", {"companyDetailsConfirmed": False, "registrationCountry": "country:GB"},
-             "/suppliers/registered-address/edit", 'Change',),
+             "/suppliers/registered-address/edit",),
             (
                 "Registration number",
                 {
@@ -737,7 +737,6 @@ class TestSupplierDetails(BaseApplicationTest):
                     "otherCompanyRegistrationNumber": None
                 },
                 "/suppliers/registration-number/edit",
-                'Correct a mistake',
             ),
             (
                 "Registration number",
@@ -746,7 +745,6 @@ class TestSupplierDetails(BaseApplicationTest):
                     "otherCompanyRegistrationNumber": None
                 },
                 "/suppliers/registration-number/edit",
-                'Change',
             ),
             (
                 "Registration number",
@@ -755,7 +753,6 @@ class TestSupplierDetails(BaseApplicationTest):
                     "otherCompanyRegistrationNumber": "EQ789"
                 },
                 "/suppliers/registration-number/edit",
-                'Correct a mistake',
             ),
             (
                 "Registration number",
@@ -764,24 +761,23 @@ class TestSupplierDetails(BaseApplicationTest):
                     "otherCompanyRegistrationNumber": "EQ789"
                 },
                 "/suppliers/registration-number/edit",
-                'Change',
             ),
             ("Trading status", {"companyDetailsConfirmed": False, "tradingStatus": "limited company (LTD)"},
-             "/suppliers/trading-status/edit", "Change"),
+             "/suppliers/trading-status/edit",),
             ("Company size", {"companyDetailsConfirmed": False, "organisationSize": "small"},
-             "/suppliers/organisation-size/edit", "Change"),
+             "/suppliers/organisation-size/edit",),
             ("VAT number", {"companyDetailsConfirmed": True, "vatNumber": "VAT654321"},
-             "/suppliers/vat-number/edit", 'Correct a mistake',),
+             "/suppliers/vat-number/edit",),
             ("VAT number", {"companyDetailsConfirmed": False, "vatNumber": "VAT654321"},
-             "/suppliers/vat-number/edit", 'Change',),
+             "/suppliers/vat-number/edit",),
             ("DUNS number", {"companyDetailsConfirmed": True, "dunsNumber": "123456789"},
-             "/suppliers/duns-number/edit", 'Correct a mistake',),
+             "/suppliers/duns-number/edit",),
             ("DUNS number", {"companyDetailsConfirmed": False, "dunsNumber": "123456789"},
-             "/suppliers/duns-number/edit", 'Correct a mistake',),
+             "/suppliers/duns-number/edit",),
         ]
     )
     def test_filled_in_question_field_has_a_change_or_correct_a_mistake_link(
-        self, question, filled_in_attribute, link_address, expected_link_text
+        self, question, filled_in_attribute, link_address
     ):
         self.data_api_client.get_supplier.return_value = get_supplier(**filled_in_attribute)
 
@@ -792,7 +788,7 @@ class TestSupplierDetails(BaseApplicationTest):
         page_html = response.get_data(as_text=True)
         document = html.fromstring(page_html)
         answer_required_link = document.xpath(
-            "//span[text()='{}']/following::td[2]/span/a[text()='{}']".format(question, expected_link_text)
+            "//span[text()='{}']/following::td[2]/span/a[text()='Change']".format(question)
         )
 
         assert answer_required_link


### PR DESCRIPTION
 ## Summary
After speaking with content again, we've decided that `Change` should be
the definitive link text and we'll add a short heading+sentence at the
bottom of the linked-to page which indicates what to do if their change
is not just about correcting a mistake.

 ## Examples
![screen shot 2018-07-04 at 10 55 59](https://user-images.githubusercontent.com/2920760/42270482-e27ef38c-7f78-11e8-9b20-ac9c91299b66.png)
![screen shot 2018-07-04 at 10 56 05](https://user-images.githubusercontent.com/2920760/42270483-e2aa8b50-7f78-11e8-8c30-c1bb2a4e404b.png)


 ## Ticket
https://trello.com/c/N5xfhxyh/191