### PR TITLE
Remove link to defunct DM blog

### DIFF
--- a/app/templates/suppliers/_frameworks_pending.html
+++ b/app/templates/suppliers/_frameworks_pending.html
@@ -24,9 +24,6 @@
       <h2 class="temporary-message-heading" id="temporary-message-heading">
         {{ framework.name }} is closed for applications
       </h2>
-      <p class="temporary-message-message">
-        Follow the <a href="https://digitalmarketplace.blog.gov.uk/">Digital Marketplace blog</a> for updates about new frameworks.
-      </p>
     </aside>
   {% endif %}
 {% endfor %}

--- a/tests/app/main/test_suppliers.py
+++ b/tests/app/main/test_suppliers.py
@@ -343,7 +343,6 @@ class TestSuppliersDashboard(BaseApplicationTest):
         message = doc.xpath('//aside[@class="temporary-message"]')
         assert len(message) > 0
         assert u"G-Cloud 7 is closed for applications" in message[0].xpath('h2/text()')[0]
-        assert len(message[0].xpath('p[1]/a[@href="https://digitalmarketplace.blog.gov.uk/"]')) > 0
 
     def test_shows_gcloud_7_closed_message_if_pending_and_no_application(self):  # noqa
         self.data_api_client.get_framework.return_value = self.framework('pending')


### PR DESCRIPTION
Trello: https://trello.com/c/HR9c6JJy/515-remove-blog-link-in-closed-applications-message

The blog closed in October 2018. Let's remove the link to it.