### PR TITLE
Pull in v19.0.0 if apiclient

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -7,5 +7,5 @@ Flask-WTF==0.14.2
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@40.8.0#egg=digitalmarketplace-utils==40.8.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.10.1#egg=digitalmarketplace-content-loader==4.10.1
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@17.2.0#egg=digitalmarketplace-apiclient==17.2.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@19.0.0#egg=digitalmarketplace-apiclient==19.0.0
 git+https://github.com/alphagov/Flask-FeatureFlags.git@1.0#egg=Flask-FeatureFlags==1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,12 +8,11 @@ Flask-WTF==0.14.2
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@40.8.0#egg=digitalmarketplace-utils==40.8.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.10.1#egg=digitalmarketplace-content-loader==4.10.1
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@17.2.0#egg=digitalmarketplace-apiclient==17.2.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@19.0.0#egg=digitalmarketplace-apiclient==19.0.0
 git+https://github.com/alphagov/Flask-FeatureFlags.git@1.0#egg=Flask-FeatureFlags==1.0
 
 ## The following requirements were added by pip freeze:
 asn1crypto==0.24.0
-backoff==1.0.7
 boto3==1.4.8
 botocore==1.8.50
 certifi==2018.4.16


### PR DESCRIPTION
See [this PR on the apiclient for more details on what this brings in.](https://github.com/alphagov/digitalmarketplace-apiclient/pull/152)

It adds retries to the base apiclient. Hopefully to catch those pesky 503s.