### PR TITLE
Update kind-of from 6.0.2 to 6.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6507,9 +6507,9 @@
       "integrity": "sha1-h/zPrv/AtozRnVX2cilD+SnqNeo="
     },
     "kind-of": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-      "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
     },
     "kleur": {
       "version": "3.0.3",


### PR DESCRIPTION
Snyk reported a [vulnerability on kind-of >=6.0.0<6.0.3][1].

I updated it by running `npm update --depth 5 kind-of`.

[1]: https://app.snyk.io/vuln/SNYK-JS-KINDOF-537849