### PR TITLE
digitalmarketplace-utils dependency: bump to 41.0.0

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -5,7 +5,7 @@ Flask==0.10.1
 Flask-Login==0.2.11
 Flask-WTF==0.14.2
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@40.8.0#egg=digitalmarketplace-utils==40.8.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@41.0.0#egg=digitalmarketplace-utils==41.0.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.10.1#egg=digitalmarketplace-content-loader==4.10.1
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@19.0.0#egg=digitalmarketplace-apiclient==19.0.0
 git+https://github.com/alphagov/Flask-FeatureFlags.git@1.0#egg=Flask-FeatureFlags==1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ Flask==0.10.1
 Flask-Login==0.2.11
 Flask-WTF==0.14.2
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@40.8.0#egg=digitalmarketplace-utils==40.8.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@41.0.0#egg=digitalmarketplace-utils==41.0.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.10.1#egg=digitalmarketplace-content-loader==4.10.1
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@19.0.0#egg=digitalmarketplace-apiclient==19.0.0
 git+https://github.com/alphagov/Flask-FeatureFlags.git@1.0#egg=Flask-FeatureFlags==1.0
@@ -47,6 +47,7 @@ s3transfer==0.1.13
 six==1.11.0
 unicodecsv==0.14.1
 urllib3==1.22
+virtualenv==15.1.0
 Werkzeug==0.14.1
 workdays==1.4
 WTForms==2.2.1


### PR DESCRIPTION
https://trello.com/c/LD2eVPTY/368-supplier-user-can-be-created-but-no-email-sent
https://trello.com/c/7m7tPP83/379-email-validation-should-we-use-notifys

This should make our email validation more strict for supplier signup.