### PR TITLE
Handle new Mailchimp responses

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -7,6 +7,6 @@ Flask-WTF==0.14.2
 Werkzeug==0.14.1 # pyup:ignore # pinning here because it was ahead of other apps
 itsdangerous==0.24 # pyup: ignore
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@47.1.0#egg=digitalmarketplace-utils==47.1.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@48.0.1#egg=digitalmarketplace-utils==48.0.1
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@5.2.0#egg=digitalmarketplace-content-loader==5.2.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@19.15.1#egg=digitalmarketplace-apiclient==19.15.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,14 +8,15 @@ Flask-WTF==0.14.2
 Werkzeug==0.14.1 # pyup:ignore # pinning here because it was ahead of other apps
 itsdangerous==0.24 # pyup: ignore
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@47.1.0#egg=digitalmarketplace-utils==47.1.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@48.0.1#egg=digitalmarketplace-utils==48.0.1
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@5.2.0#egg=digitalmarketplace-content-loader==5.2.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@19.15.1#egg=digitalmarketplace-apiclient==19.15.1
 
 ## The following requirements were added by pip freeze:
 asn1crypto==0.24.0
-boto3==1.9.117
-botocore==1.12.117
+blinker==1.4
+boto3==1.9.125
+botocore==1.12.125
 certifi==2019.3.9
 cffi==1.12.2
 chardet==3.0.4
@@ -28,6 +29,7 @@ docutils==0.14
 Flask-Script==2.0.6
 fleep==1.0.1
 future==0.17.1
+gds-metrics==0.2.0
 govuk-country-register==0.3.0
 idna==2.8
 inflection==0.3.1
@@ -39,10 +41,11 @@ MarkupSafe==1.1.1
 monotonic==1.5
 notifications-python-client==5.3.0
 odfpy==1.4.0
+prometheus-client==0.2.0
 pycparser==2.19
 PyJWT==1.7.1
 python-dateutil==2.8.0
-python-json-logger==0.1.10
+python-json-logger==0.1.11
 pytz==2018.9
 PyYAML==3.13
 requests==2.21.0


### PR DESCRIPTION
Trello: https://trello.com/c/pzAoSoTC/434-mailchimp-resubscribe-for-users-who-have-unsubscribed

Pulls in https://github.com/alphagov/digitalmarketplace-utils/pull/509 and https://github.com/alphagov/digitalmarketplace-utils/pull/511 (breaking change to subscribing users to Mailchimp lists).

The response has changed for both success and error statuses. We can now differentiate between errors where the user has already subscribed (i.e. no action required), where the user is providing a problematic email address (i.e. action should be to use a different email address) or where there is an unexpected error (do nothing for now).

Also added new flash messages type to cover this extra action (still need content approval for one of the two).
