### PR TITLE
bump docker base image to 4.5.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,1 @@
-FROM digitalmarketplace/base-frontend:4.5.2
+FROM digitalmarketplace/base-frontend:4.5.3


### PR DESCRIPTION
https://trello.com/c/PyDaRXEj
https://trello.com/c/skD666lL

...effectively bringing it back to state as of 4.5.0