### PR TITLE
switch grid elements to use digitalmarketplace-govuk-frontend classes

### DIFF
--- a/app/templates/auth/submit_email_address.html
+++ b/app/templates/auth/submit_email_address.html
@@ -35,8 +35,8 @@
 
 <form autocomplete="off" action="{{ url_for('.invite_user') }}" method="POST">
 
-    <div class="grid-row">
-        <div class="column-two-thirds">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
             {{ form.hidden_tag() }}
 
             {{ form.email_address }}

--- a/app/templates/frameworks/contract_review.html
+++ b/app/templates/frameworks/contract_review.html
@@ -29,8 +29,8 @@
 {% block mainContent %}
   {% include 'toolkit/forms/validation.html' %}
 
-<div class="grid-row">
-  <div class="column-two-thirds">
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">{{ 'Check the details you’ve given before returning the signature page for {}'.format(supplier_registered_name) }}</h1>
   </div>
 </div>
@@ -66,8 +66,8 @@
 </div>
 
 <div class="single-question-page authorisation-form-wrapper">
-<div class="grid-row">
-  <div class="column-two-thirds">
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
 
      <div class="dmspeak">
       <p class="govuk-body">Returning the signature page will notify the Crown Commercial Service and the primary contact you gave in your {{ framework.name }} application, {{ supplier_framework.declaration.primaryContact }} at {{ supplier_framework.declaration.primaryContactEmail }}.</p>

--- a/app/templates/frameworks/contract_start.html
+++ b/app/templates/frameworks/contract_start.html
@@ -29,8 +29,8 @@
 
 {% block mainContent %}
 
-  <div class="grid-row framework-dashboard">
-    <div class="column-two-thirds">
+  <div class="govuk-grid-row framework-dashboard">
+    <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-l">{{ framework.name }} framework agreement</h1>
 
       <div class="summary-item-lede">

--- a/app/templates/frameworks/contract_variation.html
+++ b/app/templates/frameworks/contract_variation.html
@@ -28,8 +28,8 @@
 {% endblock %}
 
 {% block mainContent %}
-    <div class="grid-row">
-      <div class="column-one-whole">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-full">
         {% if errors %}
          {% with
             message = "You must <a class=\"govuk-link\" href=\"#{}\">accept the changes</a> to continue.".format(errors.accept_changes.input_name)|safe, type = "destructive" %}
@@ -38,8 +38,8 @@
         {% endif %}
       </div>
     </div>
-    <div class="grid-row">
-        <div class="column-two-thirds">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
 
           <h1 class="govuk-heading-l">{{ '{} contract variation for {}'.format('The' if variation_details.get('countersignedAt') or agreed_details else 'Accept the', framework.name) }}</h1>
 
@@ -58,8 +58,8 @@
 
       </div>
     </div>
-    <div class="grid-row">
-      <div class="column-one-whole">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-full">
 
           {% if agreed_details %}
           <div class="section-summary">

--- a/app/templates/frameworks/dashboard.html
+++ b/app/templates/frameworks/dashboard.html
@@ -41,8 +41,8 @@
     {% endwith %}
   {% endif %}
 
-  <div class="grid-row framework-dashboard">
-    <div class="column-two-thirds">
+  <div class="govuk-grid-row framework-dashboard">
+    <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-l">{{ self.page_title_inner() }}</h1>
 
       {% include 'frameworks/_dashboard_lede.html' %}

--- a/app/templates/frameworks/declaration_overview.html
+++ b/app/templates/frameworks/declaration_overview.html
@@ -54,11 +54,13 @@
 
 
 {% block mainContent %}
-  <div class="grid-row">
-    <div class="column-two-thirds">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-l">Your declaration overview</h1>
     </div>
-    <div class="column-two-thirds">
+  </div>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
       {% if framework.status == "open" and supplier_framework.declaration.status != "complete" %}
         <p class="govuk-body">
           You must {% if not validates %}answer all questions and{% endif %} make your declaration
@@ -67,7 +69,9 @@
       {% endif %}
       {{ make_declaration_button_block() }}
     </div>
-    <div class="column-one-whole">
+  </div>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
       {% import "toolkit/summary-table.html" as summary %}
       {% for section_slug, (section, section_errors) in sections_errors.items() %}
         {{ summary.heading(section.name, id=section.slug) }}
@@ -120,7 +124,9 @@
         {% endcall %}
       {% endfor %}
     </div>
-    <div class="column-two-thirds">
+  </div>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
       {{ make_declaration_button_block() }}
     </div>
   </div>

--- a/app/templates/frameworks/edit_declaration_section.html
+++ b/app/templates/frameworks/edit_declaration_section.html
@@ -45,8 +45,8 @@
 
   <form method="post" enctype="multipart/form-data" class="supplier-declaration" action="#" {# remove any fragment identifier as validation messages are at the top #}>
 
-    <div class="grid-row">
-        <div class="column-two-thirds">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
             {% include 'frameworks/_session_timeout.html' %}
 
             <h1 class="govuk-heading-l">{{ section.name }}</h1>

--- a/app/templates/frameworks/reuse_declaration.html
+++ b/app/templates/frameworks/reuse_declaration.html
@@ -31,8 +31,8 @@
 {% block mainContent %}
   {% include 'toolkit/forms/validation.html' %}
 
-  <div class="grid-row">
-    <div class="column-two-thirds">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-l">{{ self.page_title_inner() }}</h1>
 
       <p class="govuk-body">In {{ old_framework_application_close_date|nbsp }}, your organisation completed a declaration for {{ old_framework.name }}.</p>

--- a/app/templates/frameworks/services.html
+++ b/app/templates/frameworks/services.html
@@ -40,8 +40,8 @@
 
   {% if framework.status == 'pending' %}
     <div class="summary-item-lede">
-      <div class="grid-row">
-        <div class="column-two-thirds">
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
           <h2 class="summary-item-heading">{{ framework.name }} is closed for applications</h2>
           <p class="govuk-body">
             You made your supplier declaration and submitted {{ complete_drafts|length }} complete {{ 'service' if complete_drafts|length == 1 else 'services' }}.

--- a/app/templates/frameworks/signature_upload.html
+++ b/app/templates/frameworks/signature_upload.html
@@ -41,8 +41,8 @@
     {% endwith %}
   {% endif %}
 
-  <div class="grid-row">
-    <div class="column-two-thirds">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
       <form method="POST" enctype="multipart/form-data" action="{{ url_for('.signature_upload', framework_slug=framework.slug, agreement_id=agreement.id) }}">
           <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
           {% set value = None %}

--- a/app/templates/frameworks/signer_details.html
+++ b/app/templates/frameworks/signer_details.html
@@ -29,8 +29,8 @@
 {% block mainContent %}
   {% include 'toolkit/forms/validation.html' %}
 
-<div class="grid-row">
-  <div class="column-two-thirds">
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">{{ 'Details of the person who is signing on behalf of {}'.format(supplier_registered_name) }}</h1>
 
     <form method="POST" action="{{ url_for('.signer_details', framework_slug=framework.slug, agreement_id=agreement['id']) }}">

--- a/app/templates/frameworks/start_declaration.html
+++ b/app/templates/frameworks/start_declaration.html
@@ -29,8 +29,8 @@
 {% endblock %}
 
 {% block mainContent %}
-  <div class="grid-row framework-dashboard">
-    <div class="column-two-thirds">
+  <div class="govuk-grid-row framework-dashboard">
+    <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-l">{{ self.page_title_inner() }}</h1>
 
       <p class="govuk-body">You must make the supplier declaration to confirm you’re eligible to provide services through {{ framework.name }}.</p>

--- a/app/templates/frameworks/submission_lots.html
+++ b/app/templates/frameworks/submission_lots.html
@@ -32,14 +32,14 @@
 
   {% include "partials/service_warning.html" %}
 
-  <div class="grid-row">
-    <div class="column-two-thirds">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-l">Your {{ framework.name }} services</h1>
     </div>
   </div>
 
-  <div class="grid-row">
-    <div class="column-two-thirds framework-lots-table">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds framework-lots-table">
       {% with items = lots %}
         {% include "toolkit/browse-list.html" %}
       {% endwith %}

--- a/app/templates/frameworks/updates.html
+++ b/app/templates/frameworks/updates.html
@@ -44,14 +44,14 @@
     {% endwith %}
   {% endif %}
 
-  <div class="grid-row">
-    <div class="column-two-thirds">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-l">{{ framework.name }} updates</h1>
     </div>
   </div>
 
-  <div class="grid-row">
-    <div class="column-one-whole updates-document-tables">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full updates-document-tables">
       {% set sections = [
         {
           "heading": "Communications",
@@ -103,9 +103,9 @@
   {% if not agreement_countersigned %}
     {% if framework.clarificationQuestionsOpen %}
       <form method="post">
-        <div class="grid-row">
+        <div class="govuk-grid-row">
 
-          <div class="column-two-thirds">
+          <div class="govuk-grid-column-two-thirds">
             {{ summary.heading("Ask a clarification question") }}
             <br />
             <p class="govuk-body">Ask a clarification question if you need a better understanding of:</p>
@@ -153,8 +153,8 @@
         </form>
     {% else %}
 
-        <div class="grid-row">
-          <div class="column-two-thirds">
+        <div class="govuk-grid-row">
+          <div class="govuk-grid-column-two-thirds">
             {{ summary.heading("Contact us") }}
 
             <p class="govuk-body">Contact the support team if <a class="govuk-link" href="{{ url_for('external.help') }}">there’s a problem with your account or to update your details</a>.</p>

--- a/app/templates/services/_base_edit_section_page.html
+++ b/app/templates/services/_base_edit_section_page.html
@@ -8,8 +8,8 @@
 {% block mainContent %}
   {% include 'toolkit/forms/validation.html' %}
 
-  <div class="grid-row">
-    <div class="column-two-thirds">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
       {% include 'frameworks/_session_timeout.html' %}
 
       <h1 class="govuk-heading-l">{{ section.name }}</h1>
@@ -26,8 +26,8 @@
   <div>
     <form method="post" enctype="multipart/form-data" action="{{ request.path }}">
 
-      <div class="grid-row">
-        <div class="column-two-thirds">
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
 
             {% for question in section.questions %}
               {% if errors and (errors[question.id] or question.type == 'multiquestion') %}

--- a/app/templates/services/_base_service_page.html
+++ b/app/templates/services/_base_service_page.html
@@ -5,7 +5,7 @@
 {% endblock %}
 
 {% block mainContent %}
-  <div class="grid-row">
+  <div class="govuk-grid-row">
     {% if confirm_remove %}
       <form method="post" action='{{ url_for(".remove_subsection", framework_slug=framework.slug, lot_slug=service_data.lot, service_id=service_id, section_id=request.args.get("section_id"), question_slug=confirm_remove, confirm=True) }}'>
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
@@ -24,11 +24,11 @@
     {% endif %}
 
     {% block before_heading %}{% endblock %}
-    <div class="column-two-thirds">
+    <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-l">{{ service_data.get('serviceName', service_data['lotName']) }}</h1>
     </div>
     {% block before_sections %}{% endblock %}
-    <div class="column-one-whole">
+    <div class="govuk-grid-column-full">
       {% import "toolkit/summary-table.html" as summary %}
       {% for section in sections %}
         {{ summary.heading(section.name, id=section.slug) }}

--- a/app/templates/services/list_services.html
+++ b/app/templates/services/list_services.html
@@ -24,8 +24,8 @@
 {% endblock %}
 
 {% block mainContent %}
-  <div class="grid-row">
-    <div class="column-two-thirds">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-l">Your {{ framework.name }} services</h1>
     </div>
   </div>

--- a/app/templates/services/previous_services.html
+++ b/app/templates/services/previous_services.html
@@ -42,8 +42,8 @@
 
     {% include "partials/service_warning.html" %}
 
-    <div class="grid-row">
-      <div class="column-two-thirds">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
         <div class="single-question-page">
           <h1 class="govuk-heading-l">{{ form.copy_service.label }}</h1>
 

--- a/app/templates/services/service.html
+++ b/app/templates/services/service.html
@@ -23,7 +23,7 @@
 {% endblock %}
 
 {% block before_heading %}
-  <div class="column-one-whole">
+  <div class="govuk-grid-column-full">
     {% if service_data.status != 'published' and service_unavailability_information %}
       {%
         with
@@ -56,7 +56,7 @@
 
 {% block before_sections %}
   {% if service_data.frameworkFamily != "digital-outcomes-and-specialists" %}
-    <div class="column-two-thirds">
+    <div class="govuk-grid-column-two-thirds">
       <div class="view-service-link">
         {%
           with
@@ -72,7 +72,7 @@
     </div>
   {% endif %}
   {% if error %}
-    <div class="column-one-whole">
+    <div class="govuk-grid-column-full">
       {% with
         lede = error,
         errors = {}
@@ -104,7 +104,7 @@
 
 {% block after_sections %}
   {% if service_data.status == 'published' and not remove_requested and service_data.frameworkFamily != "digital-outcomes-and-specialists" %}
-    <div class="column-two-thirds">
+    <div class="govuk-grid-column-two-thirds">
       <div class="edit-service-status-panel">
         <h2>Remove this service</h2>
         <p class="govuk-body">If you remove a service, it won’t be available to buy on the Digital Marketplace

--- a/app/templates/services/service_submission.html
+++ b/app/templates/services/service_submission.html
@@ -78,7 +78,7 @@
 
 {% block before_sections %}
 
-<div class="column-one-third align-with-heading">
+<div class="govuk-grid-column-one-third align-with-heading">
   <p class='last-edited hint'>
     Last edited:
     {{ last_edit.createdAt|datetimeformat }}
@@ -119,7 +119,7 @@
 
 {% block before_heading %}
   {% if delete_requested %}
-    <div class="column-one-whole">
+    <div class="govuk-grid-column-full">
       <form action="{{ url_for('.delete_draft_service', framework_slug=framework.slug, lot_slug=service_data.lot, service_id=service_id ) }}" method="POST">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
         <input type="hidden" name="delete_confirmed" value="true" />
@@ -188,10 +188,10 @@
 {% block after_sections %}
   {% if not delete_requested %}
 
-      <div class="column-two-thirds">
+      <div class="govuk-grid-column-two-thirds">
         &nbsp;
       </div>
-      <div class="column-one-third delete-draft-button">
+      <div class="govuk-grid-column-one-third delete-draft-button">
         {% if service_data.status == 'not-submitted' and can_mark_complete and framework.status == 'open' %}
           <div class="space-underneath">
             {% include "partials/complete_service.html" %}
@@ -214,7 +214,7 @@
         {% set back_to_service_url = url_for(".framework_submission_services", framework_slug=framework.slug, lot_slug=service_data.lot) %}
         {% set back_to_service_link_text = 'Back to {}'.format(service_data['lotName']|lower) %}
       {% endif %}
-      <div class="column-two-thirds">
+      <div class="govuk-grid-column-two-thirds">
           {%
             with
             url = back_to_service_url,

--- a/app/templates/suppliers/already_completed.html
+++ b/app/templates/suppliers/already_completed.html
@@ -29,9 +29,9 @@
 {% block mainContent %}
 
 <div class="single-question-page">
-  <div class="grid-row">
+  <div class="govuk-grid-row">
 
-    <div class="column-two-thirds dmspeak">
+    <div class="govuk-grid-column-two-thirds dmspeak">
       <h1 class="govuk-heading-l">{{ 'Correct a mistake in your {}'.format(completed_data_description) }}</h1>
 
       <div class="explanation-list">

--- a/app/templates/suppliers/become_a_supplier.html
+++ b/app/templates/suppliers/become_a_supplier.html
@@ -19,8 +19,8 @@
 {% endblock %}
 
 {% block mainContent %}
-  <div class="grid-row">
-    <div class="column-two-thirds">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-l">Become a supplier</h1>
 
       {% if open_fwks or opening_fwks %}

--- a/app/templates/suppliers/create_company_details.html
+++ b/app/templates/suppliers/create_company_details.html
@@ -29,11 +29,11 @@
 {% block mainContent %}
   {% include 'toolkit/forms/validation.html' %}
 
-<div class="grid-row">
-  <div class="column-one-whole">
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
 
   </div>
-    <div class="column-two-thirds">
+    <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-l">Your company details</h1>
 
       <div class="dmspeak">

--- a/app/templates/suppliers/create_confirm_company.html
+++ b/app/templates/suppliers/create_confirm_company.html
@@ -27,13 +27,13 @@
 {% endblock %}
 
 {% block mainContent %}
-  <div class="grid-row">
+  <div class="govuk-grid-row">
 
   {% if errors %}
     {% include 'toolkit/forms/validation.html' %}
   {% endif %}
 
-    <div class="column-two-thirds">
+    <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-l">We found these details</h1>
 
       {% call summary.mapping_table(

--- a/app/templates/suppliers/create_duns_number.html
+++ b/app/templates/suppliers/create_duns_number.html
@@ -27,7 +27,7 @@
 {% endblock %}
 
 {% block mainContent %}
-<div class="grid-row">
+<div class="govuk-grid-row">
   {% if errors.get("duns_number", {}).get("message", None) == 'DUNS number already used' %}
     {% with lede = "A supplier account already exists with that DUNS number",
             description = 'If you no longer have your account details, or if you think this may be an error, email <a class="govuk-link" href="mailto:{support_email_address}?subject=DUNS%20number%20question" title="Please contact {support_email_address}">{support_email_address}</a>'.format(support_email_address=support_email_address)|safe
@@ -38,7 +38,7 @@
     {% include 'toolkit/forms/validation.html' %}
   {% endif %}
 
-  <div class="column-two-thirds">
+  <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">Enter your DUNS number</h1>
 
 

--- a/app/templates/suppliers/create_new_supplier.html
+++ b/app/templates/suppliers/create_new_supplier.html
@@ -25,8 +25,8 @@
 {% block mainContent %}
 
 <div class="start-page">
-  <div class="grid-row">
-    <div class="column-two-thirds dmspeak">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds dmspeak">
       <h1 class="govuk-heading-l">Create a supplier account</h1>
 
       <div>

--- a/app/templates/suppliers/create_your_account.html
+++ b/app/templates/suppliers/create_your_account.html
@@ -30,8 +30,8 @@
 {% block mainContent %}
 {% include "toolkit/forms/validation.html" %}
 
-<div class="grid-row">
-  <div class="column-two-thirds">
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">Create login</h1>
 
     <div class="dmspeak">

--- a/app/templates/suppliers/create_your_account_complete.html
+++ b/app/templates/suppliers/create_your_account_complete.html
@@ -27,8 +27,8 @@
 {% endblock %}
 
 {% block mainContent %}
-  <div class="grid-row">
-    <div class="column-two-thirds">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-l">Activate your account</h1>
 
       <div class="dmspeak">

--- a/app/templates/suppliers/dashboard.html
+++ b/app/templates/suppliers/dashboard.html
@@ -19,15 +19,15 @@
 
 {% block mainContent %}
 
-  <div class="grid-row">
-    <div class="column-one-whole">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
       <span class="govuk-caption-xl">{{ current_user.email_address }}</span>
       <h1 class="govuk-heading-xl">{{ current_user.supplier_name }}</h1>
     </div>
   </div>
 
-  <div class="grid-row">
-    <div class="column-two-thirds">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
     {% include 'suppliers/_frameworks_coming.html' %}
     {% include 'suppliers/_frameworks_open.html' %}
     {% include 'suppliers/_frameworks_pending.html' %}
@@ -37,7 +37,7 @@
       {% include 'suppliers/_frameworks_live.html' %}
     </div>
     </div>
-    <div class="column-one-third dmspeak">
+    <div class="govuk-grid-column-one-third dmspeak">
       <h2 class="heading-xmedium">Your company</h2>
       <p class="govuk-body">
         <a class="govuk-link" href="{{ url_for('.supplier_details') }}">Company details</a>

--- a/app/templates/suppliers/details.html
+++ b/app/templates/suppliers/details.html
@@ -34,8 +34,8 @@
 
 
 {% block mainContent %}
-  <div class='grid-row'>
-    <div class='column-one-whole{% if currently_applying_to or (supplier_company_details_complete and not supplier_company_details_confirmed) %} padding-bottom-small{% endif %}'>
+  <div class='govuk-grid-row'>
+    <div class='govuk-grid-column-full{% if currently_applying_to or (supplier_company_details_complete and not supplier_company_details_confirmed) %} padding-bottom-small{% endif %}'>
       <h1 class="govuk-heading-l">Company details</h1>
 
 {{ summary.heading("What buyers will see", id="what_buyers_will_see") }}
@@ -177,8 +177,8 @@
   {% if supplier_company_details_confirmed == False or unconfirmed_open_supplier_framework_names|length > 0 %}
     {% if supplier_company_details_complete %}
     <br>
-    <div class='grid-row'>
-      <div class='column-two-thirds'>
+    <div class='govuk-grid-row'>
+      <div class='govuk-grid-column-two-thirds'>
         <form method="POST" action="{{ url_for('.confirm_supplier_details') }}">
           <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
           {% if supplier_company_details_confirmed == False %}
@@ -200,8 +200,8 @@
       </div>
     </div>
     {% elif currently_applying_to %}
-    <div class='grid-row'>
-      <div class='column-two-thirds'>
+    <div class='govuk-grid-row'>
+      <div class='govuk-grid-column-two-thirds'>
         <p class="govuk-body">You must complete your company details to make an application.</p>
       </div>
     </div>
@@ -209,8 +209,8 @@
   {% endif %}
 
   {% if currently_applying_to %}
-  <div class='grid-row'>
-    <div class='column-two-thirds'>
+  <div class='govuk-grid-row'>
+    <div class='govuk-grid-column-two-thirds'>
     {%
        with
        url = url_for(".framework_dashboard", framework_slug=currently_applying_to.slug),

--- a/app/templates/suppliers/edit_company_registration_number.html
+++ b/app/templates/suppliers/edit_company_registration_number.html
@@ -30,8 +30,8 @@
 {% include "toolkit/forms/validation.html" %}
 
 <div class="single-question-page">
-  <div class="grid-row">
-    <div class="column-two-thirds">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-l">Are you registered with Companies House?</h1>
 
       <form method="POST" action="{{ url_for('.edit_supplier_registration_number') }}">

--- a/app/templates/suppliers/edit_registered_name.html
+++ b/app/templates/suppliers/edit_registered_name.html
@@ -29,8 +29,8 @@
 {% block mainContent %}
 {% include "toolkit/forms/validation.html" %}
 <div class="single-question-page">
-  <div class="grid-row">
-    <div class="column-two-thirds">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-l">Registered company name</h1>
 
       <form method="POST" action="{{ url_for('.edit_supplier_registered_name') }}">

--- a/app/templates/suppliers/edit_supplier_organisation_size.html
+++ b/app/templates/suppliers/edit_supplier_organisation_size.html
@@ -30,8 +30,8 @@
   {% include 'toolkit/forms/validation.html' %}
 
 <div class="single-question-page">
-  <div class="grid-row">
-    <div class="column-two-thirds">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-l">What size is your organisation?</h1>
 
       <form method="POST" action="{{ url_for('.edit_supplier_organisation_size') }}">

--- a/app/templates/suppliers/edit_supplier_trading_status.html
+++ b/app/templates/suppliers/edit_supplier_trading_status.html
@@ -30,8 +30,8 @@
 {% include "toolkit/forms/validation.html" %}
 
 <div class="single-question-page">
-  <div class="grid-row">
-    <div class="column-two-thirds">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-l">What&rsquo;s your trading status?</h1>
 
       <form method="POST" action="{{ url_for('.edit_supplier_trading_status') }}">

--- a/app/templates/suppliers/edit_what_buyers_will_see.html
+++ b/app/templates/suppliers/edit_what_buyers_will_see.html
@@ -30,8 +30,8 @@
 {% block mainContent %}
 {% include "toolkit/forms/validation.html" %}
 
-  <div class="grid-row">
-    <div class="column-one-whole">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
       <h1 class="govuk-heading-xl">What buyers will see</h1>
 
       <div class="dmspeak">
@@ -45,8 +45,8 @@
 
   <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
 
-  <div class="grid-row">
-    <div class="column-two-thirds">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
 
       {{ form.contactName }}
       {{ form.email }}

--- a/app/templates/suppliers/join_open_framework_notification_mailing_list.html
+++ b/app/templates/suppliers/join_open_framework_notification_mailing_list.html
@@ -25,8 +25,8 @@
 {% block mainContent %}
 {% include "toolkit/forms/validation.html" %}
 
-<div class="grid-row">
-  <div class="column-two-thirds">
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">Sign up for Digital Marketplace email alerts</h1>
   <div class="dmspeak">
       <p class="govuk-body">

--- a/app/templates/suppliers/registered_address.html
+++ b/app/templates/suppliers/registered_address.html
@@ -35,8 +35,8 @@
 {% block mainContent %}
   {% include 'toolkit/forms/validation.html' %}
 
-  <div class="grid-row">
-    <div class="column-one-whole">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
       <h1 class="govuk-heading-l">What is your registered office address?</h1>
     </div>
   </div>
@@ -45,8 +45,8 @@
 
   <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
 
-  <div class="grid-row">
-    <div class="column-two-thirds">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
 
       {{ form.street }}
       {{ form.city }}


### PR DESCRIPTION
https://trello.com/c/B5U7elGh

I looked at examples of all the affected pages and everything _seems_ ok.

A couple of templates got their columns re-parenting, but `_base_service_page.html` needs more refactoring than I can do here.