### PR TITLE
Replace frameworkFramework with frameworkFamily

### DIFF
--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -117,7 +117,7 @@ def remove_service(framework_slug, service_id):
         abort(404)
 
     # dos services should not be removable
-    if service["frameworkFramework"] == 'digital-outcomes-and-specialists':
+    if service["frameworkFamily"] == 'digital-outcomes-and-specialists':
         abort(404)
 
     # we don't actually need the framework here; using this to 404 if framework for the service is not live

--- a/app/templates/services/service.html
+++ b/app/templates/services/service.html
@@ -35,7 +35,7 @@
       %}
         {% include "toolkit/notification-banner.html" %}
       {% endwith %}
-    {% elif remove_requested and service_data.frameworkFramework != "digital-outcomes-and-specialists" %}
+    {% elif remove_requested and service_data.frameworkFamily != "digital-outcomes-and-specialists" %}
       <div class="banner-destructive-with-action">
         <p class="banner-message">
           Are you sure you want to remove your service?
@@ -60,7 +60,7 @@
 {% endblock %}
 
 {% block before_sections %}
-  {% if service_data.frameworkFramework != "digital-outcomes-and-specialists" %}
+  {% if service_data.frameworkFamily != "digital-outcomes-and-specialists" %}
     <div class="column-two-thirds">
       <div class="view-service-link">
         {%
@@ -108,7 +108,7 @@
 {% endblock %}
 
 {% block after_sections %}
-  {% if service_data.status == 'published' and not remove_requested and service_data.frameworkFramework != "digital-outcomes-and-specialists" %}
+  {% if service_data.status == 'published' and not remove_requested and service_data.frameworkFamily != "digital-outcomes-and-specialists" %}
     <div class="column-two-thirds">
       <div class="edit-service-status-panel">
         <h2>Remove this service</h2>

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -334,6 +334,7 @@ class _BaseTestSupplierEditRemoveService(BaseApplicationTest):
             'frameworkName': framework_name,
             'frameworkSlug': framework_slug,
             'frameworkFramework': framework_family,
+            'frameworkFamily': framework_family,
             'supplierId': 1234 if service_belongs_to_user else 1235,
         }
         service_data.update(kwargs)


### PR DESCRIPTION
Trello: https://trello.com/c/R3DsCXFa/22-use-frameworkfamily-frameworkfamily-in-apps-apiclient-rather-than-frameworkframework-frameworkframework

Part of the ongoing work to deprecate `frameworkFramework` in favour of `frameworkFamily`.