### PR TITLE
Update harcoded DOS2 link to be DOS3

### DIFF
--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -95,7 +95,7 @@ def dashboard():
     if "currently_applying_to" in session:
         del session["currently_applying_to"]
 
-    # TODO remove the `dos2` key from the frameworks dict below. It's a temporary fix until a better designed solution
+    # TODO remove the `dos3` key from the frameworks dict below. It's a temporary fix until a better designed solution
     # can be implemented.
     return render_template(
         "suppliers/dashboard.html",
@@ -106,8 +106,8 @@ def dashboard():
             'pending': get_frameworks_by_status(all_frameworks, 'pending'),
             'standstill': get_frameworks_by_status(all_frameworks, 'standstill', 'made_application'),
             'live': get_frameworks_by_status(all_frameworks, 'live', 'services_count'),
-            'dos2': [
-                f for f in all_frameworks if f['slug'] == 'digital-outcomes-and-specialists-2' and f.get('onFramework')
+            'dos3': [
+                f for f in all_frameworks if f['slug'] == 'digital-outcomes-and-specialists-3' and f.get('onFramework')
             ],
         }
     ), 200

--- a/app/templates/suppliers/_frameworks_live.html
+++ b/app/templates/suppliers/_frameworks_live.html
@@ -1,4 +1,4 @@
-{% for framework in frameworks.dos2 + frameworks.live %}
+{% for framework in frameworks.dos3 + frameworks.live %}
 {% if framework.onFramework %}
   <h3 class="heading-xmedium">{{ framework.name }}</h2>
   <p>
@@ -10,7 +10,7 @@
     {% if framework.framework == 'digital-outcomes-and-specialists' %}
       <a href="{{ url_for('external.opportunities_dashboard', framework_slug=framework.slug) }}">View your opportunities</a><br>
     {% endif %}
-    {% if not framework.slug == 'digital-outcomes-and-specialists-2' %}
+    {% if not framework.slug == 'digital-outcomes-and-specialists-3' %}
       <a href="{{ url_for('.list_services', framework_slug=framework.slug) }}">View services</a><br>
       <a href="{{ url_for('.framework_dashboard', framework_slug=framework.slug) }}">View documents and ask a question</a>
     {% endif %}

--- a/tests/app/main/test_suppliers.py
+++ b/tests/app/main/test_suppliers.py
@@ -236,17 +236,17 @@ class TestSuppliersDashboard(BaseApplicationTest):
         assert u"Find out if your services are suitable" in message[0].xpath('p/a/text()')[0]
 
     @pytest.mark.parametrize('on_framework', (True, False))
-    def test_only_shows_expired_dos2_if_supplier_was_on_framework(self, on_framework):
+    def test_only_shows_expired_dos3_if_supplier_was_on_framework(self, on_framework):
         self.data_api_client.get_supplier.side_effect = get_supplier
         self.data_api_client.find_frameworks.return_value = {
             "frameworks": [
-                FrameworkStub(status='expired', slug='digital-outcomes-and-specialists-2').response(),
+                FrameworkStub(status='expired', slug='digital-outcomes-and-specialists-3').response(),
             ]
         }
         self.data_api_client.get_supplier_frameworks.return_value = {
             'frameworkInterest': [
                 {
-                    'frameworkSlug': 'digital-outcomes-and-specialists-2',
+                    'frameworkSlug': 'digital-outcomes-and-specialists-3',
                     'onFramework': on_framework,
                 }
             ]
@@ -263,24 +263,24 @@ class TestSuppliersDashboard(BaseApplicationTest):
             assert document.xpath(
                 "//h3[normalize-space(string())=$f]"
                 "[(following::a)[1][normalize-space(string())=$t1][@href=$u1]]",
-                f="Digital Outcomes and Specialists 2",
+                f="Digital Outcomes and Specialists 3",
                 t1="View your opportunities",
-                u1="/suppliers/opportunities/frameworks/digital-outcomes-and-specialists-2",
+                u1="/suppliers/opportunities/frameworks/digital-outcomes-and-specialists-3",
             )
             assert not document.xpath(
                 "//h3[normalize-space(string())=$f]"
                 "/..//a[normalize-space(string())=$t1]",
-                f="Digital Outcomes and Specialists 2",
+                f="Digital Outcomes and Specialists 3",
                 t1="View services",
             )
             assert not document.xpath(
                 "//h3[normalize-space(string())=$f]"
                 "/..//a[normalize-space(string())=$t1]",
-                f="Digital Outcomes and Specialists 2",
+                f="Digital Outcomes and Specialists 3",
                 t1="View documents and ask a question",
             )
         else:
-            assert not document.xpath("//h3[normalize-space(string())='Digital Outcomes and Specialists 2']")
+            assert not document.xpath("//h3[normalize-space(string())='Digital Outcomes and Specialists 3']")
 
     def test_shows_gcloud_7_application_button(self):
         self.data_api_client.get_framework_interest.return_value = {'frameworks': []}
@@ -1092,7 +1092,7 @@ class TestSupplierOpportunitiesDashboardLink(BaseApplicationTest):
             'agreementReturned': True,
             'complete_drafts_count': 2,
             'declaration': {'status': 'complete'},
-            'frameworkSlug': 'digital-outcomes-and-specialists-3',
+            'frameworkSlug': 'digital-outcomes-and-specialists-4',
             'onFramework': True,
             'services_count': 2,
             'supplierId': 1234
@@ -1107,7 +1107,7 @@ class TestSupplierOpportunitiesDashboardLink(BaseApplicationTest):
     def find_frameworks_stub(self):
         return {'frameworks': [
             {
-                **FrameworkStub(status='live', slug='digital-outcomes-and-specialists-3').response(),
+                **FrameworkStub(status='live', slug='digital-outcomes-and-specialists-4').response(),
                 'framework': 'digital-outcomes-and-specialists'
             }
         ]}
@@ -1128,13 +1128,13 @@ class TestSupplierOpportunitiesDashboardLink(BaseApplicationTest):
             "[(following::a)[1][normalize-space(string())=$t1][@href=$u1]]"
             "[(following::a)[2][normalize-space(string())=$t2][@href=$u2]]"
             "[(following::a)[3][normalize-space(string())=$t3][@href=$u3]]",
-            f="Digital Outcomes and Specialists 3",
+            f="Digital Outcomes and Specialists 4",
             t1="View your opportunities",
-            u1="/suppliers/opportunities/frameworks/digital-outcomes-and-specialists-3",
+            u1="/suppliers/opportunities/frameworks/digital-outcomes-and-specialists-4",
             t2="View services",
-            u2="/suppliers/frameworks/digital-outcomes-and-specialists-3/services",
+            u2="/suppliers/frameworks/digital-outcomes-and-specialists-4/services",
             t3="View documents and ask a question",
-            u3="/suppliers/frameworks/digital-outcomes-and-specialists-3",
+            u3="/suppliers/frameworks/digital-outcomes-and-specialists-4",
         )
 
     @pytest.mark.parametrize(
@@ -1157,7 +1157,7 @@ class TestSupplierOpportunitiesDashboardLink(BaseApplicationTest):
         res = self.client.get("/suppliers")
         doc = html.fromstring(res.get_data(as_text=True))
 
-        unexpected_link = "/suppliers/opportunities/frameworks/digital-outcomes-and-specialists-3"
+        unexpected_link = "/suppliers/opportunities/frameworks/digital-outcomes-and-specialists-4"
 
         assert not any(filter(lambda i: i[2] == unexpected_link, doc.iterlinks()))
 


### PR DESCRIPTION
https://trello.com/c/sMuf2MLA/1156-fix-dos3-opportunities-on-supplier-fe

This bit of hardcoded logic got missed - suppliers who were on DOS3 need to be able to see their applications for opportunities still 'in flight'. 

I vow to not let this happen next year for DOS5 😿 

![see-dos3-opportunities](https://user-images.githubusercontent.com/3492540/65961598-d7c36680-e44e-11e9-8039-0a7a157c0da1.png)
