### PR TITLE
Update DM_COMPANY_DETAILS_CHANGE_EMAIL

### DIFF
--- a/config.py
+++ b/config.py
@@ -27,7 +27,7 @@ class Config(object):
     DM_NOTIFY_API_KEY = None
     DM_CLARIFICATION_QUESTION_EMAIL = 'digitalmarketplace@mailinator.com'
     DM_FRAMEWORK_AGREEMENTS_EMAIL = 'enquiries@example.com'
-    DM_COMPANY_DETAILS_CHANGE_EMAIL = 'enquiries@digitalmarketplace.service.gov.uk'
+    DM_COMPANY_DETAILS_CHANGE_EMAIL = 'cloud_digital@crowncommercial.gov.uk'
 
     NOTIFY_TEMPLATES = {
         'create_user_account': '1d1e38a6-744a-4d5a-84af-aefccde70a6c',


### PR DESCRIPTION
For [this trello card](https://trello.com/c/4q3t3udK).

Updates the support email address for supplier detail enquiries to cloud_digital@crowncommercial.gov.uk.

### Screenshot

<img width="1440" alt="screen shot 2018-07-09 at 10 58 26" src="https://user-images.githubusercontent.com/13836290/42444774-d198fa74-8368-11e8-9319-54fcf1422fdb.png">
