### PR TITLE
consistently use current_user.email_address for updated_by in API requests

### DIFF
--- a/app/main/helpers/services.py
+++ b/app/main/helpers/services.py
@@ -85,7 +85,7 @@ def copy_service_from_previous_framework(data_api_client, content_loader, framew
 
     data_api_client.copy_draft_service_from_existing_service(
         previous_service['id'],
-        current_user.name,
+        current_user.email_address,
         {
             'targetFramework': framework_slug,
             'status': 'not-submitted',

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -866,7 +866,7 @@ def copy_all_previous_services(framework_slug, lot_slug):
     response = data_api_client.copy_published_from_framework(
         framework_slug,
         lot_slug,
-        current_user.name,
+        current_user.email_address,
         data={
             "sourceFrameworkSlug": source_framework_slug,
             "supplierId": current_user.supplier_id,

--- a/tests/app/main/helpers/test_services.py
+++ b/tests/app/main/helpers/test_services.py
@@ -47,7 +47,7 @@ class TestCopyServiceFromPreviousFramework():
 
     @mock.patch('app.main.helpers.services.current_user')
     def test_correctly_calls_api_client(self, current_user):
-        current_user.name = 'Mr Sausages'
+        current_user.email_address = 'sausage@pink.net'
         current_user.supplier_id = 1234
 
         self.api_client_mock.get_service.return_value = self.previous_service()
@@ -59,7 +59,7 @@ class TestCopyServiceFromPreviousFramework():
         assert self.api_client_mock.copy_draft_service_from_existing_service.call_args_list == [
             mock.call(
                 4444244,
-                'Mr Sausages',
+                "sausage@pink.net",
                 {
                     'targetFramework': 'dos-cloud-X',
                     'status': 'not-submitted',

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -2689,7 +2689,7 @@ class CopyingPreviousServicesSetup(BaseApplicationTest):
 
 
 class TestCopyPreviousService(CopyingPreviousServicesSetup, MockEnsureApplicationCompanyDetailsHaveBeenConfirmedMixin):
-    def test_copys_existing_service_to_new_framework(self):
+    def test_copies_existing_service_to_new_framework(self):
         res = self.client.post(
             '/suppliers/frameworks/g-cloud-10/submissions/cloud-hosting/copy-previous-framework-service/2000000000'
         )
@@ -2703,7 +2703,7 @@ class TestCopyPreviousService(CopyingPreviousServicesSetup, MockEnsureApplicatio
         assert self.data_api_client.copy_draft_service_from_existing_service.call_args_list == [
             mock.call(
                 '2000000000',
-                'Năme',
+                'email@email.com',
                 {
                     'targetFramework': 'g-cloud-10',
                     'status': 'not-submitted',
@@ -2799,7 +2799,7 @@ class TestCopyAllPreviousServices(CopyingPreviousServicesSetup,
             mock.call(
                 'g-cloud-10',
                 'cloud-hosting',
-                'Năme',
+                'email@email.com',
                 data={
                     "sourceFrameworkSlug": 'g-cloud-9',
                     "supplierId": 1234,


### PR DESCRIPTION
https://trello.com/c/IvrgIUND

This was quick & simple enough. Was going to do a total "audit" of places we were screwing this up by searching the prod database's audit table for non-`@`-containing `updated_by`s but realized we don't use email addresses in most of our script/manual updates.