### PR TITLE
Support email update

### DIFF
--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -108,6 +108,7 @@ def edit_service(framework_slug, service_id):
         framework=framework,
         sections=content.summary(service),
         remove_requested=remove_requested,
+        support_email_address=current_app.config['SUPPORT_EMAIL_ADDRESS']
     )
 
 

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -43,17 +43,15 @@ JOIN_OPEN_FRAMEWORK_NOTIFICATION_MAILING_LIST_SUCCESS_MESSAGE = (
 )
 JOIN_OPEN_FRAMEWORK_NOTIFICATION_MAILING_LIST_ERROR_MESSAGE = Markup("""
     The service is unavailable at the moment. If the problem continues please contact
-    <a href="mailto:enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.service.gov.uk</a>
+    <a href="mailto:{support_email_address}">{support_email_address}</a>.
 """)
 JOIN_OPEN_FRAMEWORK_NOTIFICATION_MAILING_LIST_ALREADY_SUBSCRIBED_MESSAGE = Markup("""
     This email address has already been used to sign up for Digital Marketplace alerts. Please use a different
-     email address or contact
-    <a href="mailto:enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.service.gov.uk</a>.
+     email address or contact <a href="mailto:{support_email_address}">{support_email_address}</a>.
 """)
 JOIN_OPEN_FRAMEWORK_NOTIFICATION_MAILING_LIST_UNSUBSCRIBED_MESSAGE = Markup("""
     This email address cannot be used to sign up for Digital Marketplace alerts. Please use a different
-     email address or contact
-    <a href="mailto:enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.service.gov.uk</a>.
+     email address or contact <a href="mailto:{support_email_address}">{support_email_address}</a>.
 """)
 
 
@@ -539,6 +537,7 @@ def duns_number():
         "suppliers/create_duns_number.html",
         form=form,
         errors=errors,
+        support_email_address=current_app.config['SUPPORT_EMAIL_ADDRESS']
     ), 200 if not errors else 400
 
 
@@ -719,11 +718,17 @@ def join_open_framework_notification_mailing_list():
             return redirect("/")
         else:
             if mc_response.get('error_type') == 'already_subscribed':
-                flash(JOIN_OPEN_FRAMEWORK_NOTIFICATION_MAILING_LIST_ALREADY_SUBSCRIBED_MESSAGE, "error")
+                flash(JOIN_OPEN_FRAMEWORK_NOTIFICATION_MAILING_LIST_ALREADY_SUBSCRIBED_MESSAGE.format(
+                    support_email_address=current_app.config['SUPPORT_EMAIL_ADDRESS']
+                ), "error")
             elif mc_response.get('error_type') in ['deleted_user', 'invalid_email']:
-                flash(JOIN_OPEN_FRAMEWORK_NOTIFICATION_MAILING_LIST_UNSUBSCRIBED_MESSAGE, "error")
+                flash(JOIN_OPEN_FRAMEWORK_NOTIFICATION_MAILING_LIST_UNSUBSCRIBED_MESSAGE.format(
+                    support_email_address=current_app.config['SUPPORT_EMAIL_ADDRESS']
+                ), "error")
             else:
-                flash(JOIN_OPEN_FRAMEWORK_NOTIFICATION_MAILING_LIST_ERROR_MESSAGE, "error")
+                flash(JOIN_OPEN_FRAMEWORK_NOTIFICATION_MAILING_LIST_ERROR_MESSAGE.format(
+                    support_email_address=current_app.config['SUPPORT_EMAIL_ADDRESS']
+                ), "error")
             # If no status code supplied, something has probably gone wrong
             status = mc_response.get('status_code', 503)
             # fall through to re-display form with error

--- a/app/templates/services/service.html
+++ b/app/templates/services/service.html
@@ -29,7 +29,7 @@
     {% if service_data.status != 'published' and service_unavailability_information %}
       {%
         with
-        message = "If you don’t know why this service was removed or you want to reinstate it, contact <a href='mailto:enquiries@digitalmarketplace.service.gov.uk'>enquiries@digitalmarketplace.service.gov.uk</a>." | safe,
+        message = "If you don’t know why this service was removed or you want to reinstate it, contact <a href='mailto:{support_email_address}'>{support_email_address}</a>.".format(support_email_address=support_email_address) | safe,
         type = "temporary-message",
         heading = "This service was removed on {}".format(service_unavailability_information.createdAt|dateformat)
       %}
@@ -41,7 +41,7 @@
           Are you sure you want to remove your service?
         </p>
         <p class="banner-message">
-          When you remove a service, you can only reinstate it by emailing <a href='mailto:enquiries@digitalmarketplace.service.gov.uk'>enquiries@digitalmarketplace.service.gov.uk</a>.
+          When you remove a service, you can only reinstate it by emailing <a href='mailto:{{ support_email_address }}'>{{ support_email_address }}</a>.
         </p>
         <form class="banner-action" action="{{ url_for('.remove_service', framework_slug=service_data["frameworkSlug"], service_id=service_id ) }}" method="POST">
           <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
@@ -117,7 +117,7 @@
         <p>Your service page will be updated to include a message showing users that the service
           is no longer available to buy.</p>
         <p>You’ll need to email
-          <a href="mailto:enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.service.gov.uk</a>
+          <a href="mailto:{{ support_email_address }}">{{ support_email_address }}</a>
            to reinstate your service.</p>
         <form action="{{ url_for('.remove_service', framework_slug=service_data["frameworkSlug"], service_id=service_id ) }}" method="POST">
           <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />

--- a/app/templates/suppliers/create_duns_number.html
+++ b/app/templates/suppliers/create_duns_number.html
@@ -27,7 +27,7 @@
 <div class="grid-row">
   {% if errors.get("duns_number", {}).get("message", None) == 'DUNS number already used' %}
     {% with lede = "A supplier account already exists with that DUNS number",
-            description = 'If you no longer have your account details, or if you think this may be an error, email <a href="mailto:enquiries@digitalmarketplace.service.gov.uk?subject=DUNS%20number%20question" title="Please contact enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.service.gov.uk</a>'|safe
+            description = 'If you no longer have your account details, or if you think this may be an error, email <a href="mailto:{support_email_address}?subject=DUNS%20number%20question" title="Please contact {support_email_address}">{support_email_address}</a>'.format(support_email_address=support_email_address)|safe
     %}
       {% include 'toolkit/forms/validation.html' %}
     {% endwith %}

--- a/config.py
+++ b/config.py
@@ -53,7 +53,7 @@ class Config(object):
     DEBUG = False
 
     INVITE_EMAIL_NAME = 'Digital Marketplace Admin'
-    INVITE_EMAIL_FROM = 'enquiries@digitalmarketplace.service.gov.uk'
+    INVITE_EMAIL_FROM = 'cloud_digital@crowncommercial.gov.uk'
     INVITE_EMAIL_SUBJECT = 'Your Digital Marketplace invitation'
 
     CLARIFICATION_EMAIL_NAME = 'Digital Marketplace Admin'
@@ -61,7 +61,7 @@ class Config(object):
 
     FRAMEWORK_AGREEMENT_RETURNED_NAME = 'Digital Marketplace Admin'
 
-    DM_ENQUIRIES_EMAIL_ADDRESS = 'enquiries@digitalmarketplace.service.gov.uk'
+    DM_ENQUIRIES_EMAIL_ADDRESS = 'cloud_digital@crowncommercial.gov.uk'
     DM_ENQUIRIES_EMAIL_ADDRESS_UUID = '24908180-b64e-513d-ab48-fdca677cec52'
 
     SECRET_KEY = None
@@ -151,7 +151,7 @@ class Live(Config):
         "user.marketplace.team": "success@simulator.amazonses.com",
     }
 
-    DM_FRAMEWORK_AGREEMENTS_EMAIL = 'enquiries@digitalmarketplace.service.gov.uk'
+    DM_FRAMEWORK_AGREEMENTS_EMAIL = 'cloud_digital@crowncommercial.gov.uk'
 
 
 class Preview(Live):

--- a/config.py
+++ b/config.py
@@ -27,6 +27,7 @@ class Config(object):
     DM_CLARIFICATION_QUESTION_EMAIL = 'clarification-questions@example.gov.uk'
     DM_FRAMEWORK_AGREEMENTS_EMAIL = 'enquiries@example.com'
     DM_COMPANY_DETAILS_CHANGE_EMAIL = 'cloud_digital@crowncommercial.gov.uk'
+    SUPPORT_EMAIL_ADDRESS = "cloud_digital@crowncommercial.gov.uk"
 
     NOTIFY_TEMPLATES = {
         "confirmation_of_clarification_question": "1a8a3408-49ef-486f-a6c9-8557d1a0dc63",

--- a/tests/app/test_application.py
+++ b/tests/app/test_application.py
@@ -29,13 +29,9 @@ class TestApplication(BaseApplicationTest):
     def test_404(self):
         res = self.client.get('/service/1234')
         assert res.status_code == 404
-        assert u"Check you’ve entered the correct web " \
-            u"address or start again on the Digital Marketplace homepage." in res.get_data(as_text=True)
-        assert u"If you can’t find what you’re looking for, contact us at " \
-            u"<a href=\"mailto:enquiries@digitalmarketplace.service.gov.uk?" \
-            u"subject=Digital%20Marketplace%20feedback\" title=\"Please " \
-            u"send feedback to enquiries@digitalmarketplace.service.gov.uk\">" \
-            u"enquiries@digitalmarketplace.service.gov.uk</a>" in res.get_data(as_text=True)
+        assert "Check you’ve entered the correct web " \
+               "address or start again on the Digital Marketplace homepage." in res.get_data(as_text=True)
+        assert "If you can’t find what you’re looking for, contact us at " in res.get_data(as_text=True)
 
     @mock.patch('app.main.views.suppliers.data_api_client')
     def test_503(self, data_api_client):


### PR DESCRIPTION
https://trello.com/c/3om47rfx/601-update-remaining-instances-of-enquiriesdigitalmarketplaceservicegovuk-to-the-new-support-address

Centralises the support email rather than hardcoding it in:

- Service template error message
- DUNS number template error message
- Error messages when signing up for the supplier mailing list

Also updates some of the existing config emails.