### PR TITLE
cookie settings link at dashboard and test for it

### DIFF
--- a/app/templates/suppliers/dashboard.html
+++ b/app/templates/suppliers/dashboard.html
@@ -50,6 +50,9 @@
         <a class="govuk-link" href="{{ url_for('external.change_password') }}">Change your password</a>
       </p>
       <p class="govuk-body">
+        <a class="govuk-link" href="{{ url_for('external.cookie_settings') }}">Change your cookie settings</a>
+      </p>
+      <p class="govuk-body">
         <a
           class="govuk-link"
           href="{{ url_for('external.user_research_consent') }}"

--- a/tests/app/main/test_suppliers.py
+++ b/tests/app/main/test_suppliers.py
@@ -1171,6 +1171,9 @@ class TestSupplierDashboardLogin(BaseApplicationTest):
 
         document = html.fromstring(response.get_data(as_text=True))
         assert len(document.xpath("//a[contains(@href,'/user/change-password')]")) == 1
+        # the cookie settings link will appear twice, once in the banner on top
+        # and again on the side of the page next to account settings
+        assert len(document.xpath("//a[contains(@href,'/user/cookie-settings')]")) == 2
 
     def test_should_redirect_to_login_if_not_logged_in(self):
         res = self.client.get("/suppliers")


### PR DESCRIPTION
trello: https://trello.com/c/X1LuXpy4/313-add-link-to-cookie-settings-page-on-user-dashboards-1

I'd rather change the paragraph elements on the side into a list. Let me know.