### PR TITLE
Declaration reuse bug

### DIFF
--- a/app/main/forms/frameworks.py
+++ b/app/main/forms/frameworks.py
@@ -65,7 +65,6 @@ class OneServiceLimitCopyServiceForm(FlaskForm):
         "Do you want to reuse your previous {lot_name} service?",
         question_advice="You still have to review your service and answer any new questions.",
         false_values=("False", "false", ""),
-        validators=[InputRequired(message="You must answer this question.")],
         widget=DMSelectionButtonBase(type="boolean"),
     )
 

--- a/app/main/forms/frameworks.py
+++ b/app/main/forms/frameworks.py
@@ -1,6 +1,6 @@
 from flask_wtf import FlaskForm
 from wtforms import HiddenField
-from wtforms.validators import DataRequired, InputRequired, Length
+from wtforms.validators import DataRequired, Length
 
 from dmutils.forms.fields import DMBooleanField, DMStripWhitespaceStringField
 from dmutils.forms.widgets import DMSelectionButtonBase
@@ -55,7 +55,6 @@ class ReuseDeclarationForm(FlaskForm):
     reuse = DMBooleanField(
         "Do you want to reuse the answers from your earlier declaration?",
         false_values=("False", "false", ""),
-        validators=[InputRequired(message="You must answer this question.")],
     )
     old_framework_slug = HiddenField()
 

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -6,6 +6,6 @@ Flask-Login==0.4.1
 Flask-WTF==0.14.2
 itsdangerous==0.24 # pyup: ignore
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@45.4.0#egg=digitalmarketplace-utils==45.4.0
-git+https://github.com/alphagov/digitalmarketplace-content-loader.git@5.0.0#egg=digitalmarketplace-content-loader==5.0.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@19.7.0#egg=digitalmarketplace-apiclient==19.7.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@46.0.0#egg=digitalmarketplace-utils==46.0.0
+git+https://github.com/alphagov/digitalmarketplace-content-loader.git@5.1.3#egg=digitalmarketplace-content-loader==5.1.3
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@19.15.0#egg=digitalmarketplace-apiclient==19.15.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,9 +7,9 @@ Flask-Login==0.4.1
 Flask-WTF==0.14.2
 itsdangerous==0.24 # pyup: ignore
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@45.4.0#egg=digitalmarketplace-utils==45.4.0
-git+https://github.com/alphagov/digitalmarketplace-content-loader.git@5.0.0#egg=digitalmarketplace-content-loader==5.0.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@19.7.0#egg=digitalmarketplace-apiclient==19.7.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@46.0.0#egg=digitalmarketplace-utils==46.0.0
+git+https://github.com/alphagov/digitalmarketplace-content-loader.git@5.1.3#egg=digitalmarketplace-content-loader==5.1.3
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@19.15.0#egg=digitalmarketplace-apiclient==19.15.0
 
 ## The following requirements were added by pip freeze:
 asn1crypto==0.24.0
@@ -22,7 +22,7 @@ Click==7.0
 contextlib2==0.5.5
 cryptography==2.3.1
 defusedxml==0.5.0
-docopt==0.4.0
+docopt==0.6.2
 docutils==0.14
 Flask-Script==2.0.6
 fleep==1.0.1
@@ -32,8 +32,7 @@ inflection==0.3.1
 Jinja2==2.10
 jmespath==0.9.3
 mailchimp3==3.0.6
-mandrill==1.0.57
-Markdown==2.6.7
+Markdown==2.6.11
 MarkupSafe==1.1.0
 monotonic==1.5
 notifications-python-client==5.3.0
@@ -43,7 +42,7 @@ PyJWT==1.7.1
 python-dateutil==2.8.0
 python-json-logger==0.1.10
 pytz==2018.9
-PyYAML==3.11
+PyYAML==3.13
 requests==2.21.0
 s3transfer==0.1.13
 six==1.12.0

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -2601,21 +2601,17 @@ class TestPostListPreviousService(BaseApplicationTest, MockEnsureApplicationComp
             t=f"You already have a draft {lot_name.lower()} service.",
         )
 
-    def test_validates_that_an_answer_is_required(self):
+    @mock.patch('app.main.views.services.copy_service_from_previous_framework')
+    def test_form_validation_treats_a_blank_answer_as_a_no(self, copy_service_from_previous_framework):
         res = self.client.post(
             '/suppliers/frameworks/digital-outcomes-and-specialists-3/'
-            'submissions/digital-specialists/previous-services',
+            'submissions/digital-outcomes/previous-services',
             data={},
         )
-        doc = html.fromstring(res.get_data(as_text=True))
 
-        assert res.status_code == 400
-        assert "Do you want to reuse your previous digital specialists service?" == doc.xpath(
-            "//a[@class='validation-masthead-link']/text()"
-        )[0].strip()
-        assert "You must answer this question." == doc.xpath(
-            '//span[@class="validation-message"]/text()'
-        )[0].strip()
+        assert res.status_code == 302
+        assert '/suppliers/frameworks/digital-outcomes-and-specialists-3/submissions/digital-outcomes' in res.location
+        assert copy_service_from_previous_framework.call_args_list == []
 
 
 class CopyingPreviousServicesSetup(BaseApplicationTest):


### PR DESCRIPTION
Trello: https://trello.com/c/itTrzlID/363-g11-declaration-re-use-bug

The declaration reuse form had an unnecessary validator on it, causing a bug where the supplier could not proceed if they did not want to copy their declaration. 

The same issue was on a DOS validator for copying services, so I've updated that too.

Also bumps our 3 DM libraries to get rid of some deprecation warnings, and get rid of the unused Mandrill dependency.