### PR TITLE
Clarification question changes for DOS4

### DIFF
--- a/app/templates/frameworks/updates.html
+++ b/app/templates/frameworks/updates.html
@@ -92,8 +92,6 @@
       <p class="hint">
         {% if framework.clarificationQuestionsOpen %}
           All clarification questions and answers will be published here regularly. You’ll receive an email when new answers are available.
-        
-       
         {% else %}
           The deadline for asking clarification questions has now passed.
           All clarification questions and answers will be published by {{ framework.clarificationsPublishAt }}.
@@ -107,24 +105,36 @@
     {% if framework.clarificationQuestionsOpen %}
       <form method="post">
         <div class="grid-row">
+
           <div class="column-two-thirds">
+            {{ summary.heading("Ask a clarification question") }}
+
+            <p>Ask a clarification question if you need a better understanding of:</p>
+            <ul class="list-bullet">
+              <li>the legal documents</li>
+              <li>your responsibilities as a supplier</li>
+            </ul>
+            <br />
+            <p>Find out about the <a href="https://www.gov.uk/guidance/digital-outcomes-and-specialists-suppliers-guide">application process, what you need to apply and what services are eligible</a> in the guidance.
+            <br /><br />
+              <a href="{{ url_for('external.help') }}">Get help if there's a problem with your account</a>
+            </p>
             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
               {%
                 with
                 large=true,
-                question = "Ask a clarification question",
                 name = clarification_question_name,
-                hint = "You should ask any questions you have about {} here. The Crown Commercial Service will not respond to you individually. (Maximum 5000 characters per question.)".format(framework.name),
+                hint = "Maximum 5000 characters per question",
                 error = error_message,
                 value = clarification_question_value
               %}
                 {% include "toolkit/forms/textbox.html" %}
               {% endwith %}
-            <p>You can also read the <a href="https://www.gov.uk/guidance/g-cloud-suppliers-guide" rel="noopener noreferrer" target="_blank">guidance on the the application process and information you must provide.</a></p> 
-             <br>
-            <p>
-                The deadline for clarification questions is {{ framework.clarificationsCloseAt }}. All responses will be published by {{ framework.clarificationsPublishAt }}.
-              </p>
+            <p>You can ask clarification questions until {{ framework.clarificationsCloseAt }}.</p>
+            <br />
+            <p>Answers are published to this page around twice a week, alongside other supplier questions and answers.</p>
+            <br />
+            <p>All responses will be published by {{ framework.clarificationsPublishAt }}.</p>
               {%
                 with
                 label="Ask question",
@@ -139,34 +149,18 @@
           </div>
         </form>
     {% else %}
-      <form method="post">
+
         <div class="grid-row">
           <div class="column-two-thirds">
-            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
-            {%
-              with
-              large=true,
-              question = "Ask a question about your {} application".format(framework.name),
-              name = clarification_question_name,
-              hint = "If you have any questions about your {} application, you can ask them here. You'll get a private reply from the Crown Commercial Service. (Maximum 5000 characters per question.)".format(framework.name),
-              error = error_message,
-              value = clarification_question_value
-            %}
-            {% include "toolkit/forms/textbox.html" %}
-            {% endwith %}
-            {%
-              with
-              label="Ask question",
-              type="save"
-            %}
-            {% include "toolkit/button.html" %}
-            {% endwith %}
-  
-            <a href="{{ url_for('.framework_dashboard', framework_slug=framework.slug) }}">Return to {{ framework.name }} application</a>
+            {{ summary.heading("Contact us") }}
+
+            <p>Contact the support team if <a href="{{ url_for('external.help') }}">there’s a problem with your account or to update your details</a>.</p>
+            <br />
+            <p><a href="{{ url_for('.framework_dashboard', framework_slug=framework.slug) }}">Return to {{ framework.name }} application</a></p>
   
           </div>
         </div>
-      </form>
+
     {% endif %}
   {% endif %}
 {% endblock %}

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -3398,7 +3398,8 @@ class TestFrameworkUpdatesPage(BaseApplicationTest):
         data = response.get_data(as_text=True)
 
         assert response.status_code == 200
-        assert "All clarification questions and answers will be published by" not in data
+        assert 'All clarification questions and answers will be published ' \
+               'by 5pm BST, Tuesday 29 September 2015.' not in data
         assert 'You can ask clarification questions until 5pm BST, Tuesday 22 September 2015.' in data
 
     def test_the_tables_should_be_displayed_correctly(self, s3):
@@ -3483,22 +3484,13 @@ class TestFrameworkUpdatesPage(BaseApplicationTest):
                     ext,
                 )
 
-    def test_contact_link_is_shown_if_countersigned_agreement_is_not_yet_returned(self, s3):
-        self.data_api_client.get_framework.return_value = self.framework('live', clarification_questions_open=False)
-        self.data_api_client.get_supplier_framework_info.return_value = self.supplier_framework()
-
-        self.login()
-
-        response = self.client.get('/suppliers/frameworks/g-cloud-7/updates')
-        data = response.get_data(as_text=True)
-
-        assert response.status_code == 200
-        assert u'Contact the support team' in data
-
-    def test_no_question_box_shown_if_countersigned_agreement_is_returned(self, s3):
+    @pytest.mark.parametrize('countersigned_path, contact_link_shown', [("path", False), (None, True)])
+    def test_contact_link_only_shown_if_countersigned_agreement_is_not_yet_returned(
+        self, s3, countersigned_path, contact_link_shown
+    ):
         self.data_api_client.get_framework.return_value = self.framework('live', clarification_questions_open=False)
         self.data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
-            countersigned_path="path"
+            countersigned_path=countersigned_path
         )
 
         self.login()
@@ -3507,7 +3499,7 @@ class TestFrameworkUpdatesPage(BaseApplicationTest):
         data = response.get_data(as_text=True)
 
         assert response.status_code == 200
-        assert u'Contact the support team' not in data
+        assert ('Contact the support team' in data) == contact_link_shown
 
 
 @mock.patch('app.main.views.frameworks.DMNotifyClient.send_email', autospec=True)

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -3386,7 +3386,7 @@ class TestFrameworkUpdatesPage(BaseApplicationTest):
         assert response.status_code == 200
         assert 'All clarification questions and answers will be published ' \
                'by 5pm BST, Tuesday 29 September 2015.' in data
-        assert "The deadline for clarification questions is" not in data
+        assert "You can ask clarification questions until " not in data
 
     def test_dates_for_open_framework_open_for_questions(self, s3):
         self.data_api_client.get_framework.return_value = self.framework('open', clarification_questions_open=True)
@@ -3399,7 +3399,7 @@ class TestFrameworkUpdatesPage(BaseApplicationTest):
 
         assert response.status_code == 200
         assert "All clarification questions and answers will be published by" not in data
-        assert 'The deadline for clarification questions is 5pm BST, Tuesday 22 September 2015.' in data
+        assert 'You can ask clarification questions until 5pm BST, Tuesday 22 September 2015.' in data
 
     def test_the_tables_should_be_displayed_correctly(self, s3):
         self.data_api_client.get_framework.return_value = self.framework('open')
@@ -3483,7 +3483,7 @@ class TestFrameworkUpdatesPage(BaseApplicationTest):
                     ext,
                 )
 
-    def test_question_box_is_shown_if_countersigned_agreement_is_not_yet_returned(self, s3):
+    def test_contact_link_is_shown_if_countersigned_agreement_is_not_yet_returned(self, s3):
         self.data_api_client.get_framework.return_value = self.framework('live', clarification_questions_open=False)
         self.data_api_client.get_supplier_framework_info.return_value = self.supplier_framework()
 
@@ -3493,7 +3493,7 @@ class TestFrameworkUpdatesPage(BaseApplicationTest):
         data = response.get_data(as_text=True)
 
         assert response.status_code == 200
-        assert u'Ask a question about your G-Cloud 7 application' in data
+        assert u'Contact the support team' in data
 
     def test_no_question_box_shown_if_countersigned_agreement_is_returned(self, s3):
         self.data_api_client.get_framework.return_value = self.framework('live', clarification_questions_open=False)
@@ -3507,7 +3507,7 @@ class TestFrameworkUpdatesPage(BaseApplicationTest):
         data = response.get_data(as_text=True)
 
         assert response.status_code == 200
-        assert u'Ask a question about your G-Cloud 7 application' not in data
+        assert u'Contact the support team' not in data
 
 
 @mock.patch('app.main.views.frameworks.DMNotifyClient.send_email', autospec=True)


### PR DESCRIPTION
Trello: https://trello.com/c/3U1ORXqu/568-dos4-clarification-question-content-improvements

We're removing the post-clarification-deadline 'followup' question functionality. Instead we are directing suppliers to the Help page where they can contact support. This new process has been agreed with CCS.

![clarification-content](https://user-images.githubusercontent.com/3492540/60110125-7448df00-9763-11e9-84a4-50c9191a944a.png)

Stefan has also supplied some new content that should help reduce the number of questions we receive (see ticket).
