### PR TITLE
Bump docker base image to 4.5.1 🔥

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,1 @@
-FROM digitalmarketplace/base-frontend:4.5.0
+FROM digitalmarketplace/base-frontend:4.5.1


### PR DESCRIPTION
https://trello.com/c/PyDaRXEj
https://trello.com/c/skD666lL
https://github.com/alphagov/digitalmarketplace-docker-base/pull/53

This _should_ make instance shutdowns more graceful.