### PR TITLE
Pull in analytics tracker name fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2096,9 +2096,9 @@
       }
     },
     "digitalmarketplace-govuk-frontend": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/digitalmarketplace-govuk-frontend/-/digitalmarketplace-govuk-frontend-0.6.3.tgz",
-      "integrity": "sha512-/HsZChuYoSV8uWfoVbqARTx7uGRnCTrRufygn7xRPJ2mTpRHYtGir/P7Iq1+pCrDjCbbkyW1zTVjAd10pQcarw=="
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/digitalmarketplace-govuk-frontend/-/digitalmarketplace-govuk-frontend-0.6.4.tgz",
+      "integrity": "sha512-5PLbOcJ7jaHyrh3NwIvkww5LeDI7jJ/WA1fpjyjn3MI6dCQP5PNGILkkmP7aRrzXzXVqCkiK/rINVsy/kn3HZA=="
     },
     "dir-glob": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "del": "^5.1.0",
     "digitalmarketplace-frameworks": "github:alphagov/digitalmarketplace-frameworks#v17.4.0",
     "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v36.1.0",
-    "digitalmarketplace-govuk-frontend": "^0.6.3",
+    "digitalmarketplace-govuk-frontend": "^0.6.4",
     "govuk-country-and-territory-autocomplete": "0.4.0",
     "govuk-elements-sass": "3.0.3",
     "govuk_frontend_toolkit": "5.0.3",


### PR DESCRIPTION
https://trello.com/c/feRizfhu/326-analytics-tracking-id-fix

Updates digitalmarketplace-govuk-frontend from 0.6.3 to 0.6.4

See equivalent Buyer FE fix: alphagov/digitalmarketplace-buyer-frontend#994