### PR TITLE
Fix breadcrumbs for company details page

### DIFF
--- a/app/templates/suppliers/details.html
+++ b/app/templates/suppliers/details.html
@@ -19,8 +19,8 @@
     {% if currently_applying_to %}
       {{ govukBreadcrumbs({"items": items + [
         {
-          "text": "Apply to " + framework.name,
-          "href": url_for(".framework_dashboard", framework_slug=framework.slug)
+          "text": "Apply to " + currently_applying_to.name,
+          "href": url_for(".framework_dashboard", framework_slug=currently_applying_to.slug)
         },
         {
           "text": "Company details"


### PR DESCRIPTION
https://trello.com/c/ExfE9b2d/188-3-update-breadcrumbs-to-use-govuk-frontend-component-in-supplier-frontend

Bug spotted while QAing the ticket above - one of the templates uses a different context variable for the current framework.

Before:
![apply-to-undefined-breadcrumbs](https://user-images.githubusercontent.com/3492540/72630342-0572e380-394a-11ea-9740-fc06127325c7.png)

After:
![apply-to-g11-breadcrumbs](https://user-images.githubusercontent.com/3492540/72630284-ee33f600-3949-11ea-9b70-39df6786dd3f.png)
