### PR TITLE
Refactor supplier-frontend forms, part 1

### DIFF
--- a/app/main/forms/auth_forms.py
+++ b/app/main/forms/auth_forms.py
@@ -5,6 +5,10 @@ from dmutils.forms.fields import DMEmailField
 
 
 class EmailAddressForm(FlaskForm):
-    email_address = DMEmailField('Email address', validators=[
-        InputRequired(message="Email address must be provided")
-    ])
+    email_address = DMEmailField(
+        "Email address",
+        hint="An invite will be sent asking the recipient to register as a contributor.",
+        validators=[
+            InputRequired(message="Email address must be provided")
+        ]
+    )

--- a/app/main/forms/frameworks.py
+++ b/app/main/forms/frameworks.py
@@ -38,11 +38,8 @@ class ContractReviewForm(FlaskForm):
 
 
 class AcceptAgreementVariationForm(FlaskForm):
-    accept_changes = BooleanField(
-        'I accept these changes',
-        validators=[
-            DataRequired(message="You need to accept these changes to continue.")
-        ]
+    accept_changes = DMBooleanField(
+        "I accept these changes", validators=[DataRequired(message="You need to accept these changes to continue.")]
     )
 
 

--- a/app/main/forms/frameworks.py
+++ b/app/main/forms/frameworks.py
@@ -1,8 +1,9 @@
 from flask_wtf import FlaskForm
-from wtforms import BooleanField, HiddenField
+from wtforms import HiddenField
 from wtforms.validators import DataRequired, InputRequired, Length
 
 from dmutils.forms.fields import DMBooleanField, DMStripWhitespaceStringField
+from dmutils.forms.widgets import DMSelectionButtonBase
 
 
 class SignerDetailsForm(FlaskForm):
@@ -61,12 +62,14 @@ class ReuseDeclarationForm(FlaskForm):
 
 class OneServiceLimitCopyServiceForm(FlaskForm):
 
+    copy_service = DMBooleanField(
+        "Do you want to reuse your previous {lot_name} service?",
+        question_advice="You still have to review your service and answer any new questions.",
+        false_values=("False", "false", ""),
+        validators=[InputRequired(message="You must answer this question.")],
+        widget=DMSelectionButtonBase(type="boolean"),
+    )
+
     def __init__(self, lot_name, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.copy_service.label.text = f"Do you want to reuse your previous {lot_name} service?"
-
-    copy_service = BooleanField(
-        'Do you want to reuse your previous service?',
-        false_values={'False', 'false', ''},
-        validators=[InputRequired(message='You must answer this question.')]
-    )
+        self.copy_service.question = self.copy_service.question.format(lot_name=lot_name)

--- a/app/main/forms/frameworks.py
+++ b/app/main/forms/frameworks.py
@@ -6,18 +6,21 @@ from dmutils.forms.fields import DMStripWhitespaceStringField
 
 
 class SignerDetailsForm(FlaskForm):
-    signerName = DMStripWhitespaceStringField('Full name', validators=[
-        DataRequired(message="You must provide the full name of the person signing on behalf of the company."),
-        Length(max=255, message="You must provide a name under 256 characters.")
-    ])
+    signerName = DMStripWhitespaceStringField(
+        "Full name",
+        validators=[
+            DataRequired(message="You must provide the full name of the person signing on behalf of the company."),
+            Length(max=255, message="You must provide a name under 256 characters."),
+        ],
+    )
     signerRole = DMStripWhitespaceStringField(
-        'Role at the company',
+        "Role at the company",
+        hint="The person signing must have the authority to agree to the framework terms,"
+             " eg director or company secretary.",
         validators=[
             DataRequired(message="You must provide the role of the person signing on behalf of the company."),
-            Length(max=255, message="You must provide a role under 256 characters.")
+            Length(max=255, message="You must provide a role under 256 characters."),
         ],
-        description='The person signing must have the authority to agree to the framework terms, '
-                    'eg director or company secretary.'
     )
 
 

--- a/app/main/forms/frameworks.py
+++ b/app/main/forms/frameworks.py
@@ -50,10 +50,11 @@ class ReuseDeclarationForm(FlaskForm):
     `old_framework` is a hidden field allowing us to pass back the framework slug of the framework they are choosing to
     reuse.
     """
-    reuse = BooleanField(
-        'Do you want to reuse the answers from your earlier declaration?',
-        false_values={'False', 'false', ''},
-        validators=[InputRequired(message='You must answer this question.')]
+
+    reuse = DMBooleanField(
+        "Do you want to reuse the answers from your earlier declaration?",
+        false_values=("False", "false", ""),
+        validators=[InputRequired(message="You must answer this question.")],
     )
     old_framework_slug = HiddenField()
 

--- a/app/main/forms/frameworks.py
+++ b/app/main/forms/frameworks.py
@@ -2,7 +2,7 @@ from flask_wtf import FlaskForm
 from wtforms import BooleanField, HiddenField
 from wtforms.validators import DataRequired, InputRequired, Length
 
-from dmutils.forms.fields import DMStripWhitespaceStringField
+from dmutils.forms.fields import DMBooleanField, DMStripWhitespaceStringField
 
 
 class SignerDetailsForm(FlaskForm):
@@ -25,10 +25,16 @@ class SignerDetailsForm(FlaskForm):
 
 
 class ContractReviewForm(FlaskForm):
-    authorisation = BooleanField(
-        'Authorisation',
-        validators=[DataRequired(message="You must confirm you have the authority to return the agreement.")]
+    authorisation = DMBooleanField(
+        "I have the authority to return this agreement on behalf of {supplier_registered_name}",
+        validators=[DataRequired(message="You must confirm you have the authority to return the agreement.")],
     )
+
+    def __init__(self, supplier_registered_name, **kwargs):
+        super().__init__(**kwargs)
+        self.authorisation.question = self.authorisation.question.format(
+            supplier_registered_name=supplier_registered_name
+        )
 
 
 class AcceptAgreementVariationForm(FlaskForm):

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -357,6 +357,7 @@ def framework_start_supplier_declaration(framework_slug):
                            framework=framework), 200
 
 
+# TODO: refactor this view to combine with reuse_framework_supplier_declaration_post
 @main.route('/frameworks/<framework_slug>/declaration/reuse', methods=['GET'])
 @login_required
 @EnsureApplicationCompanyDetailsHaveBeenConfirmed(data_api_client)

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -1114,7 +1114,9 @@ def contract_review(framework_slug, agreement_id):
     agreements_bucket = s3.S3(current_app.config['DM_AGREEMENTS_BUCKET'])
     signature_page = agreements_bucket.get_key(agreement['signedAgreementPath'])
 
-    form = ContractReviewForm()
+    supplier_registered_name = get_supplier_registered_name_from_declaration(supplier_framework['declaration'])
+
+    form = ContractReviewForm(supplier_registered_name=supplier_registered_name)
 
     if form.validate_on_submit():
         data_api_client.sign_framework_agreement(
@@ -1160,10 +1162,6 @@ def contract_review(framework_slug, agreement_id):
 
         return redirect(url_for(".framework_dashboard", framework_slug=framework_slug))
 
-    form.authorisation.description = u"I have the authority to return this agreement on behalf of {}.".format(
-        get_supplier_registered_name_from_declaration(supplier_framework['declaration'])
-    )
-
     errors = get_errors_from_wtform(form)
 
     return render_template(
@@ -1174,7 +1172,7 @@ def contract_review(framework_slug, agreement_id):
         framework=framework,
         signature_page=signature_page,
         supplier_framework=supplier_framework,
-        supplier_registered_name=get_supplier_registered_name_from_declaration(supplier_framework['declaration']),
+        supplier_registered_name=supplier_registered_name,
     ), 400 if errors else 200
 
 

--- a/app/templates/auth/submit_email_address.html
+++ b/app/templates/auth/submit_email_address.html
@@ -41,16 +41,7 @@
         <div class="column-two-thirds">
             {{ form.hidden_tag() }}
 
-            {%
-              with
-                question = "Email address",
-                name = "email_address",
-                hint = "An invite will be sent asking the recipient to register as a contributor.",
-                value = form.email_address.data,
-                error = errors.get("email_address", {}).get("message", None)
-            %}
-            {% include "toolkit/forms/textbox.html" %}
-            {% endwith %}
+            {{ form.email_address }}
 
             {%
               with

--- a/app/templates/frameworks/contract_review.html
+++ b/app/templates/frameworks/contract_review.html
@@ -80,18 +80,8 @@
 
     <form method="POST" action="{{ url_for('.contract_review', framework_slug=framework.slug, agreement_id=agreement.id) }}">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
-        {%
-          with
-          type = "checkbox",
-          name = "authorisation",
-          question = form.authorisation.label,
-          options = [{
-              "label": form.authorisation.description,
-          }],
-          error=errors.get("authorisation", {}).get("message", None)
-        %}
-          {% include "toolkit/forms/selection-buttons.html" %}
-        {% endwith %}
+
+        {{ form.authorisation }}
 
         {%
           with

--- a/app/templates/frameworks/contract_variation.html
+++ b/app/templates/frameworks/contract_variation.html
@@ -28,16 +28,16 @@
     <div class="grid-row">
       <div class="column-one-whole">
         {% if errors %}
-         {% with 
+         {% with
             message = "You must <a href=\"#{}\">accept the changes</a> to continue.".format(errors.accept_changes.input_name)|safe, type = "destructive" %}
-            {% include "toolkit/notification-banner.html" %} 
+            {% include "toolkit/notification-banner.html" %}
           {% endwith %}
         {% endif %}
       </div>
     </div>
     <div class="grid-row">
         <div class="column-two-thirds">
-          
+
           {% with
             heading = "{} contract variation for {}".format(
                "The" if variation_details.get('countersignedAt') or agreed_details
@@ -71,10 +71,10 @@
             {% call(item) summary.list_table(
               [
                 {"key": "Agreed by", "value": ("%s<br />%s<br />%s" % (agreed_details.agreedUserName, agreed_details.agreedUserEmail, agreed_details.agreedAt|datetimeformat))|safe},
-                {"key": "Countersigned by", "value": ("%s<br />%s<br />%s" % 
+                {"key": "Countersigned by", "value": ("%s<br />%s<br />%s" %
                   (
-                    variation_details.countersignerName, 
-                    variation_details.countersignerRole, 
+                    variation_details.countersignerName,
+                    variation_details.countersignerRole,
                     variation_details.countersignedAt|dateformat
                   )
                 )|safe if variation_details.get('countersignedAt') else "Waiting for CCS to countersign"}
@@ -132,24 +132,13 @@
 
             <form method="post" class="supplier-declaration">
               <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
-              {%
-                with
-                type = "checkbox",
-                name = "accept_changes",
-                options = [
-                { "label": variation.variation_agreement_label or form.accept_changes.label.text,
-                  "value": "Yes, I accept the changes"
-                }
-                ],
-                error=errors.get("accept_changes", {}).get("message", None)
-              %}
-              {% include "toolkit/forms/selection-buttons.html" %}
-              {% endwith %}
+
+              {{ form.accept_changes }}
 
               <p>
-                {% if variation.variation_comes_in_effect_description %} 
-                  {{ variation.variation_comes_in_effect_description }} 
-                {% else%} 
+                {% if variation.variation_comes_in_effect_description %}
+                  {{ variation.variation_comes_in_effect_description }}
+                {% else%}
                   We’ll tell you when CCS has countersigned the changes and they come into effect.
                 {% endif %}
               </p>

--- a/app/templates/frameworks/reuse_declaration.html
+++ b/app/templates/frameworks/reuse_declaration.html
@@ -53,16 +53,9 @@
       <form method="POST" action="{{ url_for(".reuse_framework_supplier_declaration_post", framework_slug=current_framework.slug) }}">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
         <input type="hidden" name="old_framework_slug" value="{{ old_framework.slug }}"/>
-        {%
-          with
-          name = "reuse",
-          question = "Do you want to reuse the answers from your earlier declaration?",
-          inline = true,
-          type = "boolean",
-          error = errors.get('reuse', {}).get('message', None)
-        %}
-          {% include "toolkit/forms/selection-buttons.html" %}
-        {% endwith %}
+
+        {{ form.reuse }}
+
         {% with type = "save", label = "Save and continue" %}
           {% include "toolkit/button.html" %}
         {% endwith %}

--- a/app/templates/frameworks/signer_details.html
+++ b/app/templates/frameworks/signer_details.html
@@ -38,20 +38,9 @@
 
     <form method="POST" action="{{ url_for('.signer_details', framework_slug=framework.slug, agreement_id=agreement['id']) }}">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
-        {% for question_key in question_keys %}
-          {%
-            with
-              question = form[question_key].label,
-              name = question_key,
-              value = form[question_key].data,
-              hint = form[question_key].description,
-              error = errors.get(question_key, {}).get("message", None)
-          %}
-            {% include "toolkit/forms/textbox.html" %}
-          {% endwith %}
 
-        {% endfor %}
-
+        {{ form.signerName }}
+        {{ form.signerRole }}
 
         {%
           with

--- a/app/templates/services/previous_services.html
+++ b/app/templates/services/previous_services.html
@@ -52,15 +52,8 @@
 
           <form method="POST" action="{{ url_for('.previous_services', framework_slug=framework.slug, lot_slug=lot.slug) }}">
             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
-            {%
-              with
-              name = "copy_service",
-              type = "boolean",
-              error = errors.get("copy_service", {}).get("message", None),
-              question_advice = "You still have to review your service and answer any new questions."
-            %}
-              {% include "toolkit/forms/selection-buttons.html" %}
-            {% endwith %}
+
+            {{ form.copy_service }}
 
             {%
               with

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -5,6 +5,6 @@ Flask==1.0.2
 Flask-Login==0.4.1
 Flask-WTF==0.14.2
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@44.0.1#egg=digitalmarketplace-utils==44.0.1
+git+https://github.com/alphagov/digitalmarketplace-utils.git@44.2.1#egg=digitalmarketplace-utils==44.2.1
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@5.0.0#egg=digitalmarketplace-content-loader==5.0.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@19.4.0#egg=digitalmarketplace-apiclient==19.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ Flask==1.0.2
 Flask-Login==0.4.1
 Flask-WTF==0.14.2
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@44.0.1#egg=digitalmarketplace-utils==44.0.1
+git+https://github.com/alphagov/digitalmarketplace-utils.git@44.2.1#egg=digitalmarketplace-utils==44.2.1
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@5.0.0#egg=digitalmarketplace-content-loader==5.0.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@19.4.0#egg=digitalmarketplace-apiclient==19.4.0
 


### PR DESCRIPTION
This is part of the work for [my ticket](https://trello.com/c/AQVm3WXZ) to refactor the forms in supplier-frontend.

As this app has a very large number of forms, at @katstevens's suggestion I have split the work into two PRs part 1 and part 2 (to follow).

This PR deals with all the forms in the `app/main/forms/frameworks.py` and `app/main/forms/auth_forms.py` files. These are fairly straightforward forms which have mainly just been cleaned up using some of the new features from dmutils.

Notice I had to bring in a new version of dmutils to get some bugfixes.