### PR TITLE
set DM_COOKIE_PROBE_COOKIE_EXPECT_PRESENT, enabling cookie error page

### DIFF
--- a/config.py
+++ b/config.py
@@ -18,6 +18,8 @@ class Config(object):
 
     PERMANENT_SESSION_LIFETIME = 3600  # 1 hour
 
+    DM_COOKIE_PROBE_COOKIE_EXPECT_PRESENT = True
+
     WTF_CSRF_ENABLED = True
     WTF_CSRF_TIME_LIMIT = None
 


### PR DESCRIPTION
https://trello.com/c/HsZ9mj7o

This should only ever show itself in place of a CSRF token failure, so should be a fairly safe thing to enable.