### PR TITLE
Add shared validator for G12

### DIFF
--- a/app/main/helpers/validation.py
+++ b/app/main/helpers/validation.py
@@ -271,4 +271,5 @@ VALIDATORS = {
     "digital-outcomes-and-specialists-3": SharedValidator,
     "g-cloud-11": SharedValidator,
     "digital-outcomes-and-specialists-4": SharedValidator,
+    "g-cloud-12": SharedValidator,
 }

--- a/app/main/helpers/validation.py
+++ b/app/main/helpers/validation.py
@@ -14,7 +14,7 @@ def get_validator(framework, content, answers):
     if framework is None:
         raise ValueError("a framework dictionary must be provided")
     if framework is not None:
-        validator_cls = VALIDATORS.get(framework['slug'])
+        validator_cls = VALIDATORS.get(framework['slug'], SharedValidator)
         return validator_cls(content, answers)
 
 


### PR DESCRIPTION
https://trello.com/c/ypNRnhEP/259-update-declaration-validation-code-in-supplier-fe-2

- Explicitly set `g-cloud-12` to use the `SharedValidator`. This is in case we want to switch to a custom validator at a later point (e.g. to deal with any dependency change in the first two questions)
- Use the `SharedValidator` as the default, so future frameworks won't immediately break

