### PR TITLE
Registered country fixes

### DIFF
--- a/app/main/forms/suppliers.py
+++ b/app/main/forms/suppliers.py
@@ -70,6 +70,15 @@ class EditRegisteredAddressForm(FlaskForm):
         AnyOf(values=[country[1] for country in COUNTRY_TUPLE], message="You must enter a valid country."),
     ])
 
+    def validate(self):
+        # If a user is trying to change the country and enters an invalid option (blank or not a country),
+        # and submits the form, the country field is not submitted with the form.
+        # The old value will be re-populated in the field (with the validation error message).
+        # This could be confusing if there are multiple fields with errors, so clear the field for now.
+        if not self.country.raw_data:
+            self.country.data = ''
+        return super(EditRegisteredAddressForm, self).validate()
+
 
 # "Add" rather than "Edit" because this information can only be set once by a supplier
 class AddCompanyRegisteredNameForm(FlaskForm):

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "del": "1.2.0",
     "govuk_frontend_toolkit": "5.0.3",
     "govuk-elements-sass": "3.0.3",
-    "govuk-country-and-territory-autocomplete": "0.5.1",
+    "govuk-country-and-territory-autocomplete": "0.4.0",
     "gulp": "3.8.11",
     "gulp-filelog": "0.4.1",
     "gulp-include": "2.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6,7 +6,7 @@ abbrev@1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
 
-accessible-autocomplete@^1.6.2:
+accessible-autocomplete@^1.6.1:
   version "1.6.2"
   resolved "https://registry.yarnpkg.com/accessible-autocomplete/-/accessible-autocomplete-1.6.2.tgz#cb69d37748ba5b0351c84422468538890e25759c"
   integrity sha512-7S+6Vi82LQFSSd5feKedu46tiY2/DShpdXiRp0NY3cLwc+DKe1ayWd66mb3JVi8LTQubRM7jco+u92e6w0bbvg==
@@ -976,14 +976,14 @@ glogg@^1.0.0:
   dependencies:
     sparkles "^1.0.0"
 
-govuk-country-and-territory-autocomplete@0.5.1:
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/govuk-country-and-territory-autocomplete/-/govuk-country-and-territory-autocomplete-0.5.1.tgz#6db13e6c29789a9b02e2d80878a6a1b36a38edd2"
-  integrity sha512-tfBzqd9SXjX+jlNEwFPv53R2tpuMOq8pyfnRI+023ak+1OEfLCGFqS7PlOMN4Af4+Cg6lv7R+Cue5Q07j/ECpw==
+govuk-country-and-territory-autocomplete@0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/govuk-country-and-territory-autocomplete/-/govuk-country-and-territory-autocomplete-0.4.0.tgz#9823c59098c83bb473be57f7ce60ea57da7b770f"
+  integrity sha512-MOYGPpC6TsAesWK/LDC+scKpJxzdHSROBxtA5CSRbasWU4HnzUltCK7Eg9Nq7gIAR3WIkBGLaSX1al70eKZN7g==
   dependencies:
-    accessible-autocomplete "^1.6.2"
+    accessible-autocomplete "^1.6.1"
     openregister-picker-engine "^1.2.1"
-    webpack-sources "^1.3.0"
+    webpack-sources "^1.0.1"
 
 govuk-elements-sass@3.0.3:
   version "3.0.3"
@@ -3031,7 +3031,7 @@ vinyl@^0.5.0:
     clone-stats "^0.0.1"
     replace-ext "0.0.1"
 
-webpack-sources@^1.3.0:
+webpack-sources@^1.0.1:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-1.3.0.tgz#2a28dcb9f1f45fe960d8f1493252b5ee6530fa85"
   integrity sha512-OiVgSrbGu7NEnEvQJJgdSFPl2qWKkWq5lHMhgiToIiN9w34EBnjYzSYs+VbL5KoYiLNtFFa7BZIKxRED3I32pA==


### PR DESCRIPTION
Reverts https://github.com/alphagov/digitalmarketplace-supplier-frontend/pull/1006 as it was causing functional test failures (still unsure why, but not really enough time to investigate - will create a tech debt ticket).

Also fixes a minor validation quirk - see comment in the code for details. Again, time constraints mean I haven't quite got to the root of why this is happening, but checking against staging reveals it was OK before the recent refactor to combine the country field with the other address fields into one form.