### PR TITLE
clarification/follow-up questions: use better default email addresses for these

### DIFF
--- a/config.py
+++ b/config.py
@@ -24,7 +24,7 @@ class Config(object):
     DM_DATA_API_URL = None
     DM_DATA_API_AUTH_TOKEN = None
     DM_NOTIFY_API_KEY = None
-    DM_CLARIFICATION_QUESTION_EMAIL = 'digitalmarketplace@mailinator.com'
+    DM_CLARIFICATION_QUESTION_EMAIL = 'clarification-questions@example.gov.uk'
     DM_FRAMEWORK_AGREEMENTS_EMAIL = 'enquiries@example.com'
     DM_COMPANY_DETAILS_CHANGE_EMAIL = 'cloud_digital@crowncommercial.gov.uk'
 
@@ -56,7 +56,7 @@ class Config(object):
     INVITE_EMAIL_SUBJECT = 'Your Digital Marketplace invitation'
 
     CLARIFICATION_EMAIL_NAME = 'Digital Marketplace Admin'
-    DM_FOLLOW_UP_EMAIL_TO = 'digitalmarketplace@mailinator.com'
+    DM_FOLLOW_UP_EMAIL_TO = 'follow-up@example.gov.uk'
 
     FRAMEWORK_AGREEMENT_RETURNED_NAME = 'Digital Marketplace Admin'
 
@@ -100,7 +100,6 @@ class Test(Config):
     DM_NOTIFY_API_KEY = "not_a_real_key-00000000-fake-uuid-0000-000000000000"
 
     SHARED_EMAIL_KEY = "KEY"
-    DM_CLARIFICATION_QUESTION_EMAIL = 'digitalmarketplace@mailinator.com'
 
     DM_MAILCHIMP_USERNAME = 'not_a_real_username'
     DM_MAILCHIMP_API_KEY = 'not_a_real_key'

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -3406,7 +3406,7 @@ class TestSendClarificationQuestionEmail(BaseApplicationTest):
         notify_send_email.assert_has_calls(
             [
                 mock.call(
-                    mock.ANY, to_email_address="digitalmarketplace@mailinator.com",
+                    mock.ANY, to_email_address="clarification-questions@example.gov.uk",
                     template_name_or_id='framework-clarification-question',
                     personalisation={"framework_name": "Test Framework", "supplier_id": 1234,
                                      "clarification_question": clarification_question}
@@ -3450,7 +3450,7 @@ class TestSendClarificationQuestionEmail(BaseApplicationTest):
         # Assert Notify email 2 is not sent (no receipt)
         notify_send_email.assert_called_once_with(
             mock.ANY,
-            to_email_address="digitalmarketplace@mailinator.com",
+            to_email_address="follow-up@example.gov.uk",
             personalisation={
                 "framework_name": "Test Framework",
                 "supplier_name": "Supplier NĀme",
@@ -3522,7 +3522,7 @@ class TestSendClarificationQuestionEmail(BaseApplicationTest):
         response = self._send_email(message=clarification_question)
         # Assert send_email is called only once
         notify_send_email.assert_called_once_with(
-            mock.ANY, to_email_address="digitalmarketplace@mailinator.com",
+            mock.ANY, to_email_address="clarification-questions@example.gov.uk",
             template_name_or_id='framework-clarification-question',
             personalisation={"framework_name": "Test Framework", "supplier_id": 1234,
                              "clarification_question": clarification_question}
@@ -3541,7 +3541,7 @@ class TestSendClarificationQuestionEmail(BaseApplicationTest):
         notify_send_email.assert_has_calls(
             [
                 mock.call(
-                    mock.ANY, to_email_address="digitalmarketplace@mailinator.com",
+                    mock.ANY, to_email_address="clarification-questions@example.gov.uk",
                     template_name_or_id="framework-clarification-question",
                     personalisation={"framework_name": "Test Framework", "supplier_id": 1234,
                                      "clarification_question": clarification_question}


### PR DESCRIPTION
Spurred by https://trello.com/c/49yR7N9O/

These defaults currently end up actually getting used in the functional tests, so it'll probably be good to have more deliberate ones now we're actually going to be exercising them