### PR TITLE
Include user email in follow up question email

### DIFF
--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -746,6 +746,7 @@ def framework_updates_email_clarification_question(framework_slug):
             "emails/follow_up_question.html",
             supplier_name=current_user.supplier_name,
             user_name=current_user.name,
+            user_email=current_user.email_address,
             framework_name=framework['name'],
             message=clarification_question
         )

--- a/app/templates/emails/follow_up_question.html
+++ b/app/templates/emails/follow_up_question.html
@@ -7,6 +7,8 @@
 Supplier name: {{ supplier_name }}
 <br />
 User name: {{ user_name }}
+<br />
+User email: {{ user_email }}
 <br /><br />
 {{ framework_name }} question asked:
 <br />

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -3718,7 +3718,7 @@ class TestSendClarificationQuestionEmail(BaseApplicationTest):
                 reference=mock.ANY,
             )
 
-    def _assert_application_email(self, mandrill_send_email, succeeds=True):
+    def _assert_application_email(self, mandrill_send_email, *email_body_content, succeeds=True):
 
         if succeeds:
             assert mandrill_send_email.call_count == 1
@@ -3728,7 +3728,7 @@ class TestSendClarificationQuestionEmail(BaseApplicationTest):
         if succeeds:
             mandrill_send_email.assert_called_with(
                 "digitalmarketplace@mailinator.com",
-                FakeMail('Test Framework question asked'),
+                FakeMail(*email_body_content),
                 "MANDRILL",
                 "Test Framework application question",
                 "enquiries@digitalmarketplace.service.gov.uk",
@@ -3759,7 +3759,14 @@ class TestSendClarificationQuestionEmail(BaseApplicationTest):
         clarification_question = 'This is a G7 question.'
         response = self._send_email(clarification_question)
 
-        self._assert_application_email(mandrill_send_email)
+        self._assert_application_email(
+            mandrill_send_email,
+            'Supplier name: Supplier NĀme',
+            'User name: Năme',
+            'User email: email@email.com',
+            'Test Framework question asked:',
+            'This is a G7 question',
+        )
 
         assert response.status_code == 200
 
@@ -3828,7 +3835,14 @@ class TestSendClarificationQuestionEmail(BaseApplicationTest):
         clarification_question = 'This is a G7 question'
         response = self._send_email(clarification_question)
 
-        self._assert_application_email(mandrill_send_email)
+        self._assert_application_email(
+            mandrill_send_email,
+            'Supplier name: Supplier NĀme',
+            'User name: Năme',
+            'User email: email@email.com',
+            'Test Framework question asked:',
+            'This is a G7 question',
+        )
 
         assert response.status_code == 200
         self.data_api_client.create_audit_event.assert_called_with(


### PR DESCRIPTION
For [this trello card.](https://trello.com/c/7lr17Qxo)

CCS's software strips the 'from' email address from follow up questions.
They need to be able to reply to them. We can include the users email
address in the body of the template to make sure they have it.

Rendered template before:
<img width="1440" alt="screen shot 2018-08-07 at 12 10 46" src="https://user-images.githubusercontent.com/13836290/43772741-04408a1c-9a3b-11e8-82a3-12a565940ab3.png">

Rendered template after:
<img width="1440" alt="screen shot 2018-08-07 at 12 10 35" src="https://user-images.githubusercontent.com/13836290/43772732-ffba13f0-9a3a-11e8-9d2a-8a67216a5293.png">


