### PR TITLE
Fix styles for banner using temporary message styles

### DIFF
--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -70,6 +70,7 @@ $govuk-global-styles: true;
 
 // Overrides
 @import "overrides/_notifications_banner";
+@import "overrides/_temporary-messages";
 
 // Misc styles
 .authorisation-form-wrapper {

--- a/app/assets/scss/overrides/_temporary-messages.scss
+++ b/app/assets/scss/overrides/_temporary-messages.scss
@@ -1,0 +1,17 @@
+// TODO: Remove when temporary message banners have been replaced
+
+// Ensure that text within banners contrasts with blue background
+.banner-temporary-message-without-action {
+  p.banner-message,
+  p.banner-message {
+    color: $white;
+
+    a, a:visited {
+      color: $white;
+    }
+
+    a:hover, a:active {
+      color: $light-blue-50;
+    }
+  }
+}


### PR DESCRIPTION
Ticket: https://trello.com/c/lbW5IQFx/

We have an issue where text within a temporary message style banner (dark blue box with white text) was coloured black, resulting in very low contrast that is hard to read. It seems that for some reason the styles for govuk-body and govuk-link were being treated as more specifict than the styles for content within a temporary message.

This commit adds an Sass override that adds more specific CSS, restoring the colours as defined in the Digital Marketplace Frontend Toolkit.

### Screenshots

#### After (this PR)

![Temporary message with this PR, with white text and white link](https://user-images.githubusercontent.com/503614/73265001-f0107b80-41cb-11ea-9df8-d98dc50ccf45.png)

#### Before (on preview)

![Temporary message on preview, with black text and light blue link](https://user-images.githubusercontent.com/503614/73265026-06b6d280-41cc-11ea-83a7-ea58601547e2.png)

#### Before (on staging)

![Temporary message on staging, with light blue link](https://user-images.githubusercontent.com/503614/73265116-35cd4400-41cc-11ea-84bb-b6221b41fc1a.png)
