### PR TITLE
Fix details polyfill for service categories question

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -20,13 +20,10 @@
 //= require ../../../node_modules/digitalmarketplace-frontend-toolkit/toolkit/javascripts/show-hide-content.js
 //= require ../../../node_modules/digitalmarketplace-frontend-toolkit/toolkit/javascripts/user-research-consent-banner.js
 //= require ../../../node_modules/digitalmarketplace-frontend-toolkit/toolkit/javascripts/report-a-problem.js
-//= require ../../../node_modules/govuk-frontend/all.js
 //= require _analytics.js
 //= require _selection-buttons.js
 //= require _stick-at-top-when-scrolling.js
 //= require category-picker.js
-
-GOVUKFrontend.initAll();
 
 (function(GOVUK, GDM) {
 


### PR DESCRIPTION
When we included the GOV.UK Design System we inadvertantly included a
details polyfill that conflicts with our own, causing details elements
to stop working on Internet Explorer.

Although we could use the details polyfill from the design system, it
would involve changing the styling of our checkbox tree element, which
would be inadvisable during the framework application period.

Instead we just remove the javascript for the design system; it turns
out we don't need any of it currently.

In future we might need to include javascript for the design system
module by module rather than using `all.js`.

This has been tested locally with `make test` and functional tests.