### PR TITLE
Modern slavery validation

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -8,7 +8,7 @@
 # W504: line break after binary operator
 exclude = venv*,__pycache__,node_modules
 ignore = D203,W503,W504
-max-complexity = 7
+max-complexity = 8
 max-line-length = 120
 per-file-ignores =
     app/__init__.py : E402

--- a/app/main/helpers/validation.py
+++ b/app/main/helpers/validation.py
@@ -229,6 +229,12 @@ class DOSValidator(DeclarationValidator):
             if self.answers.get('licenceOrMemberRequired') in ['licensed', 'a member of a relevant organisation']:
                 req_fields.add('licenceOrMemberRequiredDetails')
 
+        # If supplier doesn't meet the Modern Slavery reporting requirements, they don't need to upload a statement
+        # but must have mitigatingFactors3 explanation
+        if self.answers.get('modernSlaveryReportingRequirements') is False:
+            req_fields.add('mitigatingFactors3')
+            req_fields.remove('modernSlaveryStatement')
+
         return req_fields
 
 

--- a/app/main/helpers/validation.py
+++ b/app/main/helpers/validation.py
@@ -183,33 +183,35 @@ class DOSValidator(DeclarationValidator):
         "appropriateTradeRegisters", "appropriateTradeRegistersNumber",
         "licenceOrMemberRequired", "licenceOrMemberRequiredDetails",
     ])
+
+    dependent_fields = {
+        # If you responded yes to any of questions 22 to 34
+        "mitigatingFactors": [
+            'misleadingInformation', 'confidentialInformation', 'influencedContractingAuthority',
+            'witheldSupportingDocuments', 'seriousMisrepresentation', 'significantOrPersistentDeficiencies',
+            'distortedCompetition', 'conflictOfInterest', 'distortingCompetition', 'graveProfessionalMisconduct',
+            'bankrupt', 'environmentalSocialLabourLaw', 'taxEvasion'
+        ],
+        # If you responded yes to either 36 or 37
+        "mitigatingFactors2": [
+            "unspentTaxConvictions", "GAAR"
+        ],
+        # If you responded yes to 50 (Modern Slavery)
+        "modernSlaveryStatement": [
+            "modernSlaveryTurnover",
+        ],
+        "modernSlaveryReportingRequirements": [
+            "modernSlaveryTurnover"
+        ],
+    }
+
     email_validation_fields = set(["contactEmailContractNotice", "primaryContactEmail"])
     character_limit = 5000
 
     def get_required_fields(self):
         req_fields = super(DOSValidator, self).get_required_fields()
 
-        dependent_fields = {
-            # If you responded yes to any of questions 22 to 34
-            "mitigatingFactors": [
-                'misleadingInformation', 'confidentialInformation', 'influencedContractingAuthority',
-                'witheldSupportingDocuments', 'seriousMisrepresentation', 'significantOrPersistentDeficiencies',
-                'distortedCompetition', 'conflictOfInterest', 'distortingCompetition', 'graveProfessionalMisconduct',
-                'bankrupt', 'environmentalSocialLabourLaw', 'taxEvasion'
-            ],
-            # If you responded yes to either 36 or 37
-            "mitigatingFactors2": [
-                "unspentTaxConvictions", "GAAR"
-            ],
-            # If you responded yes to 50 (Modern Slavery)
-            "modernSlaveryStatement": [
-                "modernSlaveryTurnover",
-            ],
-            "modernSlaveryReportingRequirements": [
-                "modernSlaveryTurnover"
-            ],
-        }
-        for target_field, fields in dependent_fields.items():
+        for target_field, fields in self.dependent_fields.items():
             if any(self.answers.get(field) for field in fields):
                 req_fields.add(target_field)
 


### PR DESCRIPTION
Trello: https://trello.com/c/76VkxnU3/425-modern-slavery-validation-messages

The logic for required fields on the Modern Slavery section should go:

`Turnover: yes` + `Reporting requirements: yes` = statement required, explanation text not required
`Turnover: yes` + `Reporting requirements: no` = statement not required, explanation text required
`Turnover: no`: nothing else required

The extra logic triggered the flake8 complexity warning, I ignored it for the validator in the end (but did move out the declaration fields to an attribute of the validator class, which seemed neater).

The tests for the validator are a bit out of date, it might be good to update those later.

Screengrab:
![modern-slavery-declaration-validation](https://user-images.githubusercontent.com/3492540/54526796-c497f000-496f-11e9-885c-90f33dbae374.png)
