### PR TITLE
Pull in PDF guidance on G12 questions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2084,8 +2084,8 @@
       "dev": true
     },
     "digitalmarketplace-frameworks": {
-      "version": "github:alphagov/digitalmarketplace-frameworks#69e06e809b51958b108d1223c2a5d6894dcb43e2",
-      "from": "github:alphagov/digitalmarketplace-frameworks#v17.6.0"
+      "version": "github:alphagov/digitalmarketplace-frameworks#e02ef939c571a0a85a693eae0d72175e6283f1b5",
+      "from": "github:alphagov/digitalmarketplace-frameworks#v17.7.0"
     },
     "digitalmarketplace-frontend-toolkit": {
       "version": "git+https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#323b3d4b704e33782df6cdae7b105a2a9237a594",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "colors": "1.1.2",
     "del": "^5.1.0",
-    "digitalmarketplace-frameworks": "github:alphagov/digitalmarketplace-frameworks#v17.6.0",
+    "digitalmarketplace-frameworks": "github:alphagov/digitalmarketplace-frameworks#v17.7.0",
     "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v36.1.0",
     "digitalmarketplace-govuk-frontend": "^0.6.5",
     "govuk-country-and-territory-autocomplete": "0.4.0",


### PR DESCRIPTION
https://trello.com/c/Rtcc6oi6/316-add-link-to-guidance-on-making-accessible-pdfs-on-application-5-places

Adding guidance links for suppliers who are uploading PDFs.
See https://github.com/alphagov/digitalmarketplace-frameworks/pull/608 for examples.

~[WIP until the frameworks PR is merged]~ Now ready.