### PR TITLE
Fix page heading for page "Activate your account"

### DIFF
--- a/app/templates/suppliers/create_your_account_complete.html
+++ b/app/templates/suppliers/create_your_account_complete.html
@@ -29,7 +29,7 @@
 {% block mainContent %}
   <div class="grid-row">
     <div class="column-two-thirds">
-      <h1 class="govuk-heading-l">Create login</h1>
+      <h1 class="govuk-heading-l">Activate your account</h1>
 
       <div class="dmspeak">
         <p class="govuk-body">An email has been sent to {{ email_address }}.</p>


### PR DESCRIPTION
@NoraGDS spotted that the page heading for this page disagreed with the
page title and breadcrumb.

### Screenshot

!['Activate your account'](https://user-images.githubusercontent.com/503614/73363064-e2c4c100-429f-11ea-9d4e-448b409358d4.png)
