### PR TITLE
Disable FlaskLogin flash messages

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -49,7 +49,7 @@ def create_app(config_name):
     # the external NotImplemented routes in the dm-utils external blueprint).
     application.register_blueprint(external_blueprint)
 
-    login_manager.login_message_category = "must_login"
+    login_manager.login_message = None  # don't flash message to user
     main_blueprint.config = application.config.copy()
 
     gds_metrics.init_app(application)


### PR DESCRIPTION
Ticket: https://trello.com/c/sxhsW20p/88-replace-flash-messages-with-alert-component-in-briefs-frontend

We don't want to use the default flash message for when a user needs an account to access a page, so this PR disables the message flashing in FlaskLogin.