### PR TITLE
Pull in G12 error message updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2084,8 +2084,8 @@
       "dev": true
     },
     "digitalmarketplace-frameworks": {
-      "version": "github:alphagov/digitalmarketplace-frameworks#ef02823e6a52a99f3c276cf03cca71b57ae8971f",
-      "from": "github:alphagov/digitalmarketplace-frameworks#v17.4.0"
+      "version": "github:alphagov/digitalmarketplace-frameworks#69e06e809b51958b108d1223c2a5d6894dcb43e2",
+      "from": "github:alphagov/digitalmarketplace-frameworks#v17.6.0"
     },
     "digitalmarketplace-frontend-toolkit": {
       "version": "git+https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#323b3d4b704e33782df6cdae7b105a2a9237a594",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "colors": "1.1.2",
     "del": "^5.1.0",
-    "digitalmarketplace-frameworks": "github:alphagov/digitalmarketplace-frameworks#v17.4.0",
+    "digitalmarketplace-frameworks": "github:alphagov/digitalmarketplace-frameworks#v17.6.0",
     "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v36.1.0",
     "digitalmarketplace-govuk-frontend": "^0.6.4",
     "govuk-country-and-territory-autocomplete": "0.4.0",


### PR DESCRIPTION
https://trello.com/c/WyCs0t4g/302-3-review-and-update-answerrequired-error-messages-for-g-cloud-12-questions-in-frameworks-repo

Pulls in new G12 error messages that help us better meet the WCAG guidelines.

See https://github.com/alphagov/digitalmarketplace-frameworks/pull/606 for a list of changes.