### PR TITLE
Add G11 declaration validator

### DIFF
--- a/app/main/helpers/validation.py
+++ b/app/main/helpers/validation.py
@@ -238,4 +238,5 @@ VALIDATORS = {
     "g-cloud-9": DOS2Validator,
     "g-cloud-10": DOS2Validator,
     "digital-outcomes-and-specialists-3": DOS2Validator,
+    "g-cloud-11": DOS2Validator,
 }


### PR DESCRIPTION
This should fix the failing functional tests on Preview.

The supplier's G11 declaration needs to be validated against a schema. The declaration is currently the same for G9, DOS2, G10 and DOS3 (which all use `DOS2Validator`) but this may change in the future.