### PR TITLE
Download declaration docs from S3 via asset url

### DIFF
--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -721,6 +721,24 @@ def download_agreement_file(framework_slug, document_name):
     return redirect(url)
 
 
+@main.route('/assets/<framework_slug>/documents/<int:supplier_id>/<document_name>', methods=['GET'])
+@login_required
+@EnsureApplicationCompanyDetailsHaveBeenConfirmed(data_api_client)
+def download_declaration_document(framework_slug, supplier_id, document_name):
+    """
+    Equivalent to services.service_submission_document for retrieving declaration files uploaded to S3
+    """
+    if current_user.supplier_id != supplier_id:
+        abort(404)
+
+    uploader = s3.S3(current_app.config['DM_DOCUMENTS_BUCKET'])
+    s3_url = get_signed_document_url(uploader, "{}/documents/{}/{}".format(framework_slug, supplier_id, document_name))
+    if not s3_url:
+        abort(404)
+
+    return redirect(s3_url)
+
+
 @main.route('/frameworks/<framework_slug>/updates', methods=['GET'])
 @login_required
 def framework_updates(framework_slug, error_message=None, default_textbox_value=None):

--- a/tests/app/main/helpers/test_frameworks.py
+++ b/tests/app/main/helpers/test_frameworks.py
@@ -709,6 +709,7 @@ class TestEnsureApplicationCompanyDetailsHaveBeenConfirmed(BaseApplicationTest):
             'main.complete_draft_service',
             'main.delete_draft_service',
             'main.service_submission_document',
+            'main.download_declaration_document',
             'main.view_service_submission',
             'main.edit_service_submission',
             'main.remove_subsection',


### PR DESCRIPTION
Trello: https://trello.com/c/F4fl895z/683-modern-slavery-statement-bug

This somehow missed our manual QA 🤦‍♀️ Tested the fix locally and it works for me.

The equivalent download view for service documents is here: https://github.com/alphagov/digitalmarketplace-supplier-frontend/blob/master/app/main/views/services.py#L498 (test structure is copied from here: https://github.com/alphagov/digitalmarketplace-supplier-frontend/blob/master/tests/app/main/test_services.py#L2291).