### PR TITLE
content loader: implement this as a thread/context-local

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -17,6 +17,7 @@ csrf = CSRFProtect()
 
 from app.main.helpers.services import parse_document_upload_time
 from app.main.helpers.frameworks import question_references
+from app.main import get_content_loader
 
 
 def create_app(config_name):
@@ -62,6 +63,10 @@ def create_app(config_name):
 
     application.add_template_filter(question_references)
     application.add_template_filter(parse_document_upload_time)
+
+    # the lucky thread that gets to do create_app also gets to pre-load its content_loader, in the process
+    # asserting that all required content files are present and in good order
+    get_content_loader()
 
     return application
 

--- a/app/main/__init__.py
+++ b/app/main/__init__.py
@@ -3,6 +3,8 @@ from werkzeug.local import Local, LocalProxy
 
 from dmcontent.content_loader import ContentLoader
 
+from dmutils.timing import logged_duration
+
 main = Blueprint('main', __name__)
 
 # we use our own Local for objects we explicitly want to be able to retain between requests but shouldn't
@@ -10,6 +12,7 @@ main = Blueprint('main', __name__)
 _local = Local()
 
 
+@logged_duration(message="Spent {duration_real}s in get_content_loader")
 def get_content_loader():
     if hasattr(_local, "content_loader"):
         return _local.content_loader

--- a/app/main/__init__.py
+++ b/app/main/__init__.py
@@ -1,57 +1,72 @@
 from flask import Blueprint
+from werkzeug.local import Local, LocalProxy
 
 from dmcontent.content_loader import ContentLoader
 
 main = Blueprint('main', __name__)
 
-content_loader = ContentLoader('app/content')
-content_loader.load_manifest('g-cloud-6', 'services', 'edit_service')
-content_loader.load_messages('g-cloud-6', ['urls'])
+# we use our own Local for objects we explicitly want to be able to retain between requests but shouldn't
+# share a common object between concurrent threads/contexts
+_local = Local()
 
-content_loader.load_manifest('g-cloud-7', 'services', 'edit_service')
-content_loader.load_manifest('g-cloud-7', 'services', 'edit_submission')
-content_loader.load_manifest('g-cloud-7', 'declaration', 'declaration')
-content_loader.load_messages('g-cloud-7', ['urls'])
 
-content_loader.load_manifest('digital-outcomes-and-specialists', 'declaration', 'declaration')
-content_loader.load_manifest('digital-outcomes-and-specialists', 'services', 'edit_submission')
-content_loader.load_manifest('digital-outcomes-and-specialists', 'briefs', 'edit_brief')
-content_loader.load_messages('digital-outcomes-and-specialists', ['urls'])
+def get_content_loader():
+    if hasattr(_local, "content_loader"):
+        return _local.content_loader
 
-content_loader.load_manifest('digital-outcomes-and-specialists-2', 'declaration', 'declaration')
-content_loader.load_manifest('digital-outcomes-and-specialists-2', 'services', 'edit_submission')
-content_loader.load_manifest('digital-outcomes-and-specialists-2', 'services', 'edit_service')
-content_loader.load_manifest('digital-outcomes-and-specialists-2', 'briefs', 'edit_brief')
-content_loader.load_messages('digital-outcomes-and-specialists-2', ['urls'])
+    _content_loader = _local.content_loader = ContentLoader('app/content')
+    _content_loader.load_manifest('g-cloud-6', 'services', 'edit_service')
+    _content_loader.load_messages('g-cloud-6', ['urls'])
 
-content_loader.load_manifest('g-cloud-8', 'services', 'edit_service')
-content_loader.load_manifest('g-cloud-8', 'services', 'edit_submission')
-content_loader.load_manifest('g-cloud-8', 'declaration', 'declaration')
-content_loader.load_messages('g-cloud-8', ['urls'])
+    _content_loader.load_manifest('g-cloud-7', 'services', 'edit_service')
+    _content_loader.load_manifest('g-cloud-7', 'services', 'edit_submission')
+    _content_loader.load_manifest('g-cloud-7', 'declaration', 'declaration')
+    _content_loader.load_messages('g-cloud-7', ['urls'])
 
-content_loader.load_manifest('g-cloud-9', 'services', 'edit_service')
-content_loader.load_manifest('g-cloud-9', 'services', 'edit_submission')
-content_loader.load_manifest('g-cloud-9', 'declaration', 'declaration')
-content_loader.load_messages('g-cloud-9', ['urls', 'advice'])
+    _content_loader.load_manifest('digital-outcomes-and-specialists', 'declaration', 'declaration')
+    _content_loader.load_manifest('digital-outcomes-and-specialists', 'services', 'edit_submission')
+    _content_loader.load_manifest('digital-outcomes-and-specialists', 'briefs', 'edit_brief')
+    _content_loader.load_messages('digital-outcomes-and-specialists', ['urls'])
 
-content_loader.load_manifest('g-cloud-10', 'services', 'edit_service')
-content_loader.load_manifest('g-cloud-10', 'services', 'edit_submission')
-content_loader.load_manifest('g-cloud-10', 'declaration', 'declaration')
-content_loader.load_messages('g-cloud-10', ['urls', 'advice'])
-content_loader.load_metadata('g-cloud-10', ['copy_services'])
+    _content_loader.load_manifest('digital-outcomes-and-specialists-2', 'declaration', 'declaration')
+    _content_loader.load_manifest('digital-outcomes-and-specialists-2', 'services', 'edit_submission')
+    _content_loader.load_manifest('digital-outcomes-and-specialists-2', 'services', 'edit_service')
+    _content_loader.load_manifest('digital-outcomes-and-specialists-2', 'briefs', 'edit_brief')
+    _content_loader.load_messages('digital-outcomes-and-specialists-2', ['urls'])
 
-content_loader.load_manifest('digital-outcomes-and-specialists-3', 'declaration', 'declaration')
-content_loader.load_manifest('digital-outcomes-and-specialists-3', 'services', 'edit_submission')
-content_loader.load_manifest('digital-outcomes-and-specialists-3', 'services', 'edit_service')
-content_loader.load_manifest('digital-outcomes-and-specialists-3', 'briefs', 'edit_brief')
-content_loader.load_messages('digital-outcomes-and-specialists-3', ['urls'])
-content_loader.load_metadata('digital-outcomes-and-specialists-3', ['copy_services', 'following_framework'])
+    _content_loader.load_manifest('g-cloud-8', 'services', 'edit_service')
+    _content_loader.load_manifest('g-cloud-8', 'services', 'edit_submission')
+    _content_loader.load_manifest('g-cloud-8', 'declaration', 'declaration')
+    _content_loader.load_messages('g-cloud-8', ['urls'])
 
-content_loader.load_manifest('g-cloud-11', 'services', 'edit_service')
-content_loader.load_manifest('g-cloud-11', 'services', 'edit_submission')
-content_loader.load_manifest('g-cloud-11', 'declaration', 'declaration')
-content_loader.load_messages('g-cloud-11', ['urls', 'advice'])
-content_loader.load_metadata('g-cloud-11', ['copy_services', 'following_framework'])
+    _content_loader.load_manifest('g-cloud-9', 'services', 'edit_service')
+    _content_loader.load_manifest('g-cloud-9', 'services', 'edit_submission')
+    _content_loader.load_manifest('g-cloud-9', 'declaration', 'declaration')
+    _content_loader.load_messages('g-cloud-9', ['urls', 'advice'])
+
+    _content_loader.load_manifest('g-cloud-10', 'services', 'edit_service')
+    _content_loader.load_manifest('g-cloud-10', 'services', 'edit_submission')
+    _content_loader.load_manifest('g-cloud-10', 'declaration', 'declaration')
+    _content_loader.load_messages('g-cloud-10', ['urls', 'advice'])
+    _content_loader.load_metadata('g-cloud-10', ['copy_services'])
+
+    _content_loader.load_manifest('digital-outcomes-and-specialists-3', 'declaration', 'declaration')
+    _content_loader.load_manifest('digital-outcomes-and-specialists-3', 'services', 'edit_submission')
+    _content_loader.load_manifest('digital-outcomes-and-specialists-3', 'services', 'edit_service')
+    _content_loader.load_manifest('digital-outcomes-and-specialists-3', 'briefs', 'edit_brief')
+    _content_loader.load_messages('digital-outcomes-and-specialists-3', ['urls'])
+    _content_loader.load_metadata('digital-outcomes-and-specialists-3', ['copy_services', 'following_framework'])
+
+    _content_loader.load_manifest('g-cloud-11', 'services', 'edit_service')
+    _content_loader.load_manifest('g-cloud-11', 'services', 'edit_submission')
+    _content_loader.load_manifest('g-cloud-11', 'declaration', 'declaration')
+    _content_loader.load_messages('g-cloud-11', ['urls', 'advice'])
+    _content_loader.load_metadata('g-cloud-11', ['copy_services', 'following_framework'])
+
+    return _content_loader
+
+
+content_loader = LocalProxy(get_content_loader)
 
 
 @main.after_request


### PR DESCRIPTION
Well this was unexpectedly straightforward.

https://trello.com/c/i4r9f1Hd
https://trello.com/c/RW2tzjbM

I was at least expecting the mocks to break.

The content loader isn't threadsafe, so the easiest avenue towards thread-enabling an app is probably to supply each thread/context with its own copy of the content loader. the thread that manages to perform the init_app also gets to pre-load its content, in the process performing the init-time content checking that we're used to. other threads will construct their content loader on first access (it's probably quite tricky to get them to pre-load too)