### PR TITLE
Update test dependencies

### DIFF
--- a/app/main/helpers/validation.py
+++ b/app/main/helpers/validation.py
@@ -149,9 +149,11 @@ class G7Validator(DeclarationValidator):
 
         #  If you answered 'licensed' or 'a member of a relevant organisation' in question 29
         answer_29 = self.answers.get('SQ1-1j-i', [])
-        if answer_29 and len(answer_29) > 0 and \
-                ('licensed' in answer_29 or 'a member of a relevant organisation' in answer_29):
-                req_fields.add('SQ1-1j-ii')
+        if answer_29 and len(answer_29) > 0 and (
+            'licensed' in answer_29
+            or 'a member of a relevant organisation' in answer_29
+        ):
+            req_fields.add('SQ1-1j-ii')
 
         # If you answered yes to either question 53 or 54 (tax returns)
         if self.answers.get('SQ4-1a', False) or self.answers.get('SQ4-1b', False):

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -836,33 +836,33 @@ def copy_previous_service(framework_slug, lot_slug, service_id):
 @EnsureApplicationCompanyDetailsHaveBeenConfirmed(data_api_client)
 @return_404_if_applications_closed(lambda: data_api_client)
 def copy_all_previous_services(framework_slug, lot_slug):
-        framework, lot = get_framework_and_lot_or_404(
-            data_api_client, framework_slug, lot_slug, allowed_statuses=['open']
-        )
+    framework, lot = get_framework_and_lot_or_404(
+        data_api_client, framework_slug, lot_slug, allowed_statuses=['open']
+    )
 
-        # Suppliers must have registered interest in a framework before they can edit draft services
-        if not get_supplier_framework_info(data_api_client, framework_slug):
-            abort(404)
+    # Suppliers must have registered interest in a framework before they can edit draft services
+    if not get_supplier_framework_info(data_api_client, framework_slug):
+        abort(404)
 
-        questions_to_copy = content_loader.get_metadata(framework['slug'], 'copy_services', 'questions_to_copy')
-        source_framework_slug = content_loader.get_metadata(framework['slug'], 'copy_services', 'source_framework')
+    questions_to_copy = content_loader.get_metadata(framework['slug'], 'copy_services', 'questions_to_copy')
+    source_framework_slug = content_loader.get_metadata(framework['slug'], 'copy_services', 'source_framework')
 
-        response = data_api_client.copy_published_from_framework(
-            framework_slug,
-            lot_slug,
-            current_user.name,
-            data={
-                "sourceFrameworkSlug": source_framework_slug,
-                "supplierId": current_user.supplier_id,
-                "questionsToCopy": questions_to_copy
-            }
-        )['services']
+    response = data_api_client.copy_published_from_framework(
+        framework_slug,
+        lot_slug,
+        current_user.name,
+        data={
+            "sourceFrameworkSlug": source_framework_slug,
+            "supplierId": current_user.supplier_id,
+            "questionsToCopy": questions_to_copy
+        }
+    )['services']
 
-        flash(
-            ALL_SERVICES_ADDED_MESSAGE.format(
-                draft_count=response['draftsCreatedCount'], framework_name=framework['name']
-            ),
-            "success"
-        )
+    flash(
+        ALL_SERVICES_ADDED_MESSAGE.format(
+            draft_count=response['draftsCreatedCount'], framework_name=framework['name']
+        ),
+        "success"
+    )
 
-        return redirect(url_for(".framework_submission_services", framework_slug=framework_slug, lot_slug=lot_slug))
+    return redirect(url_for(".framework_submission_services", framework_slug=framework_slug, lot_slug=lot_slug))

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,12 +1,11 @@
 -r requirements.txt
 coverage==4.5.2
 cssselect==1.0.3
-flake8==3.6.0
-flake8-per-file-ignores==0.7.0
+flake8==3.7.5
 freezegun==0.3.11
 lxml==4.3.0
 mock==2.0.0
-pytest==4.1.1
+pytest==4.2.0
 pytest-cov==2.6.1
 python-coveralls==2.9.1
 requests-mock==1.5.2

--- a/tests/app/main/test_users.py
+++ b/tests/app/main/test_users.py
@@ -4,53 +4,53 @@ from tests.app.helpers import BaseApplicationTest
 
 def get_users(additional_users=None, index=None):
 
-        users = [
-            {
-                'id': 123,
-                'name': "User Name",
-                'emailAddress': "email@email.com",
-                'loggedInAt': "2015-05-06T11:57:28.008690Z",
-                'locked': False,
-                'active': True,
-                'role': 'supplier',
-                'supplier': {
-                    'name': "Supplier Name",
-                    'supplierId': 1234
-                }
-            },
-            {
-                'id': 1,
-                'name': "Don Draper",
-                'emailAddress': "don@scdp.com",
-                'loggedInAt': "2015-05-06T11:57:28.008690Z",
-                'locked': False,
-                'active': True,
-                'role': 'supplier',
-                'supplier': {
-                    'name': "Supplier Name",
-                    'supplierId': 1234
-                }
-            },
-            # inactive user
-            {
-                'id': 2,
-                'name': "Lane Pryce",
-                'emailAddress': "lane@scdp.com",
-                'loggedInAt': "2012-06-03T11:57:28.008690Z",
-                'locked': False,
-                'active': False,
-                'role': 'supplier',
-                'supplier': {
-                    'name': "Supplier Name",
-                    'supplierId': 1234
-                }
+    users = [
+        {
+            'id': 123,
+            'name': "User Name",
+            'emailAddress': "email@email.com",
+            'loggedInAt': "2015-05-06T11:57:28.008690Z",
+            'locked': False,
+            'active': True,
+            'role': 'supplier',
+            'supplier': {
+                'name': "Supplier Name",
+                'supplierId': 1234
             }
-        ]
+        },
+        {
+            'id': 1,
+            'name': "Don Draper",
+            'emailAddress': "don@scdp.com",
+            'loggedInAt': "2015-05-06T11:57:28.008690Z",
+            'locked': False,
+            'active': True,
+            'role': 'supplier',
+            'supplier': {
+                'name': "Supplier Name",
+                'supplierId': 1234
+            }
+        },
+        # inactive user
+        {
+            'id': 2,
+            'name': "Lane Pryce",
+            'emailAddress': "lane@scdp.com",
+            'loggedInAt': "2012-06-03T11:57:28.008690Z",
+            'locked': False,
+            'active': False,
+            'role': 'supplier',
+            'supplier': {
+                'name': "Supplier Name",
+                'supplierId': 1234
+            }
+        }
+    ]
 
-        if additional_users is not None and isinstance(additional_users, list):
-            users += additional_users
+    if additional_users is not None and isinstance(additional_users, list):
+        users += additional_users
 
-        return {'users': users} if index is None else {'users': users[index]}
+    return {'users': users} if index is None else {'users': users[index]}
 
 
 class TestListUsers(BaseApplicationTest):


### PR DESCRIPTION
Supersedes the current open PyUp PRs for this repo.

`flake8` now supports per-file-ignores well enough for our purposes. This means we can remove the extra `flake8-per-file-ignores` dependency.

The new version of flake8 suggested some indentation changes, which I agreed with.