### PR TITLE
Use dynamic guidance link instead of hardcoded DOS link

### DIFF
--- a/app/templates/frameworks/updates.html
+++ b/app/templates/frameworks/updates.html
@@ -119,7 +119,7 @@
             <br />
             <ul class="govuk-list govuk-list--bullet">
               <li>
-                <a class="govuk-link" href="https://www.gov.uk/guidance/digital-outcomes-and-specialists-suppliers-guide">find out about the application process and eligibility</a>
+                <a class="govuk-link" href="{{ framework_urls.supplier_guide_url }}">find out about the application process and eligibility</a>
               </li>
               <li>
                 <a class="govuk-link" href="{{ url_for('external.help') }}">get help if there’s a problem with your account</a>


### PR DESCRIPTION
Bugfix: the guidance link above the Clarification Question form points to DOS guidance (hardcoded from last year).

I've changed this to use the dynamic guidance link we use elsewhere on the Supplier FE. 