### PR TITLE
bump docker base image to 4.5.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,1 @@
-FROM digitalmarketplace/base-frontend:4.5.1
+FROM digitalmarketplace/base-frontend:4.5.2


### PR DESCRIPTION
https://trello.com/c/skD666lL/
https://trello.com/c/PyDaRXEj/

See https://github.com/alphagov/digitalmarketplace-docker-base/pull/54