### PR TITLE
Fix list entry secondary button positioning

### DIFF
--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -69,6 +69,7 @@ $govuk-global-styles: true;
 @import "_view-service-link.scss";
 
 // Overrides
+@import "overrides/_list-entry";
 @import "overrides/_notifications_banner";
 @import "overrides/_temporary-messages";
 @import "overrides/_task-list";

--- a/app/assets/scss/overrides/_list-entry.scss
+++ b/app/assets/scss/overrides/_list-entry.scss
@@ -1,0 +1,10 @@
+// TODO: Remove when list entry component has been replaced
+
+/* overrides line 106, node_modules/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss */
+
+.list-entry {
+  .button-secondary:before,
+  .button-secondary-with-advice:before {
+    position: relative;
+  }
+}


### PR DESCRIPTION
https://trello.com/c/Ydy4QR9G/

When the screen width was small enough for the 'Remove' button to wrap onto a new line, the button was previously overlapping the text input, causing the list entry row to be removed when a user was trying to click onto it.

Overriding the GOVUK Frontend button positioning only for `list-entry` secondary action buttons  fixed the problem on Chrome.