### PR TITLE
Force pyup to ignore flask updates

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -1,7 +1,7 @@
 # Run `make freeze-requirements` to update requirements.txt
 # with package version changes made in requirements-app.txt
 
-Flask==1.0.3
+Flask==1.0.3 # pyup: >=1.0.0,<1.1.0
 Flask-Login==0.4.1
 Flask-WTF==0.14.2
 itsdangerous==0.24 # pyup: ignore

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 # Run `make freeze-requirements` to update requirements.txt
 # with package version changes made in requirements-app.txt
 
-Flask==1.0.3
+Flask==1.0.3 # pyup: >=1.0.0,<1.1.0
 Flask-Login==0.4.1
 Flask-WTF==0.14.2
 itsdangerous==0.24 # pyup: ignore
@@ -14,8 +14,8 @@ git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.0.0#egg=digi
 ## The following requirements were added by pip freeze:
 asn1crypto==0.24.0
 blinker==1.4
-boto3==1.9.199
-botocore==1.12.199
+boto3==1.9.201
+botocore==1.12.201
 certifi==2019.6.16
 cffi==1.12.3
 chardet==3.0.4


### PR DESCRIPTION
We're not certain that the new version of Flask is stable, so we're going to ignore it for a couple of weeks until they've had a chance to iron out the bugs