### PR TITLE
config: re-enable WTF_CSRF_ENABLED for staging

### DIFF
--- a/config.py
+++ b/config.py
@@ -172,7 +172,7 @@ class Preview(Live):
 
 
 class Staging(Live):
-    WTF_CSRF_ENABLED = False
+    pass
 
 
 class Production(Live):


### PR DESCRIPTION
https://trello.com/c/085wlnUP

This was presumably disabled to allow gatling scripts to run, but we now have a mechanism in place that allows gatling to work properly with csrf.