### PR TITLE
Remove services and documents links from DOS2

### DIFF
--- a/app/templates/suppliers/_frameworks_live.html
+++ b/app/templates/suppliers/_frameworks_live.html
@@ -10,8 +10,10 @@
     {% if framework.framework == 'digital-outcomes-and-specialists' %}
       <a href="{{ url_for('external.opportunities_dashboard', framework_slug=framework.slug) }}">View your opportunities</a><br>
     {% endif %}
-    <a href="{{ url_for('.list_services', framework_slug=framework.slug) }}">View services</a><br>
-    <a href="{{ url_for('.framework_dashboard', framework_slug=framework.slug) }}">View documents and ask a question</a>
+    {% if not framework.slug == 'digital-outcomes-and-specialists-2' %}
+      <a href="{{ url_for('.list_services', framework_slug=framework.slug) }}">View services</a><br>
+      <a href="{{ url_for('.framework_dashboard', framework_slug=framework.slug) }}">View documents and ask a question</a>
+    {% endif %}
   {% endif %}
   </p>
 {% endif %}

--- a/tests/app/main/test_suppliers.py
+++ b/tests/app/main/test_suppliers.py
@@ -265,16 +265,22 @@ class TestSuppliersDashboard(BaseApplicationTest):
         if on_framework:
             assert document.xpath(
                 "//h3[normalize-space(string())=$f]"
-                "[(following::a)[1][normalize-space(string())=$t1][@href=$u1]]"
-                "[(following::a)[2][normalize-space(string())=$t2][@href=$u2]]"
-                "[(following::a)[3][normalize-space(string())=$t3][@href=$u3]]",
+                "[(following::a)[1][normalize-space(string())=$t1][@href=$u1]]",
                 f="Digital Outcomes and Specialists 2",
                 t1="View your opportunities",
                 u1="/suppliers/opportunities/frameworks/digital-outcomes-and-specialists-2",
-                t2="View services",
-                u2="/suppliers/frameworks/digital-outcomes-and-specialists-2/services",
-                t3="View documents and ask a question",
-                u3="/suppliers/frameworks/digital-outcomes-and-specialists-2",
+            )
+            assert not document.xpath(
+                "//h3[normalize-space(string())=$f]"
+                "/..//a[normalize-space(string())=$t1]",
+                f="Digital Outcomes and Specialists 2",
+                t1="View services",
+            )
+            assert not document.xpath(
+                "//h3[normalize-space(string())=$f]"
+                "/..//a[normalize-space(string())=$t1]",
+                f="Digital Outcomes and Specialists 2",
+                t1="View documents and ask a question",
             )
         else:
             assert not document.xpath("//h3[normalize-space(string())='Digital Outcomes and Specialists 2']")
@@ -1091,7 +1097,7 @@ class TestSupplierOpportunitiesDashboardLink(BaseApplicationTest):
             'agreementReturned': True,
             'complete_drafts_count': 2,
             'declaration': {'status': 'complete'},
-            'frameworkSlug': 'digital-outcomes-and-specialists-2',
+            'frameworkSlug': 'digital-outcomes-and-specialists-3',
             'onFramework': True,
             'services_count': 2,
             'supplierId': 1234
@@ -1106,7 +1112,7 @@ class TestSupplierOpportunitiesDashboardLink(BaseApplicationTest):
     def find_frameworks_stub(self):
         return {'frameworks': [
             {
-                **framework_stub(status='live', slug='digital-outcomes-and-specialists-2')['frameworks'],
+                **framework_stub(status='live', slug='digital-outcomes-and-specialists-3')['frameworks'],
                 'framework': 'digital-outcomes-and-specialists'
             }
         ]}
@@ -1127,13 +1133,13 @@ class TestSupplierOpportunitiesDashboardLink(BaseApplicationTest):
             "[(following::a)[1][normalize-space(string())=$t1][@href=$u1]]"
             "[(following::a)[2][normalize-space(string())=$t2][@href=$u2]]"
             "[(following::a)[3][normalize-space(string())=$t3][@href=$u3]]",
-            f="Digital Outcomes and Specialists 2",
+            f="Digital Outcomes and Specialists 3",
             t1="View your opportunities",
-            u1="/suppliers/opportunities/frameworks/digital-outcomes-and-specialists-2",
+            u1="/suppliers/opportunities/frameworks/digital-outcomes-and-specialists-3",
             t2="View services",
-            u2="/suppliers/frameworks/digital-outcomes-and-specialists-2/services",
+            u2="/suppliers/frameworks/digital-outcomes-and-specialists-3/services",
             t3="View documents and ask a question",
-            u3="/suppliers/frameworks/digital-outcomes-and-specialists-2",
+            u3="/suppliers/frameworks/digital-outcomes-and-specialists-3",
         )
 
     @pytest.mark.parametrize(
@@ -1156,7 +1162,7 @@ class TestSupplierOpportunitiesDashboardLink(BaseApplicationTest):
         res = self.client.get("/suppliers")
         doc = html.fromstring(res.get_data(as_text=True))
 
-        unexpected_link = "/suppliers/frameworks/digital-outcomes-and-specialists-2/opportunities"
+        unexpected_link = "/suppliers/opportunities/frameworks/digital-outcomes-and-specialists-3"
 
         assert not any(filter(lambda i: i[2] == unexpected_link, doc.iterlinks()))
 


### PR DESCRIPTION
The supplier dashboard page currently shows DOS2 even though it's
expired. This is a temporary fix. The reason it was brought back was so
suppliers could see the opportunities they'd applied to. The links for
viewing their services and viewing documents however, return 404's as
the framework is expired.

Making those links work is probably the wrong thing to do, and we've
only seen a user need for suppliers to access their opportunities. This
PR removes the broken links.

### Screenshot
<img width="1440" alt="screen shot 2018-10-03 at 17 24 14" src="https://user-images.githubusercontent.com/13836290/46424489-33222200-c731-11e8-9464-cee2c96ee924.png">
