### PR TITLE
Suppliers can view incomplete applications post-deadline

### DIFF
--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -105,3 +105,7 @@ $govuk-global-styles: true;
   width: 100%;
   height: 42px;
 }
+
+.browse-list-item-link {
+  text-decoration: underline;
+}

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -245,8 +245,6 @@ def framework_submission_lots(framework_slug):
     application_made = len(complete_drafts) > 0 and declaration_status == 'complete'
     if framework['status'] not in ["open", "pending", "standstill"]:
         abort(404)
-    if framework['status'] == 'pending' and not application_made:
-        abort(404)
 
     lots = [
         dict(lot,
@@ -282,6 +280,7 @@ def framework_submission_lots(framework_slug):
         declaration_status=declaration_status,
         framework=framework,
         lots=lots,
+        application_made=application_made
     ), 200
 
 

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -293,8 +293,6 @@ def framework_submission_services(framework_slug, lot_slug):
 
     drafts, complete_drafts = get_lot_drafts(data_api_client, framework_slug, lot_slug)
     declaration_status = get_declaration_status(data_api_client, framework_slug)
-    if framework['status'] == 'pending' and declaration_status != 'complete':
-        abort(404)
 
     try:
         previous_framework_slug = content_loader.get_metadata(framework['slug'], 'copy_services', 'source_framework')

--- a/app/templates/frameworks/_submitted_services.html
+++ b/app/templates/frameworks/_submitted_services.html
@@ -1,27 +1,37 @@
-{% if framework.status in ['pending', 'standstill'] and application_made %}
+{% if framework.status in ['pending', 'standstill'] %}
 <li class="browse-list-item">
-  <h2>You submitted:</h2>
-  <ul class="govuk-list govuk-list--bullet">
-    {% for lot in completed_lots %}
-      {% if lot.one_service_limit %}
-        <li>{{ lot.name }}</li>
-      {% else %}
-        <li>
-          {{ lot.complete_count }} {{ lot.name }}
-          {{ lot.unitSingular if (1 == lot.complete_count) else lot.unitPlural }}
-        </li>
-      {% endif %}
-    {% endfor %}
-  </ul>
+  {% if application_made %}
+    <h2>You submitted:</h2>
+    <ul class="govuk-list govuk-list--bullet">
+      {% for lot in completed_lots %}
+        {% if lot.one_service_limit %}
+          <li>{{ lot.name }}</li>
+        {% else %}
+          <li>
+            {{ lot.complete_count }} {{ lot.name }}
+            {{ lot.unitSingular if (1 == lot.complete_count) else lot.unitPlural }}
+          </li>
+        {% endif %}
+      {% endfor %}
+    </ul>
+  {% endif %}
   <p class="govuk-body">
     <a class="govuk-link" href="{{ url_for('.framework_submission_lots', framework_slug=framework.slug) }}">
-      View submitted services
+      {% if application_made %}
+        View submitted services
+      {% else %}
+        View draft services
+      {% endif %}
     </a>
   </p>
   <p class="govuk-body">
-    <a class="govuk-link" href="{{ url_for('.framework_supplier_declaration_overview', framework_slug=framework.slug) }}">
-      View your declaration
-    </a>
+    {% if declaration_status == 'unstarted' %}
+      You did not make a supplier declaration.
+    {% else %}
+      <a class="govuk-link" href="{{ url_for('.framework_supplier_declaration_overview', framework_slug=framework.slug) }}">
+        View your declaration
+      </a>
+    {% endif %}
   </p>
 </li>
 {% endif %}

--- a/app/templates/frameworks/_submitted_services.html
+++ b/app/templates/frameworks/_submitted_services.html
@@ -14,24 +14,51 @@
         {% endif %}
       {% endfor %}
     </ul>
-  {% endif %}
-  <p class="govuk-body">
-    <a class="govuk-link" href="{{ url_for('.framework_submission_lots', framework_slug=framework.slug) }}">
-      {% if application_made %}
+
+    <p class="govuk-body">
+      <a class="govuk-link" href="{{ url_for('.framework_submission_lots', framework_slug=framework.slug) }}">
         View submitted services
-      {% else %}
-        View draft services
-      {% endif %}
-    </a>
-  </p>
-  <p class="govuk-body">
-    {% if declaration_status == 'unstarted' %}
-      You did not make a supplier declaration.
-    {% else %}
+      </a>
+    </p>
+
+    <p class="govuk-body">
       <a class="govuk-link" href="{{ url_for('.framework_supplier_declaration_overview', framework_slug=framework.slug) }}">
         View your declaration
       </a>
+    </p>
+
+  {% else %}
+
+    {% if application_company_details_confirmed %}
+
+      {% if counts.draft or counts.complete %}
+        <p class="govuk-body">
+          <a class="govuk-link" href="{{ url_for('.framework_submission_lots', framework_slug=framework.slug) }}">
+            View draft services
+          </a>
+        </p>
+      {% else %}
+        <p>You did not create any services.</p>
+      {% endif %}
+
+      {% if declaration_status == 'unstarted' %}
+        <p class="govuk-body">You did not make a supplier declaration.</p>
+      {% else %}
+        <p class="govuk-body">
+          <a class="govuk-link" href="{{ url_for('.framework_supplier_declaration_overview', framework_slug=framework.slug) }}">
+            View your declaration
+          </a>
+        </p>
+      {% endif %}
+
+    {% else %}
+      {# If company details not confirmed, declaration and services cannot viewed #}
+      <p class="govuk-body">You did not confirm your company details.</p>
+      <p class="govuk-body">You did not make a supplier declaration.</p>
+      <p class="govuk-body">You did not create any services.</p>
     {% endif %}
-  </p>
+
+  {% endif %}
+
 </li>
 {% endif %}

--- a/app/templates/frameworks/services.html
+++ b/app/templates/frameworks/services.html
@@ -34,7 +34,9 @@
 
 {% block mainContent %}
 
-  {% include "partials/service_warning.html" %}
+  {% if framework.status == 'open' %}
+    {% include "partials/service_warning.html" %}
+  {% endif %}
 
   <h1 class="govuk-heading-l">{{ lot.name }} services</h1>
 

--- a/app/templates/frameworks/services.html
+++ b/app/templates/frameworks/services.html
@@ -49,7 +49,7 @@
             {% if declaration_status == 'complete' %}
               You made your supplier declaration and submitted {{ complete_drafts|length }} complete {{ 'service' if complete_drafts|length == 1 else 'services' }}.
             {% else %}
-              You submitted {{ complete_drafts|length }} complete {{ 'service' if complete_drafts|length == 1 else 'services' }}.
+              You completed {{ complete_drafts|length }} {{ 'service' if complete_drafts|length == 1 else 'services' }}.
             {% endif %}
           </p>
         </div>
@@ -69,7 +69,7 @@
   {% if framework.status == 'open' %}
     {{ summary.top_link("Add a service", url_for(".start_new_draft_service", framework_slug=framework.slug, lot_slug=lot.slug)) }}
   {% elif framework.status == 'pending' %}
-    <p class="hint">These services were not submitted</p>
+    <p class="hint">These services were not completed</p>
   {% endif %}
   {% call(draft) summary.list_table(
     drafts,
@@ -111,7 +111,11 @@
   {% if framework.status == 'open' %}
     {{ summary.heading("Complete services") }}
   {% elif framework.status == 'pending' or 'standstill' %}
-    {{ summary.heading("Submitted services") }}
+    {% if declaration_status == 'complete' %}
+      {{ summary.heading("Submitted services") }}
+    {% else %}
+      {{ summary.heading("Completed services") }}
+    {% endif %}
   {% endif %}
   {% call(draft) summary.list_table(
     complete_drafts,

--- a/app/templates/frameworks/services.html
+++ b/app/templates/frameworks/services.html
@@ -44,7 +44,11 @@
         <div class="govuk-grid-column-two-thirds">
           <h2 class="summary-item-heading">{{ framework.name }} is closed for applications</h2>
           <p class="govuk-body">
-            You made your supplier declaration and submitted {{ complete_drafts|length }} complete {{ 'service' if complete_drafts|length == 1 else 'services' }}.
+            {% if declaration_status == 'complete' %}
+              You made your supplier declaration and submitted {{ complete_drafts|length }} complete {{ 'service' if complete_drafts|length == 1 else 'services' }}.
+            {% else %}
+              You submitted {{ complete_drafts|length }} complete {{ 'service' if complete_drafts|length == 1 else 'services' }}.
+            {% endif %}
           </p>
         </div>
       </div>

--- a/app/templates/frameworks/submission_lots.html
+++ b/app/templates/frameworks/submission_lots.html
@@ -30,7 +30,9 @@
 
 {% block mainContent %}
 
+{% if framework.status == 'open' %}
   {% include "partials/service_warning.html" %}
+{% endif %}
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/app/templates/frameworks/submission_lots.html
+++ b/app/templates/frameworks/submission_lots.html
@@ -39,6 +39,9 @@
       <h1 class="govuk-heading-l">Your {{ framework.name }} services</h1>
         {% if framework.family == 'g-cloud' %}
           <div class="use-of-service-data">
+            {% if framework.status == 'pending' and not application_made %}
+              <p class="govuk-body">The services below were not submitted.</p>
+            {% else %}
             <p class="govuk-body">The service information you provide here:</p>
             <ul class="govuk-list govuk-list--bullet">
               <li>will be public</li>
@@ -46,6 +49,7 @@
               <li>will appear on your service description page </li>
               <li>should help buyers review and compare services</li>
             </ul>
+            {% endif %}
           </div>
         {% endif %}
     </div>

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -4227,7 +4227,7 @@ class TestFrameworkSubmissionServices(BaseApplicationTest, MockEnsureApplication
         assert "G-Cloud 7 is closed for applications" in heading[0].xpath('text()')[0]
         assert "You made your supplier declaration and submitted 0 complete services." in \
             heading[0].xpath('../p[1]/text()')[0]
-        assert "These services were not submitted" in doc.xpath('//main//p[@class="hint"]')[0].xpath('text()')[0]
+        assert "These services were not completed" in doc.xpath('//main//p[@class="hint"]')[0].xpath('text()')[0]
 
         self._assert_incomplete_application_banner_not_visible(response.get_data(as_text=True))
 

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -3847,7 +3847,7 @@ class TestSendClarificationQuestionEmail(BaseApplicationTest):
 
 
 @mock.patch('app.main.views.frameworks.count_unanswered_questions')
-class TestSubmissionLotsPage(BaseApplicationTest, MockEnsureApplicationCompanyDetailsHaveBeenConfirmedMixin):
+class TestFrameworkSubmissionLots(BaseApplicationTest, MockEnsureApplicationCompanyDetailsHaveBeenConfirmedMixin):
 
     def setup_method(self, method):
         super().setup_method(method)
@@ -4049,7 +4049,7 @@ class TestSubmissionLotsPage(BaseApplicationTest, MockEnsureApplicationCompanyDe
 
 
 @mock.patch('app.main.views.frameworks.count_unanswered_questions')
-class TestServicesList(BaseApplicationTest, MockEnsureApplicationCompanyDetailsHaveBeenConfirmedMixin):
+class TestFrameworkSubmissionServices(BaseApplicationTest, MockEnsureApplicationCompanyDetailsHaveBeenConfirmedMixin):
 
     def setup_method(self, method):
         super().setup_method(method)

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -3847,6 +3847,208 @@ class TestSendClarificationQuestionEmail(BaseApplicationTest):
 
 
 @mock.patch('app.main.views.frameworks.count_unanswered_questions')
+class TestSubmissionLotsPage(BaseApplicationTest, MockEnsureApplicationCompanyDetailsHaveBeenConfirmedMixin):
+
+    def setup_method(self, method):
+        super().setup_method(method)
+        self.get_metadata_patch = mock.patch('app.main.views.frameworks.content_loader.get_metadata')
+        self.get_metadata = self.get_metadata_patch.start()
+        self.get_metadata.return_value = 'g-cloud-6'
+        self.data_api_client_patch = mock.patch('app.main.views.frameworks.data_api_client', autospec=True)
+        self.data_api_client = self.data_api_client_patch.start()
+
+    def teardown_method(self, method):
+        self.data_api_client_patch.stop()
+        super().teardown_method(method)
+        self.get_metadata_patch.stop()
+
+    def test_drafts_list_progress_count(self, count_unanswered):
+        self.login()
+
+        count_unanswered.return_value = 3, 1
+        self.data_api_client.get_framework.return_value = self.framework(status='open')
+        self.data_api_client.find_draft_services_iter.return_value = [
+            {'serviceName': 'draft', 'lotSlug': 'scs', 'status': 'not-submitted'}
+        ]
+
+        submissions = self.client.get('/suppliers/frameworks/g-cloud-7/submissions')
+
+        assert u'1 draft service' in submissions.get_data(as_text=True)
+        assert u'complete service' not in submissions.get_data(as_text=True)
+
+    @pytest.mark.parametrize('framework_slug, show_service_data', (
+        ('digital-outcomes-and-specialists-2', 0),
+        ('g-cloud-9', 1),
+    ))
+    def test_submission_lots_page_shows_use_of_service_data_if_g_cloud_family(
+        self, count_unanswered, framework_slug, show_service_data
+    ):
+        self.login()
+        self.data_api_client.get_framework.return_value = self.framework(slug=framework_slug, status="open")
+        self.data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
+            framework_slug=framework_slug
+        )
+
+        res = self.client.get(f"/suppliers/frameworks/{framework_slug}/submissions")
+        assert res.status_code == 200
+
+        doc = html.fromstring(res.get_data(as_text=True))
+        use_of_data = doc.xpath('//div[contains(@class, "use-of-service-data")]')
+        assert len(use_of_data) == show_service_data
+
+        if show_service_data:
+            assert 'The service information you provide here:' in use_of_data[0].text_content()
+
+    @pytest.mark.parametrize(
+        'declaration, should_show_declaration_link, declaration_link_url',
+        (
+            ({'declaration': {}}, True, '/suppliers/frameworks/g-cloud-7/declaration/start'),
+            ({'declaration': {'status': 'started'}}, True, '/suppliers/frameworks/g-cloud-7/declaration'),
+            ({'declaration': {}}, True, '/suppliers/frameworks/g-cloud-7/declaration/start'),
+            ({'declaration': {'status': 'started'}}, True, '/suppliers/frameworks/g-cloud-7/declaration'),
+            ({'declaration': {'status': 'complete'}}, False, None),
+            ({'declaration': {'status': 'complete'}}, False, None),
+        )
+    )
+    def test_banner_on_submission_lot_page_shows_link_to_declaration(
+        self, count_unanswered, declaration, should_show_declaration_link, declaration_link_url
+    ):
+        self.login()
+
+        self.data_api_client.get_framework.return_value = self.framework(status='open')
+        self.data_api_client.get_supplier.return_value = SupplierStub().single_result_response()
+        self.data_api_client.get_supplier_declaration.return_value = declaration
+        self.data_api_client.find_draft_services_iter.return_value = [
+            {'serviceName': 'draft', 'lotSlug': 'scs', 'status': 'submitted'}
+        ]
+
+        submissions = self.client.get('/suppliers/frameworks/g-cloud-7/submissions')
+
+        if should_show_declaration_link:
+            doc = html.fromstring(submissions.get_data(as_text=True))
+            assert doc.xpath('//*[@class="banner-information-without-action"]')
+            decl_element = doc.xpath(
+                "//*[contains(@class,'banner-content')][contains(normalize-space(string()), $text)]",
+                text="make your supplier declaration",
+            )
+            assert decl_element[0].xpath('.//a[@href=$url]', url=declaration_link_url)
+
+        else:
+            # Application is done - don't show warning banner
+            assert "Your application is not complete" not in submissions.get_data(as_text=True)
+
+    @pytest.mark.parametrize(
+        "incomplete_declaration,expected_url",
+        (
+            ({}, "/suppliers/frameworks/g-cloud-7/declaration/start"),
+            ({"status": "started"}, "/suppliers/frameworks/g-cloud-7/declaration")
+        )
+    )
+    def test_drafts_list_completed(self, count_unanswered, incomplete_declaration, expected_url):
+        self.login()
+
+        count_unanswered.return_value = 0, 1
+
+        self.data_api_client.get_framework.return_value = self.framework(status='open')
+        self.data_api_client.get_supplier_declaration.return_value = {'declaration': incomplete_declaration}
+        self.data_api_client.find_draft_services_iter.return_value = [
+            {'serviceName': 'draft', 'lotSlug': 'scs', 'status': 'submitted'}
+        ]
+        self.data_api_client.get_supplier.return_value = SupplierStub(
+            company_details_confirmed=False
+        ).single_result_response()
+
+        submissions = self.client.get('/suppliers/frameworks/g-cloud-7/submissions')
+
+        submissions_html = submissions.get_data(as_text=True)
+
+        assert u'1 service marked as complete' in submissions_html
+        assert u'draft service' not in submissions_html
+        assert "Your application is not complete" in submissions_html
+
+        doc = html.fromstring(submissions_html)
+        assert doc.xpath('//*[@class="banner-information-without-action"]')
+        decl_element = doc.xpath(
+            "//*[contains(@class,'banner-content')][contains(normalize-space(string()), $text)]",
+            text="make your supplier declaration",
+        )
+        assert decl_element[0].xpath('.//a[@href=$url]', url=expected_url)
+
+    def test_drafts_list_completed_with_declaration_status(self, count_unanswered):
+        self.login()
+
+        self.data_api_client.get_framework.return_value = self.framework(status='open')
+        self.data_api_client.get_supplier_declaration.return_value = {'declaration': {'status': 'complete'}}
+        self.data_api_client.find_draft_services_iter.return_value = [
+            {'serviceName': 'draft', 'lotSlug': 'scs', 'status': 'submitted'}
+        ]
+        self.data_api_client.get_supplier.return_value = SupplierStub(
+            company_details_confirmed=False
+        ).single_result_response()
+
+        submissions = self.client.get('/suppliers/frameworks/g-cloud-7/submissions')
+        submissions_html = submissions.get_data(as_text=True)
+
+        assert u'1 service will be submitted' in submissions_html
+        assert u'1 complete service was submitted' not in submissions_html
+        assert u'browse-list-item-status-happy' in submissions_html
+        assert "Your application is not complete" not in submissions_html
+
+    def test_drafts_list_services_were_submitted(self, count_unanswered):
+        self.login()
+
+        self.data_api_client.get_framework.return_value = self.framework(status='standstill')
+        self.data_api_client.get_supplier_declaration.return_value = {'declaration': {'status': 'complete'}}
+        self.data_api_client.find_draft_services_iter.return_value = [
+            {'serviceName': 'draft', 'lotSlug': 'scs', 'status': 'not-submitted'},
+            {'serviceName': 'draft', 'lotSlug': 'scs', 'status': 'submitted'},
+        ]
+
+        submissions = self.client.get('/suppliers/frameworks/g-cloud-7/submissions')
+
+        assert u'1 complete service was submitted' in submissions.get_data(as_text=True)
+
+    def test_dos_drafts_list_with_open_framework(self, count_unanswered):
+        self.login()
+
+        self.data_api_client.get_framework.return_value = self.framework(
+            slug='digital-outcomes-and-specialists',
+            status='open'
+        )
+        self.data_api_client.get_supplier_declaration.return_value = {'declaration': {'status': 'complete'}}
+        self.data_api_client.get_supplier.return_value = SupplierStub().single_result_response()
+        self.data_api_client.find_draft_services_iter.return_value = [
+            {'serviceName': 'draft', 'lotSlug': 'digital-specialists', 'status': 'submitted'}
+        ]
+
+        submissions = self.client.get('/suppliers/frameworks/digital-outcomes-and-specialists/submissions')
+
+        assert u'This will be submitted' in submissions.get_data(as_text=True)
+        assert u'browse-list-item-status-happy' in submissions.get_data(as_text=True)
+        assert u'Apply to provide' in submissions.get_data(as_text=True)
+        assert "Your application is not complete" not in submissions.get_data(as_text=True)
+
+    def test_dos_drafts_list_with_closed_framework(self, count_unanswered):
+        self.login()
+
+        self.data_api_client.get_framework.return_value = self.framework(
+            slug="digital-outcomes-and-specialists",
+            status='pending'
+        )
+        self.data_api_client.get_supplier_declaration.return_value = {'declaration': {'status': 'complete'}}
+        self.data_api_client.find_draft_services_iter.return_value = [
+            {'serviceName': 'draft', 'lotSlug': 'digital-specialists', 'status': 'not-submitted'},
+            {'serviceName': 'draft', 'lotSlug': 'digital-specialists', 'status': 'submitted'},
+        ]
+
+        submissions = self.client.get('/suppliers/frameworks/digital-outcomes-and-specialists/submissions')
+
+        assert submissions.status_code == 200
+        assert u'Submitted' in submissions.get_data(as_text=True)
+        assert u'Apply to provide' not in submissions.get_data(as_text=True)
+
+
+@mock.patch('app.main.views.frameworks.count_unanswered_questions')
 class TestServicesList(BaseApplicationTest, MockEnsureApplicationCompanyDetailsHaveBeenConfirmedMixin):
 
     def setup_method(self, method):
@@ -3964,37 +4166,10 @@ class TestServicesList(BaseApplicationTest, MockEnsureApplicationCompanyDetailsH
             {'serviceName': 'draft', 'lotSlug': 'scs', 'status': 'not-submitted'}
         ]
 
-        submissions = self.client.get('/suppliers/frameworks/g-cloud-7/submissions')
         lot_page = self.client.get('/suppliers/frameworks/g-cloud-7/submissions/scs')
 
         assert u'Service can be moved to complete' not in lot_page.get_data(as_text=True)
         assert u'4 unanswered questions' in lot_page.get_data(as_text=True)
-
-        assert u'1 draft service' in submissions.get_data(as_text=True)
-        assert u'complete service' not in submissions.get_data(as_text=True)
-
-    @pytest.mark.parametrize('framework_slug, show_service_data', (
-        ('digital-outcomes-and-specialists-2', 0),
-        ('g-cloud-9', 1),
-    ))
-    def test_submission_lots_page_shows_use_of_service_data_if_g_cloud_family(
-        self, count_unanswered, framework_slug, show_service_data
-    ):
-        self.login()
-        self.data_api_client.get_framework.return_value = self.framework(slug=framework_slug, status="open")
-        self.data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
-            framework_slug=framework_slug
-        )
-
-        res = self.client.get(f"/suppliers/frameworks/{framework_slug}/submissions")
-        assert res.status_code == 200
-
-        doc = html.fromstring(res.get_data(as_text=True))
-        use_of_data = doc.xpath('//div[contains(@class, "use-of-service-data")]')
-        assert len(use_of_data) == show_service_data
-
-        if show_service_data:
-            assert 'The service information you provide here:' in use_of_data[0].text_content()
 
     def test_drafts_list_can_be_completed(self, count_unanswered):
         self.login()
@@ -4032,136 +4207,11 @@ class TestServicesList(BaseApplicationTest, MockEnsureApplicationCompanyDetailsH
             company_details_confirmed=False
         ).single_result_response()
 
-        submissions = self.client.get('/suppliers/frameworks/g-cloud-7/submissions')
         lot_page = self.client.get('/suppliers/frameworks/g-cloud-7/submissions/scs')
 
-        submissions_html = submissions.get_data(as_text=True)
         lot_page_html = lot_page.get_data(as_text=True)
-
         assert u'Service can be moved to complete' not in lot_page_html
-
-        assert u'1 service marked as complete' in submissions_html
-        assert u'draft service' not in submissions_html
-
-        self._assert_incomplete_application_banner(submissions_html, decl_item_href=expected_url)
         self._assert_incomplete_application_banner(lot_page_html, decl_item_href=expected_url)
-
-    def test_drafts_list_completed_with_declaration_status(self, count_unanswered):
-        self.login()
-
-        self.data_api_client.get_framework.return_value = self.framework(status='open')
-        self.data_api_client.get_supplier_declaration.return_value = {'declaration': {'status': 'complete'}}
-        self.data_api_client.find_draft_services_iter.return_value = [
-            {'serviceName': 'draft', 'lotSlug': 'scs', 'status': 'submitted'}
-        ]
-        self.data_api_client.get_supplier.return_value = SupplierStub(
-            company_details_confirmed=False
-        ).single_result_response()
-
-        submissions = self.client.get('/suppliers/frameworks/g-cloud-7/submissions')
-        submissions_html = submissions.get_data(as_text=True)
-
-        assert u'1 service will be submitted' in submissions_html
-        assert u'1 complete service was submitted' not in submissions_html
-        assert u'browse-list-item-status-happy' in submissions_html
-
-        self._assert_incomplete_application_banner_not_visible(submissions_html)
-
-    def test_drafts_list_services_were_submitted(self, count_unanswered):
-        self.login()
-
-        self.data_api_client.get_framework.return_value = self.framework(status='standstill')
-        self.data_api_client.get_supplier_declaration.return_value = {'declaration': {'status': 'complete'}}
-        self.data_api_client.find_draft_services_iter.return_value = [
-            {'serviceName': 'draft', 'lotSlug': 'scs', 'status': 'not-submitted'},
-            {'serviceName': 'draft', 'lotSlug': 'scs', 'status': 'submitted'},
-        ]
-
-        submissions = self.client.get('/suppliers/frameworks/g-cloud-7/submissions')
-
-        assert u'1 complete service was submitted' in submissions.get_data(as_text=True)
-
-    def test_dos_drafts_list_with_open_framework(self, count_unanswered):
-        self.login()
-
-        self.data_api_client.get_framework.return_value = self.framework(
-            slug='digital-outcomes-and-specialists',
-            status='open'
-        )
-        self.data_api_client.get_supplier_declaration.return_value = {'declaration': {'status': 'complete'}}
-        self.data_api_client.get_supplier.return_value = SupplierStub().single_result_response()
-        self.data_api_client.find_draft_services_iter.return_value = [
-            {'serviceName': 'draft', 'lotSlug': 'digital-specialists', 'status': 'submitted'}
-        ]
-
-        submissions = self.client.get('/suppliers/frameworks/digital-outcomes-and-specialists/submissions')
-
-        assert u'This will be submitted' in submissions.get_data(as_text=True)
-        assert u'browse-list-item-status-happy' in submissions.get_data(as_text=True)
-        assert u'Apply to provide' in submissions.get_data(as_text=True)
-
-        self._assert_incomplete_application_banner_not_visible(submissions.get_data(as_text=True))
-
-    def test_dos_drafts_list_with_closed_framework(self, count_unanswered):
-        self.login()
-
-        self.data_api_client.get_framework.return_value = self.framework(
-            slug="digital-outcomes-and-specialists",
-            status='pending'
-        )
-        self.data_api_client.get_supplier_declaration.return_value = {'declaration': {'status': 'complete'}}
-        self.data_api_client.find_draft_services_iter.return_value = [
-            {'serviceName': 'draft', 'lotSlug': 'digital-specialists', 'status': 'not-submitted'},
-            {'serviceName': 'draft', 'lotSlug': 'digital-specialists', 'status': 'submitted'},
-        ]
-
-        submissions = self.client.get('/suppliers/frameworks/digital-outcomes-and-specialists/submissions')
-
-        assert submissions.status_code == 200
-        assert u'Submitted' in submissions.get_data(as_text=True)
-        assert u'Apply to provide' not in submissions.get_data(as_text=True)
-
-    @pytest.mark.parametrize('declaration,'
-                             'should_show_declaration_link,'
-                             'declaration_link_url',
-                             (
-                                 ({'declaration': {}},
-                                  True, '/suppliers/frameworks/g-cloud-7/declaration/start'),
-                                 ({'declaration': {'status': 'started'}},
-                                  True, '/suppliers/frameworks/g-cloud-7/declaration'),
-                                 ({'declaration': {}},
-                                  True, '/suppliers/frameworks/g-cloud-7/declaration/start'),
-                                 ({'declaration': {'status': 'started'}},
-                                  True, '/suppliers/frameworks/g-cloud-7/declaration'),
-                                 ({'declaration': {'status': 'complete'}},
-                                  False, None),
-                                 ({'declaration': {'status': 'complete'}},
-                                  False, None),
-                             ))
-    def test_banner_on_service_pages_shows_link_to_declaration(self,
-                                                               count_unanswered,
-                                                               declaration,
-                                                               should_show_declaration_link,
-                                                               declaration_link_url):
-        self.login()
-
-        self.data_api_client.get_framework.return_value = self.framework(status='open')
-        self.data_api_client.get_supplier.return_value = SupplierStub().single_result_response()
-        self.data_api_client.get_supplier_declaration.return_value = declaration
-        self.data_api_client.find_draft_services_iter.return_value = [
-            {'serviceName': 'draft', 'lotSlug': 'scs', 'status': 'submitted'}
-        ]
-
-        submissions = self.client.get('/suppliers/frameworks/g-cloud-7/submissions')
-
-        if should_show_declaration_link:
-            self._assert_incomplete_application_banner(
-                submissions.get_data(as_text=True),
-                decl_item_href=declaration_link_url
-            )
-
-        else:
-            self._assert_incomplete_application_banner_not_visible(submissions.get_data(as_text=True))
 
     @pytest.mark.parametrize(
         ('copied', 'link_shown'),

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -837,6 +837,63 @@ class TestFrameworksDashboardPendingStandstill(BaseApplicationTest):
             ),
         )
 
+    def test_dashboard_pending_before_award_no_declaration(self, s3):
+        self.login()
+
+        self.data_api_client.get_framework.return_value = self.framework(status='pending')
+        self.data_api_client.find_draft_services_iter.return_value = [
+            {'serviceName': 'A service', 'status': 'submitted', 'lotSlug': 'iaas'}
+        ]
+        self.data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
+            declaration={}
+        )
+
+        res = self.client.get("/suppliers/frameworks/g-cloud-7")
+        assert res.status_code == 200
+
+        doc = html.fromstring(res.get_data(as_text=True))
+        assert doc.xpath(
+            "//main//p[contains(normalize-space(string()), $declaration_text)]",
+            declaration_text="You did not make a supplier declaration",
+        )
+        assert doc.xpath(
+            "//main//a[@href=$href or normalize-space(string())=$label]",
+            href="/frameworks/g-cloud-7/submissions",
+            label="View draft services",
+        )
+
+    @pytest.mark.parametrize('declaration_status', ('started', 'complete'))
+    def test_dashboard_pending_before_award_with_declaration(self, s3, declaration_status):
+        self.login()
+
+        self.data_api_client.get_framework.return_value = self.framework(status='pending')
+        self.data_api_client.find_draft_services_iter.return_value = [
+            {'serviceName': 'A service', 'status': 'submitted', 'lotSlug': 'iaas'}
+        ]
+        self.data_api_client.get_supplier_framework_info.return_value = self.supplier_framework(
+            declaration={'status': declaration_status}
+        )
+
+        res = self.client.get("/suppliers/frameworks/g-cloud-7")
+
+        doc = html.fromstring(res.get_data(as_text=True))
+
+        assert doc.xpath(
+            "//main//a[@href=$href or normalize-space(string())=$label]",
+            href="/frameworks/g-cloud-7/declaration",
+            label="View your declaration",
+        )
+        if declaration_status == 'complete':
+            assert doc.xpath(
+                "//main//p[contains(normalize-space(string()), $declaration_text)]",
+                declaration_text="You made your supplier declaration",
+            )
+            assert doc.xpath(
+                "//main//a[@href=$href or normalize-space(string())=$label]",
+                href="/frameworks/g-cloud-7/submissions",
+                label="View submitted services",
+            )
+
     def test_result_letter_is_shown_when_is_in_standstill(self, s3):
         self.login()
 


### PR DESCRIPTION
https://trello.com/c/PbSiUZeG/1800-allow-g12-suppliers-to-view-incomplete-applications-post-deadline

Makes changes to three views in the framework application process:
- Framework dashboard (summary of application)
- Framework submission lots (summary of services on all lots)
- Framework submission services (list of submitted/unsubmitted services for a lot)

Suppliers who completed an application can already view the details of what they submitted (declaration and services).

These changes allow suppliers who did not complete an application to view details of their partial application.

On the framework dashboard:
- Add links to services (if any have been created)
- Add links to declaration (if started)
- Display appropriate content if either services or declaration are not available

On the submission lots and submission services pages:
- allow suppliers with incomplete applications to view the pages (currently these 404)
- hide warning messages, as the application can no longer be edited
- change content to 'completed services' instead of 'submitted services' if application not fully complete
- add underline to lot links so it's more obvious that it's a link

Also adds/tidies tests.