### PR TITLE
Allow viewing contract variation for expired framework

### DIFF
--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -1175,7 +1175,7 @@ def contract_review(framework_slug, agreement_id):
 @main.route('/frameworks/<framework_slug>/contract-variation/<variation_slug>', methods=['GET', 'POST'])
 @login_required
 def view_contract_variation(framework_slug, variation_slug):
-    framework = get_framework_or_404(data_api_client, framework_slug, allowed_statuses=['live'])
+    framework = get_framework_or_404(data_api_client, framework_slug, allowed_statuses=['live', 'expired'])
     supplier_framework = return_supplier_framework_info_if_on_framework_or_abort(data_api_client, framework_slug)
     variation_details = framework.get('variations', {}).get(variation_slug)
 

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -5151,6 +5151,16 @@ class TestContractVariation(BaseApplicationTest):
 
         assert res.status_code == 404
 
+    @pytest.mark.parametrize("framework_status", ("live", "expired"))
+    def test_is_available_after_framework_goes_live(self, framework_status):
+        self.g8_framework["frameworks"]["status"] = framework_status
+        self.data_api_client.get_framework.return_value = self.g8_framework
+        self.data_api_client.get_supplier_framework_info.return_value = self.good_supplier_framework
+
+        res = self.client.get("/suppliers/frameworks/g-cloud-8/contract-variation/1")
+
+        assert res.status_code == 200
+
     def test_agreement_must_be_returned_already(self):
         agreement_not_returned = self.good_supplier_framework.copy()
         agreement_not_returned['frameworkInterest']['agreementReturned'] = False


### PR DESCRIPTION
A recent support ticket has come in from a supplier wishing to view the contract variation for DOS 2.

Talking to product, it was agreed that suppliers should be able to view contract details even after a framework has expired.

Ideally a full solution would involve going through the framework pages and looking at what is accessible at what framework state, but for now to enable a quick fix for the user this PR will cover the contract variation case specifically.