### PR TITLE
Supplier FE: Update Flask Login to v0.4.1

### DIFF
--- a/app/main/helpers/frameworks.py
+++ b/app/main/helpers/frameworks.py
@@ -4,8 +4,8 @@ from functools import wraps
 from itertools import chain, islice, groupby
 import re
 
-from flask import abort, render_template, request
-from flask_login import current_user, current_app
+from flask import abort, current_app, render_template, request
+from flask_login import current_user
 
 from dmapiclient import APIError, HTTPError
 from dmutils.dates import update_framework_with_formatted_dates
@@ -418,7 +418,7 @@ class EnsureApplicationCompanyDetailsHaveBeenConfirmed:
             current_app.logger.error("Required parameter `framework_slug` is undefined for the calling view.")
             abort(500, "There was a problem accessing this page of your application. Please try again later.")
 
-        if current_user.is_authenticated() and current_user.supplier_id:
+        if current_user.is_authenticated and current_user.supplier_id:
             supplier_framework = self.data_api_client.get_supplier_framework_info(
                 current_user.supplier_id, kwargs['framework_slug']
             )['frameworkInterest']

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -1,8 +1,8 @@
 # coding=utf-8
 from itertools import chain
 
-from flask import request, redirect, url_for, abort, session, Markup, flash
-from flask_login import current_user, current_app
+from flask import current_app, request, redirect, url_for, abort, session, Markup, flash
+from flask_login import current_user
 
 from dmapiclient.audit import AuditTypes
 from dmcontent.content_loader import ContentNotFoundError

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "colors": "1.1.2",
     "jquery": "1.12.0",
     "hogan.js": "3.0.2",
-    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v31.7.0",
+    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v31.8.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.19.2/jinja_govuk_template-0.19.2.tgz",
     "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#13.6.0"
   },

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -2,7 +2,7 @@
 # with package version changes made in requirements-app.txt
 
 Flask==0.12.4
-Flask-Login==0.2.11
+Flask-Login==0.4.1
 Flask-WTF==0.14.2
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@43.0.0#egg=digitalmarketplace-utils==43.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@
 # with package version changes made in requirements-app.txt
 
 Flask==0.12.4
-Flask-Login==0.2.11
+Flask-Login==0.4.1
 Flask-WTF==0.14.2
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@43.0.0#egg=digitalmarketplace-utils==43.0.0
@@ -14,7 +14,7 @@ git+https://github.com/alphagov/digitalmarketplace-apiclient.git@19.0.0#egg=digi
 asn1crypto==0.24.0
 boto3==1.4.8
 botocore==1.8.50
-certifi==2018.8.13
+certifi==2018.8.24
 cffi==1.11.5
 chardet==3.0.4
 click==6.7

--- a/tests/app/main/helpers/test_frameworks.py
+++ b/tests/app/main/helpers/test_frameworks.py
@@ -677,7 +677,7 @@ class TestEnsureApplicationCompanyDetailsHaveBeenConfirmed(BaseApplicationTest):
         )
 
         with mock.patch('app.main.helpers.frameworks.current_user') as current_user_patch:
-            current_user_patch.is_authenticated.return_value = True
+            current_user_patch.return_value.is_authenticated = True
             current_user_patch.supplier_id.return_value = 1
 
             with pytest.raises(HTTPException) as e:
@@ -694,7 +694,7 @@ class TestEnsureApplicationCompanyDetailsHaveBeenConfirmed(BaseApplicationTest):
         )
 
         with mock.patch('app.main.helpers.frameworks.current_user') as current_user_patch:
-            current_user_patch.is_authenticated.return_value = True
+            current_user_patch.return_value.is_authenticated = True
             current_user_patch.supplier_id.return_value = 1
 
             assert decorator.validator(framework_slug='g-cloud-10') is True

--- a/yarn.lock
+++ b/yarn.lock
@@ -546,9 +546,9 @@ detect-file@^1.0.0:
   version "13.6.0"
   resolved "https://github.com/alphagov/digitalmarketplace-frameworks.git#5a3de41042844ad95ad6cfe6e461fb40a8928f69"
 
-"digitalmarketplace-frontend-toolkit@https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v31.7.0":
-  version "31.7.0"
-  resolved "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#74459b8b9a5e8da35e967509ace77ceeedfd8e4a"
+"digitalmarketplace-frontend-toolkit@https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v31.8.0":
+  version "31.8.0"
+  resolved "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#b30b2ad578d56e17889ce86a0004ee77db047751"
   dependencies:
     del "^2.2.2"
     govuk-elements-sass "3.0.3"


### PR DESCRIPTION
Trello: https://trello.com/c/euSnpBnN/65-update-flask-login

- Update the Flask Login version
- Pull in related FE toolkit changes
- Fix occurrences of `current_user.is_authenticated()` --> `current_user.is_authenticated`
- Fix imports (we should not really have been importing `current_app` from `flask_login` anyway)