### PR TITLE
43-create-a-base-page-for-the-apps

### DIFF
--- a/app/templates/_base_page.html
+++ b/app/templates/_base_page.html
@@ -1,0 +1,3 @@
+{% extends "toolkit/layouts/_base_page.html" %}
+
+// Insert line for each component module import

--- a/app/templates/auth/submit_email_address.html
+++ b/app/templates/auth/submit_email_address.html
@@ -1,6 +1,6 @@
 <!-- place holder page until pull requests that will use invite supplier code is finished -->
 
-{% extends "toolkit/layouts/_base_page.html" %}
+{% extends "_base_page.html" %}
 
 {% block page_title %}Their email address - Add or remove contributors – Digital Marketplace{% endblock %}
 

--- a/app/templates/errors/applications_closed.html
+++ b/app/templates/errors/applications_closed.html
@@ -1,4 +1,4 @@
-{% extends "toolkit/layouts/_base_page.html" %}
+{% extends "_base_page.html" %}
 
 {% block page_title %}Applications closed - Digital Marketplace{% endblock %}
 

--- a/app/templates/frameworks/contract_review.html
+++ b/app/templates/frameworks/contract_review.html
@@ -1,4 +1,4 @@
-{% extends "toolkit/layouts/_base_page.html" %}
+{% extends "_base_page.html" %}
 
 {% block page_title %}Review your contract – Digital Marketplace{% endblock %}
 

--- a/app/templates/frameworks/contract_start.html
+++ b/app/templates/frameworks/contract_start.html
@@ -1,4 +1,4 @@
-{% extends "toolkit/layouts/_base_page.html" %}
+{% extends "_base_page.html" %}
 {% import "toolkit/summary-table.html" as summary %}
 
 {% block page_title %}Apply to {{ framework.name }} – Digital Marketplace{% endblock %}

--- a/app/templates/frameworks/contract_variation.html
+++ b/app/templates/frameworks/contract_variation.html
@@ -1,4 +1,4 @@
-{% extends "toolkit/layouts/_base_page.html" %}
+{% extends "_base_page.html" %}
 {% import "toolkit/summary-table.html" as summary %}
 
 {% block page_title %}{{ framework.name }} contract variation – Digital Marketplace{% endblock %}

--- a/app/templates/frameworks/dashboard.html
+++ b/app/templates/frameworks/dashboard.html
@@ -1,4 +1,4 @@
-{% extends "toolkit/layouts/_base_page.html" %}
+{% extends "_base_page.html" %}
 
 {% block page_title %}
   {% block page_title_inner %}

--- a/app/templates/frameworks/declaration_overview.html
+++ b/app/templates/frameworks/declaration_overview.html
@@ -1,4 +1,4 @@
-{% extends "toolkit/layouts/_base_page.html" %}
+{% extends "_base_page.html" %}
 
 
 {% block page_title %}Your {{ framework.name }} declaration – Digital Marketplace{% endblock %}

--- a/app/templates/frameworks/edit_declaration_section.html
+++ b/app/templates/frameworks/edit_declaration_section.html
@@ -1,4 +1,4 @@
-{% extends "toolkit/layouts/_base_page.html" %}
+{% extends "_base_page.html" %}
 {% import "macros/toolkit_forms.html" as forms %}
 
 {% block page_title %}{{ framework.name }} supplier declaration – Digital Marketplace{% endblock %}

--- a/app/templates/frameworks/reuse_declaration.html
+++ b/app/templates/frameworks/reuse_declaration.html
@@ -1,4 +1,4 @@
-{% extends "toolkit/layouts/_base_page.html" %}
+{% extends "_base_page.html" %}
 
 {% block page_title %}
   {% block page_title_inner %}

--- a/app/templates/frameworks/services.html
+++ b/app/templates/frameworks/services.html
@@ -1,4 +1,4 @@
-{% extends "toolkit/layouts/_base_page.html" %}
+{% extends "_base_page.html" %}
 {% import "toolkit/summary-table.html" as summary %}
 {% import "macros/submission.html" as submission %}
 

--- a/app/templates/frameworks/signature_upload.html
+++ b/app/templates/frameworks/signature_upload.html
@@ -1,4 +1,4 @@
-{% extends "toolkit/layouts/_base_page.html" %}
+{% extends "_base_page.html" %}
 
 {% block page_title %}Signature upload – Digital Marketplace{% endblock %}
 

--- a/app/templates/frameworks/signer_details.html
+++ b/app/templates/frameworks/signer_details.html
@@ -1,4 +1,4 @@
-{% extends "toolkit/layouts/_base_page.html" %}
+{% extends "_base_page.html" %}
 
 {% block page_title %}Signer details – Digital Marketplace{% endblock %}
 

--- a/app/templates/frameworks/start_declaration.html
+++ b/app/templates/frameworks/start_declaration.html
@@ -1,4 +1,4 @@
-{% extends "toolkit/layouts/_base_page.html" %}
+{% extends "_base_page.html" %}
 
 {% block page_title %}
   {% block page_title_inner %}

--- a/app/templates/frameworks/submission_lots.html
+++ b/app/templates/frameworks/submission_lots.html
@@ -1,4 +1,4 @@
-{% extends "toolkit/layouts/_base_page.html" %}
+{% extends "_base_page.html" %}
 
 {% import "macros/submission.html" as submission %}
 

--- a/app/templates/frameworks/updates.html
+++ b/app/templates/frameworks/updates.html
@@ -1,4 +1,4 @@
-{% extends "toolkit/layouts/_base_page.html" %}
+{% extends "_base_page.html" %}
 {% import "toolkit/summary-table.html" as summary %}
 
 {% block page_title %}{{ framework.name }} updates – Digital Marketplace{% endblock %}

--- a/app/templates/services/_base_edit_section_page.html
+++ b/app/templates/services/_base_edit_section_page.html
@@ -1,4 +1,4 @@
-{% extends "toolkit/layouts/_base_page.html" %}
+{% extends "_base_page.html" %}
 {% import "macros/toolkit_forms.html" as forms %}
 {% from "macros/assurance.html" import assurance_question %}
 

--- a/app/templates/services/_base_service_page.html
+++ b/app/templates/services/_base_service_page.html
@@ -1,4 +1,4 @@
-{% extends "toolkit/layouts/_base_page.html" %}
+{% extends "_base_page.html" %}
 
 {% block page_title %}{{ service_data.serviceName or service_data.lotName }} – Digital Marketplace{% endblock %}
 

--- a/app/templates/services/list_services.html
+++ b/app/templates/services/list_services.html
@@ -1,4 +1,4 @@
-{% extends "toolkit/layouts/_base_page.html" %}
+{% extends "_base_page.html" %}
 {% import "toolkit/summary-table.html" as summary %}
 
 {% block page_title %}Current services – Digital Marketplace{% endblock %}

--- a/app/templates/services/previous_services.html
+++ b/app/templates/services/previous_services.html
@@ -1,4 +1,4 @@
-{% extends "toolkit/layouts/_base_page.html" %}
+{% extends "_base_page.html" %}
 {% import "toolkit/summary-table.html" as summary %}
 {% import "macros/submission.html" as submission %}
 

--- a/app/templates/suppliers/already_completed.html
+++ b/app/templates/suppliers/already_completed.html
@@ -1,4 +1,4 @@
-{% extends "toolkit/layouts/_base_page.html" %}
+{% extends "_base_page.html" %}
 
 {% block page_title %}Change your {{ completed_data_description }} – Digital Marketplace{% endblock %}
 

--- a/app/templates/suppliers/become_a_supplier.html
+++ b/app/templates/suppliers/become_a_supplier.html
@@ -1,4 +1,4 @@
-{% extends "toolkit/layouts/_base_page.html" %}
+{% extends "_base_page.html" %}
 
 {% block page_title %}Become a supplier – Digital Marketplace{% endblock %}
 

--- a/app/templates/suppliers/create_company_details.html
+++ b/app/templates/suppliers/create_company_details.html
@@ -1,4 +1,4 @@
-{% extends "toolkit/layouts/_base_page.html" %}
+{% extends "_base_page.html" %}
 
 {% block page_title %}Company details – Create a supplier account – Digital Marketplace{% endblock %}
 

--- a/app/templates/suppliers/create_company_summary.html
+++ b/app/templates/suppliers/create_company_summary.html
@@ -1,4 +1,4 @@
-{% extends "toolkit/layouts/_base_page.html" %}
+{% extends "_base_page.html" %}
 {% import "toolkit/summary-table.html" as summary %}
 
 {% block page_title %}Check your information – Create a supplier account – Digital Marketplace{% endblock %}

--- a/app/templates/suppliers/create_duns_number.html
+++ b/app/templates/suppliers/create_duns_number.html
@@ -1,4 +1,4 @@
-{% extends "toolkit/layouts/_base_page.html" %}
+{% extends "_base_page.html" %}
 
 {% block page_title %}DUNS number – Create a supplier account – Digital Marketplace{% endblock %}
 

--- a/app/templates/suppliers/create_new_supplier.html
+++ b/app/templates/suppliers/create_new_supplier.html
@@ -1,4 +1,4 @@
-{% extends "toolkit/layouts/_base_page.html" %}
+{% extends "_base_page.html" %}
 
 {% block page_title %}Create a supplier account – Digital Marketplace{% endblock %}
 

--- a/app/templates/suppliers/create_your_account.html
+++ b/app/templates/suppliers/create_your_account.html
@@ -1,4 +1,4 @@
-{% extends "toolkit/layouts/_base_page.html" %}
+{% extends "_base_page.html" %}
 {% import "toolkit/summary-table.html" as summary %}
 
 {% block page_title %}Create login — Create a supplier account – Digital Marketplace{% endblock %}

--- a/app/templates/suppliers/create_your_account_complete.html
+++ b/app/templates/suppliers/create_your_account_complete.html
@@ -1,4 +1,4 @@
-{% extends "toolkit/layouts/_base_page.html" %}
+{% extends "_base_page.html" %}
 
 {% block page_title %}Activate your account - Create a supplier account – Digital Marketplace{% endblock %}
 

--- a/app/templates/suppliers/dashboard.html
+++ b/app/templates/suppliers/dashboard.html
@@ -1,4 +1,4 @@
-{% extends "toolkit/layouts/_base_page.html" %}
+{% extends "_base_page.html" %}
 {% block page_title %}Your account – Digital Marketplace{% endblock %}
 
 {% block breadcrumb %}

--- a/app/templates/suppliers/details.html
+++ b/app/templates/suppliers/details.html
@@ -1,4 +1,4 @@
-{% extends "toolkit/layouts/_base_page.html" %}
+{% extends "_base_page.html" %}
 {% import "toolkit/summary-table.html" as summary %}
 {% block page_title %}Company details – Digital Marketplace{% endblock %}
 

--- a/app/templates/suppliers/edit_company_registration_number.html
+++ b/app/templates/suppliers/edit_company_registration_number.html
@@ -1,4 +1,4 @@
-{% extends "toolkit/layouts/_base_page.html" %}
+{% extends "_base_page.html" %}
 
 {% block page_title %}Company registration number – Digital Marketplace{% endblock %}
 

--- a/app/templates/suppliers/edit_registered_name.html
+++ b/app/templates/suppliers/edit_registered_name.html
@@ -1,4 +1,4 @@
-{% extends "toolkit/layouts/_base_page.html" %}
+{% extends "_base_page.html" %}
 
 {% block page_title %}Registered company name – Digital Marketplace{% endblock %}
 

--- a/app/templates/suppliers/edit_supplier_organisation_size.html
+++ b/app/templates/suppliers/edit_supplier_organisation_size.html
@@ -1,4 +1,4 @@
-{% extends "toolkit/layouts/_base_page.html" %}
+{% extends "_base_page.html" %}
 
 {% block page_title %}Organisation size – Digital Marketplace{% endblock %}
 

--- a/app/templates/suppliers/edit_supplier_trading_status.html
+++ b/app/templates/suppliers/edit_supplier_trading_status.html
@@ -1,4 +1,4 @@
-{% extends "toolkit/layouts/_base_page.html" %}
+{% extends "_base_page.html" %}
 
 {% block page_title %}Trading status – Digital Marketplace{% endblock %}
 

--- a/app/templates/suppliers/edit_what_buyers_will_see.html
+++ b/app/templates/suppliers/edit_what_buyers_will_see.html
@@ -1,4 +1,4 @@
-{% extends "toolkit/layouts/_base_page.html" %}
+{% extends "_base_page.html" %}
 {% import "toolkit/forms/macros/forms.html" as forms %}
 
 {% block page_title %}What buyers will see – Digital Marketplace{% endblock %}

--- a/app/templates/suppliers/join_open_framework_notification_mailing_list.html
+++ b/app/templates/suppliers/join_open_framework_notification_mailing_list.html
@@ -1,4 +1,4 @@
-{% extends "toolkit/layouts/_base_page.html" %}
+{% extends "_base_page.html" %}
 
 {% block page_title %}Sign up for Digital Marketplace email alerts – Digital Marketplace{% endblock %}
 

--- a/app/templates/suppliers/registered_address.html
+++ b/app/templates/suppliers/registered_address.html
@@ -1,4 +1,4 @@
-{% extends "toolkit/layouts/_base_page.html" %}
+{% extends "_base_page.html" %}
 {% import "toolkit/forms/macros/forms.html" as forms %}
 {% import "toolkit/summary-table.html" as summary %}
 {% block head %}

--- a/app/templates/users/list_users.html
+++ b/app/templates/users/list_users.html
@@ -1,4 +1,4 @@
-{% extends "toolkit/layouts/_base_page.html" %}
+{% extends "_base_page.html" %}
 {% import "toolkit/summary-table.html" as summary %}
 
 {% block page_title %}Add or remove contributors – Your account - Digital Marketplace{% endblock %}


### PR DESCRIPTION
https://trello.com/c/PpFz5qRc/43-create-a-base-page-for-the-apps

The work to move to govuk-frontend will be easier if we have a base page in each app in which to import macros.

GOVUK Frontend may solve this down the road
https://github.com/alphagov/govuk-frontend/issues/1278

It seems from research (Googling and GOV Pay) for now this is the accepted pattern