### PR TITLE
Pull in frameworks 15.0.5 with copy-services fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "hogan.js": "3.0.2",
     "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v31.11.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.19.2/jinja_govuk_template-0.19.2.tgz",
-    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#15.0.4"
+    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#15.0.5"
   },
   "scripts": {
     "frontend-build:development": "./node_modules/gulp/bin/gulp.js build:development",

--- a/yarn.lock
+++ b/yarn.lock
@@ -543,9 +543,9 @@ detect-file@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/detect-file/-/detect-file-1.0.0.tgz#f0d66d03672a825cb1b73bdb3fe62310c8e552b7"
 
-"digitalmarketplace-frameworks@https://github.com/alphagov/digitalmarketplace-frameworks.git#15.0.4":
-  version "15.0.4"
-  resolved "https://github.com/alphagov/digitalmarketplace-frameworks.git#df520e9f9f752739e855d6f33c41803dca5c0f99"
+"digitalmarketplace-frameworks@https://github.com/alphagov/digitalmarketplace-frameworks.git#15.0.5":
+  version "15.0.5"
+  resolved "https://github.com/alphagov/digitalmarketplace-frameworks.git#f390f099888662c1b8fbbe7f41eb99a7bd5faef7"
 
 "digitalmarketplace-frontend-toolkit@https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v31.11.0":
   version "31.11.0"


### PR DESCRIPTION
Trello: https://trello.com/c/2IUa5FqD/676-launchcloud-error-with-g-cloud-11-application-process

Don't copy across the `managementAccessAuthentication` field when copying services (as the value has changed and it breaks validation).