### PR TITLE
Pull in DOS4 frameworks content 16.0.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "hogan.js": "3.0.2",
     "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v33.0.2",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.19.2/jinja_govuk_template-0.19.2.tgz",
-    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#16.0.5"
+    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#16.0.6"
   },
   "scripts": {
     "frontend-build:development": "./node_modules/gulp/bin/gulp.js build:development",

--- a/yarn.lock
+++ b/yarn.lock
@@ -817,9 +817,9 @@ detect-libc@^1.0.2:
   resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
   integrity sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=
 
-"digitalmarketplace-frameworks@https://github.com/alphagov/digitalmarketplace-frameworks.git#16.0.5":
-  version "16.0.5"
-  resolved "https://github.com/alphagov/digitalmarketplace-frameworks.git#3d11cd3ca259fec1e9c283fee86bb31693aa713f"
+"digitalmarketplace-frameworks@https://github.com/alphagov/digitalmarketplace-frameworks.git#16.0.6":
+  version "16.0.6"
+  resolved "https://github.com/alphagov/digitalmarketplace-frameworks.git#f2d7c3b479242d7fa82ce27c2acf6c331f64919b"
 
 "digitalmarketplace-frontend-toolkit@https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v33.0.2":
   version "33.0.2"


### PR DESCRIPTION
https://trello.com/c/BZ1PRdXo/567-update-text-what-it-means-to-be-on-digital-outcomes-and-specialists-4

Thought this was included in the last Supplier FE pull request, but it got missed. Adds in hardcoded list style: https://github.com/alphagov/digitalmarketplace-frameworks/pull/582