### PR TITLE
This replaces toolkit/page-headings with govuk frontend page titles

### DIFF
--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -80,6 +80,7 @@ $govuk-compatibility-govukelements: true;
 
 // Overrides
 @import "overrides/_notifications_banner";
+@import "overrides/_page_headings.scss";
 
 // Misc styles
 // TODO: Move misc styling into their own partial files or the Digital Marketplace FE Toolkit

--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -31,7 +31,6 @@ $path: "/suppliers/static/images/";
 @import "toolkit/_grids.scss";
 @import "toolkit/_instruction-list.scss";
 @import "toolkit/_notification-banners.scss";
-@import "toolkit/_page-headings.scss";
 @import "toolkit/_phase-banner.scss";
 @import "toolkit/_proposition-header.scss";
 @import "toolkit/_secondary-action-link.scss";

--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -31,6 +31,7 @@ $path: "/suppliers/static/images/";
 @import "toolkit/_grids.scss";
 @import "toolkit/_instruction-list.scss";
 @import "toolkit/_notification-banners.scss";
+@import "toolkit/_page-headings.scss";
 @import "toolkit/_phase-banner.scss";
 @import "toolkit/_proposition-header.scss";
 @import "toolkit/_secondary-action-link.scss";

--- a/app/assets/scss/overrides/_notifications_banner.scss
+++ b/app/assets/scss/overrides/_notifications_banner.scss
@@ -5,3 +5,62 @@
   @include govuk-responsive-margin(1, "top");
   @include govuk-responsive-margin(0, "bottom");
 }
+
+
+// FIXME: Only needed to give vertical spacing between notifications
+// and page heading.
+//
+// Can remove this once notifications, temporary messages have been
+// standardised
+
+%banner {
+  @include govuk-responsive-margin(6, "bottom");
+}
+
+%banner-destructive {
+  @extend %banner;
+}
+
+.banner-destructive-without-action {
+  @extend %banner-destructive;
+}
+
+.banner-destructive-with-action {
+  @extend %banner-destructive;
+}
+
+%banner-warning {
+  @extend %banner;
+}
+
+.banner-warning-with-action {
+  @extend %banner-warning;
+}
+
+.banner-warning-without-action {
+  @extend %banner-warning;
+}
+
+%banner-success {
+  @extend %banner;
+}
+
+.banner-success-with-action {
+  @extend %banner-success;
+}
+
+.banner-success-without-action {
+  @extend %banner-success;
+}
+
+%banner-information {
+  @extend %banner;
+}
+
+.banner-information-with-action {
+  @extend %banner-information;
+}
+
+.banner-information-without-action {
+  @extend %banner-information;
+}

--- a/app/assets/scss/overrides/_page_headings.scss
+++ b/app/assets/scss/overrides/_page_headings.scss
@@ -1,0 +1,11 @@
+// FIXME: Temporary, remove once we are using govuk-frontend grids
+//
+// This is needed to push down the page content but more specifically page
+// headings.
+//
+// Previously CSS would adjust top and bottom margins/padding. We should try
+// spacing by pushing content down and not worrying about what is above it.
+
+#content {
+    @include govuk-responsive-margin(7, "top");
+}

--- a/app/templates/auth/submit_email_address.html
+++ b/app/templates/auth/submit_email_address.html
@@ -30,12 +30,7 @@
 {% block main_content %}
 {% include "toolkit/forms/validation.html" %}
 
-  {% with
-    heading = "Invite a contributor",
-    smaller = true
-  %}
-    {% include 'toolkit/page-heading.html' %}
-  {% endwith %}
+<h1 class="govuk-heading-l">Invite a contributor</h1>
 
 <form autocomplete="off" action="{{ url_for('.invite_user') }}" method="POST">
 

--- a/app/templates/errors/applications_closed.html
+++ b/app/templates/errors/applications_closed.html
@@ -7,9 +7,7 @@
 {% block main_content %}
 
 <div class="error-page">
-  <header class="page-heading-smaller">
-    <h1>You can no longer apply to {{ framework['name'] }}</h1>
-  </header>
+  <h1 class="govuk-heading-l">You can no longer apply to {{ framework['name'] }}</h1>
 
   <div class="dmspeak">
     <p class="govuk-body">

--- a/app/templates/frameworks/contract_review.html
+++ b/app/templates/frameworks/contract_review.html
@@ -30,13 +30,6 @@
 
 <div class="grid-row">
   <div class="column-two-thirds">
-    {%
-      with
-      heading = "Check the details you’ve given before returning the signature page for %s" | format(supplier_registered_name),
-      smaller = True
-    %}
-      {% include "toolkit/page-heading.html" %}
-    {% endwith %}
     <h1 class="govuk-heading-l">{{ 'Check the details you’ve given before returning the signature page for {}'.format(supplier_registered_name) }}</h1>
   </div>
 </div>

--- a/app/templates/frameworks/contract_review.html
+++ b/app/templates/frameworks/contract_review.html
@@ -37,6 +37,7 @@
     %}
       {% include "toolkit/page-heading.html" %}
     {% endwith %}
+    <h1 class="govuk-heading-l">{{ 'Check the details you’ve given before returning the signature page for {}'.format(supplier_registered_name) }}</h1>
   </div>
 </div>
 

--- a/app/templates/frameworks/contract_start.html
+++ b/app/templates/frameworks/contract_start.html
@@ -30,14 +30,7 @@
 
   <div class="grid-row framework-dashboard">
     <div class="column-two-thirds">
-      {% with
-         heading = (
-           framework.name + " framework agreement"
-         ),
-         smaller = True
-      %}
-        {% include "toolkit/page-heading.html" %}
-      {% endwith %}
+      <h1 class="govuk-heading-l">{{ framework.name }} framework agreement</h1>
 
       <div class="summary-item-lede">
         <p class="govuk-body">Your application was successful. You must return a signed framework agreement signature page before you can sell services on the Digital Marketplace.</p>

--- a/app/templates/frameworks/contract_variation.html
+++ b/app/templates/frameworks/contract_variation.html
@@ -40,14 +40,7 @@
     <div class="grid-row">
         <div class="column-two-thirds">
 
-          {% with
-            heading = "{} contract variation for {}".format(
-               "The" if variation_details.get('countersignedAt') or agreed_details
-               else "Accept the", framework.name),
-            smaller = True
-          %}
-            {% include 'toolkit/page-heading.html' %}
-          {% endwith %}
+          <h1 class="govuk-heading-l">{{ '{} contract variation for {}'.format('The' if variation_details.get('countersignedAt') or agreed_details else 'Accept the', framework.name) }}</h1>
 
           <div class="section-description">
           {% if variation_details.get('countersignedAt') and agreed_details %}

--- a/app/templates/frameworks/dashboard.html
+++ b/app/templates/frameworks/dashboard.html
@@ -42,12 +42,7 @@
 
   <div class="grid-row framework-dashboard">
     <div class="column-two-thirds">
-      {% with
-         heading = self.page_title_inner(),
-         smaller = True
-      %}
-        {% include "toolkit/page-heading.html" %}
-      {% endwith %}
+      <h1 class="govuk-heading-l">{{ self.page_title_inner() }}</h1>
 
       {% include 'frameworks/_dashboard_lede.html' %}
 

--- a/app/templates/frameworks/declaration_overview.html
+++ b/app/templates/frameworks/declaration_overview.html
@@ -56,12 +56,7 @@
 {% block main_content %}
   <div class="grid-row">
     <div class="column-two-thirds">
-      {% with
-        heading = "Your declaration overview",
-        smaller = true
-      %}
-        {% include "toolkit/page-heading.html" %}
-      {% endwith %}
+      <h1 class="govuk-heading-l">Your declaration overview</h1>
     </div>
     <div class="column-two-thirds">
       {% if framework.status == "open" and supplier_framework.declaration.status != "complete" %}

--- a/app/templates/frameworks/edit_declaration_section.html
+++ b/app/templates/frameworks/edit_declaration_section.html
@@ -48,12 +48,8 @@
         <div class="column-two-thirds">
             {% include 'frameworks/_session_timeout.html' %}
 
-            {% with
-              heading = section.name,
-              smaller = True
-            %}
-              {% include 'toolkit/page-heading.html' %}
-            {% endwith %}
+            <h1 class="govuk-heading-l">{{ section.name }}</h1>
+
             {% if section.description %}
               <div class="section-description">
                 {{ section.description|question_references(get_question) }}

--- a/app/templates/frameworks/reuse_declaration.html
+++ b/app/templates/frameworks/reuse_declaration.html
@@ -32,12 +32,7 @@
 
   <div class="grid-row">
     <div class="column-two-thirds">
-      {% with
-         heading = self.page_title_inner(),
-         smaller = True
-      %}
-        {% include "toolkit/page-heading.html" %}
-      {% endwith %}
+      <h1 class="govuk-heading-l">{{ self.page_title_inner() }}</h1>
 
       <p class="govuk-body">In {{ old_framework_application_close_date|nbsp }}, your organisation completed a declaration for {{ old_framework.name }}.</p>
       <p class="govuk-body">You can reuse some of the answers from that declaration.</p>

--- a/app/templates/frameworks/services.html
+++ b/app/templates/frameworks/services.html
@@ -35,13 +35,7 @@
 
   {% include "partials/service_warning.html" %}
 
-  {% with
-     heading = lot.name + " services",
-     smaller = True,
-     with_breadcrumb = True
-  %}
-    {% include "toolkit/page-heading.html" %}
-  {% endwith %}
+  <h1 class="govuk-heading-l">{{ lot.name }} services</h1>
 
   {% if framework.status == 'pending' %}
     <div class="summary-item-lede">

--- a/app/templates/frameworks/signature_upload.html
+++ b/app/templates/frameworks/signature_upload.html
@@ -27,13 +27,7 @@
 
 {% block main_content %}
 <div class="single-question-page">
-  {%
-    with
-    heading = "Upload your signed signature page",
-    smaller = True
-  %}
-    {% include "toolkit/page-heading.html" %}
-  {% endwith %}
+  <h1 class="govuk-heading-l">Upload your signed signature page</h1>
 
   {% if upload_error %}
     {% with errors = {

--- a/app/templates/frameworks/signer_details.html
+++ b/app/templates/frameworks/signer_details.html
@@ -30,13 +30,7 @@
 
 <div class="grid-row">
   <div class="column-two-thirds">
-    {%
-    with
-      heading = "Details of the person who is signing on behalf of %s" | format(supplier_registered_name),
-      smaller = True
-    %}
-      {% include "toolkit/page-heading.html" %}
-    {% endwith %}
+    <h1 class="govuk-heading-l">{{ 'Details of the person who is signing on behalf of {}'.format(supplier_registered_name) }}</h1>
 
     <form method="POST" action="{{ url_for('.signer_details', framework_slug=framework.slug, agreement_id=agreement['id']) }}">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>

--- a/app/templates/frameworks/start_declaration.html
+++ b/app/templates/frameworks/start_declaration.html
@@ -30,12 +30,7 @@
 {% block main_content %}
   <div class="grid-row framework-dashboard">
     <div class="column-two-thirds">
-      {% with
-         heading = self.page_title_inner(),
-         smaller = True
-      %}
-        {% include "toolkit/page-heading.html" %}
-      {% endwith %}
+      <h1 class="govuk-heading-l">{{ self.page_title_inner() }}</h1>
 
       <p class="govuk-body">You must make the supplier declaration to confirm you’re eligible to provide services through {{ framework.name }}.</p>
       <br>

--- a/app/templates/frameworks/submission_lots.html
+++ b/app/templates/frameworks/submission_lots.html
@@ -33,11 +33,7 @@
 
   <div class="grid-row">
     <div class="column-two-thirds">
-      {% with
-        heading = "Your " + framework.name + " services"
-      %}
-        {% include 'toolkit/page-heading.html' %}
-      {% endwith %}
+      <h1 class="govuk-heading-l">Your {{ framework.name }} services</h1>
     </div>
   </div>
 

--- a/app/templates/frameworks/updates.html
+++ b/app/templates/frameworks/updates.html
@@ -51,6 +51,7 @@
       %}
         {% include "toolkit/page-heading.html" %}
       {% endwith %}
+      <h1 class="govuk-heading-l">{{ '{} updates'.format(framework.name) }}</h1>
     </div>
   </div>
 

--- a/app/templates/frameworks/updates.html
+++ b/app/templates/frameworks/updates.html
@@ -45,13 +45,7 @@
 
   <div class="grid-row">
     <div class="column-two-thirds">
-      {% with
-         smaller = true,
-         heading = "{} updates".format(framework.name)
-      %}
-        {% include "toolkit/page-heading.html" %}
-      {% endwith %}
-      <h1 class="govuk-heading-l">{{ '{} updates'.format(framework.name) }}</h1>
+      <h1 class="govuk-heading-l">{{ framework.name }} updates</h1>
     </div>
   </div>
 

--- a/app/templates/services/_base_edit_section_page.html
+++ b/app/templates/services/_base_edit_section_page.html
@@ -13,12 +13,7 @@
     <div class="column-two-thirds">
       {% include 'frameworks/_session_timeout.html' %}
 
-      {% with
-        heading = section.name,
-        smaller = true
-      %}
-        {% include 'toolkit/page-heading.html' %}
-      {% endwith %}
+      <h1 class="govuk-heading-l">{{ section.name }}</h1>
 
       {% if section.description %}
         <div class="section-description">

--- a/app/templates/services/_base_service_page.html
+++ b/app/templates/services/_base_service_page.html
@@ -25,12 +25,7 @@
 
     {% block before_heading %}{% endblock %}
     <div class="column-two-thirds">
-      {% with
-        heading = service_data.get('serviceName', service_data['lotName']),
-        smaller = true
-      %}
-        {% include "toolkit/page-heading.html" %}
-      {% endwith %}
+      <h1 class="govuk-heading-l">{{ service_data.get('serviceName', service_data['lotName']) }}</h1>
     </div>
     {% block before_sections %}{% endblock %}
     <div class="column-one-whole">

--- a/app/templates/services/list_services.html
+++ b/app/templates/services/list_services.html
@@ -25,12 +25,7 @@
 {% block main_content %}
   <div class="grid-row">
     <div class="column-two-thirds">
-      {% set heading %}
-        Your {{ framework.name }} services
-      {% endset %}
-      {% with smaller=true %}
-        {% include 'toolkit/page-heading.html' %}
-      {% endwith %}
+      <h1 class="govuk-heading-l">Your {{ framework.name }} services</h1>
     </div>
   </div>
 

--- a/app/templates/services/previous_services.html
+++ b/app/templates/services/previous_services.html
@@ -90,13 +90,7 @@
 
     {% include "partials/service_warning.html" %}
 
-    {% with
-       heading = "Previous {} services".format(lot.name|lower),
-       smaller = True,
-       with_breadcrumb = True
-    %}
-      {% include "toolkit/page-heading.html" %}
-    {% endwith %}
+    <h1 class="govuk-heading-l">Previous {{ lot.name|lower }} services</h1>
 
     {{ summary.heading("Your services from {}".format(source_framework.name)) }}
     {% if previous_services_still_to_copy|length > 1 %}

--- a/app/templates/services/previous_services.html
+++ b/app/templates/services/previous_services.html
@@ -44,13 +44,7 @@
     <div class="grid-row">
       <div class="column-two-thirds">
         <div class="single-question-page">
-          {% with
-             heading = form.copy_service.label,
-             smaller = True,
-             with_breadcrumb = True
-          %}
-            {% include "toolkit/page-heading.html" %}
-          {% endwith %}
+          <h1 class="govuk-heading-l">{{ form.copy_service.label }}</h1>
 
           <form method="POST" action="{{ url_for('.previous_services', framework_slug=framework.slug, lot_slug=lot.slug) }}">
             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>

--- a/app/templates/suppliers/already_completed.html
+++ b/app/templates/suppliers/already_completed.html
@@ -29,9 +29,7 @@
   <div class="grid-row">
 
     <div class="column-two-thirds dmspeak">
-      {% with heading = "Correct a mistake in your {}".format(completed_data_description), smaller = True %}
-        {% include "toolkit/page-heading.html" %}
-      {% endwith %}
+      <h1 class="govuk-heading-l">{{ 'Correct a mistake in your {}'.format(completed_data_description) }}</h1>
 
       <div class="explanation-list">
       <p class="govuk-body-l">Contact <a class="govuk-link" href="mailto:{{ company_details_change_email }}">{{ company_details_change_email }}</a> to correct a mistake in your:</p>

--- a/app/templates/suppliers/become_a_supplier.html
+++ b/app/templates/suppliers/become_a_supplier.html
@@ -20,9 +20,7 @@
 {% block main_content %}
   <div class="grid-row">
     <div class="column-two-thirds">
-      {% with heading = "Become a supplier", smaller = True %}
-        {% include "toolkit/page-heading.html" %}
-      {% endwith %}
+      <h1 class="govuk-heading-l">Become a supplier</h1>
 
       {% if open_fwks or opening_fwks %}
         <div class="dmspeak">

--- a/app/templates/suppliers/create_company_details.html
+++ b/app/templates/suppliers/create_company_details.html
@@ -33,9 +33,7 @@
 
   </div>
     <div class="column-two-thirds">
-      {% with heading = "What buyers will see", smaller = True %}
-        {% include "toolkit/page-heading.html" %}
-      {% endwith %}
+      <h1 class="govuk-heading-l">What buyers will see</h1>
 
       <div class="dmspeak">
         <p class="govuk-body">This information will be visible on the Digital Marketplace.</p>

--- a/app/templates/suppliers/create_company_summary.html
+++ b/app/templates/suppliers/create_company_summary.html
@@ -38,12 +38,7 @@
 
 <div class="company-information-summary">
 
-{%
-  with heading = "Check your information ",
-       smaller = True
-%}
-  {% include "toolkit/page-heading.html" %}
-{% endwith %}
+  <h1 class="govuk-heading-l">Check your information </h1>
 
   {{ summary.heading('Your company details') }}
   {% call summary.mapping_table(

--- a/app/templates/suppliers/create_duns_number.html
+++ b/app/templates/suppliers/create_duns_number.html
@@ -38,10 +38,7 @@
   {% endif %}
 
   <div class="column-two-thirds">
-    {% with heading = "Enter your DUNS number",
-            smaller = True %}
-      {% include "toolkit/page-heading.html" %}
-    {% endwith %}
+    <h1 class="govuk-heading-l">Enter your DUNS number</h1>
 
 
     <form method="POST" action="{{ url_for('.duns_number') }}">

--- a/app/templates/suppliers/create_new_supplier.html
+++ b/app/templates/suppliers/create_new_supplier.html
@@ -26,9 +26,7 @@
 <div class="start-page">
   <div class="grid-row">
     <div class="column-two-thirds dmspeak">
-      {% with heading = "Create a supplier account", smaller = True %}
-        {% include "toolkit/page-heading.html" %}
-      {% endwith %}
+      <h1 class="govuk-heading-l">Create a supplier account</h1>
 
       <div>
         <p class="govuk-body-l">You must provide:</p>

--- a/app/templates/suppliers/create_your_account.html
+++ b/app/templates/suppliers/create_your_account.html
@@ -31,9 +31,7 @@
 
 <div class="grid-row">
   <div class="column-two-thirds">
-    {% with heading = "Create login", smaller = True %}
-      {% include "toolkit/page-heading.html" %}
-    {% endwith %}
+    <h1 class="govuk-heading-l">Create login</h1>
 
     <div class="dmspeak">
        <p class="govuk-body">You’ll use this to sign in to your company’s supplier account.</p>

--- a/app/templates/suppliers/create_your_account_complete.html
+++ b/app/templates/suppliers/create_your_account_complete.html
@@ -28,9 +28,7 @@
 {% block main_content %}
   <div class="grid-row">
     <div class="column-two-thirds">
-      {% with heading = "Create login", smaller = True %}
-        {% include "toolkit/page-heading.html" %}
-      {% endwith %}
+      <h1 class="govuk-heading-l">Create login</h1>
 
       <div class="dmspeak">
         <p class="govuk-body">An email has been sent to {{ email_address }}.</p>

--- a/app/templates/suppliers/dashboard.html
+++ b/app/templates/suppliers/dashboard.html
@@ -20,12 +20,8 @@
 
   <div class="grid-row">
     <div class="column-one-whole">
-      {% with
-        context = current_user.email_address,
-        heading = current_user.supplier_name
-      %}
-        {% include 'toolkit/page-heading.html' %}
-      {% endwith %}
+      <span class="govuk-caption-xl">{{ current_user.email_address }}</span>
+      <h1 class="govuk-heading-xl">{{ current_user.supplier_name }}</h1>
     </div>
   </div>
 

--- a/app/templates/suppliers/details.html
+++ b/app/templates/suppliers/details.html
@@ -25,13 +25,7 @@
 {% block main_content %}
   <div class='grid-row'>
     <div class='column-one-whole{% if currently_applying_to or (supplier_company_details_complete and not supplier_company_details_confirmed) %} padding-bottom-small{% endif %}'>
-{%
-  with
-    heading = "Company details",
-    smaller = true
-%}
-  {% include "toolkit/page-heading.html" %}
-{% endwith %}
+      <h1 class="govuk-heading-l">Company details</h1>
 
 {{ summary.heading("What buyers will see", id="what_buyers_will_see") }}
 {{ summary.top_link('Change', url_for('.edit_what_buyers_will_see')) }}

--- a/app/templates/suppliers/edit_company_registration_number.html
+++ b/app/templates/suppliers/edit_company_registration_number.html
@@ -29,9 +29,7 @@
 <div class="single-question-page">
   <div class="grid-row">
     <div class="column-two-thirds">
-      {% with heading = "Are you registered with Companies House?", smaller = True %}
-        {% include "toolkit/page-heading.html" %}
-      {% endwith %}
+      <h1 class="govuk-heading-l">Are you registered with Companies House?</h1>
 
       <form method="POST" action="{{ url_for('.edit_supplier_registration_number') }}">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>

--- a/app/templates/suppliers/edit_registered_name.html
+++ b/app/templates/suppliers/edit_registered_name.html
@@ -28,9 +28,7 @@
 <div class="single-question-page">
   <div class="grid-row">
     <div class="column-two-thirds">
-      {% with heading = "Registered company name", smaller = True %}
-        {% include "toolkit/page-heading.html" %}
-      {% endwith %}
+      <h1 class="govuk-heading-l">Registered company name</h1>
 
       <form method="POST" action="{{ url_for('.edit_supplier_registered_name') }}">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>

--- a/app/templates/suppliers/edit_supplier_organisation_size.html
+++ b/app/templates/suppliers/edit_supplier_organisation_size.html
@@ -29,9 +29,7 @@
 <div class="single-question-page">
   <div class="grid-row">
     <div class="column-two-thirds">
-      {% with heading = "What size is your organisation?", smaller = True %}
-        {% include "toolkit/page-heading.html" %}
-      {% endwith %}
+      <h1 class="govuk-heading-l">What size is your organisation?</h1>
 
       <form method="POST" action="{{ url_for('.edit_supplier_organisation_size') }}">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>

--- a/app/templates/suppliers/edit_supplier_trading_status.html
+++ b/app/templates/suppliers/edit_supplier_trading_status.html
@@ -29,9 +29,7 @@
 <div class="single-question-page">
   <div class="grid-row">
     <div class="column-two-thirds">
-      {% with heading = "What&rsquo;s your trading status?"|safe, smaller = True %}
-        {% include "toolkit/page-heading.html" %}
-      {% endwith %}
+      <h1 class="govuk-heading-l">What&rsquo;s your trading status?</h1>
 
       <form method="POST" action="{{ url_for('.edit_supplier_trading_status') }}">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>

--- a/app/templates/suppliers/edit_what_buyers_will_see.html
+++ b/app/templates/suppliers/edit_what_buyers_will_see.html
@@ -31,11 +31,7 @@
 
   <div class="grid-row">
     <div class="column-one-whole">
-      {% with
-        heading = "What buyers will see"
-      %}
-        {% include 'toolkit/page-heading.html' %}
-      {% endwith %}
+      <h1 class="govuk-heading-xl">What buyers will see</h1>
 
       <div class="dmspeak">
         <p class="govuk-body">This information will be visible on the Digital Marketplace.</p>

--- a/app/templates/suppliers/join_open_framework_notification_mailing_list.html
+++ b/app/templates/suppliers/join_open_framework_notification_mailing_list.html
@@ -22,14 +22,8 @@
 
 <div class="grid-row">
   <div class="column-two-thirds">
-    {%
-    with
-        heading = "Sign up for Digital Marketplace email alerts",
-        smaller = True
-    %}
-      {% include "toolkit/page-heading.html" %}
-    {% endwith %}
-    <div class="dmspeak">
+    <h1 class="govuk-heading-l">Sign up for Digital Marketplace email alerts</h1>
+  <div class="dmspeak">
       <p class="govuk-body">
         We’ll let you know when applications to sell your services will open.
       </p>

--- a/app/templates/suppliers/registered_address.html
+++ b/app/templates/suppliers/registered_address.html
@@ -36,12 +36,7 @@
 
   <div class="grid-row">
     <div class="column-one-whole">
-      {% with
-        heading = "What is your registered office address?",
-        smaller = true
-      %}
-        {% include 'toolkit/page-heading.html' %}
-      {% endwith %}
+      <h1 class="govuk-heading-l">What is your registered office address?</h1>
     </div>
   </div>
 

--- a/app/templates/users/list_users.html
+++ b/app/templates/users/list_users.html
@@ -24,13 +24,9 @@
 
 {% block main_content %}
   <div class="single-summary-page">
-    {% with
-      context = current_user.email_address,
-      heading = "Invite or remove contributors",
-      smaller = true
-    %}
-      {% include 'toolkit/page-heading.html' %}
-    {% endwith %}
+    <span class="govuk-caption-l">{{ current_user.email_address }}</span>
+    <h1 class="govuk-heading-l">Invite or remove contributors</h1>
+
     <a class="govuk-link" class="summary-change-link" href="{{ url_for('.invite_user') }}">Invite a contributor</a>
     {% call(item) summary.table(
       users,

--- a/tests/app/main/test_suppliers.py
+++ b/tests/app/main/test_suppliers.py
@@ -1189,7 +1189,7 @@ class TestSupplierDashboardLogin(BaseApplicationTest):
 
         assert response.status_code == 200
 
-        assert self.strip_all_whitespace(u"<h1>Supplier NĀme</h1>") in \
+        assert self.strip_all_whitespace(u'<h1 class="govuk-heading-xl">Supplier NĀme</h1>') in \
             self.strip_all_whitespace(response.get_data(as_text=True))
         assert self.strip_all_whitespace("email@email.com") in \
             self.strip_all_whitespace(response.get_data(as_text=True))
@@ -2395,7 +2395,7 @@ class TestBecomeASupplier(BaseApplicationTest):
         res = self.client.get("/suppliers/supply")
 
         assert res.status_code == 200
-        assert self.strip_all_whitespace(u"<h1>Become a supplier</h1>") in \
+        assert self.strip_all_whitespace(u'<h1 class="govuk-heading-l">Become a supplier</h1>') in \
             self.strip_all_whitespace(res.get_data(as_text=True))
 
     @mock.patch('app.main.suppliers.get_frameworks_closed_and_open_for_applications', autospec=True)


### PR DESCRIPTION
trello: https://trello.com/c/9LvUzYaP/158-2-update-page-headings-to-govuk-frontend-style-in-supplier-frontend