### PR TITLE
Use digitalmarketplace-govuk-frontend error templates

### DIFF
--- a/config.py
+++ b/config.py
@@ -88,9 +88,12 @@ class Config(object):
     @staticmethod
     def init_app(app):
         repo_root = os.path.abspath(os.path.dirname(__file__))
+        digitalmarketplace_govuk_frontend = os.path.join(repo_root, "node_modules", "digitalmarketplace-govuk-frontend")
         template_folders = [
             os.path.join(repo_root, "app", "templates"),
-            os.path.join(repo_root, "node_modules", "digitalmarketplace-govuk-frontend", "govuk-frontend"),
+            os.path.join(digitalmarketplace_govuk_frontend),
+            os.path.join(digitalmarketplace_govuk_frontend, "digitalmarketplace", "templates"),
+            os.path.join(digitalmarketplace_govuk_frontend, 'govuk-frontend'),
         ]
         jinja_loader = jinja2.FileSystemLoader(template_folders)
         app.jinja_loader = jinja_loader

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -3364,10 +3364,8 @@ class TestFrameworkUpdatesPage(BaseApplicationTest):
         response = self.client.get('/suppliers/frameworks/g-cloud-7/updates')
 
         assert response.status_code == 503
-        assert (
-            self.strip_all_whitespace("<h1>Sorry, we’re experiencing technical difficulties</h1>")
-            in self.strip_all_whitespace(response.get_data(as_text=True))
-        )
+        doc = html.fromstring(response.get_data(as_text=True))
+        assert doc.xpath('//h1/text()')[0] == "Sorry, we’re experiencing technical difficulties"
 
     def test_empty_messages_exist_if_no_files_returned(self, s3):
         self.data_api_client.get_framework.return_value = self.framework('open')

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -2678,7 +2678,7 @@ class TestPostListPreviousService(BaseApplicationTest, MockEnsureApplicationComp
 
         assert res.status_code == 400
         assert doc.xpath(
-            "//div[@class='error-page']//p[normalize-space(string())=$t]",
+            "//div//p[normalize-space(string())=$t]",
             t=f"You already have a draft {lot_name.lower()} service.",
         )
 


### PR DESCRIPTION
https://trello.com/c/4mGcaQuR/225-2-add-error-page-templates-to-supplier-frontend

Only a couple of xpath updates needed for the tests. 

I've checked that the custom error page in `app/templates/errors/applications_closed.html` still displays OK 👍 