### PR TITLE
content loader: use new `inplace_allowed` options in .filter() and .summary() methods where appropriate

### DIFF
--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -343,8 +343,10 @@ def framework_submission_services(framework_slug, lot_slug):
     with logged_duration(message="Annotated draft details in {duration_real}s"):
         for draft in chain(drafts, complete_drafts):
             draft['priceString'] = format_service_price(draft)
-            content = content_loader.get_manifest(framework_slug, 'edit_submission').filter(draft)
-            sections = content.summary(draft)
+            sections = content_loader.get_manifest(
+                framework_slug,
+                'edit_submission',
+            ).filter(draft, inplace_allowed=True).summary(draft, inplace_allowed=True)
 
             unanswered_required, unanswered_optional = count_unanswered_questions(sections)
             draft.update({
@@ -508,7 +510,10 @@ def framework_supplier_declaration_overview(framework_slug):
         abort(410)
 
     try:
-        content = content_loader.get_manifest(framework_slug, 'declaration').filter(sf["declaration"])
+        content = content_loader.get_manifest(
+            framework_slug,
+            'declaration',
+        ).filter(sf["declaration"], inplace_allowed=True)
     except ContentNotFoundError:
         abort(404)
 
@@ -550,7 +555,10 @@ def framework_supplier_declaration_submit(framework_slug):
     # ensure our declaration is at least a dict
     sf["declaration"] = sf.get("declaration") or {}
 
-    content = content_loader.get_manifest(framework_slug, 'declaration').filter(sf["declaration"])
+    content = content_loader.get_manifest(
+        framework_slug,
+        'declaration',
+    ).filter(sf["declaration"], inplace_allowed=True)
 
     validator = get_validator(framework, content, sf["declaration"])
     errors = validator.get_error_messages()
@@ -581,7 +589,7 @@ def framework_supplier_declaration_submit(framework_slug):
 def framework_supplier_declaration_edit(framework_slug, section_id):
     framework = get_framework_or_404(data_api_client, framework_slug, allowed_statuses=['open'])
 
-    content = content_loader.get_manifest(framework_slug, 'declaration').filter({})
+    content = content_loader.get_manifest(framework_slug, 'declaration').filter({}, inplace_allowed=True)
     status_code = 200
 
     # Get and check the current section.

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -95,7 +95,10 @@ def edit_service(framework_slug, service_id):
     framework = get_framework_or_404(data_api_client, service['frameworkSlug'], allowed_statuses=['live'])
 
     try:
-        content = content_loader.get_manifest(framework['slug'], 'edit_service').filter(service)
+        content = content_loader.get_manifest(framework['slug'], 'edit_service').filter(
+            service,
+            inplace_allowed=True,
+        )
     except ContentNotFoundError:
         abort(404)
     remove_requested = bool(request.args.get('remove_requested'))
@@ -106,7 +109,7 @@ def edit_service(framework_slug, service_id):
         service_data=service,
         service_unavailability_information=service_unavailability_information,
         framework=framework,
-        sections=content.summary(service),
+        sections=content.summary(service, inplace_allowed=True),
         remove_requested=remove_requested,
         support_email_address=current_app.config['SUPPORT_EMAIL_ADDRESS']
     )
@@ -182,7 +185,10 @@ def edit_section(framework_slug, service_id, section_id):
     get_framework_or_404(data_api_client, service['frameworkSlug'], allowed_statuses=['live'])
 
     try:
-        content = content_loader.get_manifest(service["frameworkSlug"], 'edit_service').filter(service)
+        content = content_loader.get_manifest(service["frameworkSlug"], 'edit_service').filter(
+            service,
+            inplace_allowed=True,
+        )
     except ContentNotFoundError:
         abort(404)
     section = content.get_section(section_id)
@@ -221,7 +227,10 @@ def update_section(framework_slug, service_id, section_id):
     get_framework_or_404(data_api_client, service['frameworkSlug'], allowed_statuses=['live'])
 
     try:
-        content = content_loader.get_manifest(service["frameworkSlug"], 'edit_service').filter(service)
+        content = content_loader.get_manifest(service["frameworkSlug"], 'edit_service').filter(
+            service,
+            inplace_allowed=True,
+        )
     except ContentNotFoundError:
         abort(404)
     section = content.get_section(section_id)
@@ -311,7 +320,8 @@ def start_new_draft_service(framework_slug, lot_slug):
         abort(404)
 
     content = content_loader.get_manifest(framework_slug, 'edit_submission').filter(
-        {'lot': lot['slug']}
+        {'lot': lot['slug']},
+        inplace_allowed=True,
     )
 
     section = content.get_section(content.get_next_editable_section_id())
@@ -385,7 +395,8 @@ def copy_draft_service(framework_slug, lot_slug, service_id):
         abort(404)
 
     content = content_loader.get_manifest(framework_slug, 'edit_submission').filter(
-        {'lot': lot['slug']}
+        {'lot': lot['slug']},
+        inplace_allowed=True,
     )
 
     draft_copy = data_api_client.copy_draft_service(
@@ -528,9 +539,10 @@ def view_service_submission(framework_slug, lot_slug, service_id):
     if not is_service_associated_with_supplier(draft):
         abort(404)
 
-    content = content_loader.get_manifest(framework['slug'], 'edit_submission').filter(draft)
-
-    sections = content.summary(draft)
+    sections = content_loader.get_manifest(
+        framework['slug'],
+        'edit_submission',
+    ).filter(draft, inplace_allowed=True).summary(draft, inplace_allowed=True)
 
     unanswered_required, unanswered_optional = count_unanswered_questions(sections)
     delete_requested = True if request.args.get('delete_requested') else False
@@ -585,7 +597,7 @@ def edit_service_submission(framework_slug, lot_slug, service_id, section_id, qu
     if not is_service_associated_with_supplier(draft):
         abort(404)
 
-    content = content_loader.get_manifest(framework_slug, 'edit_submission').filter(draft)
+    content = content_loader.get_manifest(framework_slug, 'edit_submission').filter(draft, inplace_allowed=True)
     section = content.get_section(section_id)
     if section and (question_slug is not None):
         next_question = section.get_question_by_slug(section.get_next_question_slug(question_slug))
@@ -681,7 +693,7 @@ def remove_subsection(framework_slug, lot_slug, service_id, section_id, question
     if not is_service_associated_with_supplier(draft):
         abort(404)
 
-    content = content_loader.get_manifest(framework_slug, 'edit_submission').filter(draft)
+    content = content_loader.get_manifest(framework_slug, 'edit_submission').filter(draft, inplace_allowed=True)
     section = content.get_section(section_id)
     containing_section = section
     if section and (question_slug is not None):

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -7,6 +7,6 @@ Flask-WTF==0.14.2
 itsdangerous==0.24 # pyup: ignore
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@51.1.0#egg=digitalmarketplace-utils==51.1.0
-git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.2.0#egg=digitalmarketplace-content-loader==7.2.0
+git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.3.0#egg=digitalmarketplace-content-loader==7.3.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.4.1#egg=digitalmarketplace-apiclient==21.4.1
 git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.1-alpha#egg=govuk-frontend-jinja==0.5.1-alpha

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ Flask-WTF==0.14.2
 itsdangerous==0.24 # pyup: ignore
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@51.1.0#egg=digitalmarketplace-utils==51.1.0
-git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.2.0#egg=digitalmarketplace-content-loader==7.2.0
+git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.3.0#egg=digitalmarketplace-content-loader==7.3.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.4.1#egg=digitalmarketplace-apiclient==21.4.1
 git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.1-alpha#egg=govuk-frontend-jinja==0.5.1-alpha
 


### PR DESCRIPTION
https://trello.com/c/ooTuJDCw

Significant performance gains here. Partly from the content loader bump as it contains some opaque optimizations, but mostly stemming from these additions. These are all in places where it can be seen that the original object reference is discarded afterwards, so it can be considered safe.