### PR TITLE
content loader: implement this as a thread/context-local (deepcopy edition)

### DIFF
--- a/app/main/__init__.py
+++ b/app/main/__init__.py
@@ -1,64 +1,91 @@
+from copy import deepcopy
+
 from flask import Blueprint
+from werkzeug.local import Local, LocalProxy
 
 from dmcontent.content_loader import ContentLoader
 
+from dmutils.timing import logged_duration
+
 main = Blueprint('main', __name__)
 
-content_loader = ContentLoader('app/content')
-content_loader.load_manifest('g-cloud-6', 'services', 'edit_service')
-content_loader.load_messages('g-cloud-6', ['urls'])
+# we use our own Local for objects we explicitly want to be able to retain between requests but shouldn't
+# share a common object between concurrent threads/contexts
+_local = Local()
 
-content_loader.load_manifest('g-cloud-7', 'services', 'edit_service')
-content_loader.load_manifest('g-cloud-7', 'services', 'edit_submission')
-content_loader.load_manifest('g-cloud-7', 'declaration', 'declaration')
-content_loader.load_messages('g-cloud-7', ['urls'])
 
-content_loader.load_manifest('digital-outcomes-and-specialists', 'declaration', 'declaration')
-content_loader.load_manifest('digital-outcomes-and-specialists', 'services', 'edit_submission')
-content_loader.load_manifest('digital-outcomes-and-specialists', 'briefs', 'edit_brief')
-content_loader.load_messages('digital-outcomes-and-specialists', ['urls'])
+def _make_content_loader_factory():
+    master_cl = ContentLoader('app/content')
+    master_cl.load_manifest('g-cloud-6', 'services', 'edit_service')
+    master_cl.load_messages('g-cloud-6', ['urls'])
 
-content_loader.load_manifest('digital-outcomes-and-specialists-2', 'declaration', 'declaration')
-content_loader.load_manifest('digital-outcomes-and-specialists-2', 'services', 'edit_submission')
-content_loader.load_manifest('digital-outcomes-and-specialists-2', 'services', 'edit_service')
-content_loader.load_manifest('digital-outcomes-and-specialists-2', 'briefs', 'edit_brief')
-content_loader.load_messages('digital-outcomes-and-specialists-2', ['urls'])
+    master_cl.load_manifest('g-cloud-7', 'services', 'edit_service')
+    master_cl.load_manifest('g-cloud-7', 'services', 'edit_submission')
+    master_cl.load_manifest('g-cloud-7', 'declaration', 'declaration')
+    master_cl.load_messages('g-cloud-7', ['urls'])
 
-content_loader.load_manifest('g-cloud-8', 'services', 'edit_service')
-content_loader.load_manifest('g-cloud-8', 'services', 'edit_submission')
-content_loader.load_manifest('g-cloud-8', 'declaration', 'declaration')
-content_loader.load_messages('g-cloud-8', ['urls'])
+    master_cl.load_manifest('digital-outcomes-and-specialists', 'declaration', 'declaration')
+    master_cl.load_manifest('digital-outcomes-and-specialists', 'services', 'edit_submission')
+    master_cl.load_manifest('digital-outcomes-and-specialists', 'briefs', 'edit_brief')
+    master_cl.load_messages('digital-outcomes-and-specialists', ['urls'])
 
-content_loader.load_manifest('g-cloud-9', 'services', 'edit_service')
-content_loader.load_manifest('g-cloud-9', 'services', 'edit_submission')
-content_loader.load_manifest('g-cloud-9', 'declaration', 'declaration')
-content_loader.load_messages('g-cloud-9', ['urls', 'advice'])
+    master_cl.load_manifest('digital-outcomes-and-specialists-2', 'declaration', 'declaration')
+    master_cl.load_manifest('digital-outcomes-and-specialists-2', 'services', 'edit_submission')
+    master_cl.load_manifest('digital-outcomes-and-specialists-2', 'services', 'edit_service')
+    master_cl.load_manifest('digital-outcomes-and-specialists-2', 'briefs', 'edit_brief')
+    master_cl.load_messages('digital-outcomes-and-specialists-2', ['urls'])
 
-content_loader.load_manifest('g-cloud-10', 'services', 'edit_service')
-content_loader.load_manifest('g-cloud-10', 'services', 'edit_submission')
-content_loader.load_manifest('g-cloud-10', 'declaration', 'declaration')
-content_loader.load_messages('g-cloud-10', ['urls', 'advice'])
-content_loader.load_metadata('g-cloud-10', ['copy_services'])
+    master_cl.load_manifest('g-cloud-8', 'services', 'edit_service')
+    master_cl.load_manifest('g-cloud-8', 'services', 'edit_submission')
+    master_cl.load_manifest('g-cloud-8', 'declaration', 'declaration')
+    master_cl.load_messages('g-cloud-8', ['urls'])
 
-content_loader.load_manifest('digital-outcomes-and-specialists-3', 'declaration', 'declaration')
-content_loader.load_manifest('digital-outcomes-and-specialists-3', 'services', 'edit_submission')
-content_loader.load_manifest('digital-outcomes-and-specialists-3', 'services', 'edit_service')
-content_loader.load_manifest('digital-outcomes-and-specialists-3', 'briefs', 'edit_brief')
-content_loader.load_messages('digital-outcomes-and-specialists-3', ['urls'])
-content_loader.load_metadata('digital-outcomes-and-specialists-3', ['copy_services', 'following_framework'])
+    master_cl.load_manifest('g-cloud-9', 'services', 'edit_service')
+    master_cl.load_manifest('g-cloud-9', 'services', 'edit_submission')
+    master_cl.load_manifest('g-cloud-9', 'declaration', 'declaration')
+    master_cl.load_messages('g-cloud-9', ['urls', 'advice'])
 
-content_loader.load_manifest('g-cloud-11', 'services', 'edit_service')
-content_loader.load_manifest('g-cloud-11', 'services', 'edit_submission')
-content_loader.load_manifest('g-cloud-11', 'declaration', 'declaration')
-content_loader.load_messages('g-cloud-11', ['urls', 'advice'])
-content_loader.load_metadata('g-cloud-11', ['copy_services', 'following_framework'])
+    master_cl.load_manifest('g-cloud-10', 'services', 'edit_service')
+    master_cl.load_manifest('g-cloud-10', 'services', 'edit_submission')
+    master_cl.load_manifest('g-cloud-10', 'declaration', 'declaration')
+    master_cl.load_messages('g-cloud-10', ['urls', 'advice'])
+    master_cl.load_metadata('g-cloud-10', ['copy_services'])
 
-content_loader.load_manifest('digital-outcomes-and-specialists-4', 'declaration', 'declaration')
-content_loader.load_manifest('digital-outcomes-and-specialists-4', 'services', 'edit_submission')
-content_loader.load_manifest('digital-outcomes-and-specialists-4', 'services', 'edit_service')
-content_loader.load_manifest('digital-outcomes-and-specialists-4', 'briefs', 'edit_brief')
-content_loader.load_messages('digital-outcomes-and-specialists-4', ['urls'])
-content_loader.load_metadata('digital-outcomes-and-specialists-4', ['copy_services', 'following_framework'])
+    master_cl.load_manifest('digital-outcomes-and-specialists-3', 'declaration', 'declaration')
+    master_cl.load_manifest('digital-outcomes-and-specialists-3', 'services', 'edit_submission')
+    master_cl.load_manifest('digital-outcomes-and-specialists-3', 'services', 'edit_service')
+    master_cl.load_manifest('digital-outcomes-and-specialists-3', 'briefs', 'edit_brief')
+    master_cl.load_messages('digital-outcomes-and-specialists-3', ['urls'])
+    master_cl.load_metadata('digital-outcomes-and-specialists-3', ['copy_services', 'following_framework'])
+
+    master_cl.load_manifest('g-cloud-11', 'services', 'edit_service')
+    master_cl.load_manifest('g-cloud-11', 'services', 'edit_submission')
+    master_cl.load_manifest('g-cloud-11', 'declaration', 'declaration')
+    master_cl.load_messages('g-cloud-11', ['urls', 'advice'])
+    master_cl.load_metadata('g-cloud-11', ['copy_services', 'following_framework'])
+
+    master_cl.load_manifest('digital-outcomes-and-specialists-4', 'declaration', 'declaration')
+    master_cl.load_manifest('digital-outcomes-and-specialists-4', 'services', 'edit_submission')
+    master_cl.load_manifest('digital-outcomes-and-specialists-4', 'services', 'edit_service')
+    master_cl.load_manifest('digital-outcomes-and-specialists-4', 'briefs', 'edit_brief')
+    master_cl.load_messages('digital-outcomes-and-specialists-4', ['urls'])
+    master_cl.load_metadata('digital-outcomes-and-specialists-4', ['copy_services', 'following_framework'])
+
+    # seal master_cl in a closure by returning a function which will only ever return an independent copy of it
+    return lambda: deepcopy(master_cl)
+
+
+_content_loader_factory = _make_content_loader_factory()
+
+
+@logged_duration(message="Spent {duration_real}s in get_content_loader")
+def get_content_loader():
+    if not hasattr(_local, "content_loader"):
+        _local.content_loader = _content_loader_factory()
+    return _local.content_loader
+
+
+content_loader = LocalProxy(get_content_loader)
 
 
 @main.after_request

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -7,5 +7,5 @@ Flask-WTF==0.14.2
 itsdangerous==0.24 # pyup: ignore
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@48.3.0#egg=digitalmarketplace-utils==48.3.0
-git+https://github.com/alphagov/digitalmarketplace-content-loader.git@5.2.1#egg=digitalmarketplace-content-loader==5.2.1
+git+https://github.com/alphagov/digitalmarketplace-content-loader.git@6.0.0#egg=digitalmarketplace-content-loader==6.0.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@19.15.1#egg=digitalmarketplace-apiclient==19.15.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ Flask-WTF==0.14.2
 itsdangerous==0.24 # pyup: ignore
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@48.3.0#egg=digitalmarketplace-utils==48.3.0
-git+https://github.com/alphagov/digitalmarketplace-content-loader.git@5.2.1#egg=digitalmarketplace-content-loader==5.2.1
+git+https://github.com/alphagov/digitalmarketplace-content-loader.git@6.0.0#egg=digitalmarketplace-content-loader==6.0.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@19.15.1#egg=digitalmarketplace-apiclient==19.15.1
 
 ## The following requirements were added by pip freeze:


### PR DESCRIPTION
https://trello.com/c/RW2tzjbM

A reworked version of https://github.com/alphagov/digitalmarketplace-supplier-frontend/pull/1067

The content loader isn't threadsafe, so the easiest avenue towards thread-enabling an app is probably to supply each thread/context with its own copy of the content loader. Rather than constructing a new `ContentLoader` from scratch for each thread, allow the initial importing process to construct a "master" `ContentLoader` which we seal in a closure. The only things that can escape this closure are deep copies which should not share any mutable objects with each other and therefore be sufficiently
independent.

Each thread will make its own deep copy of this master content loader when it first needs one - a comparatively cheap operation.