### PR TITLE
replace page_title block with pageTitle

### DIFF
--- a/app/templates/_base_page.html
+++ b/app/templates/_base_page.html
@@ -3,3 +3,7 @@
 // Insert line for each component module import
 
 {% from "components/button/macro.njk" import govukButton %}
+
+{# TODO: Remove once we start removing govuk_template, GOV.UK Frontend template uses pageTitle #}
+{% block page_title %}{% block pageTitle %}{% endblock %}{% endblock %}
+

--- a/app/templates/auth/submit_email_address.html
+++ b/app/templates/auth/submit_email_address.html
@@ -2,7 +2,9 @@
 
 {% extends "_base_page.html" %}
 
-{% block page_title %}Their email address - Add or remove contributors – Digital Marketplace{% endblock %}
+{% block pageTitle %}
+  Their email address - Add or remove contributors – Digital Marketplace
+{% endblock %}
 
 {% block breadcrumb %}
   {%

--- a/app/templates/errors/applications_closed.html
+++ b/app/templates/errors/applications_closed.html
@@ -1,6 +1,8 @@
 {% extends "_base_page.html" %}
 
-{% block page_title %}Applications closed - Digital Marketplace{% endblock %}
+{% block pageTitle %}
+  Applications closed - Digital Marketplace
+{% endblock %}
 
 {% block main_content %}
 

--- a/app/templates/frameworks/contract_review.html
+++ b/app/templates/frameworks/contract_review.html
@@ -1,6 +1,8 @@
 {% extends "_base_page.html" %}
 
-{% block page_title %}Review your contract – Digital Marketplace{% endblock %}
+{% block pageTitle %}
+  Review your contract – Digital Marketplace
+{% endblock %}
 
 {% block breadcrumb %}
   {%

--- a/app/templates/frameworks/contract_start.html
+++ b/app/templates/frameworks/contract_start.html
@@ -1,7 +1,9 @@
 {% extends "_base_page.html" %}
 {% import "toolkit/summary-table.html" as summary %}
 
-{% block page_title %}Apply to {{ framework.name }} – Digital Marketplace{% endblock %}
+{% block pageTitle %}
+  Apply to {{ framework.name }} – Digital Marketplace
+{% endblock %}
 
 {% block breadcrumb %}
   {%

--- a/app/templates/frameworks/contract_variation.html
+++ b/app/templates/frameworks/contract_variation.html
@@ -1,7 +1,9 @@
 {% extends "_base_page.html" %}
 {% import "toolkit/summary-table.html" as summary %}
 
-{% block page_title %}{{ framework.name }} contract variation – Digital Marketplace{% endblock %}
+{% block pageTitle %}
+  {{ framework.name }} contract variation – Digital Marketplace
+{% endblock %}
 
 {% block breadcrumb %}
   {%

--- a/app/templates/frameworks/dashboard.html
+++ b/app/templates/frameworks/dashboard.html
@@ -1,6 +1,6 @@
 {% extends "_base_page.html" %}
 
-{% block page_title %}
+{% block pageTitle %}
   {% block page_title_inner %}
     {% if framework.status == "open" %}
       Apply to {{ framework.name }}
@@ -32,7 +32,7 @@
 {% block main_content %}
   {# Confidence Banner #}
   {% if application_made and framework.status == 'open' %}
-    {% with 
+    {% with
       message = "Your application will be submitted at %s. <br> You can edit your declaration and services at any time before the deadline."|safe % (framework.applicationsCloseAt | nbsp),
       type="success"
     %}

--- a/app/templates/frameworks/declaration_overview.html
+++ b/app/templates/frameworks/declaration_overview.html
@@ -1,7 +1,9 @@
 {% extends "_base_page.html" %}
 
 
-{% block page_title %}Your {{ framework.name }} declaration – Digital Marketplace{% endblock %}
+{% block pageTitle %}
+  Your {{ framework.name }} declaration – Digital Marketplace
+{% endblock %}
 
 
 {% block breadcrumb %}
@@ -64,7 +66,7 @@
     <div class="column-two-thirds">
       {% if framework.status == "open" and supplier_framework.declaration.status != "complete" %}
         <p class="govuk-body">
-          You must {% if not validates %}answer all questions and{% endif %} make your declaration 
+          You must {% if not validates %}answer all questions and{% endif %} make your declaration
           before {{ framework.applicationsCloseAt | nbsp }} to apply to {{ framework.name }}.
         </p>
       {% endif %}

--- a/app/templates/frameworks/edit_declaration_section.html
+++ b/app/templates/frameworks/edit_declaration_section.html
@@ -1,7 +1,9 @@
 {% extends "_base_page.html" %}
 {% import "macros/toolkit_forms.html" as forms %}
 
-{% block page_title %}{{ framework.name }} supplier declaration – Digital Marketplace{% endblock %}
+{% block pageTitle %}
+  {{ framework.name }} supplier declaration – Digital Marketplace
+{% endblock %}
 
 {% block breadcrumb %}
   {%

--- a/app/templates/frameworks/reuse_declaration.html
+++ b/app/templates/frameworks/reuse_declaration.html
@@ -1,6 +1,6 @@
 {% extends "_base_page.html" %}
 
-{% block page_title %}
+{% block pageTitle %}
   {% block page_title_inner %}
     Reusing answers from an earlier declaration
   {% endblock %} – Digital Marketplace

--- a/app/templates/frameworks/services.html
+++ b/app/templates/frameworks/services.html
@@ -2,7 +2,9 @@
 {% import "toolkit/summary-table.html" as summary %}
 {% import "macros/submission.html" as submission %}
 
-{% block page_title %}Apply to {{ framework.name }} – Digital Marketplace{% endblock %}
+{% block pageTitle %}
+  Apply to {{ framework.name }} – Digital Marketplace
+{% endblock %}
 
 {% block breadcrumb %}
   {%

--- a/app/templates/frameworks/signature_upload.html
+++ b/app/templates/frameworks/signature_upload.html
@@ -1,6 +1,8 @@
 {% extends "_base_page.html" %}
 
-{% block page_title %}Signature upload – Digital Marketplace{% endblock %}
+{% block pageTitle %}
+  Signature upload – Digital Marketplace
+{% endblock %}
 
 {% block breadcrumb %}
   {%
@@ -60,7 +62,7 @@
             with
             question = "Upload your signed signature page",
             name = "signature_page",
-            question_advice = 
+            question_advice =
               "You only need to return the signed signature page.
               \n\nThe file must be saved as a PDF, JPG or PNG.",
             value=value,

--- a/app/templates/frameworks/signer_details.html
+++ b/app/templates/frameworks/signer_details.html
@@ -1,6 +1,8 @@
 {% extends "_base_page.html" %}
 
-{% block page_title %}Signer details – Digital Marketplace{% endblock %}
+{% block pageTitle %}
+  Signer details – Digital Marketplace
+{% endblock %}
 
 {% block breadcrumb %}
   {%

--- a/app/templates/frameworks/start_declaration.html
+++ b/app/templates/frameworks/start_declaration.html
@@ -1,6 +1,6 @@
 {% extends "_base_page.html" %}
 
-{% block page_title %}
+{% block pageTitle %}
   {% block page_title_inner %}
     Make your supplier declaration
   {% endblock %} – Digital Marketplace

--- a/app/templates/frameworks/submission_lots.html
+++ b/app/templates/frameworks/submission_lots.html
@@ -2,7 +2,9 @@
 
 {% import "macros/submission.html" as submission %}
 
-{% block page_title %}Apply to {{ framework.name }} – Digital Marketplace{% endblock %}
+{% block pageTitle %}
+  Apply to {{ framework.name }} – Digital Marketplace
+{% endblock %}
 
 {% block breadcrumb %}
   {%

--- a/app/templates/frameworks/updates.html
+++ b/app/templates/frameworks/updates.html
@@ -1,7 +1,9 @@
 {% extends "_base_page.html" %}
 {% import "toolkit/summary-table.html" as summary %}
 
-{% block page_title %}{{ framework.name }} updates – Digital Marketplace{% endblock %}
+{% block pageTitle %}
+  {{ framework.name }} updates – Digital Marketplace
+{% endblock %}
 
 {% block breadcrumb %}
   {%
@@ -147,9 +149,9 @@
               {{ govukButton({
                 "text": "Ask a question"
               }) }}
-  
+
               <a class="govuk-link" href="{{ url_for('.framework_dashboard', framework_slug=framework.slug) }}">Return to {{ framework.name }} application</a>
-  
+
             </div>
           </div>
         </form>
@@ -162,7 +164,7 @@
             <p class="govuk-body">Contact the support team if <a class="govuk-link" href="{{ url_for('external.help') }}">there’s a problem with your account or to update your details</a>.</p>
             <br />
             <p class="govuk-body"><a class="govuk-link" href="{{ url_for('.framework_dashboard', framework_slug=framework.slug) }}">Return to {{ framework.name }} application</a></p>
-  
+
           </div>
         </div>
 

--- a/app/templates/services/_base_edit_section_page.html
+++ b/app/templates/services/_base_edit_section_page.html
@@ -2,7 +2,9 @@
 {% import "macros/toolkit_forms.html" as forms %}
 {% from "macros/assurance.html" import assurance_question %}
 
-{% block page_title %}{{ section.name }} – Digital Marketplace{% endblock %}
+{% block pageTitle %}
+  {{ section.name }} – Digital Marketplace
+{% endblock %}
 
 {% block main_content %}
   {% include 'toolkit/forms/validation.html' %}

--- a/app/templates/services/_base_service_page.html
+++ b/app/templates/services/_base_service_page.html
@@ -1,6 +1,8 @@
 {% extends "_base_page.html" %}
 
-{% block page_title %}{{ service_data.serviceName or service_data.lotName }} – Digital Marketplace{% endblock %}
+{% block pageTitle %}
+  {{ service_data.serviceName or service_data.lotName }} – Digital Marketplace
+{% endblock %}
 
 {% block main_content %}
   <div class="grid-row">

--- a/app/templates/services/list_services.html
+++ b/app/templates/services/list_services.html
@@ -1,7 +1,9 @@
 {% extends "_base_page.html" %}
 {% import "toolkit/summary-table.html" as summary %}
 
-{% block page_title %}Current services – Digital Marketplace{% endblock %}
+{% block pageTitle %}
+  Current services – Digital Marketplace
+{% endblock %}
 
 {% block breadcrumb %}
   {%

--- a/app/templates/services/previous_services.html
+++ b/app/templates/services/previous_services.html
@@ -2,7 +2,9 @@
 {% import "toolkit/summary-table.html" as summary %}
 {% import "macros/submission.html" as submission %}
 
-{% block page_title %}Copy your {{ framework.name }} services – Digital Marketplace{% endblock %}
+{% block pageTitle %}
+  Copy your {{ framework.name }} services – Digital Marketplace
+{% endblock %}
 
 {% block breadcrumb %}
   {%

--- a/app/templates/services/service_submission.html
+++ b/app/templates/services/service_submission.html
@@ -1,6 +1,8 @@
 {% extends "services/_base_service_page.html" %}
 
-{% block page_title %}{{ service_data.lotName }} submission summary – Digital Marketplace{% endblock %}
+{% block pageTitle %}
+  {{ service_data.lotName }} submission summary – Digital Marketplace
+{% endblock %}
 
 {% import "macros/submission.html" as submission %}
 

--- a/app/templates/suppliers/already_completed.html
+++ b/app/templates/suppliers/already_completed.html
@@ -1,6 +1,8 @@
 {% extends "_base_page.html" %}
 
-{% block page_title %}Change your {{ completed_data_description }} – Digital Marketplace{% endblock %}
+{% block pageTitle %}
+  Change your {{ completed_data_description }} – Digital Marketplace
+{% endblock %}
 
 {% block breadcrumb %}
   {% with items = [

--- a/app/templates/suppliers/become_a_supplier.html
+++ b/app/templates/suppliers/become_a_supplier.html
@@ -1,6 +1,8 @@
 {% extends "_base_page.html" %}
 
-{% block page_title %}Become a supplier – Digital Marketplace{% endblock %}
+{% block pageTitle %}
+  Become a supplier – Digital Marketplace
+{% endblock %}
 
 {% block breadcrumb %}
   {%

--- a/app/templates/suppliers/create_company_details.html
+++ b/app/templates/suppliers/create_company_details.html
@@ -1,6 +1,8 @@
 {% extends "_base_page.html" %}
 
-{% block page_title %}Company details – Create a supplier account – Digital Marketplace{% endblock %}
+{% block pageTitle %}
+  Company details – Create a supplier account – Digital Marketplace
+{% endblock %}
 
 {% block breadcrumb %}
 {%

--- a/app/templates/suppliers/create_company_summary.html
+++ b/app/templates/suppliers/create_company_summary.html
@@ -1,7 +1,9 @@
 {% extends "_base_page.html" %}
 {% import "toolkit/summary-table.html" as summary %}
 
-{% block page_title %}Check your information – Create a supplier account – Digital Marketplace{% endblock %}
+{% block pageTitle %}
+  Check your information – Create a supplier account – Digital Marketplace
+{% endblock %}
 
 {% block breadcrumb %}
 {%

--- a/app/templates/suppliers/create_duns_number.html
+++ b/app/templates/suppliers/create_duns_number.html
@@ -1,6 +1,8 @@
 {% extends "_base_page.html" %}
 
-{% block page_title %}DUNS number – Create a supplier account – Digital Marketplace{% endblock %}
+{% block pageTitle %}
+  DUNS number – Create a supplier account – Digital Marketplace
+{% endblock %}
 
 {% block breadcrumb %}
 {%
@@ -34,14 +36,14 @@
   {% elif errors %}
     {% include 'toolkit/forms/validation.html' %}
   {% endif %}
-  
+
   <div class="column-two-thirds">
     {% with heading = "Enter your DUNS number",
             smaller = True %}
       {% include "toolkit/page-heading.html" %}
     {% endwith %}
-  
-    
+
+
     <form method="POST" action="{{ url_for('.duns_number') }}">
       <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
       <div class="dmspeak">
@@ -56,7 +58,7 @@
           <li><a class="govuk-link" href="https://www.dnb.co.uk/duns-number/lookup/request-a-duns-number.html" rel="external">apply for
             a DUNS number</a> if you don&rsquo;t have one</li>
         </ul>
-      
+
       {% with question = "DUNS number",
               name = "duns_number",
               value = form.duns_number.data,

--- a/app/templates/suppliers/create_new_supplier.html
+++ b/app/templates/suppliers/create_new_supplier.html
@@ -1,6 +1,8 @@
 {% extends "_base_page.html" %}
 
-{% block page_title %}Create a supplier account – Digital Marketplace{% endblock %}
+{% block pageTitle %}
+  Create a supplier account – Digital Marketplace
+{% endblock %}
 
 {% block breadcrumb %}
   {%
@@ -27,18 +29,18 @@
       {% with heading = "Create a supplier account", smaller = True %}
         {% include "toolkit/page-heading.html" %}
       {% endwith %}
-  
+
       <div>
         <p class="govuk-body-l">You must provide:</p>
-    
+
         <ul class="govuk-list govuk-list--bullet">
           <li>a company name and company details that buyers may use to contact you</li>
           <li>your own details to create a login</li>
         </ul>
-        
+
         <p class="govuk-body">It will take about 5 minutes to create your account.</p>
       </div>
-  
+
       <h2 class="heading-xmedium">If your company isn’t registered with Companies&nbsp;House</h2>
       <div>
         <p class="govuk-body">If your company isn’t <a class="govuk-link" href="https://beta.companieshouse.gov.uk/" rel="external">registered with Companies House</a>,

--- a/app/templates/suppliers/create_your_account.html
+++ b/app/templates/suppliers/create_your_account.html
@@ -1,7 +1,9 @@
 {% extends "_base_page.html" %}
 {% import "toolkit/summary-table.html" as summary %}
 
-{% block page_title %}Create login — Create a supplier account – Digital Marketplace{% endblock %}
+{% block pageTitle %}
+  Create login — Create a supplier account – Digital Marketplace
+{% endblock %}
 
 {% block breadcrumb %}
 {%

--- a/app/templates/suppliers/create_your_account_complete.html
+++ b/app/templates/suppliers/create_your_account_complete.html
@@ -1,6 +1,8 @@
 {% extends "_base_page.html" %}
 
-{% block page_title %}Activate your account - Create a supplier account – Digital Marketplace{% endblock %}
+{% block pageTitle %}
+  Activate your account - Create a supplier account – Digital Marketplace
+{% endblock %}
 
 {% block breadcrumb %}
 {%
@@ -29,7 +31,7 @@
       {% with heading = "Create login", smaller = True %}
         {% include "toolkit/page-heading.html" %}
       {% endwith %}
-      
+
       <div class="dmspeak">
         <p class="govuk-body">An email has been sent to {{ email_address }}.</p>
         <p class="govuk-body">You must click on the link in the email to activate your account.</p>

--- a/app/templates/suppliers/dashboard.html
+++ b/app/templates/suppliers/dashboard.html
@@ -1,5 +1,7 @@
 {% extends "_base_page.html" %}
-{% block page_title %}Your account – Digital Marketplace{% endblock %}
+{% block pageTitle %}
+  Your account – Digital Marketplace
+{% endblock %}
 
 {% block breadcrumb %}
   {%

--- a/app/templates/suppliers/details.html
+++ b/app/templates/suppliers/details.html
@@ -1,6 +1,8 @@
 {% extends "_base_page.html" %}
 {% import "toolkit/summary-table.html" as summary %}
-{% block page_title %}Company details – Digital Marketplace{% endblock %}
+{% block pageTitle %}
+  Company details – Digital Marketplace
+{% endblock %}
 
 {% block breadcrumb %}
   {%

--- a/app/templates/suppliers/edit_company_registration_number.html
+++ b/app/templates/suppliers/edit_company_registration_number.html
@@ -1,6 +1,8 @@
 {% extends "_base_page.html" %}
 
-{% block page_title %}Company registration number – Digital Marketplace{% endblock %}
+{% block pageTitle %}
+  Company registration number – Digital Marketplace
+{% endblock %}
 
 {% block breadcrumb %}
   {% with items = [

--- a/app/templates/suppliers/edit_registered_name.html
+++ b/app/templates/suppliers/edit_registered_name.html
@@ -1,6 +1,8 @@
 {% extends "_base_page.html" %}
 
-{% block page_title %}Registered company name – Digital Marketplace{% endblock %}
+{% block pageTitle %}
+  Registered company name – Digital Marketplace
+{% endblock %}
 
 {% block breadcrumb %}
   {% with items = [

--- a/app/templates/suppliers/edit_supplier_organisation_size.html
+++ b/app/templates/suppliers/edit_supplier_organisation_size.html
@@ -1,6 +1,8 @@
 {% extends "_base_page.html" %}
 
-{% block page_title %}Organisation size – Digital Marketplace{% endblock %}
+{% block pageTitle %}
+  Organisation size – Digital Marketplace
+{% endblock %}
 
 {% block breadcrumb %}
   {% with items = [

--- a/app/templates/suppliers/edit_supplier_trading_status.html
+++ b/app/templates/suppliers/edit_supplier_trading_status.html
@@ -1,6 +1,8 @@
 {% extends "_base_page.html" %}
 
-{% block page_title %}Trading status – Digital Marketplace{% endblock %}
+{% block pageTitle %}
+  Trading status – Digital Marketplace
+{% endblock %}
 
 {% block breadcrumb %}
   {% with items = [

--- a/app/templates/suppliers/edit_what_buyers_will_see.html
+++ b/app/templates/suppliers/edit_what_buyers_will_see.html
@@ -1,7 +1,9 @@
 {% extends "_base_page.html" %}
 {% import "toolkit/forms/macros/forms.html" as forms %}
 
-{% block page_title %}What buyers will see – Digital Marketplace{% endblock %}
+{% block pageTitle %}
+  What buyers will see – Digital Marketplace
+{% endblock %}
 
 {% block breadcrumb %}
   {%

--- a/app/templates/suppliers/join_open_framework_notification_mailing_list.html
+++ b/app/templates/suppliers/join_open_framework_notification_mailing_list.html
@@ -1,6 +1,8 @@
 {% extends "_base_page.html" %}
 
-{% block page_title %}Sign up for Digital Marketplace email alerts – Digital Marketplace{% endblock %}
+{% block pageTitle %}
+  Sign up for Digital Marketplace email alerts – Digital Marketplace
+{% endblock %}
 
 {% block breadcrumb %}
 {%

--- a/app/templates/suppliers/registered_address.html
+++ b/app/templates/suppliers/registered_address.html
@@ -5,7 +5,9 @@
   <link type="text/css" rel="stylesheet" media="screen" href="{{ asset_fingerprinter.get_url('stylesheets/location-autocomplete.min.css') }}"/>
   {{ super() }}
 {% endblock %}
-{% block page_title %}Registered address – Digital Marketplace{% endblock %}
+{% block pageTitle %}
+  Registered address – Digital Marketplace
+{% endblock %}
 
 {% block breadcrumb %}
   {%

--- a/app/templates/users/list_users.html
+++ b/app/templates/users/list_users.html
@@ -1,7 +1,9 @@
 {% extends "_base_page.html" %}
 {% import "toolkit/summary-table.html" as summary %}
 
-{% block page_title %}Add or remove contributors – Your account - Digital Marketplace{% endblock %}
+{% block pageTitle %}
+  Add or remove contributors – Your account - Digital Marketplace
+{% endblock %}
 
 {% block breadcrumb %}
   {%

--- a/tests/app/main/helpers/test_frameworks.py
+++ b/tests/app/main/helpers/test_frameworks.py
@@ -893,7 +893,7 @@ class TestReturn404IfApplicationClosed(BaseApplicationTest):
 
         document = html.fromstring(response[0])
         assert response[1] == 404
-        assert document.xpath('//title/text()')[0] == "Applications closed - Digital Marketplace"
+        assert document.xpath('//title/text()')[0].strip() == "Applications closed - Digital Marketplace"
         assert document.xpath('//h1/text()')[0] == "You can no longer apply to G-Cloud 10"
         assert "The deadline for applying was 12am GMT, Monday 3 January 2000." in \
             document.xpath('//div[@class="dmspeak"]/p/text()')[0]


### PR DESCRIPTION
As part of migrating us off govuk_template and on to govuk frontend template
we need to be mindful of what blocks govuk frontend used. govuk frontend
template uses pageTitle so instead of adding this commit to that work it
can be done as a separate commit and then once we come to replace govuk_template
we can just remove the two lines of code in `_base_page` which we added
in this commit.

Ticket: https://trello.com/c/oYTyw0pb