### PR TITLE
Refactor forms

### DIFF
--- a/app/main/forms/suppliers.py
+++ b/app/main/forms/suppliers.py
@@ -232,6 +232,8 @@ class CompanyTradingStatusForm(FlaskForm):
         },
     ]
 
-    trading_status = RadioField('Trading status',
-                                validators=[InputRequired(message="You must choose a trading status.")],
-                                choices=[(o['value'], o['label']) for o in OPTIONS])
+    trading_status = DMRadioField(
+        "What’s your trading status?",
+        hint="This information will be used to find out about the types of companies on frameworks.",
+        validators=[InputRequired(message="You must choose a trading status.")],
+        options=OPTIONS)

--- a/app/main/forms/suppliers.py
+++ b/app/main/forms/suppliers.py
@@ -2,7 +2,7 @@ from flask_wtf import FlaskForm
 from wtforms import RadioField
 from wtforms.validators import AnyOf, InputRequired, Length, Optional, Regexp, ValidationError
 
-from dmutils.forms.fields import DMStripWhitespaceStringField, DMEmailField
+from dmutils.forms.fields import DMStripWhitespaceStringField, DMEmailField, DMRadioField
 from dmutils.forms.validators import EmailValidator
 from dmutils.forms.widgets import DMTextArea
 from ..helpers.suppliers import COUNTRY_TUPLE
@@ -192,9 +192,12 @@ class CompanyOrganisationSizeForm(FlaskForm):
         },
     ]
 
-    organisation_size = RadioField('Organisation size',
-                                   validators=[InputRequired(message="You must choose an organisation size.")],
-                                   choices=[(o['value'], o['label']) for o in OPTIONS])
+    organisation_size = DMRadioField(
+        "What size is your organisation?",
+        hint="This information will be used to report on the number of contracts that go"
+        " to small and medium sized enterprises (SMEs).",
+        validators=[InputRequired(message="You must choose an organisation size.")],
+        options=OPTIONS)
 
 
 class CompanyTradingStatusForm(FlaskForm):

--- a/app/main/forms/suppliers.py
+++ b/app/main/forms/suppliers.py
@@ -53,22 +53,19 @@ class EditSupplierInformationForm(FlaskForm):
 
 
 class EditRegisteredAddressForm(FlaskForm):
-    address1 = DMStripWhitespaceStringField('Building and street', validators=[
+    street = DMStripWhitespaceStringField("Building and street", validators=[
         InputRequired(message="You need to enter the street address."),
         Length(max=255, message="You must provide a building and street name under 256 characters."),
     ])
-    city = DMStripWhitespaceStringField('Town or city', validators=[
+    city = DMStripWhitespaceStringField("Town or city", validators=[
         InputRequired(message="You need to enter the town or city."),
         Length(max=255, message="You must provide a town or city name under 256 characters."),
     ])
-    postcode = DMStripWhitespaceStringField('Postcode', validators=[
+    postcode = DMStripWhitespaceStringField("Postcode", validators=[
         InputRequired(message="You need to enter the postcode."),
         Length(max=15, message="You must provide a valid postcode under 15 characters."),
     ])
-
-
-class EditRegisteredCountryForm(FlaskForm):
-    registrationCountry = DMStripWhitespaceStringField('Country', validators=[
+    country = DMStripWhitespaceStringField("Country", validators=[
         InputRequired(message="You need to enter a country."),
         AnyOf(values=[country[1] for country in COUNTRY_TUPLE], message="You must enter a valid country."),
     ])

--- a/app/main/forms/suppliers.py
+++ b/app/main/forms/suppliers.py
@@ -4,6 +4,7 @@ from wtforms.validators import AnyOf, InputRequired, Length, Optional, Regexp, V
 
 from dmutils.forms.fields import DMStripWhitespaceStringField, DMEmailField
 from dmutils.forms.validators import EmailValidator
+from dmutils.forms.widgets import DMTextArea
 from ..helpers.suppliers import COUNTRY_TUPLE
 
 
@@ -21,25 +22,34 @@ def word_length(limit=None, message=None):
     return _length
 
 
-class EditSupplierForm(FlaskForm):
-    description = DMStripWhitespaceStringField('Supplier summary', validators=[
-        word_length(50, 'Your summary must not be more than %d words')
-    ])
-
-
-class EditContactInformationForm(FlaskForm):
-    contactName = DMStripWhitespaceStringField('Contact name', validators=[
-        InputRequired(message="You must provide a contact name."),
-        Length(max=255, message="You must provide a contact name under 256 characters."),
-    ])
-    email = DMEmailField('Contact email address', validators=[
-        InputRequired(message="You must provide an email address."),
-        EmailValidator(message="You must provide a valid email address."),
-    ])
-    phoneNumber = DMStripWhitespaceStringField('Contact phone number', validators=[
-        InputRequired(message="You must provide a phone number."),
-        Length(max=20, message="You must provide a phone number under 20 characters.")
-    ])
+class EditSupplierInformationForm(FlaskForm):
+    contactName = DMStripWhitespaceStringField(
+        "Contact name",
+        hint="This can be the name of the person or team you want buyers to contact",
+        validators=[
+            InputRequired(message="You must provide a contact name."),
+            Length(max=255, message="You must provide a contact name under 256 characters."),
+        ])
+    email = DMEmailField(
+        "Contact email address",
+        hint="This is the email buyers will use to contact you",
+        validators=[
+            InputRequired(message="You must provide an email address."),
+            EmailValidator(message="You must provide a valid email address."),
+        ])
+    phoneNumber = DMStripWhitespaceStringField(
+        "Contact phone number",
+        validators=[
+            InputRequired(message="You must provide a phone number."),
+            Length(max=20, message="You must provide a phone number under 20 characters.")
+        ])
+    description = DMStripWhitespaceStringField(
+        "Supplier summary",
+        hint="50 words maximum",
+        widget=DMTextArea(max_length_in_words=50),
+        validators=[
+            word_length(50, "Your summary must not be more than %d words"),
+        ])
 
 
 class EditRegisteredAddressForm(FlaskForm):

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -10,7 +10,7 @@ from dmutils.dates import update_framework_with_formatted_dates
 from dmutils.email import send_user_account_email
 from dmutils.email.dm_mailchimp import DMMailChimpClient
 from dmutils.flask import timed_render_template as render_template
-from dmutils.forms.helpers import remove_csrf_token, get_errors_from_wtform
+from dmutils.forms.helpers import get_errors_from_wtform
 from dmutils.errors import render_error_page
 
 from ...main import main, content_loader
@@ -23,7 +23,6 @@ from ..forms.suppliers import (
     CompanyTradingStatusForm,
     DunsNumberForm,
     EditRegisteredAddressForm,
-    EditRegisteredCountryForm,
     EditSupplierInformationForm,
     EmailAddressForm,
 )
@@ -174,52 +173,50 @@ def confirm_supplier_details():
         return redirect(url_for(".supplier_details"))
 
 
-@main.route('/registered-address/edit', methods=['GET', 'POST'])
+@main.route("/registered-address/edit", methods=["GET", "POST"])
 @login_required
 def edit_registered_address():
-    supplier = data_api_client.get_supplier(
-        current_user.supplier_id
-    )['suppliers']
-    supplier['contact'] = supplier['contactInformation'][0]
+    supplier = data_api_client.get_supplier(current_user.supplier_id)["suppliers"]
+    contact = supplier["contactInformation"][0]
 
-    registered_address_form = EditRegisteredAddressForm()
-    registered_country_form = EditRegisteredCountryForm()
+    prefill_data = {
+        "street": contact.get("address1"),
+        "city": contact.get("city"),
+        "postcode": contact.get("postcode"),
+        "country": supplier.get("registrationCountry"),
+    }
 
-    if request.method == 'POST':
-        address_valid = registered_address_form.validate_on_submit()
-        country_valid = registered_country_form.validate_on_submit()
+    registered_address_form = EditRegisteredAddressForm(data=prefill_data)
 
-        if address_valid and country_valid:
-            data_api_client.update_supplier(
-                current_user.supplier_id,
-                remove_csrf_token(registered_country_form.data),
-                current_user.email_address,
-            )
+    if registered_address_form.validate_on_submit():
+        data_api_client.update_supplier(
+            current_user.supplier_id,
+            {
+                "registrationCountry": registered_address_form.country.data,
+            },
+            current_user.email_address,
+        )
 
-            data_api_client.update_contact_information(
-                current_user.supplier_id,
-                supplier['contact']['id'],
-                remove_csrf_token(registered_address_form.data),
-                current_user.email_address
-            )
+        data_api_client.update_contact_information(
+            current_user.supplier_id,
+            contact["id"],
+            {
+                "address1": registered_address_form.street.data,
+                "city": registered_address_form.city.data,
+                "postcode": registered_address_form.postcode.data,
+            },
+            current_user.email_address
+        )
 
-            return redirect(url_for(".supplier_details"))
+        return redirect(url_for(".supplier_details"))
 
-    else:
-        registered_address_form.address1.data = supplier['contact'].get('address1')
-        registered_address_form.city.data = supplier['contact'].get('city')
-        registered_address_form.postcode.data = supplier['contact'].get('postcode')
-
-        registered_country_form.registrationCountry.data = supplier.get('registrationCountry')
-
-    errors = {**get_errors_from_wtform(registered_address_form), **get_errors_from_wtform(registered_country_form)}
+    errors = get_errors_from_wtform(registered_address_form)
 
     return render_template(
         "suppliers/registered_address.html",
         supplier=supplier,
         countries=COUNTRY_TUPLE,
-        registered_address_form=registered_address_form,
-        registered_country_form=registered_country_form,
+        form=registered_address_form,
         errors=errors,
     ), 200 if not errors else 400
 

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -393,6 +393,7 @@ def edit_supplier_organisation_size():
 
             return redirect(url_for('.supplier_details'))
 
+        # TODO: see if we can remove this
         current_app.logger.warning(
             "supplieredit.fail: organisation-size:{osize}, errors:{osize_errors}",
             extra={

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -416,7 +416,13 @@ def edit_supplier_organisation_size():
 @main.route('/trading-status/edit', methods=['GET', 'POST'])
 @login_required
 def edit_supplier_trading_status():
-    form = CompanyTradingStatusForm()
+
+    prefill_data = {}
+    if request.method == "GET":
+        supplier = data_api_client.get_supplier(current_user.supplier_id)['suppliers']
+        prefill_data = {"trading_status": supplier.get("tradingStatus")}
+
+    form = CompanyTradingStatusForm(data=prefill_data)
 
     if request.method == 'POST':
         if form.validate_on_submit():
@@ -432,16 +438,6 @@ def edit_supplier_trading_status():
                 'tstatus': form.trading_status.data,
                 'tstatus_errors': ",".join(form.trading_status.errors)
             })
-
-    else:
-        supplier = data_api_client.get_supplier(current_user.supplier_id)['suppliers']
-
-        prefill_trading_status = None
-        if supplier.get('tradingStatus'):
-            if supplier['tradingStatus'] in map(lambda x: x['value'], form.OPTIONS):
-                prefill_trading_status = supplier['tradingStatus']
-
-        form.trading_status.data = prefill_trading_status
 
     errors = get_errors_from_wtform(form)
 

--- a/app/templates/suppliers/edit_supplier_organisation_size.html
+++ b/app/templates/suppliers/edit_supplier_organisation_size.html
@@ -33,20 +33,8 @@
 
       <form method="POST" action="{{ url_for('.edit_supplier_organisation_size') }}">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
-        {% set hint %}
-          This information will be used to report on the number of contracts that go to small and medium sized
-          enterprises (SMEs).
-        {% endset %}
 
-        {% with question = "What size is your organisation?",
-                name = "organisation_size",
-                value = form.organisation_size.data,
-                error = errors.get('organisation_size', {}).get('message', None),
-                type = "radio",
-                options = form.OPTIONS,
-                hint = hint %}
-          {% include "toolkit/forms/selection-buttons.html" %}
-        {% endwith %}
+        {{ form.organisation_size }}
 
         {% with type = "save",
                 label = "Save and return" %}

--- a/app/templates/suppliers/edit_supplier_trading_status.html
+++ b/app/templates/suppliers/edit_supplier_trading_status.html
@@ -33,19 +33,8 @@
 
       <form method="POST" action="{{ url_for('.edit_supplier_trading_status') }}">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
-        {% set hint %}
-          This information will be used to find out about the types of companies on frameworks.
-        {% endset %}
 
-        {% with question = "What&rsquo;s your trading status?"|safe,
-                name = "trading_status",
-                value = form.trading_status.data,
-                error = errors.get("trading_status", {}).get("message", None),
-                type = "radio",
-                options = form.OPTIONS,
-                hint = hint %}
-          {% include "toolkit/forms/selection-buttons.html" %}
-        {% endwith %}
+        {{ form.trading_status }}
 
         {% with type = "save",
                 label = "Save and return" %}

--- a/app/templates/suppliers/edit_what_buyers_will_see.html
+++ b/app/templates/suppliers/edit_what_buyers_will_see.html
@@ -45,16 +45,15 @@
   <form action="{{ url_for('.edit_what_buyers_will_see') }}" method="post">
 
   <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
-  
+
   <div class="grid-row">
     <div class="column-two-thirds">
 
-      {{ forms.question_textbox('contactName', 'Contact name', contact_form.contactName.data, 'This can be the name of the person or team you want buyers to contact', errors=[errors.get("contactName", {}).get("message", None)]) }}
-      {{ forms.question_textbox('email', 'Contact email address', contact_form.email.data, 'This is the email buyers will use to contact you', errors=[errors.get("email", {}).get("message", None)]) }}
-      {{ forms.question_textbox('phoneNumber', 'Contact phone number', contact_form.phoneNumber.data, errors=[errors.get("phoneNumber", {}).get("message", None)]) }}
+      {{ form.contactName }}
+      {{ form.email }}
+      {{ form.phoneNumber }}
+      {{ form.description }}
 
-
-      {{ forms.question_textarea('description', 'Supplier summary', supplier_form.description.data, '50 words maximum', errors=[errors.get("description", {}).get("message", None)], max_length_in_words=50) }}
     </div>
   </div>
 

--- a/app/templates/suppliers/registered_address.html
+++ b/app/templates/suppliers/registered_address.html
@@ -50,11 +50,12 @@
   <div class="grid-row">
     <div class="column-two-thirds">
 
-      {{ forms.question_textbox('address1', 'Building and street', value=registered_address_form.address1.data, errors=registered_address_form.address1.errors) }}
-      {{ forms.question_textbox('city', 'Town or city', value=registered_address_form.city.data, errors=registered_address_form.city.errors) }}
-      {{ forms.question_textbox('postcode', 'Postcode', value=registered_address_form.postcode.data, errors=registered_address_form.postcode.errors) }}
+      {{ form.street }}
+      {{ form.city }}
+      {{ form.postcode }}
 
-      {% if registered_country_form.registrationCountry.errors %}
+      {# TODO: make sure this is using the standard GOV.UK design system location autocomplete #}
+      {% if form.country.errors %}
       <div class="validation-wrapper">
         <style>
           #location-autocomplete {border: 5px solid #B10E1E;}
@@ -62,19 +63,19 @@
         </style>
       {% endif %}
 
-      <div class="question" id="registrationCountry">
+      <div class="question" id="country">
         <span class="question-heading" id="country-label">Country</span>
-        {{ forms.field_errors('registrationCountry', errors=registered_country_form.registrationCountry.errors) }}
-        <select name="registrationCountry" id="location-autocomplete" class="location-autocomplete-fallback">
-        {% if not registered_country_form.registrationCountry.data %}
+        {{ forms.field_errors(form.country.name, errors=form.country.errors) }}
+        <select name="country" id="location-autocomplete" class="location-autocomplete-fallback">
+        {% if not form.country.data %}
           <option value="" selected="selected"></option>
         {% endif %}
         {% for country in countries %}
-          <option value="{{country[1]}}"{% if registered_country_form.registrationCountry.data == country[1]%} selected="selected"{% endif %}>{{country[0]}}</option>
+          <option value="{{country[1]}}"{% if form.country.data == country[1]%} selected="selected"{% endif %}>{{country[0]}}</option>
         {% endfor %}
         </select>
       </div>
-      {% if registered_country_form.registrationCountry.errors %}
+      {% if form.country.errors %}
       </div>
       {% endif %}
 

--- a/tests/app/main/test_suppliers.py
+++ b/tests/app/main/test_suppliers.py
@@ -2527,7 +2527,7 @@ class TestSupplierEditOrganisationSize(BaseApplicationTest):
 
         self.assert_single_question_page_validation_errors(
             res,
-            question_name="Organisation size",
+            question_name="What size is your organisation?",
             validation_message=expected_error
         )
 

--- a/tests/app/main/test_suppliers.py
+++ b/tests/app/main/test_suppliers.py
@@ -719,12 +719,12 @@ class TestSupplierDetails(BaseApplicationTest):
         page_html = response.get_data(as_text=True)
         document = html.fromstring(page_html)
 
-        address1 = document.xpath("//span[text()='Registered company address']/following::td[1]/span/p/span[1]")
+        street = document.xpath("//span[text()='Registered company address']/following::td[1]/span/p/span[1]")
         town = document.xpath("//span[text()='Registered company address']/following::td[1]/span/p/span[2]")
         postcode = document.xpath("//span[text()='Registered company address']/following::td[1]/span/p/span[3]")
         country = document.xpath("//span[text()='Registered company address']/following::td[1]/span/p/span[4]")
 
-        assert "1 Street" in address1[0].text
+        assert "1 Street" in street[0].text
         assert "Supplierville" in town[0].text
         assert "11 AB" in postcode[0].text
         assert "United Kingdom" in country[0].text
@@ -1465,10 +1465,10 @@ class TestEditSupplierRegisteredAddress(BaseApplicationTest):
     def post_supplier_address_edit(self, data=None, **kwargs):
         if data is None:
             data = {
-                "address1": "1 Street",
+                "street": "1 Street",
                 "city": "Supplierville",
                 "postcode": "11 AB",
-                "registrationCountry": "country:GB",
+                "country": "country:GB",
             }
         data.update(kwargs)
         res = self.client.post("/suppliers/registered-address/edit", data=data)
@@ -1553,10 +1553,10 @@ class TestEditSupplierRegisteredAddress(BaseApplicationTest):
         }
 
         data = {
-            "address1": "  1 Street  ",
+            "street": "  1 Street  ",
             "city": "  Supplierville  ",
             "postcode": "  11 AB  ",
-            "registrationCountry": "country:GB",
+            "country": "country:GB",
         }
 
         status, _ = self.post_supplier_address_edit(data=data)
@@ -1577,7 +1577,7 @@ class TestEditSupplierRegisteredAddress(BaseApplicationTest):
         self.login()
 
         status, response = self.post_supplier_address_edit({
-            "address1": "SomeStreet",
+            "street": "SomeStreet",
             "city": "",
             "postcode": "11 AB",
             "registeredCountry": "",
@@ -1604,10 +1604,10 @@ class TestEditSupplierRegisteredAddress(BaseApplicationTest):
         self.login()
 
         status, response = self.post_supplier_address_edit({
-            "address1": "A" * length,
+            "street": "A" * length,
             "city": "C" * length,
             "postcode": "P" * (length - 240),
-            "registrationCountry": "country:GB",
+            "country": "country:GB",
         })
 
         assert status == status_code
@@ -1635,7 +1635,7 @@ class TestEditSupplierRegisteredAddress(BaseApplicationTest):
         self.login()
 
         status, response = self.post_supplier_address_edit({
-            "address1": "SomeStreet",
+            "street": "SomeStreet",
             "city": "Florence",
             "postcode": "11 AB",
             "registeredCountry": "country:BLAH",

--- a/tests/app/main/test_suppliers.py
+++ b/tests/app/main/test_suppliers.py
@@ -2687,7 +2687,7 @@ class TestSupplierEditTradingStatus(BaseApplicationTest):
         assert error[0].text.strip() == expected_error, 'The validation message is not as anticipated.'
 
         self.assert_single_question_page_validation_errors(res,
-                                                           question_name="Trading status",
+                                                           question_name="What’s your trading status?",
                                                            validation_message=expected_error)
 
     @pytest.mark.parametrize('trading_status', (None, 'limited company (LTD)', 'other'))


### PR DESCRIPTION
Here's some refactoring I did of some of the forms in the supplier frontend.

The changes are part of what I was doing https://github.com/alphagov/digitalmarketplace-supplier-frontend/tree/ldeb-107-wtforms-dmfields-supplier-forms, but packaged nicer.

I want these changes to be in the supplier frontend now because I intend to reuse (some of) the code for the admin frontend, and it would be helpful to be able to point to the supplier frontend code in `master` as an exemplar.