### PR TITLE
Improve framework dashboard load time for local envs

### DIFF
--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -163,7 +163,8 @@ def framework_dashboard(framework_slug):
             supplier_framework_info['agreementPath']
         )
 
-    key_list = s3.S3(current_app.config['DM_COMMUNICATIONS_BUCKET']).list(framework_slug, load_timestamps=True)
+    communications_folder = "{}/communications".format(framework_slug)
+    key_list = s3.S3(current_app.config['DM_COMMUNICATIONS_BUCKET']).list(communications_folder, load_timestamps=True)
     key_list.reverse()
 
     base_communications_files = {

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -353,6 +353,9 @@ class TestFrameworksDashboardOpenApplications(BaseApplicationTest):
             "//main//table[normalize-space(string(./caption))=$b]",
             b="Agreement details",
         )
+        assert s3.return_value.list.call_args_list == [
+            mock.call("g-cloud-7/communications", load_timestamps=True)
+        ]
 
     def test_downloads_shown_open_framework_clarification_questions_closed(self, s3):
         files = [
@@ -438,6 +441,10 @@ class TestFrameworksDashboardOpenApplications(BaseApplicationTest):
         assert not doc.xpath("//main[contains(normalize-space(string()), $a)]",
                              a="until 5pm BST, Tuesday 22 September 2015")
         assert not doc.xpath("//main//table[normalize-space(string(./caption))=$b]", b="Agreement details")
+
+        assert s3.return_value.list.call_args_list == [
+            mock.call("g-cloud-7/communications", load_timestamps=True)
+        ]
 
     def test_final_agreement_download_shown_open_framework(self, s3):
         files = [


### PR DESCRIPTION
On the supplier's framework dashboard, in order to show the 'last updated' dates on the framework legal documents, we traverse the entire framework directory in the S3 comms bucket. 

For local developers, this means *everything* in the dev-uploads bucket is parsed, which could be hundreds of documents (from functional tests). The longer the framework runs, the more documents will be in the bucket, and the slower it will get.

This PR narrows down the scope to just the communications folder (legal docs and clarification updates), which should be a fixed number of files throughout the lifetime of the framework.

This change won't affect Preview/Staging/Production as submission documents go to a separate bucket. There are potential improvements to be made here too, but they're more involved.

Local testing improved page load times from ~30s to ~2s.

