### PR TITLE
Pull in frameworks 15.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "hogan.js": "3.0.2",
     "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v31.11.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.19.2/jinja_govuk_template-0.19.2.tgz",
-    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#15.3.1"
+    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#15.3.2"
   },
   "scripts": {
     "frontend-build:development": "./node_modules/gulp/bin/gulp.js build:development",

--- a/yarn.lock
+++ b/yarn.lock
@@ -543,9 +543,9 @@ detect-file@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/detect-file/-/detect-file-1.0.0.tgz#f0d66d03672a825cb1b73bdb3fe62310c8e552b7"
 
-"digitalmarketplace-frameworks@https://github.com/alphagov/digitalmarketplace-frameworks.git#15.3.1":
-  version "15.3.1"
-  resolved "https://github.com/alphagov/digitalmarketplace-frameworks.git#0aeb95b06fd35e4322b084817437fe653906a692"
+"digitalmarketplace-frameworks@https://github.com/alphagov/digitalmarketplace-frameworks.git#15.3.2":
+  version "15.3.2"
+  resolved "https://github.com/alphagov/digitalmarketplace-frameworks.git#99642aaca46a021ed31d902f30da27964b8ecfa3"
 
 "digitalmarketplace-frontend-toolkit@https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v31.11.0":
   version "31.11.0"


### PR DESCRIPTION
Trello: https://trello.com/c/1YUXLv7P/473-remove-unnecessary-clause-from-declaration-question

Pulls in https://github.com/alphagov/digitalmarketplace-frameworks/pull/565 to reinstate the old answer option for validation purposes.