### PR TITLE
Fix styles for temporary message text

### DIFF
--- a/app/assets/scss/overrides/_temporary-messages.scss
+++ b/app/assets/scss/overrides/_temporary-messages.scss
@@ -15,3 +15,17 @@
     }
   }
 }
+
+.temporary-message {
+  p.temporary-message-message {
+    color: $white;
+
+    a, a:visited {
+      color: $white;
+    }
+
+    a:hover, a:active {
+      color: $light-blue-50;
+    }
+  }
+}

--- a/app/templates/suppliers/_frameworks_coming.html
+++ b/app/templates/suppliers/_frameworks_coming.html
@@ -1,19 +1,3 @@
 {% for framework in frameworks.coming %}
-  {% if framework.slug == 'digital-outcomes-and-specialists' %}
-
-    {% set blog_link %}
-    <a class="govuk-link" href='https://digitalmarketplace.blog.gov.uk/2015/11/12/digital-outcomes-and-specialists-suitable-suppliers-and-services/'>Find out if your services are suitable</a>
-    {% endset %}
-
-    {%
-      with
-      messages = [
-        "We’ll email you when you can apply to Digital Outcomes and Specialists.",
-        blog_link
-      ],
-      heading = "{} will be open for applications soon".format(framework.name)
-    %}
-      {% include "toolkit/temporary-message.html" %}
-    {% endwith %}
-  {% endif %}
+  {# add banners/cards here for messages to suppliers about upcoming frameworks #}
 {% endfor %}

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -9,7 +9,7 @@ const path = require('path')
 const sourcemaps = require('gulp-sourcemaps')
 
 // Paths
-let environment
+let environment = 'development'
 const repoRoot = path.join(__dirname)
 const npmRoot = path.join(repoRoot, 'node_modules')
 const govukCountryPickerDist = path.join(npmRoot, 'govuk-country-and-territory-autocomplete', 'dist')

--- a/tests/app/main/test_suppliers.py
+++ b/tests/app/main/test_suppliers.py
@@ -207,34 +207,6 @@ class TestSuppliersDashboard(BaseApplicationTest):
         )
         assert not document.xpath("//a[@href=$u]", u="/suppliers/frameworks/digital-rhymes-and-reasons/services")
 
-    def test_shows_dos_is_coming(self):
-        self.data_api_client.get_supplier.side_effect = get_supplier
-        self.data_api_client.get_supplier_frameworks.return_value = {
-            'frameworkInterest': []
-        }
-        self.data_api_client.find_frameworks.return_value = {
-            "frameworks": [
-                FrameworkStub(
-                    status='coming', slug='bad-framework', name='Framework that should’t have coming message'
-                ).response(),
-                FrameworkStub(
-                    status='coming', slug='digital-outcomes-and-specialists', name='Digital Outcomes and Specialists'
-                ).response(),
-            ]
-        }
-
-        self.login()
-        res = self.client.get("/suppliers")
-        doc = html.fromstring(res.get_data(as_text=True))
-
-        message = doc.xpath('//div[@class="temporary-message"]')
-        assert len(message) == 1
-        assert u"Digital Outcomes and Specialists will be open for applications soon" in \
-            message[0].xpath('h3/text()')[0]
-        assert u"We’ll email you when you can apply to Digital Outcomes and Specialists" in \
-            message[0].xpath('p/text()')[0]
-        assert u"Find out if your services are suitable" in message[0].xpath('p/a/text()')[0]
-
     @pytest.mark.parametrize('on_framework', (True, False))
     def test_only_shows_expired_dos3_if_supplier_was_on_framework(self, on_framework):
         self.data_api_client.get_supplier.side_effect = get_supplier


### PR DESCRIPTION
Ticket: https://trello.com/c/lbW5IQFx/

Copied from alphagov/digitalmarketplace-buyer-frontend#982

The framework pending message (if you've started a framework application but not completed it) also has the black text on dark blue background problem; using @katsteven's fix worked a treat :)

Also I cleaned up a temporary message component instance from 2015, and made a small tweak to our gulpfile to make it more dev friendly.

### Screenshots

#### After

![Supplier account dashboard, for a supplier that had started an application to G-Cloud 12 but not completed it, with G-Cloud 12 in the pending state. After the fix is applied the text explaining that the supplier did not submit an application is easy to read against the dark background.](https://user-images.githubusercontent.com/503614/73527423-f04a8a00-440a-11ea-9e65-e3f84f92c1d4.png)

#### Before

![Supplier account dashboard, for a supplier that had started an application to G-Cloud 12 but not completed it, with G-Cloud 12 in the pending state. Before the fix is applied the text explaining that the supplier did not submit an application is difficult to read against the dark background.](https://user-images.githubusercontent.com/503614/73527688-63ec9700-440b-11ea-8207-1dc9c4f4229c.png)
