### PR TITLE
Pull in FE toolkit error pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "colors": "1.1.2",
     "jquery": "1.12.0",
     "hogan.js": "3.0.2",
-    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v33.0.2",
+    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v34.1.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.19.2/jinja_govuk_template-0.19.2.tgz",
     "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#16.0.10"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -821,9 +821,9 @@ detect-libc@^1.0.2:
   version "16.0.10"
   resolved "https://github.com/alphagov/digitalmarketplace-frameworks.git#960bc2709719ee31e77a5bbe4503de6a846d23ae"
 
-"digitalmarketplace-frontend-toolkit@https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v33.0.2":
-  version "33.0.2"
-  resolved "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#4dbdc9783ed661040ae801846f9ab86c3c05ebf4"
+"digitalmarketplace-frontend-toolkit@https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v34.1.0":
+  version "34.1.0"
+  resolved "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#acb4f5e2b902df76d5517a37512980e8b911902a"
   dependencies:
     del "^4.1.0"
     govuk-elements-sass "3.0.3"


### PR DESCRIPTION
https://trello.com/c/3om47rfx/601-update-remaining-instances-of-enquiriesdigitalmarketplaceservicegovuk-to-the-new-support-address

Most of the 404 error pages fall through to the Buyer FE, which is showing the new support email address. But duff URLs served by the other FE apps (e.g. /suppliers/some-sort-of-hijinks) haven't yet had the FE toolkit bumped and will show the old address.

The breaking change is for the reverted attempt to fix the JS for the functional tests.