### PR TITLE
Update G-Cloud 12 dates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2078,8 +2078,8 @@
       "dev": true
     },
     "digitalmarketplace-frameworks": {
-      "version": "github:alphagov/digitalmarketplace-frameworks#d1ddf8575d2b8aec318bed1d4797d3030beb0fc2",
-      "from": "github:alphagov/digitalmarketplace-frameworks#v17.8.1"
+      "version": "github:alphagov/digitalmarketplace-frameworks#301e129389edf2a8a8f809fe3a1e2b9d70ade87b",
+      "from": "github:alphagov/digitalmarketplace-frameworks#v17.8.2"
     },
     "digitalmarketplace-frontend-toolkit": {
       "version": "git+https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#323b3d4b704e33782df6cdae7b105a2a9237a594",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "colors": "1.1.2",
     "del": "^5.1.0",
-    "digitalmarketplace-frameworks": "github:alphagov/digitalmarketplace-frameworks#v17.8.1",
+    "digitalmarketplace-frameworks": "github:alphagov/digitalmarketplace-frameworks#v17.8.2",
     "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v36.1.0",
     "digitalmarketplace-govuk-frontend": "^0.6.5",
     "govuk-country-and-territory-autocomplete": "0.4.0",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -36,7 +36,7 @@ pytest-cov==2.7.1         # via -r requirements-dev.in
 pytest==4.6.3             # via -r requirements-dev.in, pytest-cov
 python-dateutil==2.8.1    # via -c requirements.txt, freezegun
 python-dotenv==0.10.3     # via -r requirements-dev.in
-pyyaml==5.3               # via -c requirements.txt, watchdog
+pyyaml==5.3.1             # via -c requirements.txt, watchdog
 requests-mock==1.6.0      # via -r requirements-dev.in
 requests==2.23.0          # via -c requirements.txt, coveralls, requests-mock
 six==1.14.0               # via -c requirements.txt, freezegun, mock, packaging, pip-tools, pytest, python-dateutil, requests-mock

--- a/requirements.txt
+++ b/requirements.txt
@@ -47,7 +47,7 @@ pyjwt==1.7.1              # via notifications-python-client
 python-dateutil==2.8.1    # via botocore
 python-json-logger==0.1.11  # via digitalmarketplace-utils
 pytz==2019.3              # via digitalmarketplace-utils
-pyyaml==5.3               # via digitalmarketplace-content-loader
+pyyaml==5.3.1             # via digitalmarketplace-content-loader
 requests==2.23.0          # via digitalmarketplace-apiclient, digitalmarketplace-utils, mailchimp3, notifications-python-client
 s3transfer==0.3.3         # via boto3
 six==1.14.0               # via cryptography, python-dateutil


### PR DESCRIPTION
Pulls in digitalmarketplace-frameworks 17.8.2 with alphagov/digitalmarketplace-frameworks#615.

Also had to update PyYAML to make PyUp SafetyCI happy.