### PR TITLE
Update link text for 'G-Cloud supplier A to Z' for footer link

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2096,9 +2096,9 @@
       }
     },
     "digitalmarketplace-govuk-frontend": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/digitalmarketplace-govuk-frontend/-/digitalmarketplace-govuk-frontend-0.3.1.tgz",
-      "integrity": "sha512-nw/f5oDTE7L2KboC8ujqw5hyI0B5fkAEh5a6kKnesO4kQl8JOV8rviYfgOcVUzf0MdcwwT9fBUOO2bMPcd13WQ=="
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/digitalmarketplace-govuk-frontend/-/digitalmarketplace-govuk-frontend-0.4.1.tgz",
+      "integrity": "sha512-SecGO1BzepmOg9z13n5ZHoRIyw1FwrhntI2y5gum3hRFkKf38MwsRHNcq0MzR8HsyIc3UsIGj2pjehJqG7rdUA=="
     },
     "dir-glob": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "del": "^5.1.0",
     "digitalmarketplace-frameworks": "github:alphagov/digitalmarketplace-frameworks#v17.1.0",
     "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v36.1.0",
-    "digitalmarketplace-govuk-frontend": "^0.3.1",
+    "digitalmarketplace-govuk-frontend": "^0.4.1",
     "govuk-country-and-territory-autocomplete": "0.4.0",
     "govuk-elements-sass": "3.0.3",
     "govuk_frontend_toolkit": "5.0.3",


### PR DESCRIPTION
Ticket: https://trello.com/c/i4eJBbNC/274-replace-content-supplier-a-z-with-supplier-a-to-z

Updates digitalmarketplace-govuk-frontend from 0.3.1 to 0.4.1, pulling in the new footer.