### PR TITLE
DOS4 declaration validator

### DIFF
--- a/app/main/__init__.py
+++ b/app/main/__init__.py
@@ -53,6 +53,13 @@ content_loader.load_manifest('g-cloud-11', 'declaration', 'declaration')
 content_loader.load_messages('g-cloud-11', ['urls', 'advice'])
 content_loader.load_metadata('g-cloud-11', ['copy_services', 'following_framework'])
 
+content_loader.load_manifest('digital-outcomes-and-specialists-4', 'declaration', 'declaration')
+content_loader.load_manifest('digital-outcomes-and-specialists-4', 'services', 'edit_submission')
+content_loader.load_manifest('digital-outcomes-and-specialists-4', 'services', 'edit_service')
+content_loader.load_manifest('digital-outcomes-and-specialists-4', 'briefs', 'edit_brief')
+content_loader.load_messages('digital-outcomes-and-specialists-4', ['urls'])
+content_loader.load_metadata('digital-outcomes-and-specialists-4', ['copy_services', 'following_framework'])
+
 
 @main.after_request
 def add_cache_control(response):

--- a/app/main/helpers/validation.py
+++ b/app/main/helpers/validation.py
@@ -257,4 +257,5 @@ VALIDATORS = {
     "g-cloud-10": DOS2Validator,
     "digital-outcomes-and-specialists-3": DOS2Validator,
     "g-cloud-11": DOS2Validator,
+    "digital-outcomes-and-specialists-4": DOS2Validator,
 }

--- a/app/main/helpers/validation.py
+++ b/app/main/helpers/validation.py
@@ -240,22 +240,19 @@ class DOSValidator(DeclarationValidator):
         return req_fields
 
 
-class G8Validator(DOSValidator):
+class SharedValidator(DOSValidator):
+    # From DOS2 and G8 onwards, validate DUNS number length
     number_string_fields = [('dunsNumber', 9)]
-
-
-class DOS2Validator(G8Validator):
-    pass
 
 
 VALIDATORS = {
     "g-cloud-7": G7Validator,
-    "g-cloud-8": G8Validator,
+    "g-cloud-8": SharedValidator,
     "digital-outcomes-and-specialists": DOSValidator,
-    "digital-outcomes-and-specialists-2": DOS2Validator,
-    "g-cloud-9": DOS2Validator,
-    "g-cloud-10": DOS2Validator,
-    "digital-outcomes-and-specialists-3": DOS2Validator,
-    "g-cloud-11": DOS2Validator,
-    "digital-outcomes-and-specialists-4": DOS2Validator,
+    "digital-outcomes-and-specialists-2": SharedValidator,
+    "g-cloud-9": SharedValidator,
+    "g-cloud-10": SharedValidator,
+    "digital-outcomes-and-specialists-3": SharedValidator,
+    "g-cloud-11": SharedValidator,
+    "digital-outcomes-and-specialists-4": SharedValidator,
 }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "hogan.js": "3.0.2",
     "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v31.11.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.19.2/jinja_govuk_template-0.19.2.tgz",
-    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#15.3.3"
+    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#15.4.2"
   },
   "scripts": {
     "frontend-build:development": "./node_modules/gulp/bin/gulp.js build:development",

--- a/tests/app/main/helpers/validation/test_g8_declaration.py
+++ b/tests/app/main/helpers/validation/test_g8_declaration.py
@@ -1,6 +1,6 @@
 import pytest
 
-from app.main.helpers.validation import get_validator, G8Validator
+from app.main.helpers.validation import get_validator, SharedValidator
 from app.main import content_loader
 
 
@@ -92,10 +92,10 @@ def test_duns_number_validation(content, submission):
 
     for val, errors in test_cases:
         submission['dunsNumber'] = val
-        validator = G8Validator(content, submission)
+        validator = SharedValidator(content, submission)
         assert validator.errors() == errors
 
 
 def test_get_validator():
     validator = get_validator({"slug": "g-cloud-8"}, None, None)
-    assert isinstance(validator, G8Validator)
+    assert isinstance(validator, SharedValidator)

--- a/yarn.lock
+++ b/yarn.lock
@@ -543,9 +543,9 @@ detect-file@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/detect-file/-/detect-file-1.0.0.tgz#f0d66d03672a825cb1b73bdb3fe62310c8e552b7"
 
-"digitalmarketplace-frameworks@https://github.com/alphagov/digitalmarketplace-frameworks.git#15.3.3":
-  version "15.3.3"
-  resolved "https://github.com/alphagov/digitalmarketplace-frameworks.git#b34869f70bcd5440be232b77ce49d30b44db3ecf"
+"digitalmarketplace-frameworks@https://github.com/alphagov/digitalmarketplace-frameworks.git#15.4.2":
+  version "15.4.2"
+  resolved "https://github.com/alphagov/digitalmarketplace-frameworks.git#6c195d9c2527d6217d5e3160d4d485359909e849"
 
 "digitalmarketplace-frontend-toolkit@https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v31.11.0":
   version "31.11.0"


### PR DESCRIPTION
Trello: https://trello.com/c/kTVN6PlQ/532-clone-dos4-content

- Pulls in latest frameworks package and loads the DOS4 content in `__init__`
- Renames the `DOS2Validator` (used by all post-G8 frameworks) to something more sane, `SharedValidator`. 
- Adds tests for all that custom behaviour in the `get_required_fields` method (not enough time to do a proper refactor of this - we have a tech debt ticket already)

I'm going to update the section of the manual (https://alphagov.github.io/digitalmarketplace-manual/content-and-frameworks/adding-frameworks.html#add-a-declaration-validator) with these changes.