### PR TITLE
Show expired DOS2 on supplier dashboard

### DIFF
--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -90,6 +90,8 @@ def dashboard():
     if "currently_applying_to" in session:
         del session["currently_applying_to"]
 
+    # TODO remove the `dos2` key from the frameworks dict below. It's a temporary fix until a better designed solution
+    # can be implemented.
     return render_template(
         "suppliers/dashboard.html",
         supplier=supplier,
@@ -98,7 +100,10 @@ def dashboard():
             'open': get_frameworks_by_status(all_frameworks, 'open'),
             'pending': get_frameworks_by_status(all_frameworks, 'pending'),
             'standstill': get_frameworks_by_status(all_frameworks, 'standstill', 'made_application'),
-            'live': get_frameworks_by_status(all_frameworks, 'live', 'services_count')
+            'live': get_frameworks_by_status(all_frameworks, 'live', 'services_count'),
+            'dos2': [
+                f for f in all_frameworks if f['slug'] == 'digital-outcomes-and-specialists-2' and f.get('onFramework')
+            ],
         }
     ), 200
 

--- a/app/templates/suppliers/_frameworks_live.html
+++ b/app/templates/suppliers/_frameworks_live.html
@@ -1,4 +1,4 @@
-{% for framework in frameworks.live %}
+{% for framework in frameworks.dos2 + frameworks.live %}
 {% if framework.onFramework %}
   <h3 class="heading-xmedium">{{ framework.name }}</h2>
   <p>


### PR DESCRIPTION
Bugfix [for this trello ticket.](https://trello.com/c/7JftBnpe)

This is a temporary hot fix and will need proper design for a future proof
solution.

As DOS2 has expired it's no longer shown on the supplier dashboard. This
is a problem, as there are still active DOS2 opportunities that DOS2
suppliers can, and will for a couple of weeks, apply to.

Suppliers need to be able to access the details of the opportunities
they've applied to.

