### PR TITLE
Bump docker base to 9.3.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,1 @@
-FROM digitalmarketplace/base-frontend:9.2.0
+FROM digitalmarketplace/base-frontend:9.3.0


### PR DESCRIPTION
https://trello.com/c/7enkYdUF/1516-vulnerability-fix-tracking

Pulls in latest frontend Docker image with latest security fixes.