### PR TITLE
framework_updates_email_clarification_question: log supplier_reference before sending

### DIFF
--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -809,6 +809,11 @@ def framework_updates_email_clarification_question(framework_slug):
     suffix = hash_string(now.strftime("%H:%M:%S.%f") + clarification_question)[:6].replace("_", "Z")
     supplier_reference = "{}-{}".format(now.strftime("%Y-%m-%d"), suffix).upper()
 
+    current_app.logger.info(
+        "Preparing to send clarification question with supplier_reference {supplier_reference}",
+        extra={"supplier_reference": supplier_reference},
+    )
+
     personalisation = {
         "framework_name": framework['name'],
         "supplier_id": current_user.supplier_id,


### PR DESCRIPTION
Could save our butts in a pinch.