### PR TITLE
Handle pre-existing file uploads in declaration data

### DIFF
--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -647,6 +647,15 @@ def framework_supplier_declaration_edit(framework_slug, section_id):
         # If no document errors, look for other errors
         if not errors:
             errors = validator.get_error_messages_for_page(section)
+            # Handle bug for pre-existing files - the filepath value is not included in the POST data,
+            # so this fails validation if the user has resubmitted without changes (or changed a different field).
+            # If the user *does* change the file, any errors will be picked up by the 'document_errors' section above
+            # (and this code won't be reached)
+            if 'modernSlaveryStatement' in errors and saved_declaration.get('modernSlaveryStatement'):
+                current_app.logger.info("Existing modern slavery statement file is unchanged")
+                mutable_errors = {k: v for k, v in errors.items()}
+                mutable_errors.pop('modernSlaveryStatement')
+                errors = mutable_errors
 
         all_answers = dict(saved_declaration, **submitted_answers)
 


### PR DESCRIPTION
Bug found during G12 QA: if a supplier goes back and edits the Modern Slavery statement (multiquestion) section, then re-submits, it gives an error that the existing file hasn’t been uploaded. This is because the form macro doesn't set the value on the file upload input (for good reason - it's a security hole).

Therefore we need to address this on the validation side. I can recreate it with the new unit test. It's a complete hack, given the short timescale - better suggestions very welcome!  

![g12-declaration-modern-slavery-file-upload-error](https://user-images.githubusercontent.com/3492540/75778306-71b97300-5d4f-11ea-8919-373b6d1b1676.png)

