### PR TITLE
801-metrics-on-buyer-and-supplier-we-need-to-find-evidence-of-what-is-causing-the-slow-requests

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -31,10 +31,12 @@ def create_app(config_name):
         login_manager=login_manager,
     )
 
+    from .metrics import metrics as metrics_blueprint, gds_metrics
     from .main import main as main_blueprint
     from .status import status as status_blueprint
     from dmutils.external import external as external_blueprint
 
+    application.register_blueprint(metrics_blueprint, url_prefix='/suppliers')
     application.register_blueprint(main_blueprint, url_prefix='/suppliers')
     application.register_blueprint(status_blueprint, url_prefix='/suppliers')
 
@@ -45,6 +47,7 @@ def create_app(config_name):
     login_manager.login_message_category = "must_login"
     main_blueprint.config = application.config.copy()
 
+    gds_metrics.init_app(application)
     csrf.init_app(application)
 
     @application.before_request

--- a/app/metrics.py
+++ b/app/metrics.py
@@ -1,0 +1,9 @@
+from flask import Blueprint
+from dmutils.metrics import DMGDSMetrics
+
+
+metrics = Blueprint('metrics', __name__)
+
+gds_metrics = DMGDSMetrics()
+
+metrics.add_url_rule(gds_metrics.metrics_path, 'metrics', gds_metrics.metrics_endpoint)

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,8 +14,8 @@ git+https://github.com/alphagov/digitalmarketplace-apiclient.git@19.15.1#egg=dig
 ## The following requirements were added by pip freeze:
 asn1crypto==0.24.0
 blinker==1.4
-boto3==1.9.134
-botocore==1.12.134
+boto3==1.9.139
+botocore==1.12.139
 certifi==2019.3.9
 cffi==1.12.3
 chardet==3.0.4

--- a/tests/app/helpers.py
+++ b/tests/app/helpers.py
@@ -243,6 +243,9 @@ class MockEnsureApplicationCompanyDetailsHaveBeenConfirmedMixin:
 
 class BaseApplicationTest:
     def setup_method(self, method):
+        self.app_env_var_mock = patch.dict('gds_metrics.os.environ', {'PROMETHEUS_METRICS_PATH': '_metrics'})
+        self.app_env_var_mock.start()
+
         self.app = create_app('test')
         self.app.jinja_options = ImmutableDict({**self.app.jinja_options, 'undefined': jinja2.StrictUndefined})
         self.app.register_blueprint(login_for_tests)
@@ -251,6 +254,7 @@ class BaseApplicationTest:
 
     def teardown_method(self, method):
         self.teardown_login()
+        self.app_env_var_mock.stop()
 
     @staticmethod
     def get_cookie_by_name(response, name):

--- a/tests/app/main/test_metrics.py
+++ b/tests/app/main/test_metrics.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+import re
+
+from tests.app.helpers import BaseApplicationTest
+
+
+def load_prometheus_metrics(response_bytes):
+    return dict(re.findall(rb"(\w+{.+?}) (\d+)", response_bytes))
+
+
+class TestMetricsPage(BaseApplicationTest):
+
+    def test_metrics_page_accessible(self):
+        metrics_response = self.client.get('/suppliers/_metrics')
+
+        assert metrics_response.status_code == 200
+
+    def test_metrics_page_contents(self):
+        metrics_response = self.client.get('/suppliers/_metrics')
+        results = load_prometheus_metrics(metrics_response.data)
+        assert (
+            b'http_server_requests_total{code="200",host="localhost",method="GET",path="/suppliers/_metrics"}'
+        ) in results
+
+
+class TestMetricsPageRegistersPageViews(BaseApplicationTest):
+
+    def test_metrics_page_registers_page_views(self):
+        expected_metric_name = (
+            b'http_server_requests_total{code="200",host="localhost",method="GET",path="/suppliers/create/start"}'
+        )
+
+        res = self.client.get('/suppliers/create/start')
+        assert res.status_code == 200
+
+        metrics_response = self.client.get('/suppliers/_metrics')
+        results = load_prometheus_metrics(metrics_response.data)
+        assert expected_metric_name in results
+
+    def test_metrics_page_registers_multiple_page_views(self):
+        expected_metric_name = (
+            b'http_server_requests_total{code="200",host="localhost",method="GET",path="/suppliers/create/start"}'
+        )
+
+        initial_metrics_response = self.client.get('/suppliers/_metrics')
+        initial_results = load_prometheus_metrics(initial_metrics_response.data)
+        initial_metric_value = int(initial_results.get(expected_metric_name, 0))
+
+        for _ in range(3):
+            res = self.client.get('/suppliers/create/start')
+            assert res.status_code == 200
+
+        metrics_response = self.client.get('/suppliers/_metrics')
+        results = load_prometheus_metrics(metrics_response.data)
+        metric_value = int(results.get(expected_metric_name, 0))
+
+        assert expected_metric_name in results
+        assert metric_value - initial_metric_value == 3


### PR DESCRIPTION

* Add metrics
* Add tests

https://trello.com/c/7NhpkDWC/801-metrics-on-buyer-and-supplier-we-need-to-find-evidence-of-what-is-causing-the-slow-requests