### PR TITLE
317-1-transfer-content-and-design-changes-from-prototype-to-preview-for-g12

### DIFF
--- a/app/templates/suppliers/create_confirm_company.html
+++ b/app/templates/suppliers/create_confirm_company.html
@@ -58,12 +58,12 @@
           name = "confirmed",
           value = form.confirmed.value,
           error = errors.get("confirmed", {}).get("message", None),
-          hint = 'You can change how the name appears later on.',
-          hint_underneath = true,
           type = 'boolean'
         %}
           {% include "toolkit/forms/selection-buttons.html" %}
         {% endwith %}
+
+        <p>You can change how the name appears later on.</p>
 
         {{ govukButton({"text": "Continue"}) }}
 

--- a/app/templates/suppliers/create_new_supplier.html
+++ b/app/templates/suppliers/create_new_supplier.html
@@ -35,6 +35,7 @@
         <ul class="govuk-list govuk-list--bullet">
           <li>a company name and company details that buyers may use to contact you</li>
           <li>your own details to create a login</li>
+          <li>a DUNS number</li>
         </ul>
 
         <p class="govuk-body">It will take about 5 minutes to create your account.</p>
@@ -55,6 +56,7 @@
       {{ govukButton({
         "text": "Start",
         "href": url_for(".duns_number"),
+        "classes": "govuk-button--start",
       }) }}
     </div>
   </div>


### PR DESCRIPTION
See ticket:
https://trello.com/c/O0KrgXHE/317-transfer-content-and-design-changes-from-prototype-to-preview-for-g12

### New start button and 'a DUNS number' bullet

![screencapture-localhost-suppliers-create-start-2020-02-18-16_04_33](https://user-images.githubusercontent.com/3469840/74754701-ebd6fb80-5269-11ea-9f97-9b2837d806cb.png)

### You can change company name as not hint text

![screencapture-localhost-suppliers-create-confirm-company-2020-02-18-16_15_00](https://user-images.githubusercontent.com/3469840/74754695-eb3e6500-5269-11ea-9fb5-bd88d6e02f61.png)


