### PR TITLE
Pin itsdangerous to version 0.24

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -4,6 +4,7 @@
 Flask==1.0.2
 Flask-Login==0.4.1
 Flask-WTF==0.14.2
+itsdangerous==0.24
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@44.2.1#egg=digitalmarketplace-utils==44.2.1
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@5.0.0#egg=digitalmarketplace-content-loader==5.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@
 Flask==1.0.2
 Flask-Login==0.4.1
 Flask-WTF==0.14.2
+itsdangerous==0.24
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@44.2.1#egg=digitalmarketplace-utils==44.2.1
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@5.0.0#egg=digitalmarketplace-content-loader==5.0.0
@@ -23,10 +24,9 @@ cryptography==2.3
 docopt==0.4.0
 docutils==0.14
 Flask-Script==2.0.6
-future==0.16.0
+future==0.17.0
 idna==2.7
 inflection==0.3.1
-ItsDangerous==1.0.0
 Jinja2==2.10
 jmespath==0.9.3
 mailchimp3==2.0.11
@@ -38,7 +38,7 @@ notifications-python-client==4.1.0
 odfpy==1.3.6
 pycparser==2.19
 PyJWT==1.6.4
-python-dateutil==2.7.3
+python-dateutil==2.7.5
 python-json-logger==0.1.4
 pytz==2015.4
 PyYAML==3.11


### PR DESCRIPTION
Pallets recently released and then pulled version 1.0.0 of the library itsdangerous, which is a requirement of Flask. See [this Trello card](https://trello.com/b/NnlGJoWD) for details.

We've decided that this time we want to wait a bit before commiting to the new version, so this commit pins this app to the old 0.24 version