### PR TITLE
257-service-question-change-make-servicedefinitiondocumenturl-mandatory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2084,8 +2084,8 @@
       "dev": true
     },
     "digitalmarketplace-frameworks": {
-      "version": "github:alphagov/digitalmarketplace-frameworks#5f78d6fddff55b35615b510666decc6b12290ca1",
-      "from": "github:alphagov/digitalmarketplace-frameworks#v17.1.0"
+      "version": "github:alphagov/digitalmarketplace-frameworks#491762c70617d9e98474f411c95b0aa461ae2fe6",
+      "from": "github:alphagov/digitalmarketplace-frameworks#v17.2.0"
     },
     "digitalmarketplace-frontend-toolkit": {
       "version": "git+https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#323b3d4b704e33782df6cdae7b105a2a9237a594",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "colors": "1.1.2",
     "del": "^5.1.0",
-    "digitalmarketplace-frameworks": "github:alphagov/digitalmarketplace-frameworks#v17.1.0",
+    "digitalmarketplace-frameworks": "github:alphagov/digitalmarketplace-frameworks#v17.2.0",
     "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v36.1.0",
     "digitalmarketplace-govuk-frontend": "^0.4.1",
     "govuk-country-and-territory-autocomplete": "0.4.0",


### PR DESCRIPTION
https://trello.com/c/VLjBsVoc/257-service-question-change-make-servicedefinitiondocumenturl-mandatory
    
Make service definition document mandatory
    
Update package.json for new mandatory service definition doc

#### Depends on
https://github.com/alphagov/digitalmarketplace-frameworks/pull/602