### PR TITLE
Upgrade Jquery to 3.x

### DIFF
--- a/app/assets/javascripts/_stop-scrolling-at-footer.js
+++ b/app/assets/javascripts/_stop-scrolling-at-footer.js
@@ -1,0 +1,141 @@
+// Stop scrolling at footer.
+//
+// This can be added to elements with `position: fixed` to stop them from
+// overflowing on the footer.
+//
+// Usage:
+//
+//    GOVUK.stopScrollingAtFooter.addEl($(node), $(node).height());
+//
+// Height is passed in separatly incase the scrolling element has no height
+// itself.
+
+// Copied from original GOVUK frontend toolkit to add Jquery 3.x support for .load(...) -> .on('load', ...)
+
+;(function (global) {
+  'use strict'
+
+  var $ = global.jQuery
+  var GOVUK = global.GOVUK || {}
+
+  var stopScrollingAtFooter = {
+    _pollingId: null,
+    _isPolling: false,
+    _hasScrollEvt: false,
+    _els: [],
+
+    addEl: function ($fixedEl, height) {
+      var fixedOffset
+
+      if (!$fixedEl.length) { return }
+
+      fixedOffset = parseInt($fixedEl.css('top'), 10)
+      fixedOffset = isNaN(fixedOffset) ? 0 : fixedOffset
+
+      stopScrollingAtFooter.updateFooterTop()
+      $(global).on('govuk.pageSizeChanged', stopScrollingAtFooter.updateFooterTop)
+
+      var $siblingEl = $('<div></div>')
+      $siblingEl.insertBefore($fixedEl)
+      var fixedTop = $siblingEl.offset().top - $siblingEl.position().top
+      $siblingEl.remove()
+
+      var el = {
+        $fixedEl: $fixedEl,
+        height: height + fixedOffset,
+        fixedTop: height + fixedTop,
+        state: 'fixed'
+      }
+      stopScrollingAtFooter._els.push(el)
+
+      stopScrollingAtFooter.initTimeout()
+    },
+    updateFooterTop: function () {
+      var footer = $('.js-footer:eq(0)')
+      if (footer.length === 0) {
+        return 0
+      }
+      stopScrollingAtFooter.footerTop = footer.offset().top - 10
+    },
+    initTimeout: function () {
+      if (stopScrollingAtFooter._hasScrollEvt === false) {
+        $(window).scroll(stopScrollingAtFooter.onScroll)
+        stopScrollingAtFooter._hasScrollEvt = true
+      }
+    },
+    onScroll: function () {
+      if (stopScrollingAtFooter._isPolling === false) {
+        stopScrollingAtFooter.startPolling()
+      }
+    },
+    startPolling: (function () {
+      if (window.requestAnimationFrame) {
+        return function () {
+          var callback = function () {
+            stopScrollingAtFooter.checkScroll()
+            if (stopScrollingAtFooter._isPolling === true) {
+              stopScrollingAtFooter.startPolling()
+            }
+          }
+          stopScrollingAtFooter._pollingId = window.requestAnimationFrame(callback)
+          stopScrollingAtFooter._isPolling = true
+        }
+      } else {
+        return function () {
+          stopScrollingAtFooter._pollingId = window.setInterval(stopScrollingAtFooter.checkScroll, 16)
+          stopScrollingAtFooter._isPolling = true
+        }
+      }
+    }()),
+    stopPolling: (function () {
+      if (window.requestAnimationFrame) {
+        return function () {
+          window.cancelAnimationFrame(stopScrollingAtFooter._pollingId)
+          stopScrollingAtFooter._isPolling = false
+        }
+      } else {
+        return function () {
+          window.clearInterval(stopScrollingAtFooter._pollingId)
+          stopScrollingAtFooter._isPolling = false
+        }
+      }
+    }()),
+    checkScroll: function () {
+      var cachedScrollTop = $(window).scrollTop()
+      if ((cachedScrollTop < (stopScrollingAtFooter.cachedScrollTop + 2)) && (cachedScrollTop > (stopScrollingAtFooter.cachedScrollTop - 2))) {
+        stopScrollingAtFooter.stopPolling()
+        return
+      } else {
+        stopScrollingAtFooter.cachedScrollTop = cachedScrollTop
+      }
+
+      $.each(stopScrollingAtFooter._els, function (i, el) {
+        var bottomOfEl = cachedScrollTop + el.height
+
+        if (bottomOfEl > stopScrollingAtFooter.footerTop) {
+          stopScrollingAtFooter.stick(el)
+        } else {
+          stopScrollingAtFooter.unstick(el)
+        }
+      })
+    },
+    stick: function (el) {
+      if (el.state === 'fixed' && el.$fixedEl.css('position') === 'fixed') {
+        el.$fixedEl.css({ 'position': 'absolute', 'top': stopScrollingAtFooter.footerTop - el.fixedTop })
+        el.state = 'absolute'
+      }
+    },
+    unstick: function (el) {
+      if (el.state === 'absolute') {
+        el.$fixedEl.css({ 'position': '', 'top': '' })
+        el.state = 'fixed'
+      }
+    }
+  }
+
+  GOVUK.stopScrollingAtFooter = stopScrollingAtFooter
+
+  $(global).on('load', function () { $(global).trigger('govuk.pageSizeChanged') })
+
+  global.GOVUK = GOVUK
+})(window)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -15,7 +15,6 @@
 //= require ../../../node_modules/govuk_frontend_toolkit/javascripts/govuk/selection-buttons.js
 //= require ../../../node_modules/govuk_frontend_toolkit/javascripts/govuk/shim-links-with-button-role.js
 //= require ../../../node_modules/govuk_frontend_toolkit/javascripts/govuk/stick-at-top-when-scrolling.js
-//= require ../../../node_modules/govuk_frontend_toolkit/javascripts/govuk/stop-scrolling-at-footer.js
 //= require ../../../node_modules/digitalmarketplace-frontend-toolkit/toolkit/javascripts/shim-links-with-button-role.js
 //= require ../../../node_modules/digitalmarketplace-frontend-toolkit/toolkit/javascripts/show-hide-content.js
 //= require ../../../node_modules/digitalmarketplace-frontend-toolkit/toolkit/javascripts/user-research-consent-banner.js
@@ -23,6 +22,7 @@
 //= require _analytics.js
 //= require _selection-buttons.js
 //= require _stick-at-top-when-scrolling.js
+//= require _stop-scrolling-at-footer.js
 //= require category-picker.js
 
 (function(GOVUK, GDM) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4233,9 +4233,9 @@
       "integrity": "sha512-HU/YxV4i6GcmiH4duATwAbJQMlE0MsDIR5XmSVxURxKHn3aGAdbY1/ZJFmVRbKtnLwIxxMJD7gYaPsypcbYimg=="
     },
     "jquery": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-1.12.0.tgz",
-      "integrity": "sha1-RGU75OPkYosQa/IUHf0Q+8pgIe8="
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.4.1.tgz",
+      "integrity": "sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw=="
     },
     "js-base64": {
       "version": "2.5.1",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "gulp-sourcemaps": "^2.6.5",
     "gulp-uglify": "^3.0.2",
     "hogan.js": "3.0.2",
-    "jquery": "1.12.0"
+    "jquery": "3.4.1"
   },
   "scripts": {
     "frontend-build:development": "gulp build:development",


### PR DESCRIPTION
https://trello.com/c/aQbqH2uC/1196-vulnerability-fix-weekly-tracking

Addresses https://app.snyk.io/vuln/npm:jquery:20150627 and https://app.snyk.io/vuln/SNYK-JS-JQUERY-174006 as highlighted by Snyk.

We no longer need to support IE7/8. 

There's one breaking change affecting the Supplier FE: `.load(fn)` has been deprecated (see [Changelog](https://jquery.com/upgrade-guide/3.0/#breaking-change-load-unload-and-error-removed)) so and needs to be replaced with `.on('load', fn)`. 

The occurrence was in one of the old govuk_frontend_toolkit modules, so I've copied that file to `/assets` and made the change to the old `$(global).load(function (), ...)` call.

## Context
The checkbox-tree component itself is only used in the supplier framework application journey (when selecting service categories), so the next time this will be used is March 2020. It's unclear how well this component currently meets WCAG guidelines but anecdotally it's not a great experience to click or scroll through anyway, even for developers. Our long term goal should be to upgrade or replace this component, and work with CCS to potentially reduce the number of categories on the page at any one time.