### PR TITLE
Fix session timeout warning

### DIFF
--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -188,11 +188,14 @@ def edit_section(framework_slug, service_id, section_id):
     if section is None or not section.editable:
         abort(404)
 
+    session_timeout = displaytimeformat(datetime.utcnow() + timedelta(hours=1))
+
     return render_template(
         "services/edit_section.html",
         section=section,
         service_data=service,
         service_id=service_id,
+        session_timeout=session_timeout,
     )
 
 
@@ -251,11 +254,13 @@ def update_section(framework_slug, service_id, section_id):
             errors = section.get_error_messages(e.message)
 
     if errors:
+        session_timeout = displaytimeformat(datetime.utcnow() + timedelta(hours=1))
         return render_template(
             "services/edit_section.html",
             section=section,
             service_data=service,
             service_id=service_id,
+            session_timeout=session_timeout,
             errors=errors,
         ), 400
     flash(SERVICE_UPDATED_MESSAGE, "success")
@@ -316,6 +321,8 @@ def start_new_draft_service(framework_slug, lot_slug):
 
         section = section.get_question_as_section(section.get_next_question_slug())
 
+    session_timeout = displaytimeformat(datetime.utcnow() + timedelta(hours=1))
+
     if request.method == 'POST':
         update_data = section.get_data(request.form)
 
@@ -332,6 +339,7 @@ def start_new_draft_service(framework_slug, lot_slug):
                 "services/edit_submission_section.html",
                 framework=framework,
                 section=section,
+                session_timeout=session_timeout,
                 service_data=update_data,
                 errors=errors
             ), 400
@@ -351,6 +359,7 @@ def start_new_draft_service(framework_slug, lot_slug):
         lot=lot,
         service_data={},
         section=section,
+        session_timeout=session_timeout,
         force_continue_button=True,
     ), 200
 

--- a/app/templates/frameworks/_session_timeout.html
+++ b/app/templates/frameworks/_session_timeout.html
@@ -2,7 +2,7 @@
   <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
   <strong class="govuk-warning-text__text">
     <span class="govuk-warning-text__assistive">Warning</span>
-    <p>You must save these answers by {{session_timeout}}.</p>
+    <p>You must save these answers {{ "by {}".format(session_timeout) if session_timeout else "within one hour" }}.</p>
     <p>
       If you don’t save, your session will time out for security reasons.
       You’ll lose any information you’ve entered on this page.


### PR DESCRIPTION
I missed a few views that were using the page template :embarassed:.

This PR adds the `session_timeout` variable to the views I missed.

It also adds some default text to make sure that in future the output will always make sense.

![Example of session timeout warning when time is not supplied](https://user-images.githubusercontent.com/503614/54768718-acd29d00-4bf7-11e9-8d8e-343883f6e7c6.png)
