### PR TITLE
live service editing: fix update_section view's use of service data to ensure breadcrumbs work properly

### DIFF
--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -246,15 +246,12 @@ def update_section(framework_slug, service_id, section_id):
                 current_user.email_address)
         except HTTPError as e:
             errors = section.get_error_messages(e.message)
-            # If the service name is empty the final breadcrumb will disappear, so re-populate with the current name
-            if not posted_data.get('serviceName', None):
-                posted_data['serviceName'] = service.get('serviceName', '')
 
     if errors:
         return render_template(
             "services/edit_section.html",
             section=section,
-            service_data=posted_data,
+            service_data=service,
             service_id=service_id,
             errors=errors,
         ), 400


### PR DESCRIPTION
https://trello.com/c/MQlYqizw/

This wasn't so much a "double slash" problem - double slashes are (should be) squashed by our router so shouldn't be an issue. What it in fact _is_ is a missing framework slug element of the path. This is because the view was using `posted_data` as a substitute for `service_data` being passed to the template - but it's just not sufficient, missing most fields. This happened only on the "error" page because these urls have their `GET` and `POST` behaviours implemented as separate views, and the error case is the only time the `POST` view ends up rendering the page. It should be no surprise to you that this & other reasons is why I vastly prefer the "shared view" pattern instead.

The tests around this were also woefully under-assertive - nothing testing a single thing about the presence of the breadcrumbs (or even the presence of the form elements). So I've done something about that whilst resisting the temptation to refactor the shit out of it all.