### PR TITLE
Rebuild pricing input component using GOV.UK Design System components

### DIFF
--- a/app/templates/macros/pricing-input/content-loader-macro.j2
+++ b/app/templates/macros/pricing-input/content-loader-macro.j2
@@ -1,0 +1,63 @@
+{% from "govuk-frontend/components/fieldset/macro.njk" import govukFieldset %}
+
+{% from "./macro.njk" import dmPricingInput %}
+
+{% macro clPricingInput(question_content, data, errors) %}
+{% with
+  errors = kwargs.get("errors", errors.get(question_content.id)),
+  fields = kwargs.get("fields", question_content.fields),
+  id = kwargs.get("name", question_content.id),
+  optional = kwargs.get("optional", question_content.optional),
+  optional_fields = kwargs.get("optional_fields", question_content.optional_fields),
+  question = kwargs.get("question", question_content.question),
+  question_advice = kwargs.get("question_advice", question_content.question_advice),
+  question_number = kwargs.question_number
+%}
+
+  {% set errorMessage = {
+    "text": errors.message
+    } if errors else None
+  %}
+  {% set paramItems = {} %}
+
+  {%- for itemname, fieldname, label in (
+    ("unit", "price_unit", "Unit"),
+    ("time", "price_interval", "Time"),
+    ("minimumPrice", "minimum_price", "Minimum price"),
+    ("maximumPrice", "maximum_price", "Maximum price"),
+  ) %}
+    {% if fieldname in fields %}
+      {% with name = fields[fieldname] %}
+      {% set _ = paramItems.update({
+        itemname: {
+          "name": name,
+          "label": label
+            + (" (optional)" if fieldname in optional_fields else ""),
+          "error": True if errors.field == name else None,
+          "value": kwargs.get(fieldname, data.get(name))
+        }
+      }) %}
+      {% endwith %}
+    {% endif %}
+  {% endfor %}
+
+  {% call govukFieldset({
+    "legend": {
+      "text": question + (" (optional)" if optional else ""),
+      "classes": "govuk-fieldset__legend--m",
+    }
+  }) %}
+
+    <p class="govuk-body dm-question-advice">
+      {{ question_advice }}
+    </p>
+
+    {{ dmPricingInput({
+      "errorMessage": errorMessage,
+      "id": id,
+      "items": paramItems,
+    }) }}
+
+  {% endcall %}
+{% endwith %}
+{% endmacro %}

--- a/app/templates/macros/pricing-input/macro.njk
+++ b/app/templates/macros/pricing-input/macro.njk
@@ -1,0 +1,3 @@
+{% macro dmPricingInput(params) %}
+  {%- include "./template.njk" -%}
+{% endmacro %}

--- a/app/templates/macros/pricing-input/pricing-input.yaml
+++ b/app/templates/macros/pricing-input/pricing-input.yaml
@@ -1,0 +1,78 @@
+params:
+- name: id
+  type: string
+  required: true
+  description: This is used for the main component and to compose id attribute for each item.
+- name: namePrefix
+  type: string
+  required: false
+  description: Optional prefix. This is used to prefix each `item.name` using `-`.
+- name: items
+  type: array
+  required: false
+  description: An array of input objects with name, value and classes.
+  params:
+  - name: id
+    type: string
+    required: false
+    description: Item-specific id. If provided, it will be used instead of the generated id.
+  - name: name
+    type: string
+    required: true
+    description: Item-specific name attribute.
+  - name: label
+    type: string
+    required: true
+    description: Item-specific label text. If provided, this will be used instead of `name` for item label text.
+  - name: value
+    type: string
+    required: false
+    description: If provided, it will be used as the initial value of the input.
+  - name: autocomplete
+    type: string
+    required: false
+    description: Attribute to [identify input purpose](https://www.w3.org/WAI/WCAG21/Understanding/identify-input-purpose.html), for instance "postal-code" or "username". See [autofill](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill) for full list of attributes that can be used.
+  - name: pattern
+    type: string
+    required: false
+    description: Attribute to [provide a regular expression pattern](https://www.w3.org/TR/html51/sec-forms.html#the-pattern-attribute), used to match allowed character combinations for the input value.
+  - name: classes
+    type: string
+    required: false
+    description: Classes to add to pricing input item.
+  - name: attributes
+    type: object
+    required: false
+    description: HTML attributes (for example data attributes) to add to the pricing input tag.
+- name: hint
+  type: object
+  required: false
+  description: Options for the hint component.
+  isComponent: true
+- name: errorMessage
+  type: object
+  required: false
+  description: Options for the error message component. The error message component will not display if you use a falsy value for `errorMessage`, for example `false` or `null`.
+  isComponent: true
+- name: formGroup
+  type: object
+  required: false
+  description: Options for the form-group wrapper
+  params:
+  - name: classes
+    type: string
+    required: false
+    description: Classes to add to the form group (e.g. to show error state for the whole group)
+- name: fieldset
+  type: object
+  required: false
+  description: Options for the fieldset component (e.g. legend).
+  isComponent: true
+- name: classes
+  type: string
+  required: false
+  description: Classes to add to the pricing-input container.
+- name: attributes
+  type: object
+  required: false
+  description: HTML attributes (for example data attributes) to add to the pricing-input container.

--- a/app/templates/macros/pricing-input/template.njk
+++ b/app/templates/macros/pricing-input/template.njk
@@ -1,0 +1,253 @@
+{% from "govuk-frontend/components/error-message/macro.njk" import govukErrorMessage %}
+{% from "govuk-frontend/components/fieldset/macro.njk" import govukFieldset %}
+{% from "govuk-frontend/components/hint/macro.njk" import govukHint %}
+{% from "govuk-frontend/components/input/macro.njk" import govukInput %}
+{% from "govuk-frontend/components/select/macro.njk" import govukSelect %}
+
+{#- a record of other elements that we need to associate with the input using
+   aria-describedby – for example hints or error messages -#}
+{% set describedBy = params.fieldset.describedBy if params.fieldset.describedBy else "" %}
+
+{% if params.items | length %}
+  {% set priceInputItems = params.items %}
+{% else %}
+  {% set priceInputItems = {
+    "unit": {
+      "label": "Unit",
+    },
+    "time": {
+      "label": "Time",
+    },
+    "minimumPrice": {
+      "label": "Minimum price",
+    },
+    "maximumPrice": {
+      "label": "Maximum price",
+    },
+  } %}
+{% endif %}
+
+{% if "unit" in priceInputItems %}
+  {% set priceInputUnit = priceInputItems.unit %}
+  {% if priceInputUnit.items | length %}
+    {% set priceInputUnitItems = priceInputUnit.items %}
+  {% else %}
+    {% set priceInputUnitItems = [
+      {
+        value: "",
+        text: "",
+        selected: True if "" == priceInputUnit.value else False,
+      },
+      {
+        value: "Unit",
+        text: "per unit",
+        selected: True if "Unit" == priceInputUnit.value else False,
+      },
+      {
+        value: "Person",
+        text: "per person",
+        selected: True if "Person" == priceInputUnit.value else False,
+      },
+      {
+        value: "Licence",
+        text: "per licence",
+        selected: True if "Licence" == priceInputUnit.value else False,
+      },
+      {
+        value: "User",
+        text: "per user",
+        selected: True if "User" == priceInputUnit.value else False,
+      },
+      {
+        value: "Device",
+        text: "per device",
+        selected: True if "Device" == priceInputUnit.value else False,
+      },
+      {
+        value: "Instance",
+        text: "per instance",
+        selected: True if "Instance" == priceInputUnit.value else False,
+      },
+      {
+        value: "Server",
+        text: "per server",
+        selected: True if "Server" == priceInputUnit.value else False,
+      },
+      {
+        value: "Virtual machine",
+        text: "per virtual machine",
+        selected: True if "Virtual machine" == priceInputUnit.value else False,
+      },
+      {
+        value: "Transaction",
+        text: "per transaction",
+        selected: True if "Transaction" == priceInputUnit.value else False,
+      },
+      {
+        value: "Megabyte",
+        text: "per megabyte",
+        selected: True if "Megabyte" == priceInputUnit.value else False,
+      },
+      {
+        value: "Gigabyte",
+        text: "per gigabyte",
+        selected: True if "Gigabyte" == priceInputUnit.value else False,
+      },
+      {
+        value: "Terabyte",
+        text: "per terabyte",
+        selected: True if "Terabyte" == priceInputUnit.value else False,
+      },
+    ] %}
+  {% endif %}
+{% endif %}
+
+{% if "time" in priceInputItems %}
+  {% set priceInputTime = priceInputItems.time %}
+  {% if priceInputTime.items | length %}
+    {% set priceInputTimeItems = priceInputTime.items %}
+  {% else %}
+    {% set priceInputTimeItems = [
+      {
+        value: "",
+        text: "",
+        selected: True if "" == priceInputTime.value else False,
+      },
+      {
+        value: "Second",
+        text: "per second",
+        selected: True if "Second" == priceInputTime.value else False,
+      },
+      {
+        value: "Minute",
+        text: "per minute",
+        selected: True if "Minute" == priceInputTime.value else False,
+      },
+      {
+        value: "Hour",
+        text: "per hour",
+        selected: True if "Hour" == priceInputTime.value else False,
+      },
+      {
+        value: "Day",
+        text: "per day",
+        selected: True if "Day" == priceInputTime.value else False,
+      },
+      {
+        value: "Week",
+        text: "per week",
+        selected: True if "Week" == priceInputTime.value else False,
+      },
+      {
+        value: "Month",
+        text: "per month",
+        selected: True if "Month" == priceInputTime.value else False,
+      },
+      {
+        value: "Quarter",
+        text: "per quarter",
+        selected: True if "Quarter" == priceInputTime.value else False,
+      },
+      {
+        value: "6 months",
+        text: "per 6 months",
+        selected: True if "6 months" == priceInputTime.value else False,
+      },
+      {
+        value: "Year",
+        text: "per year",
+        selected: True if "Year" == priceInputTime.value else False,
+      },
+    ] %}
+  {% endif %}
+{% endif %}
+
+{#- Capture the HTML so we can optionally nest it in a fieldset -#}
+{% set innerHtml %}
+{% if params.hint %}
+  {% set hintId = params.id + "-hint" %}
+  {% set describedBy = describedBy + " " + hintId if describedBy else hintId %}
+  {{ govukHint({
+    id: hintId,
+    classes: params.hint.classes,
+    attributes: params.hint.attributes,
+    html: params.hint.html,
+    text: params.hint.text
+  }) | indent(2) | trim }}
+{% endif %}
+{% if params.errorMessage %}
+  {% set errorId = params.id + "-error" %}
+  {% set describedBy = describedBy + " " + errorId if describedBy else errorId %}
+  {{ govukErrorMessage({
+    id: errorId,
+    classes: params.errorMessage.classes,
+    attributes: params.errorMessage.attributes,
+    html: params.errorMessage.html,
+    text: params.errorMessage.text,
+    visuallyHiddenText: params.errorMessage.visuallyHiddenText
+  }) | indent(2) | trim }}
+{% endif %}
+  <div class="dmp-price-input"
+    {%- if params.id %} id ="{{ params.id }}"{% endif %}>
+    {%- for item, label, items in ((priceInputItems.unit, "Unit", priceInputUnitItems),
+                                   (priceInputItems.time, "Time", priceInputTimeItems)) %}
+    {% if item | length %}
+    <div class="dmp-price-input__item govuk-form-group">
+      {{ govukSelect({
+        "label": {
+          "text": item.label if item.label else label,
+          "classes": "dmp-price-input__label",
+        },
+        "id": item.id if item.id else (params.id + "-" + item.name),
+        "classes": "dmp-price-input__input "
+          + ("govuk-select--error" if item.error) + (item.classes if item.classes),
+        "name": (params.namePrefix + "-" + item.name) if params.namePrefix else item.name,
+        "items": items,
+      }) | indent(6) | trim }}
+    </div>
+    {% endif %}
+    {% endfor %}
+    {%- for item, label in ((priceInputItems.minimumPrice, "Minimum price"),
+                            (priceInputItems.maximumPrice, "Maximum price")) %}
+    {% if item | length %}
+    <div class="dmp-price-input__item govuk-form-group">
+      {{ govukInput({
+        "label": {
+          "text": item.label if item.label else label,
+          "classes": "dmp-price-input__label",
+        },
+        "hint": {
+          "text": item.hint if item.hint else "For example, £199.99",
+          "classes": "dmp-price-input__hint",
+        },
+        "id": item.id if item.id else (params.id + "-" + item.name),
+        "classes": "dmp-price-input__input govuk-input--width-10 "
+          + ("govuk-input--error" if item.error) + (item.classes if item.classes),
+        "name": (params.namePrefix + "-" + item.name) if params.namePrefix else item.name,
+        "value": item.value,
+        "type": "text",
+        "inputmode": "decimal",
+        "autocomplete": item.autocomplete,
+        "pattern": item.pattern if item.pattern else "£?[0-9]+([.,][0-9]+)?",
+        "attributes": item.attributes,
+      }) | indent(6) | trim }}
+    </div>
+    {% endif %}
+    {% endfor %}
+  </div>
+{% endset %}
+
+<div class="govuk-form-group {%- if params.errorMessage %} govuk-form-group--error{% endif %} {%- if params.formGroup.classes %} {{ params.formGroup.classes }}{% endif %}">
+{% if params.fieldset %}
+  {% call govukFieldset({
+    describedBy: describedBy,
+    classes: params.fieldset.classes,
+    attributes: params.fieldset.attributes,
+    legend: params.fieldset.legend
+  }) %}
+  {{ innerHtml | trim | safe }}
+  {% endcall %}
+{% else %}
+  {{ innerHtml | trim | safe }}
+{% endif %}
+</div>

--- a/app/templates/macros/toolkit_forms.html
+++ b/app/templates/macros/toolkit_forms.html
@@ -15,6 +15,8 @@ set a custom filter on its value.
 
 {% import "toolkit/forms/macros/forms.html" as upstream_forms %}
 
+{% from "./pricing-input/content-loader-macro.j2" import clPricingInput %}
+
 {% macro text(question_content, service_data, errors) -%}
   {{ upstream_forms.text(question_content, service_data, errors,
     error=errors.get(question_content.id)['message']|question_references(kwargs.get_question),
@@ -91,7 +93,7 @@ set a custom filter on its value.
 {%- endmacro %}
 
 {% macro pricing(question_content, service_data, errors) -%}
-  {{ upstream_forms.pricing(question_content, service_data, errors,
+  {{ clPricingInput(question_content, service_data, errors,
     error=errors.get(question_content.id)['message']|question_references(kwargs.get_question),
     hint=(question_content.hint or '')|question_references(kwargs.get_question),
     question=question_content.question|question_references(kwargs.get_question),

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -1902,12 +1902,12 @@ class TestEditDraftService(BaseApplicationTest, MockEnsureApplicationCompanyDeta
         )[0].strip()
 
     @pytest.mark.parametrize("field,error,expected_message", (
-        ('priceMin', 'answer_required', 'Minimum price requires an answer.',),
+        ('priceMin', 'answer_required', 'Error: Minimum price requires an answer.',),
         ('priceUnit', 'answer_required',
-            u"Pricing unit requires an answer. If none of the provided units apply, please choose ‘Unit’."),
-        ('priceMin', 'not_money_format', 'Minimum price must be a number, without units, eg 99.95',),
-        ('priceMax', 'not_money_format', 'Maximum price must be a number, without units, eg 99.95',),
-        ('priceMax', 'max_less_than_min', 'Minimum price must be less than maximum price.',),
+            u"Error: Pricing unit requires an answer. If none of the provided units apply, please choose ‘Unit’."),
+        ('priceMin', 'not_money_format', 'Error: Minimum price must be a number, without units, eg 99.95',),
+        ('priceMax', 'not_money_format', 'Error: Maximum price must be a number, without units, eg 99.95',),
+        ('priceMax', 'max_less_than_min', 'Error: Minimum price must be less than maximum price.',),
     ))
     def test_update_with_pricing_errors(self, s3, field, error, expected_message):
         self.data_api_client.get_framework.return_value = self.framework(slug='g-cloud-9', status='open')
@@ -1921,7 +1921,7 @@ class TestEditDraftService(BaseApplicationTest, MockEnsureApplicationCompanyDeta
 
         assert res.status_code == 200
         document = html.fromstring(res.get_data(as_text=True))
-        assert document.xpath("normalize-space(string(//*[@class='validation-message']))") == expected_message
+        assert document.xpath("normalize-space(string(//*[@class='govuk-error-message']))") == expected_message
         assert document.xpath("normalize-space(string(//*[@class='validation-masthead']//a))") == \
             "How much does the service cost (excluding VAT)?"
 


### PR DESCRIPTION
https://trello.com/c/yld9eBvJ/6-3-rebuild-pricing-form-template-using-govuk-design-system-components-in-supplier-frontend

## Design

A new pricing input macro `dmPricingInput` has been created in the supplier frontend. I haven't added it to digitalmarketplace-govuk-frontend because it is only used in the supplier frontend. The template is based on the [date input component in govuk-frontend].

Another separate macro has also been created, `clPricingInput` (suggestions on a better name welcome), to take input from the content loader and create a form. It was split into two macros in this way partly to keep the implementation of `dmPricingInput` clean, and also as an experiment into how we can create content loader macros for other form components in future.

Things I decided not to implement:

- message parameter (only used for declarations, this question is not used for declarations)
- question_number parameter: this doesn't appear to be used anywhere in the old template

[date input component in govuk-frontend]: https://github.com/alphagov/govuk-frontend/blob/master/src/govuk/components/date-input/template.njk

## Screenshots

Before (with bug) | After
------------------|------
![screencapture-localhost-suppliers-frameworks-g-cloud-12-submissions-cloud-hosting-168927-edit-pricing-price-2020-04-20-17_14_48](https://user-images.githubusercontent.com/503614/79841522-785b8280-83af-11ea-92a9-65cd1574b048.png) | ![screencapture-localhost-suppliers-frameworks-g-cloud-12-submissions-cloud-hosting-168927-edit-pricing-price-2020-04-20-17_13_05](https://user-images.githubusercontent.com/503614/79841587-8ad5bc00-83af-11ea-933d-6bbe667aabf0.png)

## Checklist

- [x] Write macro for pricing input component
- [x] Write macro to take content loader manifest and instantiate pricing input component
- [x] Replace call of digitalmarketplace-frontend-toolkit pricing macro in `toolkit_forms` with new macro
- [x] Fix tests