### PR TITLE
Protect application editing routes with decorator

### DIFF
--- a/app/main/__init__.py
+++ b/app/main/__init__.py
@@ -45,7 +45,7 @@ content_loader.load_manifest('digital-outcomes-and-specialists-3', 'services', '
 content_loader.load_manifest('digital-outcomes-and-specialists-3', 'services', 'edit_service')
 content_loader.load_manifest('digital-outcomes-and-specialists-3', 'briefs', 'edit_brief')
 content_loader.load_messages('digital-outcomes-and-specialists-3', ['urls'])
-content_loader.load_metadata('digital-outcomes-and-specialists-3', ['copy_services'])
+content_loader.load_metadata('digital-outcomes-and-specialists-3', ['copy_services', 'following_framework'])
 
 
 @main.after_request

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -48,6 +48,7 @@ from ..helpers.frameworks import (
     register_interest_in_framework,
     return_supplier_framework_info_if_on_framework_or_abort,
     returned_agreement_email_recipients,
+    return_404_if_applications_closed
 )
 from ..helpers.services import (
     count_unanswered_questions,
@@ -347,6 +348,7 @@ def framework_submission_services(framework_slug, lot_slug):
 @main.route('/frameworks/<framework_slug>/declaration/start', methods=['GET'])
 @login_required
 @EnsureApplicationCompanyDetailsHaveBeenConfirmed(data_api_client)
+@return_404_if_applications_closed(lambda: data_api_client)
 def framework_start_supplier_declaration(framework_slug):
     framework = get_framework_or_404(data_api_client, framework_slug, allowed_statuses=['open'])
     update_framework_with_formatted_dates(framework)
@@ -358,6 +360,7 @@ def framework_start_supplier_declaration(framework_slug):
 @main.route('/frameworks/<framework_slug>/declaration/reuse', methods=['GET'])
 @login_required
 @EnsureApplicationCompanyDetailsHaveBeenConfirmed(data_api_client)
+@return_404_if_applications_closed(lambda: data_api_client)
 def reuse_framework_supplier_declaration(framework_slug):
     """Attempt to find a supplier framework declaration that we can reuse.
 
@@ -405,6 +408,7 @@ def reuse_framework_supplier_declaration(framework_slug):
 @main.route('/frameworks/<framework_slug>/declaration/reuse', methods=['POST'])
 @login_required
 @EnsureApplicationCompanyDetailsHaveBeenConfirmed(data_api_client)
+@return_404_if_applications_closed(lambda: data_api_client)
 def reuse_framework_supplier_declaration_post(framework_slug):
     """Set the prefill preference if a reusable framework slug is provided and redirect to declaration."""
 
@@ -519,6 +523,7 @@ def framework_supplier_declaration_overview(framework_slug):
 @main.route('/frameworks/<framework_slug>/declaration', methods=['POST'])
 @login_required
 @EnsureApplicationCompanyDetailsHaveBeenConfirmed(data_api_client)
+@return_404_if_applications_closed(lambda: data_api_client)
 def framework_supplier_declaration_submit(framework_slug):
     framework = get_framework_or_404(data_api_client, framework_slug, allowed_statuses=['open'])
 
@@ -553,6 +558,7 @@ def framework_supplier_declaration_submit(framework_slug):
 @main.route('/frameworks/<framework_slug>/declaration/edit/<string:section_id>', methods=['GET', 'POST'])
 @login_required
 @EnsureApplicationCompanyDetailsHaveBeenConfirmed(data_api_client)
+@return_404_if_applications_closed(lambda: data_api_client)
 def framework_supplier_declaration_edit(framework_slug, section_id):
     framework = get_framework_or_404(data_api_client, framework_slug, allowed_statuses=['open'])
 

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -27,6 +27,7 @@ from ..helpers.frameworks import (
     get_framework_or_404,
     get_framework_or_500,
     EnsureApplicationCompanyDetailsHaveBeenConfirmed,
+    return_404_if_applications_closed,
 )
 from ..forms.frameworks import OneServiceLimitCopyServiceForm
 
@@ -293,6 +294,7 @@ def redirect_direct_service_urls(service_id, trailing_path):
 @main.route('/frameworks/<framework_slug>/submissions/<lot_slug>/create', methods=['GET', 'POST'])
 @login_required
 @EnsureApplicationCompanyDetailsHaveBeenConfirmed(data_api_client)
+@return_404_if_applications_closed(lambda: data_api_client)
 def start_new_draft_service(framework_slug, lot_slug):
     """Page to kick off creation of a new service."""
 
@@ -356,6 +358,7 @@ def start_new_draft_service(framework_slug, lot_slug):
 @main.route('/frameworks/<framework_slug>/submissions/<lot_slug>/<service_id>/copy', methods=['POST'])
 @login_required
 @EnsureApplicationCompanyDetailsHaveBeenConfirmed(data_api_client)
+@return_404_if_applications_closed(lambda: data_api_client)
 def copy_draft_service(framework_slug, lot_slug, service_id):
     framework, lot = get_framework_and_lot_or_404(data_api_client, framework_slug, lot_slug, allowed_statuses=['open'])
 
@@ -403,6 +406,7 @@ def copy_draft_service(framework_slug, lot_slug, service_id):
 @main.route('/frameworks/<framework_slug>/submissions/<lot_slug>/<service_id>/complete', methods=['POST'])
 @login_required
 @EnsureApplicationCompanyDetailsHaveBeenConfirmed(data_api_client)
+@return_404_if_applications_closed(lambda: data_api_client)
 def complete_draft_service(framework_slug, lot_slug, service_id):
     framework, lot = get_framework_and_lot_or_404(data_api_client, framework_slug, lot_slug, allowed_statuses=['open'])
 
@@ -442,6 +446,7 @@ def complete_draft_service(framework_slug, lot_slug, service_id):
 @main.route('/frameworks/<framework_slug>/submissions/<lot_slug>/<service_id>/delete', methods=['POST'])
 @login_required
 @EnsureApplicationCompanyDetailsHaveBeenConfirmed(data_api_client)
+@return_404_if_applications_closed(lambda: data_api_client)
 def delete_draft_service(framework_slug, lot_slug, service_id):
     framework, lot = get_framework_and_lot_or_404(data_api_client, framework_slug, lot_slug, allowed_statuses=['open'])
 
@@ -543,6 +548,7 @@ def view_service_submission(framework_slug, lot_slug, service_id):
             methods=('GET', 'POST',))
 @login_required
 @EnsureApplicationCompanyDetailsHaveBeenConfirmed(data_api_client)
+@return_404_if_applications_closed(lambda: data_api_client)
 def edit_service_submission(framework_slug, lot_slug, service_id, section_id, question_slug=None):
     """
         Also accepts URL parameter `force_continue_button` which will allow rendering of a 'Save and continue' button,
@@ -648,6 +654,7 @@ def edit_service_submission(framework_slug, lot_slug, service_id, section_id, qu
             methods=['GET', 'POST'])
 @login_required
 @EnsureApplicationCompanyDetailsHaveBeenConfirmed(data_api_client)
+@return_404_if_applications_closed(lambda: data_api_client)
 def remove_subsection(framework_slug, lot_slug, service_id, section_id, question_slug):
     # Suppliers must have registered interest in a framework before they can edit draft services
     if not get_supplier_framework_info(data_api_client, framework_slug):
@@ -739,10 +746,9 @@ def remove_subsection(framework_slug, lot_slug, service_id, section_id, question
 @main.route('/frameworks/<framework_slug>/submissions/<lot_slug>/previous-services', methods=['GET', 'POST'])
 @login_required
 @EnsureApplicationCompanyDetailsHaveBeenConfirmed(data_api_client)
+@return_404_if_applications_closed(lambda: data_api_client)
 def previous_services(framework_slug, lot_slug):
-    framework, lot = get_framework_and_lot_or_404(data_api_client, framework_slug, lot_slug)
-    if framework['status'] != 'open':
-        abort(404)
+    framework, lot = get_framework_and_lot_or_404(data_api_client, framework_slug, lot_slug, allowed_statuses=['open'])
 
     form = OneServiceLimitCopyServiceForm(lot['name'].lower()) if lot.get('oneServiceLimit') else None
     source_framework_slug = content_loader.get_metadata(framework['slug'], 'copy_services', 'source_framework')
@@ -816,6 +822,7 @@ def previous_services(framework_slug, lot_slug):
             methods=['POST'])
 @login_required
 @EnsureApplicationCompanyDetailsHaveBeenConfirmed(data_api_client)
+@return_404_if_applications_closed(lambda: data_api_client)
 def copy_previous_service(framework_slug, lot_slug, service_id):
     framework, lot = get_framework_and_lot_or_404(
         data_api_client, framework_slug, lot_slug, allowed_statuses=['open']
@@ -830,6 +837,7 @@ def copy_previous_service(framework_slug, lot_slug, service_id):
             methods=['POST'])
 @login_required
 @EnsureApplicationCompanyDetailsHaveBeenConfirmed(data_api_client)
+@return_404_if_applications_closed(lambda: data_api_client)
 def copy_all_previous_services(framework_slug, lot_slug):
         framework, lot = get_framework_and_lot_or_404(
             data_api_client, framework_slug, lot_slug, allowed_statuses=['open']

--- a/app/templates/errors/applications_closed.html
+++ b/app/templates/errors/applications_closed.html
@@ -1,0 +1,29 @@
+{% extends "toolkit/layouts/_base_page.html" %}
+
+{% block page_title %}Applications closed - Digital Marketplace{% endblock %}
+
+{% block main_content %}
+
+<div class="error-page">
+  <header class="page-heading-smaller">
+    <h1>You can no longer apply to {{ framework['name'] }}</h1>
+  </header>
+
+  <div class="dmspeak">
+    <p>
+        The deadline for applying was {{ framework['applicationsCloseAt'] }}.
+    </p>
+    {% if following_framework_content %}
+      <p>
+          {{ following_framework_content.name }} is expected to open in {{ following_framework_content.coming }}. <a href="{{ url_for('.join_open_framework_notification_mailing_list') }}">Sign up for emails</a> about when you can apply.
+      </p>
+    {% endif %}
+  </div>
+  <div class="secondary-action-link">
+    <p>
+      <a href="{{ url_for('.dashboard') }}">Return to your account</a>.
+    </p>
+  </div>
+</div>
+
+{% endblock %}

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "hogan.js": "3.0.2",
     "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v31.7.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.19.2/jinja_govuk_template-0.19.2.tgz",
-    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#13.4.0"
+    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#13.6.0"
   },
   "scripts": {
     "frontend-build:development": "./node_modules/gulp/bin/gulp.js build:development",

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -1314,6 +1314,7 @@ class TestCopyDraft(BaseApplicationTest, MockEnsureApplicationCompanyDetailsHave
 
         self.data_api_client_patch = mock.patch('app.main.views.services.data_api_client', autospec=True)
         self.data_api_client = self.data_api_client_patch.start()
+        self.data_api_client.get_framework.return_value = self.framework(status='open')
 
     def teardown_method(self, method):
         self.data_api_client_patch.stop()
@@ -1322,7 +1323,6 @@ class TestCopyDraft(BaseApplicationTest, MockEnsureApplicationCompanyDetailsHave
     def test_copy_draft_with_editable_sections(self):
         # G7 drafts use editable=True, edit_questions=False on every section, which should emit a URL without
         # a question-slug parameter.
-        self.data_api_client.get_framework.return_value = self.framework(status='open')
         self.data_api_client.get_draft_service.return_value = {'services': self.g7_draft}
 
         copy_of_draft = empty_g7_draft_service()
@@ -1363,7 +1363,6 @@ class TestCopyDraft(BaseApplicationTest, MockEnsureApplicationCompanyDetailsHave
         assert res.status_code == 404
 
     def test_cannot_copy_draft_if_no_supplier_framework(self):
-        self.data_api_client.get_framework.return_value = self.framework(status='open')
         self.data_api_client.get_supplier_framework_info.return_value = {'frameworkInterest': {}}
 
         res = self.client.post('/suppliers/frameworks/g-cloud-7/submissions/scs/1/copy')
@@ -1379,13 +1378,13 @@ class TestCompleteDraft(BaseApplicationTest, MockEnsureApplicationCompanyDetails
         self.draft = empty_g7_draft_service()
         self.data_api_client_patch = mock.patch('app.main.views.services.data_api_client', autospec=True)
         self.data_api_client = self.data_api_client_patch.start()
+        self.data_api_client.get_framework.return_value = self.framework(status='open')
 
     def teardown_method(self, method):
         self.data_api_client_patch.stop()
         super().teardown_method(method)
 
     def test_complete_draft(self):
-        self.data_api_client.get_framework.return_value = self.framework(status='open')
         self.data_api_client.get_draft_service.return_value = {'services': self.draft}
         res = self.client.post('/suppliers/frameworks/g-cloud-7/submissions/scs/1/complete')
         assert res.status_code == 302
@@ -1406,7 +1405,6 @@ class TestCompleteDraft(BaseApplicationTest, MockEnsureApplicationCompanyDetails
         assert res.status_code == 404
 
     def test_cannot_complete_draft_if_no_supplier_framework(self):
-        self.data_api_client.get_framework.return_value = self.framework(status='open')
         self.data_api_client.get_supplier_framework_info.return_value = {'frameworkInterest': {}}
 
         res = self.client.post('/suppliers/frameworks/g-cloud-7/submissions/scs/1/complete')
@@ -1448,13 +1446,13 @@ class TestEditDraftService(BaseApplicationTest, MockEnsureApplicationCompanyDeta
         }
         self.data_api_client_patch = mock.patch('app.main.views.services.data_api_client', autospec=True)
         self.data_api_client = self.data_api_client_patch.start()
+        self.data_api_client.get_framework.return_value = self.framework(status='open')
 
     def teardown_method(self, method):
         self.data_api_client_patch.stop()
         super().teardown_method(method)
 
     def test_questions_for_this_draft_section_can_be_changed(self, s3):
-        self.data_api_client.get_framework.return_value = self.framework(status='open')
         self.data_api_client.get_draft_service.return_value = self.empty_draft
         res = self.client.post(
             '/suppliers/frameworks/g-cloud-7/submissions/scs/1/edit/service-description',
@@ -1473,7 +1471,6 @@ class TestEditDraftService(BaseApplicationTest, MockEnsureApplicationCompanyDeta
     def test_update_without_changes_is_not_sent_to_the_api(self, s3):
         draft = self.empty_draft['services'].copy()
         draft.update({'serviceSummary': u"summary"})
-        self.data_api_client.get_framework.return_value = self.framework(status='open')
         self.data_api_client.get_draft_service.return_value = {'services': draft}
 
         res = self.client.post(
@@ -1488,7 +1485,6 @@ class TestEditDraftService(BaseApplicationTest, MockEnsureApplicationCompanyDeta
     def test_S3_should_not_be_called_if_there_are_no_files(self, s3):
         uploader = mock.Mock()
         s3.return_value = uploader
-        self.data_api_client.get_framework.return_value = self.framework(status='open')
         self.data_api_client.get_draft_service.return_value = self.empty_draft
         res = self.client.post(
             '/suppliers/frameworks/g-cloud-7/submissions/scs/1/edit/service-description',
@@ -1524,7 +1520,6 @@ class TestEditDraftService(BaseApplicationTest, MockEnsureApplicationCompanyDeta
         assert res.status_code == 404
 
     def test_draft_section_cannot_be_edited_if_no_supplier_framework(self, s3):
-        self.data_api_client.get_framework.return_value = self.framework(status='open')
         self.data_api_client.get_supplier_framework_info.return_value = {'frameworkInterest': {}}
         res = self.client.post(
             '/suppliers/frameworks/g-cloud-7/submissions/scs/1/edit/service-description',
@@ -1534,7 +1529,6 @@ class TestEditDraftService(BaseApplicationTest, MockEnsureApplicationCompanyDeta
         assert res.status_code == 404
 
     def test_only_questions_for_this_draft_section_can_be_changed(self, s3):
-        self.data_api_client.get_framework.return_value = self.framework(status='open')
         self.data_api_client.get_draft_service.return_value = self.empty_draft
         res = self.client.post(
             '/suppliers/frameworks/g-cloud-7/submissions/scs/1/edit/service-description',
@@ -1551,7 +1545,6 @@ class TestEditDraftService(BaseApplicationTest, MockEnsureApplicationCompanyDeta
     def test_display_file_upload_with_existing_file(self, s3):
         draft = copy.deepcopy(self.empty_draft)
         draft['services']['serviceDefinitionDocumentURL'] = 'http://localhost/fooo-2012-12-12-1212.pdf'
-        self.data_api_client.get_framework.return_value = self.framework(status='open')
         self.data_api_client.get_draft_service.return_value = draft
         response = self.client.get(
             '/suppliers/frameworks/g-cloud-7/submissions/scs/1/edit/service-definition'
@@ -1562,7 +1555,6 @@ class TestEditDraftService(BaseApplicationTest, MockEnsureApplicationCompanyDeta
         assert len(document.cssselect('p.file-upload-existing-value')) == 1
 
     def test_display_file_upload_with_no_existing_file(self, s3):
-        self.data_api_client.get_framework.return_value = self.framework(status='open')
         self.data_api_client.get_draft_service.return_value = self.empty_draft
         response = self.client.get(
             '/suppliers/frameworks/g-cloud-7/submissions/scs/1/edit/service-definition'
@@ -1573,7 +1565,6 @@ class TestEditDraftService(BaseApplicationTest, MockEnsureApplicationCompanyDeta
         assert len(document.cssselect('p.file-upload-existing-value')) == 0
 
     def test_file_upload(self, s3):
-        self.data_api_client.get_framework.return_value = self.framework(status='open')
         self.data_api_client.get_draft_service.return_value = self.empty_draft
         with freeze_time('2015-01-02 03:04:05'):
             res = self.client.post(
@@ -1597,7 +1588,6 @@ class TestEditDraftService(BaseApplicationTest, MockEnsureApplicationCompanyDeta
         )
 
     def test_file_upload_filters_empty_and_unknown_files(self, s3):
-        self.data_api_client.get_framework.return_value = self.framework(status='open')
         self.data_api_client.get_draft_service.return_value = self.empty_draft
         res = self.client.post(
             '/suppliers/frameworks/g-cloud-7/submissions/scs/1/edit/service-definition',
@@ -1616,7 +1606,6 @@ class TestEditDraftService(BaseApplicationTest, MockEnsureApplicationCompanyDeta
         assert s3.return_value.save.called is False
 
     def test_upload_question_not_accepted_as_form_data(self, s3):
-        self.data_api_client.get_framework.return_value = self.framework(status='open')
         self.data_api_client.get_draft_service.return_value = self.empty_draft
         res = self.client.post(
             '/suppliers/frameworks/g-cloud-7/submissions/scs/1/edit/service-definition',
@@ -1631,7 +1620,6 @@ class TestEditDraftService(BaseApplicationTest, MockEnsureApplicationCompanyDeta
         )
 
     def test_pricing_fields_are_added_correctly(self, s3):
-        self.data_api_client.get_framework.return_value = self.framework(status='open')
         self.data_api_client.get_draft_service.return_value = self.empty_draft
         res = self.client.post(
             '/suppliers/frameworks/g-cloud-7/submissions/scs/1/edit/pricing',
@@ -1668,7 +1656,6 @@ class TestEditDraftService(BaseApplicationTest, MockEnsureApplicationCompanyDeta
         assert res.status_code == 404
 
     def test_edit_draft_section_with_no_supplier_framework_404(self, s3):
-        self.data_api_client.get_framework.return_value = self.framework(status='open')
         self.data_api_client.get_draft_service.return_value = self.empty_draft
         self.data_api_client.get_supplier_framework_info.return_value = {'frameworkInterest': {}}
 
@@ -1741,7 +1728,6 @@ class TestEditDraftService(BaseApplicationTest, MockEnsureApplicationCompanyDeta
         assert len(document.xpath("//input[@type='submit'][@name='save_and_continue']")) == 0
 
     def test_update_redirects_to_edit_submission_if_no_next_editable_section(self, s3):
-        self.data_api_client.get_framework.return_value = self.framework(status='open')
         self.data_api_client.get_draft_service.return_value = self.empty_draft
         self.data_api_client.update_draft_service.return_value = None
 
@@ -1754,7 +1740,6 @@ class TestEditDraftService(BaseApplicationTest, MockEnsureApplicationCompanyDeta
             res.headers['Location']
 
     def test_update_doesnt_offer_continue_to_next_editable_section_if_no_next_editable_section(self, s3):
-        self.data_api_client.get_framework.return_value = self.framework(status='open')
         self.data_api_client.get_draft_service.return_value = self.empty_draft
 
         res = self.client.get(
@@ -1766,7 +1751,6 @@ class TestEditDraftService(BaseApplicationTest, MockEnsureApplicationCompanyDeta
         assert len(document.xpath("//input[@type='submit'][@name='save_and_continue']")) == 0
 
     def test_update_offers_continue_to_next_editable_section_if_force_continue_button(self, s3):
-        self.data_api_client.get_framework.return_value = self.framework(status='open')
         self.data_api_client.get_draft_service.return_value = self.empty_draft
 
         res = self.client.get(
@@ -1778,7 +1762,6 @@ class TestEditDraftService(BaseApplicationTest, MockEnsureApplicationCompanyDeta
         assert len(document.xpath("//input[@type='submit'][@name='save_and_continue']")) == 1
 
     def test_update_redirects_to_edit_submission_if_save_and_return_grey_button_clicked(self, s3):
-        self.data_api_client.get_framework.return_value = self.framework(status='open')
         self.data_api_client.get_draft_service.return_value = self.empty_draft
         self.data_api_client.update_draft_service.return_value = None
 
@@ -1791,7 +1774,6 @@ class TestEditDraftService(BaseApplicationTest, MockEnsureApplicationCompanyDeta
             res.headers['Location']
 
     def test_update_with_answer_required_error(self, s3):
-        self.data_api_client.get_framework.return_value = self.framework(status='open')
         self.data_api_client.get_draft_service.return_value = self.empty_draft
         self.data_api_client.update_draft_service.side_effect = HTTPError(
             mock.Mock(status_code=400),
@@ -1807,7 +1789,6 @@ class TestEditDraftService(BaseApplicationTest, MockEnsureApplicationCompanyDeta
         )[0].strip()
 
     def test_update_with_under_50_words_error(self, s3):
-        self.data_api_client.get_framework.return_value = self.framework(status='open')
         self.data_api_client.get_draft_service.return_value = self.empty_draft
         self.data_api_client.update_draft_service.side_effect = HTTPError(
             mock.Mock(status_code=400),
@@ -2151,13 +2132,13 @@ class TestDeleteDraftService(BaseApplicationTest, MockEnsureApplicationCompanyDe
         self.login()
         self.data_api_client_patch = mock.patch('app.main.views.services.data_api_client', autospec=True)
         self.data_api_client = self.data_api_client_patch.start()
+        self.data_api_client.get_framework.return_value = self.framework(status='open')
 
     def teardown_method(self, method):
         self.data_api_client_patch.stop()
         super().teardown_method(method)
 
     def test_delete_button_redirects_with_are_you_sure(self):
-        self.data_api_client.get_framework.return_value = self.framework(status='open')
         self.data_api_client.get_draft_service.return_value = self.draft_to_delete
 
         res = self.client.post(
@@ -2178,14 +2159,12 @@ class TestDeleteDraftService(BaseApplicationTest, MockEnsureApplicationCompanyDe
         assert res.status_code == 404
 
     def test_cannot_delete_draft_if_no_supplier_framework(self):
-        self.data_api_client.get_framework.return_value = self.framework(status='open')
         self.data_api_client.get_supplier_framework_info.return_value = {'frameworkInterest': {}}
 
         res = self.client.post('/suppliers/frameworks/g-cloud-7/submissions/scs/1/delete')
         assert res.status_code == 404
 
     def test_confirm_delete_button_deletes_and_redirects_to_dashboard(self):
-        self.data_api_client.get_framework.return_value = self.framework(status='open')
         self.data_api_client.get_draft_service.return_value = self.draft_to_delete
         res = self.client.post(
             '/suppliers/frameworks/g-cloud-7/submissions/scs/1/delete',
@@ -2266,6 +2245,7 @@ class TestGetListPreviousServices(BaseApplicationTest, MockEnsureApplicationComp
     def test_lists_correct_services_for_previous_framework_and_lot(self, get_metadata):
         self.data_api_client.get_framework.side_effect = [
             self.framework(slug='g-cloud-10'),
+            self.framework(slug='g-cloud-10'),
             self.framework(slug='g-cloud-9'),
         ]
         self.data_api_client.find_services.return_value = {
@@ -2317,6 +2297,7 @@ class TestGetListPreviousServices(BaseApplicationTest, MockEnsureApplicationComp
     def test_shows_boolean_question_for_single_service_lots(self, get_metadata, lot_slug, lot_name):
         self.data_api_client.get_framework.side_effect = [
             self.framework(slug='digital-outcomes-and-specialists-3'),
+            self.framework(slug='digital-outcomes-and-specialists-3'),
             self.framework(slug='digital-outcomes-and-specialists-2'),
         ]
         get_metadata.return_value = 'digital-outcomes-and-specialists-2'
@@ -2352,6 +2333,7 @@ class TestGetListPreviousServices(BaseApplicationTest, MockEnsureApplicationComp
     def test_returns_500_if_source_framework_not_found(self, get_metadata):
         self.data_api_client.get_framework.side_effect = [
             self.framework(slug='g-cloud-10'),
+            self.framework(slug='g-cloud-10'),
             HTTPError(mock.Mock(status_code=404)),
         ]
 
@@ -2372,6 +2354,7 @@ class TestGetListPreviousServices(BaseApplicationTest, MockEnsureApplicationComp
     def test_redirects_to_draft_service_page_if_no_services_to_copy(self, get_metadata, services):
         self.data_api_client.get_framework.side_effect = [
             self.framework(slug='g-cloud-10'),
+            self.framework(slug='g-cloud-10'),
             self.framework(slug='g-cloud-9'),
         ]
         self.data_api_client.find_services.return_value = {
@@ -2385,6 +2368,7 @@ class TestGetListPreviousServices(BaseApplicationTest, MockEnsureApplicationComp
 
     def test_shows_confirmation_banner_and_button_when_copying_all(self, get_metadata):
         self.data_api_client.get_framework.side_effect = [
+            self.framework(slug='g-cloud-10'),
             self.framework(slug='g-cloud-10'),
             self.framework(slug='g-cloud-9'),
         ]
@@ -2417,6 +2401,7 @@ class TestGetListPreviousServices(BaseApplicationTest, MockEnsureApplicationComp
         self, get_metadata, declaration_status, banner_present
     ):
         self.data_api_client.get_framework.side_effect = [
+            self.framework(slug='g-cloud-10'),
             self.framework(slug='g-cloud-10'),
             self.framework(slug='g-cloud-9'),
         ]

--- a/yarn.lock
+++ b/yarn.lock
@@ -542,9 +542,9 @@ detect-file@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/detect-file/-/detect-file-1.0.0.tgz#f0d66d03672a825cb1b73bdb3fe62310c8e552b7"
 
-"digitalmarketplace-frameworks@https://github.com/alphagov/digitalmarketplace-frameworks.git#13.4.0":
-  version "13.4.0"
-  resolved "https://github.com/alphagov/digitalmarketplace-frameworks.git#b67118dca8d6e299b2e1c0ee02fc59f6e292451d"
+"digitalmarketplace-frameworks@https://github.com/alphagov/digitalmarketplace-frameworks.git#13.6.0":
+  version "13.6.0"
+  resolved "https://github.com/alphagov/digitalmarketplace-frameworks.git#5a3de41042844ad95ad6cfe6e461fb40a8928f69"
 
 "digitalmarketplace-frontend-toolkit@https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v31.7.0":
   version "31.7.0"


### PR DESCRIPTION
For [this trello ticket.](https://trello.com/c/Msvn4HAz)

When applications for a framework close some views are no longer
available. This decorator is applied to those routes to provide users
with meaningful feedback and some extra logging for us.

The apiclient that's passed to the outer wrapper of the decorator is a
callable. This is because the decorator is evaluated at module import
time, which makes mocking the apiclient difficult. By providing it as a
callable it's evaluated at runtime and a mock can be patched in.

The custom error template includes content that is in the frameworks
repo. Its content that describes the expected following framework. If
that hasn't been defined, we show a reduced error message.

### Screenshot! 

![applications_closed_decorator](https://user-images.githubusercontent.com/13836290/44351705-67e85b80-a49a-11e8-868a-ff3fe5a21fd1.gif)

