### PR TITLE
Prepare Supplier FE with G11 content

### DIFF
--- a/app/main/__init__.py
+++ b/app/main/__init__.py
@@ -47,6 +47,12 @@ content_loader.load_manifest('digital-outcomes-and-specialists-3', 'briefs', 'ed
 content_loader.load_messages('digital-outcomes-and-specialists-3', ['urls'])
 content_loader.load_metadata('digital-outcomes-and-specialists-3', ['copy_services', 'following_framework'])
 
+content_loader.load_manifest('g-cloud-11', 'services', 'edit_service')
+content_loader.load_manifest('g-cloud-11', 'services', 'edit_submission')
+content_loader.load_manifest('g-cloud-11', 'declaration', 'declaration')
+content_loader.load_messages('g-cloud-11', ['urls', 'advice'])
+content_loader.load_metadata('g-cloud-11', ['copy_services', 'following_framework'])
+
 
 @main.after_request
 def add_cache_control(response):

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "hogan.js": "3.0.2",
     "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v31.9.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.19.2/jinja_govuk_template-0.19.2.tgz",
-    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#13.6.1"
+    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#13.7.0"
   },
   "scripts": {
     "frontend-build:development": "./node_modules/gulp/bin/gulp.js build:development",

--- a/yarn.lock
+++ b/yarn.lock
@@ -542,9 +542,9 @@ detect-file@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/detect-file/-/detect-file-1.0.0.tgz#f0d66d03672a825cb1b73bdb3fe62310c8e552b7"
 
-"digitalmarketplace-frameworks@https://github.com/alphagov/digitalmarketplace-frameworks.git#13.6.1":
-  version "13.6.1"
-  resolved "https://github.com/alphagov/digitalmarketplace-frameworks.git#1f78e1b8655e899560fc63e325731404d0a7ada9"
+"digitalmarketplace-frameworks@https://github.com/alphagov/digitalmarketplace-frameworks.git#13.7.0":
+  version "13.7.0"
+  resolved "https://github.com/alphagov/digitalmarketplace-frameworks.git#30c13434a1cbbf73f76d98c51fb64cce43a8c829"
 
 "digitalmarketplace-frontend-toolkit@https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v31.9.0":
   version "31.9.0"


### PR DESCRIPTION
Trello: https://trello.com/c/JPSjopsY/337-create-g11-framework-on-preview-and-set-to-coming

We explicitly load the content per framework on the Supplier FE's app init. It's quite verbose but the last time we looked at making this better, it proved too annoying to fix (https://github.com/alphagov/digitalmarketplace-supplier-frontend/pull/768). 