### PR TITLE
Bump digitalmarketplace-utils dependency to 48.5.0

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -6,6 +6,6 @@ Flask-Login==0.4.1
 Flask-WTF==0.14.2
 itsdangerous==0.24 # pyup: ignore
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@48.3.0#egg=digitalmarketplace-utils==48.3.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@48.5.0#egg=digitalmarketplace-utils==48.5.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@6.0.0#egg=digitalmarketplace-content-loader==6.0.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.0.0#egg=digitalmarketplace-apiclient==21.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,15 +7,15 @@ Flask-Login==0.4.1
 Flask-WTF==0.14.2
 itsdangerous==0.24 # pyup: ignore
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@48.3.0#egg=digitalmarketplace-utils==48.3.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@48.5.0#egg=digitalmarketplace-utils==48.5.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@6.0.0#egg=digitalmarketplace-content-loader==6.0.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.0.0#egg=digitalmarketplace-apiclient==21.0.0
 
 ## The following requirements were added by pip freeze:
 asn1crypto==0.24.0
 blinker==1.4
-boto3==1.9.205
-botocore==1.12.205
+boto3==1.9.214
+botocore==1.12.214
 certifi==2019.6.16
 cffi==1.12.3
 chardet==3.0.4
@@ -24,12 +24,12 @@ contextlib2==0.5.5
 cryptography==2.3.1
 defusedxml==0.6.0
 docopt==0.6.2
-docutils==0.14
+docutils==0.15.2
 Flask-Script==2.0.6
 fleep==1.0.1
 future==0.17.1
 gds-metrics==0.2.0
-govuk-country-register==0.4.0
+govuk-country-register==0.5.0
 idna==2.8
 inflection==0.3.1
 Jinja2==2.10.1


### PR DESCRIPTION
https://trello.com/c/HsZ9mj7o

bringing in "probe cookie"-setting, along with a re-freeze of dependencies