### PR TITLE
Fix cookie warnings

### DIFF
--- a/config.py
+++ b/config.py
@@ -92,7 +92,6 @@ class Test(Config):
     DM_PLAIN_TEXT_LOGS = True
     DM_LOG_LEVEL = 'CRITICAL'
     WTF_CSRF_ENABLED = False
-    SERVER_NAME = 'localhost'
     DM_MANDRILL_API_KEY = 'MANDRILL'
     DM_NOTIFY_API_KEY = "not_a_real_key-00000000-fake-uuid-0000-000000000000"
 


### PR DESCRIPTION
Flask was complaining that our cookie domain was invalid, which resulted in a lot of warning messages in our pytest output.

It turns out this was because we were setting the `SERVER_NAME` config variable in the Test config, which as far as I can tell is unnecessary; none of our other apps do it, and removing the setting didn't break any tests.

This PR closes https://trello.com/c/jUtB90p3/157-supplier-frontend-pytest-emits-a-lot-of-warnings-about-cookie-domains