### PR TITLE
Replace main_content with mainContent 

### DIFF
--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -39,10 +39,10 @@ from ..forms.frameworks import OneServiceLimitCopyServiceForm
 SERVICE_REMOVED_MESSAGE = "{service_name} has been removed."
 SERVICE_UPDATED_MESSAGE = "You’ve edited your service. The changes are now live on the Digital Marketplace."
 SERVICE_COMPLETED_MESSAGE = Markup("<strong>{service_name}</strong> was marked as complete")
-SERVICE_DELETED_MESSAGE = Markup("<strong>{service_name}</strong> was deleted")
+SERVICE_DELETED_MESSAGE = Markup("<strong>{service_name}</strong> was removed")
 REMOVE_LAST_SUBSECTION_ERROR_MESSAGE = Markup(
     "You must offer one of the {section_name} to be eligible.<br>"
-    "If you don’t want to offer {service_name}, delete this service."
+    "If you don’t want to offer {service_name}, remove this service."
 )
 SINGLE_SERVICE_LOT_SINGLE_SERVICE_ADDED_MESSAGE = (
     "You've added your service to {framework_name} as a draft. You'll need to review it before it can be completed."

--- a/app/templates/_base_page.html
+++ b/app/templates/_base_page.html
@@ -16,7 +16,11 @@
     {% endblock %}
     <main id="content" role="main">
       {% include "toolkit/flash_messages.html" %}
-      {% block main_content %}{% endblock %}
+      {# TODO: Remove this block when we start removing govuk_template but be sure #}
+      {#       To keep the inner block mainContent otherwise no content will be rendered #}
+      {% block main_content %}
+        {% block mainContent %}{% endblock %}
+      {% endblock %}
     </main>
   </div>
 {% endblock %}

--- a/app/templates/auth/submit_email_address.html
+++ b/app/templates/auth/submit_email_address.html
@@ -28,7 +28,7 @@
   }) }}
 {% endblock %}
 
-{% block main_content %}
+{% block mainContent %}
 {% include "toolkit/forms/validation.html" %}
 
 <h1 class="govuk-heading-l">Invite a contributor</h1>

--- a/app/templates/errors/applications_closed.html
+++ b/app/templates/errors/applications_closed.html
@@ -4,7 +4,7 @@
   Applications closed - Digital Marketplace
 {% endblock %}
 
-{% block main_content %}
+{% block mainContent %}
 
 <div class="error-page">
   <h1 class="govuk-heading-l">You can no longer apply to {{ framework['name'] }}</h1>

--- a/app/templates/frameworks/contract_review.html
+++ b/app/templates/frameworks/contract_review.html
@@ -26,7 +26,7 @@
   }) }}
 {% endblock %}
 
-{% block main_content %}
+{% block mainContent %}
   {% include 'toolkit/forms/validation.html' %}
 
 <div class="grid-row">

--- a/app/templates/frameworks/contract_start.html
+++ b/app/templates/frameworks/contract_start.html
@@ -27,7 +27,7 @@
   }) }}
 {% endblock %}
 
-{% block main_content %}
+{% block mainContent %}
 
   <div class="grid-row framework-dashboard">
     <div class="column-two-thirds">

--- a/app/templates/frameworks/contract_variation.html
+++ b/app/templates/frameworks/contract_variation.html
@@ -27,7 +27,7 @@
   }) }}
 {% endblock %}
 
-{% block main_content %}
+{% block mainContent %}
     <div class="grid-row">
       <div class="column-one-whole">
         {% if errors %}

--- a/app/templates/frameworks/dashboard.html
+++ b/app/templates/frameworks/dashboard.html
@@ -30,7 +30,7 @@
   }) }}
 {% endblock %}
 
-{% block main_content %}
+{% block mainContent %}
   {# Confidence Banner #}
   {% if application_made and framework.status == 'open' %}
     {% with

--- a/app/templates/frameworks/declaration_overview.html
+++ b/app/templates/frameworks/declaration_overview.html
@@ -53,7 +53,7 @@
 {% endmacro %}
 
 
-{% block main_content %}
+{% block mainContent %}
   <div class="grid-row">
     <div class="column-two-thirds">
       <h1 class="govuk-heading-l">Your declaration overview</h1>

--- a/app/templates/frameworks/edit_declaration_section.html
+++ b/app/templates/frameworks/edit_declaration_section.html
@@ -31,7 +31,7 @@
   }) }}
 {% endblock %}
 
-{% block main_content %}
+{% block mainContent %}
   {% include "toolkit/forms/validation.html" %}
 
   {% if name_of_framework_that_section_has_been_prefilled_from %}

--- a/app/templates/frameworks/reuse_declaration.html
+++ b/app/templates/frameworks/reuse_declaration.html
@@ -28,7 +28,7 @@
   }) }}
 {% endblock %}
 
-{% block main_content %}
+{% block mainContent %}
   {% include 'toolkit/forms/validation.html' %}
 
   <div class="grid-row">

--- a/app/templates/frameworks/services.html
+++ b/app/templates/frameworks/services.html
@@ -32,7 +32,7 @@
   }) }}
 {% endblock %}
 
-{% block main_content %}
+{% block mainContent %}
 
   {% include "partials/service_warning.html" %}
 

--- a/app/templates/frameworks/signature_upload.html
+++ b/app/templates/frameworks/signature_upload.html
@@ -26,7 +26,7 @@
   }) }}
 {% endblock %}
 
-{% block main_content %}
+{% block mainContent %}
 <div class="single-question-page">
   <h1 class="govuk-heading-l">Upload your signed signature page</h1>
 

--- a/app/templates/frameworks/signer_details.html
+++ b/app/templates/frameworks/signer_details.html
@@ -26,7 +26,7 @@
   }) }}
 {% endblock %}
 
-{% block main_content %}
+{% block mainContent %}
   {% include 'toolkit/forms/validation.html' %}
 
 <div class="grid-row">

--- a/app/templates/frameworks/start_declaration.html
+++ b/app/templates/frameworks/start_declaration.html
@@ -28,7 +28,7 @@
   }) }}
 {% endblock %}
 
-{% block main_content %}
+{% block mainContent %}
   <div class="grid-row framework-dashboard">
     <div class="column-two-thirds">
       <h1 class="govuk-heading-l">{{ self.page_title_inner() }}</h1>

--- a/app/templates/frameworks/submission_lots.html
+++ b/app/templates/frameworks/submission_lots.html
@@ -28,7 +28,7 @@
   }) }}
 {% endblock %}
 
-{% block main_content %}
+{% block mainContent %}
 
   {% include "partials/service_warning.html" %}
 

--- a/app/templates/frameworks/updates.html
+++ b/app/templates/frameworks/updates.html
@@ -27,7 +27,7 @@
   }) }}
 {% endblock %}
 
-{% block main_content %}
+{% block mainContent %}
 
   {% if error_message %}
     {%

--- a/app/templates/services/_base_edit_section_page.html
+++ b/app/templates/services/_base_edit_section_page.html
@@ -5,7 +5,7 @@
   {{ section.name }} – Digital Marketplace
 {% endblock %}
 
-{% block main_content %}
+{% block mainContent %}
   {% include 'toolkit/forms/validation.html' %}
 
   <div class="grid-row">

--- a/app/templates/services/_base_service_page.html
+++ b/app/templates/services/_base_service_page.html
@@ -4,7 +4,7 @@
   {{ service_data.serviceName or service_data.lotName }} – Digital Marketplace
 {% endblock %}
 
-{% block main_content %}
+{% block mainContent %}
   <div class="grid-row">
     {% if confirm_remove %}
       <form method="post" action='{{ url_for(".remove_subsection", framework_slug=framework.slug, lot_slug=service_data.lot, service_id=service_id, section_id=request.args.get("section_id"), question_slug=confirm_remove, confirm=True) }}'>

--- a/app/templates/services/list_services.html
+++ b/app/templates/services/list_services.html
@@ -23,7 +23,7 @@
   }) }}
 {% endblock %}
 
-{% block main_content %}
+{% block mainContent %}
   <div class="grid-row">
     <div class="column-two-thirds">
       <h1 class="govuk-heading-l">Your {{ framework.name }} services</h1>

--- a/app/templates/services/previous_services.html
+++ b/app/templates/services/previous_services.html
@@ -36,7 +36,7 @@
   }) }}
 {% endblock %}
 
-{% block main_content %}
+{% block mainContent %}
   {% if lot.oneServiceLimit %}
     {% include 'toolkit/forms/validation.html' %}
 

--- a/app/templates/services/service_submission.html
+++ b/app/templates/services/service_submission.html
@@ -125,10 +125,10 @@
         <input type="hidden" name="delete_confirmed" value="true" />
         <div class="banner-destructive-with-action">
           <p class="banner-message">
-            Are you sure you want to delete {{ service_data.lotName.lower() if lot.oneServiceLimit else 'this {}'.format(lot.unitSingular) }}?
+            Are you sure you want to remove {{ service_data.lotName.lower() if lot.oneServiceLimit else 'this {}'.format(lot.unitSingular) }}?
           </p>
           {{ govukButton({
-            "text": "Yes, delete",
+            "text": "Yes, remove",
             "classes": "govuk-button--warning app-banner-action",
           }) }}
         </div>

--- a/app/templates/services/service_submission.html
+++ b/app/templates/services/service_submission.html
@@ -187,7 +187,7 @@
 
 {% block after_sections %}
   {% if not delete_requested %}
-    <div class="grid-row">
+
       <div class="column-two-thirds">
         &nbsp;
       </div>
@@ -201,8 +201,8 @@
         <form action="{{ url_for('.delete_draft_service', framework_slug=framework.slug, lot_slug=service_data.lot, service_id=service_id ) }}" method="POST">
           <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
           {{ govukButton({
-            "text": "Delete",
-            "classes": "govuk-button--warning",
+            "text": "Delete draft service",
+            "classes": "govuk-button--warning button-destructive",
           }) }}
         </form>
         {% endif %}
@@ -223,6 +223,6 @@
             {% include "toolkit/secondary-action-link.html" %}
           {% endwith %}
       </div>
-    </div>
+
   {% endif %}
 {% endblock %}

--- a/app/templates/services/service_submission.html
+++ b/app/templates/services/service_submission.html
@@ -201,7 +201,7 @@
         <form action="{{ url_for('.delete_draft_service', framework_slug=framework.slug, lot_slug=service_data.lot, service_id=service_id ) }}" method="POST">
           <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
           {{ govukButton({
-            "text": "Delete draft service",
+            "text": "Remove draft service",
             "classes": "govuk-button--warning button-destructive",
           }) }}
         </form>

--- a/app/templates/suppliers/already_completed.html
+++ b/app/templates/suppliers/already_completed.html
@@ -35,7 +35,7 @@
       <h1 class="govuk-heading-l">{{ 'Correct a mistake in your {}'.format(completed_data_description) }}</h1>
 
       <div class="explanation-list">
-      <p class="govuk-body-l">Contact <a class="govuk-link" href="mailto:{{ company_details_change_email }}">{{ company_details_change_email }}</a> to correct a mistake in your:</p>
+      <p class="govuk-body-m">Contact <a class="govuk-link" href="mailto:{{ company_details_change_email }}">{{ company_details_change_email }}</a> to correct a mistake in your:</p>
 
       <ul class="govuk-list govuk-list--bullet">
         <li>registered company name</li>

--- a/app/templates/suppliers/already_completed.html
+++ b/app/templates/suppliers/already_completed.html
@@ -26,7 +26,7 @@
   }) }}
 {% endblock %}
 
-{% block main_content %}
+{% block mainContent %}
 
 <div class="single-question-page">
   <div class="grid-row">

--- a/app/templates/suppliers/become_a_supplier.html
+++ b/app/templates/suppliers/become_a_supplier.html
@@ -18,7 +18,7 @@
   }) }}
 {% endblock %}
 
-{% block main_content %}
+{% block mainContent %}
   <div class="grid-row">
     <div class="column-two-thirds">
       <h1 class="govuk-heading-l">Become a supplier</h1>

--- a/app/templates/suppliers/create_company_details.html
+++ b/app/templates/suppliers/create_company_details.html
@@ -26,7 +26,7 @@
   }) }}
 {% endblock %}
 
-{% block main_content %}
+{% block mainContent %}
   {% include 'toolkit/forms/validation.html' %}
 
 <div class="grid-row">

--- a/app/templates/suppliers/create_company_summary.html
+++ b/app/templates/suppliers/create_company_summary.html
@@ -27,7 +27,7 @@
   }) }}
 {% endblock %}
 
-{% block main_content %}
+{% block mainContent %}
 
   {% if missing_fields %}
   <div class="banner-destructive-without-action">

--- a/app/templates/suppliers/create_duns_number.html
+++ b/app/templates/suppliers/create_duns_number.html
@@ -26,7 +26,7 @@
   }) }}
 {% endblock %}
 
-{% block main_content %}
+{% block mainContent %}
 <div class="grid-row">
   {% if errors.get("duns_number", {}).get("message", None) == 'DUNS number already used' %}
     {% with lede = "A supplier account already exists with that DUNS number",

--- a/app/templates/suppliers/create_duns_number.html
+++ b/app/templates/suppliers/create_duns_number.html
@@ -49,7 +49,7 @@
           DUNS number.</p>
         <p class="govuk-body">The Digital Marketplace uses this to check if your business already has a supplier account.</p>
       </div>
-        <p class="govuk-body-l">You can either:</p>
+        <p class="govuk-body-m">You can either:</p>
         <ul class="govuk-list govuk-list--bullet">
           <li><a class="govuk-link" href="https://www.dnb.co.uk/duns-number/lookup.html" rel="external">find your DUNS number</a> on the
             Dun &amp; Bradstreet website</li>

--- a/app/templates/suppliers/create_new_supplier.html
+++ b/app/templates/suppliers/create_new_supplier.html
@@ -22,7 +22,7 @@
   }) }}
 {% endblock %}
 
-{% block main_content %}
+{% block mainContent %}
 
 <div class="start-page">
   <div class="grid-row">

--- a/app/templates/suppliers/create_new_supplier.html
+++ b/app/templates/suppliers/create_new_supplier.html
@@ -30,7 +30,7 @@
       <h1 class="govuk-heading-l">Create a supplier account</h1>
 
       <div>
-        <p class="govuk-body-l">You must provide:</p>
+        <p class="govuk-body-m">You must provide:</p>
 
         <ul class="govuk-list govuk-list--bullet">
           <li>a company name and company details that buyers may use to contact you</li>

--- a/app/templates/suppliers/create_your_account.html
+++ b/app/templates/suppliers/create_your_account.html
@@ -27,7 +27,7 @@
   }) }}
 {% endblock %}
 
-{% block main_content %}
+{% block mainContent %}
 {% include "toolkit/forms/validation.html" %}
 
 <div class="grid-row">

--- a/app/templates/suppliers/create_your_account_complete.html
+++ b/app/templates/suppliers/create_your_account_complete.html
@@ -26,7 +26,7 @@
   }) }}
 {% endblock %}
 
-{% block main_content %}
+{% block mainContent %}
   <div class="grid-row">
     <div class="column-two-thirds">
       <h1 class="govuk-heading-l">Create login</h1>

--- a/app/templates/suppliers/dashboard.html
+++ b/app/templates/suppliers/dashboard.html
@@ -17,7 +17,7 @@
   }) }}
 {% endblock %}
 
-{% block main_content %}
+{% block mainContent %}
 
   <div class="grid-row">
     <div class="column-one-whole">

--- a/app/templates/suppliers/details.html
+++ b/app/templates/suppliers/details.html
@@ -33,7 +33,7 @@
 {% endblock %}
 
 
-{% block main_content %}
+{% block mainContent %}
   <div class='grid-row'>
     <div class='column-one-whole{% if currently_applying_to or (supplier_company_details_complete and not supplier_company_details_confirmed) %} padding-bottom-small{% endif %}'>
       <h1 class="govuk-heading-l">Company details</h1>

--- a/app/templates/suppliers/edit_company_registration_number.html
+++ b/app/templates/suppliers/edit_company_registration_number.html
@@ -26,7 +26,7 @@
   }) }}
 {% endblock %}
 
-{% block main_content %}
+{% block mainContent %}
 {% include "toolkit/forms/validation.html" %}
 
 <div class="single-question-page">

--- a/app/templates/suppliers/edit_registered_name.html
+++ b/app/templates/suppliers/edit_registered_name.html
@@ -26,7 +26,7 @@
   }) }}
 {% endblock %}
 
-{% block main_content %}
+{% block mainContent %}
 {% include "toolkit/forms/validation.html" %}
 <div class="single-question-page">
   <div class="grid-row">

--- a/app/templates/suppliers/edit_supplier_organisation_size.html
+++ b/app/templates/suppliers/edit_supplier_organisation_size.html
@@ -26,7 +26,7 @@
   }) }}
 {% endblock %}
 
-{% block main_content %}
+{% block mainContent %}
   {% include 'toolkit/forms/validation.html' %}
 
 <div class="single-question-page">

--- a/app/templates/suppliers/edit_supplier_trading_status.html
+++ b/app/templates/suppliers/edit_supplier_trading_status.html
@@ -26,7 +26,7 @@
   }) }}
 {% endblock %}
 
-{% block main_content %}
+{% block mainContent %}
 {% include "toolkit/forms/validation.html" %}
 
 <div class="single-question-page">

--- a/app/templates/suppliers/edit_what_buyers_will_see.html
+++ b/app/templates/suppliers/edit_what_buyers_will_see.html
@@ -27,7 +27,7 @@
   }) }}
 {% endblock %}
 
-{% block main_content %}
+{% block mainContent %}
 {% include "toolkit/forms/validation.html" %}
 
   <div class="grid-row">

--- a/app/templates/suppliers/join_open_framework_notification_mailing_list.html
+++ b/app/templates/suppliers/join_open_framework_notification_mailing_list.html
@@ -22,7 +22,7 @@
   }) }}
 {% endblock %}
 
-{% block main_content %}
+{% block mainContent %}
 {% include "toolkit/forms/validation.html" %}
 
 <div class="grid-row">

--- a/app/templates/suppliers/registered_address.html
+++ b/app/templates/suppliers/registered_address.html
@@ -32,7 +32,7 @@
 {% endblock %}
 
 
-{% block main_content %}
+{% block mainContent %}
   {% include 'toolkit/forms/validation.html' %}
 
   <div class="grid-row">

--- a/app/templates/users/list_users.html
+++ b/app/templates/users/list_users.html
@@ -28,7 +28,9 @@
     <span class="govuk-caption-l">{{ current_user.email_address }}</span>
     <h1 class="govuk-heading-l">Invite or remove contributors</h1>
 
-    <a class="govuk-link" class="summary-change-link" href="{{ url_for('.invite_user') }}">Invite a contributor</a>
+    <p class="govuk-body">
+      <a class="govuk-link" class="summary-change-link" href="{{ url_for('.invite_user') }}">Invite a contributor</a>
+    </p>
     {% call(item) summary.table(
       users,
       caption="Contributors for " + current_user.supplier_name,

--- a/app/templates/users/list_users.html
+++ b/app/templates/users/list_users.html
@@ -23,7 +23,7 @@
   }) }}
 {% endblock %}
 
-{% block main_content %}
+{% block mainContent %}
   <div class="single-summary-page">
     <span class="govuk-caption-l">{{ current_user.email_address }}</span>
     <h1 class="govuk-heading-l">Invite or remove contributors</h1>

--- a/package-lock.json
+++ b/package-lock.json
@@ -2107,9 +2107,9 @@
       }
     },
     "digitalmarketplace-govuk-frontend": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/digitalmarketplace-govuk-frontend/-/digitalmarketplace-govuk-frontend-0.2.0.tgz",
-      "integrity": "sha512-sELMElO6SS4MuPYHYEDr0+ZhIg2ZKr2TzWrxm52lcZKuMmgJ2otq3x1aezcZbj7ZXpwdNtoTOrvlTH1xy08bkQ=="
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/digitalmarketplace-govuk-frontend/-/digitalmarketplace-govuk-frontend-0.2.1.tgz",
+      "integrity": "sha512-rrXK/GEFiHDsXv2IP0d8lOYfW1yDgh5OX/lOl38gn/uAmHlqNdzhpZws6Ioro7IoG593CoSl5aWewuuUHBdgYA=="
     },
     "dir-glob": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": "^ 10.15"
+    "node": "^10.16.3"
   },
   "dependencies": {
     "colors": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "del": "^5.1.0",
     "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#v16.0.10",
     "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v36.1.0",
-    "digitalmarketplace-govuk-frontend": "^0.2.0",
+    "digitalmarketplace-govuk-frontend": "^0.2.1",
     "govuk-country-and-territory-autocomplete": "0.4.0",
     "govuk-elements-sass": "3.0.3",
     "govuk_frontend_toolkit": "5.0.3",

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -2267,7 +2267,7 @@ class TestDeleteDraftService(BaseApplicationTest, MockEnsureApplicationCompanyDe
         assert res.status_code == 302
         assert '/frameworks/g-cloud-7/submissions/scs/1?delete_requested=True' in res.location
         res2 = self.client.get('/suppliers/frameworks/g-cloud-7/submissions/scs/1?delete_requested=True')
-        assert b"Are you sure you want to delete this service?" in res2.get_data()
+        assert b"Are you sure you want to remove this service?" in res2.get_data()
 
     def test_cannot_delete_if_not_open(self):
         self.data_api_client.get_framework.return_value = self.framework(status='other')


### PR DESCRIPTION
https://trello.com/c/oYTyw0pb/97-1-replace-pagetitle-maincontent-block-with-pagetitle-maincontent-in-supplier-frontend

Following the example commits in https://github.com/alphagov/digitalmarketplace-brief-responses-frontend/pull/168.

- Updates Node
- Bumps digitalmarketplace-govuk-frontend
- Find + replace for `{% block main_content %}` to `{% block mainContent %}`, putting the latter inside the former on `_base_page.html`
- Small spacing fix for the invite_contributor link 
- Small sizing fix for some paragraphs that looked weirdly huge compared to their parent `h2`
- Styling fix for the draft service action buttons (see pics below - the buttons are only visible when frameworks are open). This style is still part of the custom CSS that we eventually want to delete, but I don't want to start revamping that in this PR - merely getting the button style back to where it was. 

Before:
![draft-service-action-buttons-old](https://user-images.githubusercontent.com/3492540/72544367-1efb2900-387f-11ea-8040-67189e287c0b.png)

After:
![draft-service-action-buttons-new](https://user-images.githubusercontent.com/3492540/72544365-1efb2900-387f-11ea-964d-fb7e01366174.png)

(I changed the text on the button because 'Delete' felt weirdly ambiguous - delete what? Happy to put it back if people feel strongly)