### PR TITLE
Add DMSelectionButtonBase widget to declaration copy form

### DIFF
--- a/app/main/forms/frameworks.py
+++ b/app/main/forms/frameworks.py
@@ -55,6 +55,7 @@ class ReuseDeclarationForm(FlaskForm):
     reuse = DMBooleanField(
         "Do you want to reuse the answers from your earlier declaration?",
         false_values=("False", "false", ""),
+        widget=DMSelectionButtonBase(type="boolean"),
     )
     old_framework_slug = HiddenField()
 


### PR DESCRIPTION
Trello: https://trello.com/c/I9MdAoMl/666-users-having-problem-copying-declarations-question

Weird bug where the form widget (or lack thereof?) wasn't allowing a True value to be posted.

This changes the presentation of the form to be a Yes/No question, will run it past product/content before merging.

![reuse-declaration-yes-no](https://user-images.githubusercontent.com/3492540/54994775-01da2e80-4fbd-11e9-903a-654ad63003ee.png)

