### PR TITLE
Copy services using questions_to_exclude list

### DIFF
--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -872,18 +872,24 @@ def copy_all_previous_services(framework_slug, lot_slug):
     if not get_supplier_framework_info(data_api_client, framework_slug):
         abort(404)
 
+    questions_to_exclude = content_loader.get_metadata(framework['slug'], 'copy_services', 'questions_to_exclude')
     questions_to_copy = content_loader.get_metadata(framework['slug'], 'copy_services', 'questions_to_copy')
     source_framework_slug = content_loader.get_metadata(framework['slug'], 'copy_services', 'source_framework')
+
+    copy_options = {
+        "sourceFrameworkSlug": source_framework_slug,
+        "supplierId": current_user.supplier_id
+    }
+    if questions_to_exclude:
+        copy_options['questionsToExclude'] = questions_to_exclude
+    elif questions_to_copy:
+        copy_options['questionsToCopy'] = questions_to_copy
 
     response = data_api_client.copy_published_from_framework(
         framework_slug,
         lot_slug,
         current_user.email_address,
-        data={
-            "sourceFrameworkSlug": source_framework_slug,
-            "supplierId": current_user.supplier_id,
-            "questionsToCopy": questions_to_copy
-        }
+        data=copy_options
     )['services']
 
     flash(


### PR DESCRIPTION
https://trello.com/c/WBjRZd14/80-2-frameworks-repo-copyservices-list-exclude-rather-than-include-fields

Implements the changes in https://github.com/alphagov/digitalmarketplace-api/pull/1038.

If a `questionsToExclude` list is provided in the frameworks metadata, use that instead of the `questionsToCopy` list (which is to be deprecated).  For G12 we are still using the `questionsToCopy` list.

Notes to reviewers: 
- I tried splitting this into smaller commits, but without refactoring a bunch of stuff I couldn't get each commit in a state where the tests were passing.
- The bulk-copy API endpoint expects a list of questions, not a set or tuple, so I've changed the test data returned from the mock metadata call to reflect this.

~Functional tests PR coming shortly!~ Functional tests now merged 😸 