### PR TITLE
Simplify framework dashboard

### DIFF
--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -71,6 +71,7 @@ $govuk-global-styles: true;
 // Overrides
 @import "overrides/_notifications_banner";
 @import "overrides/_temporary-messages";
+@import "overrides/_task-list";
 
 // Misc styles
 .authorisation-form-wrapper {

--- a/app/assets/scss/overrides/_task-list.scss
+++ b/app/assets/scss/overrides/_task-list.scss
@@ -1,0 +1,70 @@
+// TODO: Remove when task lists incorporated into digitalmarketplace-govuk-frontend
+
+$indicator-colour: $black;
+
+%dm-task-list-indicator {
+  @include bold-16;
+  display: inline-block;
+  padding: 3px 8px 1px 8px;
+  position: absolute;
+  right: 0;
+  top: $gutter - 2px;
+  margin-top: -15px;
+  border: 2px solid $indicator-colour;
+  pointer-events: none;
+  z-index: 2;
+  min-width: 20%;
+  text-align: center;
+}
+
+.dm-task-list {
+
+  border-top: 1px solid $border-colour;
+  margin: $gutter 0;
+
+  &-item {
+
+    position: relative;
+
+    a {
+      border-bottom: 1px solid $border-colour;
+      display: block;
+      padding: $gutter-half 0;
+      padding-right: 20%;
+      position: relative;
+
+      &:hover {
+        color: $link-hover-colour;
+      }
+
+      &:focus {
+        outline: none;
+        color: $black;
+        box-shadow: -3px 0 0 0 $focus-colour, 3px 0 0 0 $focus-colour;
+        border-color: transparent;
+        top: -1px;
+        margin-bottom: -2px;
+        padding-top: $gutter-half + 1px;
+        padding-bottom: $gutter-half + 1px;
+      }
+
+    }
+
+  }
+
+  &-indicator-completed {
+    @extend %dm-task-list-indicator;
+    background-color: $indicator-colour;
+    color: $grey-4;
+    // Just a pinch of letter spacing to make reversed-out text a bit
+    // easier to read
+    letter-spacing: 0.02em;
+  }
+
+  &-indicator-not-completed {
+    @extend %dm-task-list-indicator;
+    background-color: $white;
+    color: $indicator-colour;
+  }
+
+}

--- a/app/assets/scss/overrides/_task-list.scss
+++ b/app/assets/scss/overrides/_task-list.scss
@@ -50,6 +50,14 @@ $indicator-colour: $black;
 
     }
 
+    span.dm-task-list__text {
+      border-bottom: 1px solid $border-colour;
+      display: block;
+      padding: $gutter-half 0;
+      padding-right: 20%;
+      position: relative;
+    }
+
   }
 
   &-indicator-completed {

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -129,11 +129,6 @@ def framework_dashboard(framework_slug):
     )
     lots_with_completed_drafts = [lot for lot in framework['lots'] if count_drafts_by_lot(complete_drafts, lot['slug'])]
 
-    try:
-        framework_advice = content_loader.get_message(framework_slug, 'advice')
-    except ContentNotFoundError:
-        framework_advice = None
-
     # GA custom dimension stages for the application
     if supplier_framework_info and not supplier_framework_info['applicationCompanyDetailsConfirmed']:
         custom_dimension_stage = "application_started"
@@ -233,7 +228,6 @@ def framework_dashboard(framework_slug):
         result_letter_filename=result_letter_filename,
         supplier_framework=supplier_framework_info,
         supplier_is_on_framework=supplier_is_on_framework,
-        framework_advice=framework_advice,
         supplier_company_details_complete=supplier_company_details_are_complete(supplier),
         application_company_details_confirmed=application_company_details_confirmed,
         custom_dimensions=custom_dimensions

--- a/app/templates/_base_page.html
+++ b/app/templates/_base_page.html
@@ -10,6 +10,7 @@
 
 {# Import DM components #}
 {% from "digitalmarketplace/components/cookie-banner/macro.njk" import dmCookieBanner %}
+{% from "digitalmarketplace/components/alert/macro.njk" import dmAlert %}
 {% from "digitalmarketplace/components/header/macro.njk" import dmHeader %}
 {% from "digitalmarketplace/components/footer/macro.njk" import dmFooter %}
 

--- a/app/templates/frameworks/_framework_actions.html
+++ b/app/templates/frameworks/_framework_actions.html
@@ -24,128 +24,80 @@
 {% endif %}
 
 {% if framework.status == 'open' %}
-<li class="browse-list-item">
-  <a class="browse-list-item-link"
-     href="{{ url_for('.supplier_details') }}">
-    <h2>1. Enter your company details</h2>
-  </a>
-  {% if not application_company_details_confirmed %}
-  <div class="browse-list-item-status-quiet">
-    <p class="browse-list-item-status-title">You must {% if supplier_company_details_complete %}confirm{% else %}add{% endif %} your organisation’s details</p>
-  </div>
-  {% else %}
-  {% if declaration_status == 'complete' and counts.complete %}
-  <div class="browse-list-item-status-happy">
-  {% else %}
-    <div class="browse-list-item-status-default">
-  {% endif %}
-    <p class="browse-list-item-status-title">
-      <strong>Your company details were saved</strong>
-    </p>
-  </div>
-  {% endif %}
-</li>
-
-<li class="browse-list-item">
-  {% if not application_company_details_confirmed %}
-    <h2>2. Make supplier declaration</h2>
-    <p class="instruction-list-item-box inactive">Can't start yet</p>
-  {% else %}
-    {% if declaration_status == 'unstarted' %}
-    <a class="browse-list-item-link" href="{{ url_for('.framework_start_supplier_declaration', framework_slug=framework.slug) }}">
-      <h2>2. Make supplier declaration</h2>
-    </a>
+ {% if application_made %}
+    {% if counts.draft %}
+      {{ dmAlert({
+        "titleText": "Your application is complete, and will be automatically submitted.",
+        "text": "You still have {count} unsubmitted draft {service_string}. You can edit or remove draft services at any time before the deadline.".format(count=counts.draft, service_string=pluralize(counts.draft, 'service', 'services')),
+        "type" : "success"
+        })
+      }}
     {% else %}
-    <a class="browse-list-item-link" href="{{ url_for('.framework_supplier_declaration_overview', framework_slug=framework.slug) }}">
-      <h2>2. Edit supplier declaration</h2>
-    </a>
-    {% endif %}
-    <p class="browse-list-item-body">
-      Confirm eligibility, agree to the application terms and provide supplier&nbsp;information.
-    </p>
-    {% if declaration_status == 'unstarted' and not counts.complete %}
-      <div class="browse-list-item-status-quiet">
-        <p class="browse-list-item-status-title">You need to make the supplier declaration</p>
-      </div>
-    {% elif declaration_status == 'started' and not counts.complete %}
-      <div class="browse-list-item-status-quiet">
-        <p class="browse-list-item-status-title">You need to finish making the supplier declaration</p>
-      </div>
-    {% elif declaration_status == 'unstarted' and counts.complete %}
-      <div class="browse-list-item-status-angry">
-        <p class="browse-list-item-status-title">
-          <strong>No services will be submitted because you haven’t made the supplier declaration</strong>
-        </p>
-      </div>
-    {% elif declaration_status == 'started' and counts.complete %}
-      <div class="browse-list-item-status-angry">
-        <p class="browse-list-item-status-title">
-          <strong>No services will be submitted because you haven’t finished making the supplier declaration</strong>
-        </p>
-      </div>
-    {% elif declaration_status == 'complete' %}
-      {% if counts.complete and application_company_details_confirmed %}
-        <div class="browse-list-item-status-happy">
-      {% else %}
-        <div class="browse-list-item-status-default">
-      {% endif %}
-        <p class="browse-list-item-status-title">
-          <strong>You’ve made the supplier declaration</strong>
-        </p>
-      </div>
+      {{ dmAlert({
+        "titleText": "Your application is complete, and will be automatically submitted.",
+        "text": "You can change it at any time before the deadline.",
+        "type" : "success"
+        })
+      }}
     {% endif %}
   {% endif %}
-</li>
-
-<li class="browse-list-item">
-  {% if not application_company_details_confirmed %}
-    <h2>3. Add, edit and complete services</h2>
-    <p class="instruction-list-item-box inactive">Can't start yet</p>
-  {% else %}
-    <a class="browse-list-item-link" href="{{ url_for('.framework_submission_lots', framework_slug=framework.slug) }}">
-      <h2>3. Add, edit and complete services</h2>
-    </a>
-    {% if framework_advice.use_of_service_data %}
-    <div class="browse-list-item-body use-of-service-data">
-      {{ framework_advice.use_of_service_data }}
-    </div>
-    {% endif %}
-  
-    {% if not counts.complete %}
-      {% if not counts.draft %}
-    <div class="browse-list-item-status-quiet">
-      <p class="browse-list-item-status-title">You need to add and complete services</p>
-    </div>
+  <ul class="dm-task-list">
+    <li class="dm-task-list-item">
+      <span class="dm-task-list__task-name">
+        <a href="{{ url_for('.supplier_details') }}">
+          Confirm your company details
+        </a>
+      </span>
+      {% if application_company_details_confirmed %}
+        <strong class="dm-task-list-indicator-completed" id="dm-companydetails-done">Done</strong>
+      {% elif supplier_company_details_complete %}
+        {# Supplier details exist from a previous framework application, but haven't yet been confirmed for this one #}
+        <strong class="dm-task-list-indicator-completed" id="dm-companydetails-inprogress">In Progress</strong>
       {% else %}
-    <div class="browse-list-item-status-quiet">
-      <p class="browse-list-item-status-title">No services marked as complete</p>
-    </div>
+        <strong class="dm-task-list-indicator-not-completed" id="dm-companydetails-todo">To do</strong>
       {% endif %}
-    {% else %}
-      {% if declaration_status == 'complete' %}
-    <div class="browse-list-item-status-happy">
-      <p class="browse-list-item-status-title">You’re submitting</p>
-      {% else %}
-    <div class="browse-list-item-status-default">
-      <p class="browse-list-item-status-title">You’ve completed:</p>
-      {% endif %}
-      <ul class="browse-list-item-status-list">
-        {% for lot in completed_lots %}
-          {% if lot.one_service_limit %}
-        <li>
-            {{lot.name|lower}}
-        </li>
+    </li>
+    <li class="dm-task-list-item">
+      <span class="app-task-list__task-name">
+        {% if application_company_details_confirmed %}
+          {% if declaration_status == 'unstarted' %}
+            <a href="{{ url_for('.framework_start_supplier_declaration', framework_slug=framework.slug) }}">Make your supplier declaration</a>
           {% else %}
-        <li>
-          {{ lot.complete_count }}
-          {{ lot.unitSingular if (1 == lot.complete_count) else lot.unitPlural }} in
-          {{ lot.name|lower }}
-        </li>
+            <a href="{{ url_for('.framework_supplier_declaration_overview', framework_slug=framework.slug) }}">Make your supplier declaration</a>
           {% endif %}
-        {% endfor %}
-      </ul>
-    </div>
-    {% endif %}
-  {% endif %}
-</li>
+        {% else %}
+          Make your supplier declaration
+        {% endif %}
+      </span>
+      {% if not application_company_details_confirmed %}
+        <strong class="dm-task-list-indicator-not-completed" id="dm-declaration-cantstart">Can't start yet</strong>
+      {% elif declaration_status == 'unstarted' %}
+        <strong class="dm-task-list-indicator-not-completed" id="dm-declaration-todo">To do</strong>
+      {% elif declaration_status == 'started' %}
+        <strong class="dm-task-list-indicator-not-completed" id="dm-declaration-inprogress">In progress</strong>
+      {% elif declaration_status == 'complete' %}
+        <strong class="dm-task-list-indicator-completed" id="dm-declaration-done">Done</strong>
+      {% endif %}
+    </li>
+    <li class="dm-task-list-item">
+
+        {% if application_company_details_confirmed %}
+        <a href="{{ url_for('.framework_submission_lots', framework_slug=framework.slug) }}">
+          Add, edit and complete services
+        </a>
+        {% else %}
+          Add, edit and complete services
+        {% endif %}
+
+      {% if not application_company_details_confirmed %}
+        <strong class="dm-task-list-indicator-not-completed" id="dm-services-cantstart">Can't start yet</strong>
+      {% elif not counts.draft and not counts.complete %}
+        <strong class="dm-task-list-indicator-not-completed" id="dm-services-todo">To Do</strong>
+      {% elif counts.draft %}
+        <strong class="dm-task-list-indicator-not-completed" id="dm-services-inprogress">In progress</strong>
+      {% else %}
+        <strong class="dm-task-list-indicator-completed" id="dm-services-done">{{ counts.complete }} {{ pluralize(counts.complete, 'service', 'services') }}</strong>
+      {% endif %}
+    </li>
+  </ul>
 {% endif %}

--- a/app/templates/frameworks/_framework_actions.html
+++ b/app/templates/frameworks/_framework_actions.html
@@ -27,14 +27,14 @@
  {% if application_made %}
     {% if counts.draft %}
       {{ dmAlert({
-        "titleText": "Your application is complete, and will be automatically submitted.",
+        "titleText": "Your application is complete and will be submitted automatically.",
         "text": "You still have {count} unsubmitted draft {service_string}. You can edit or remove draft services at any time before the deadline.".format(count=counts.draft, service_string=pluralize(counts.draft, 'service', 'services')),
         "type" : "success"
         })
       }}
     {% else %}
       {{ dmAlert({
-        "titleText": "Your application is complete, and will be automatically submitted.",
+        "titleText": "Your application is complete and will be submitted automatically.",
         "text": "You can change it at any time before the deadline.",
         "type" : "success"
         })

--- a/app/templates/frameworks/_framework_actions.html
+++ b/app/templates/frameworks/_framework_actions.html
@@ -58,7 +58,7 @@
       {% endif %}
     </li>
     <li class="dm-task-list-item">
-      <span class="app-task-list__task-name">
+      <span class="dm-task-list__task-name">
         {% if application_company_details_confirmed %}
           {% if declaration_status == 'unstarted' %}
             <a href="{{ url_for('.framework_start_supplier_declaration', framework_slug=framework.slug) }}">Make your supplier declaration</a>
@@ -66,7 +66,7 @@
             <a href="{{ url_for('.framework_supplier_declaration_overview', framework_slug=framework.slug) }}">Make your supplier declaration</a>
           {% endif %}
         {% else %}
-          Make your supplier declaration
+        <span class="dm-task-list__text">Make your supplier declaration</span>
         {% endif %}
       </span>
       {% if not application_company_details_confirmed %}
@@ -80,15 +80,15 @@
       {% endif %}
     </li>
     <li class="dm-task-list-item">
-
+      <span class="dm-task-list__task-name">
         {% if application_company_details_confirmed %}
         <a href="{{ url_for('.framework_submission_lots', framework_slug=framework.slug) }}">
           Add, edit and complete services
         </a>
         {% else %}
-          Add, edit and complete services
+        <span class="dm-task-list__text">Add, edit and complete services</span>
         {% endif %}
-
+      </span>
       {% if not application_company_details_confirmed %}
         <strong class="dm-task-list-indicator-not-completed" id="dm-services-cantstart">Can't start yet</strong>
       {% elif not counts.draft and not counts.complete %}

--- a/app/templates/frameworks/_framework_actions.html
+++ b/app/templates/frameworks/_framework_actions.html
@@ -52,7 +52,7 @@
         <strong class="dm-task-list-indicator-completed" id="dm-companydetails-done">Done</strong>
       {% elif supplier_company_details_complete %}
         {# Supplier details exist from a previous framework application, but haven't yet been confirmed for this one #}
-        <strong class="dm-task-list-indicator-completed" id="dm-companydetails-inprogress">In Progress</strong>
+        <strong class="dm-task-list-indicator-completed" id="dm-companydetails-inprogress">In progress</strong>
       {% else %}
         <strong class="dm-task-list-indicator-not-completed" id="dm-companydetails-todo">To do</strong>
       {% endif %}
@@ -92,7 +92,7 @@
       {% if not application_company_details_confirmed %}
         <strong class="dm-task-list-indicator-not-completed" id="dm-services-cantstart">Can't start yet</strong>
       {% elif not counts.draft and not counts.complete %}
-        <strong class="dm-task-list-indicator-not-completed" id="dm-services-todo">To Do</strong>
+        <strong class="dm-task-list-indicator-not-completed" id="dm-services-todo">To do</strong>
       {% elif counts.draft %}
         <strong class="dm-task-list-indicator-not-completed" id="dm-services-inprogress">In progress</strong>
       {% else %}

--- a/app/templates/frameworks/dashboard.html
+++ b/app/templates/frameworks/dashboard.html
@@ -31,15 +31,6 @@
 {% endblock %}
 
 {% block mainContent %}
-  {# Confidence Banner #}
-  {% if application_made and framework.status == 'open' %}
-    {% with
-      message = "Your application will be submitted at %s. <br> You can edit your declaration and services at any time before the deadline."|safe % (framework.applicationsCloseAt | nbsp),
-      type="success"
-    %}
-      {% include "toolkit/notification-banner.html" %}
-    {% endwith %}
-  {% endif %}
 
   <div class="govuk-grid-row framework-dashboard">
     <div class="govuk-grid-column-two-thirds">

--- a/app/templates/frameworks/submission_lots.html
+++ b/app/templates/frameworks/submission_lots.html
@@ -35,9 +35,19 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-l">Your {{ framework.name }} services</h1>
+        {% if framework.family == 'g-cloud' %}
+          <div class="use-of-service-data">
+            <p class="govuk-body">The service information you provide here:</p>
+            <ul class="govuk-list govuk-list--bullet">
+              <li>will be public</li>
+              <li>may be used as filters</li>
+              <li>will appear on your service description page </li>
+              <li>should help buyers review and compare services</li>
+            </ul>
+          </div>
+        {% endif %}
     </div>
   </div>
-
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds framework-lots-table">
       {% with items = lots %}

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -696,7 +696,7 @@ class TestFrameworksDashboardSuccessBanner(BaseApplicationTest):
         assert len(alert_banner) == 1
         assert alert_banner[0].xpath(
             "//h2[contains(normalize-space(string()), $t)]",
-            t="Your application is complete, and will be automatically submitted.",
+            t="Your application is complete and will be submitted automatically.",
         )
         assert alert_banner[0].xpath(
             "//div[contains(normalize-space(string()), $t)]",
@@ -728,7 +728,7 @@ class TestFrameworksDashboardSuccessBanner(BaseApplicationTest):
         assert len(alert_banner) == 1
         assert alert_banner[0].xpath(
             "//h2[contains(normalize-space(string()), $t)]",
-            t="Your application is complete, and will be automatically submitted.",
+            t="Your application is complete and will be submitted automatically.",
         )
         assert alert_banner[0].xpath(
             "//div[contains(normalize-space(string()), $t)]",
@@ -773,7 +773,7 @@ class TestFrameworksDashboardSuccessBanner(BaseApplicationTest):
         # Alert banner should not be shown
         alert_banner = document.xpath('//div[@class="dm-alert dm-alert--success"]')
         assert len(alert_banner) == 0
-        assert 'Your application is complete, and will be automatically submitted.' not in res.get_data(as_text=True)
+        assert 'Your application is complete and will be submitted automatically.' not in res.get_data(as_text=True)
 
         # Check GA custom dimension values
         doc = html.fromstring(res.get_data(as_text=True))


### PR DESCRIPTION
https://trello.com/c/W9biikjw/352-implement-framework-application-dashboard-design-changes

Following design review from @joelanman. 

## Screenshot

![new-dashboard](https://user-images.githubusercontent.com/3492540/75277336-b5682600-57ff-11ea-8fbf-0e465cadd5be.png)

## Notes
- SCSS and template structure are taken from the Notify task-list component (see ticket).
- Removing some of the content simplified the logic on the template
- Note that the URL for 'Make your supplier declaration' is still different depending on whether they've already started it or not.
- I've removed the 'success' banner from the main dashboard template, and moved it into the `_framework_actions` template (as it only gets shown during an open framework)
- I've tweaked the success banner content to try and clarify to suppliers that their application will still be submitted if at least 1 service is complete, even if they have remaining unsubmitted draft services. However if they submit/remove remaining drafts, they now get a nice 'Done' message on the service row.
- I've tried not to refactor *all* the tests in test_frameworks.py, even though I really want to. But I've renamed some of them to make it clear which conditions are being tested, and regrouped some of the test classes to make it easier to manage. I've kept this last bit in a separate commit, so if we don't want to include it here, I'm happy to drop that commit.
- I moved some important info about services (i.e. that they will be publicly visible!) to the service page, and only visible for G-Cloud family frameworks. This was previously coming from the frameworks repo content, but it's not changed for years so we might as well hard-code it. Open to suggestions whether I should move the other now-removed content advice to other pages, e.g. explaining what a declaration is on the declaration page.
- Functional tests will need updating, as they look for specific content on this page.

## TODO
- Get content changes checked by @NoraGDS 
- Create a tech debt ticket to remove `framework_advice.use_of_service_data` in the frameworks repo
- see if we can remove any more code 🎉 
