### PR TITLE
Use self for GOV.UK Frontend static assets

### DIFF
--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -56,9 +56,9 @@ $path: "/suppliers/static/images/";
 @import "toolkit/_report-a-problem.scss";
 
 // GOV.UK Design System (compatible with old toolkit/elements)
-$govuk-assets-path: '/admin/static/';
-$govuk-images-path: '/admin/static/images/';
-$govuk-fonts-path: '/admin/static/fonts/';
+$govuk-assets-path: '/suppliers/static/';
+$govuk-images-path: '/suppliers/static/images/';
+$govuk-fonts-path: '/suppliers/static/fonts/';
 $govuk-compatibility-govukfrontendtoolkit: true;
 $govuk-compatibility-govuktemplate: true;
 $govuk-compatibility-govukelements: true;


### PR DESCRIPTION
@katstevens noticed entries like this

```
2019-04-03T15:28:59.13+0100 [APP/PROC/WEB/1] ERR 2019/04/03 14:28:59 [error] 65#65: *1651608 access forbidden by rule, client: <REDACTED>, server: www.*, request: "GET /admin/static/fonts/bold-a2452cb66f-v1.woff2 HTTP/1.1", host: "www.digitalmarketplace.service.gov.uk", referrer: "https://www.digitalmarketplace.service.gov.uk/suppliers/static/stylesheets/application.css?f920dc2f15bf65d7d7b723e027092dbc"
```
in the router log recently, this change might help