### PR TITLE
add secrets baseline

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,0 +1,120 @@
+{
+  "exclude": {
+    "files": "package-lock.json",
+    "lines": null
+  },
+  "generated_at": "2020-08-20T10:45:38Z",
+  "plugins_used": [
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "base64_limit": 4.5,
+      "name": "Base64HighEntropyString"
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "hex_limit": 3,
+      "name": "HexHighEntropyString"
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "keyword_exclude": null,
+      "name": "KeywordDetector"
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "results": {
+    "config.py": [
+      {
+        "hashed_secret": "6ece33acdf8a843e90915a2b661ab55941348059",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 146,
+        "type": "Secret Keyword"
+      },
+      {
+        "hashed_secret": "e9dcc6d93c625c72f0c2e7197e80fe49760d5c75",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 150,
+        "type": "Secret Keyword"
+      }
+    ],
+    "tests/app/main/test_frameworks.py": [
+      {
+        "hashed_secret": "6955d0539c7ae97361ab63d21bc2bb730edbce7a",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 3903,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "5b10c4aa69a96ad5a1a11ff1add1a37cdc71fb20",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 3919,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "b818bf7ee968a5c29d4436a8243c223576f1d75a",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 3920,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "e5223482a22578724452e2315f44d0bc5fc457a3",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 5427,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "82cae5b1d77db4d964804f85ef2c818c6bec2614",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 5452,
+        "type": "Base64 High Entropy String"
+      }
+    ]
+  },
+  "version": "0.13.1",
+  "word_list": {
+    "file": null,
+    "hash": null
+  }
+}


### PR DESCRIPTION
Adds secrets baseline as per
https://github.com/alphagov/gds-pre-commit/
https://trello.com/c/jbk1Il5K/1851-install-gds-pre-commit-and-commit-secretsbaseline-to-repos

## Notes on setup.

 I was initially getting some weird behaviour where `detect-secrets` would not work if virtualenv was enabled. Or the global `detect-secrets` did not produce the file in the same format expected by the pre-commit hook. To workaround this I ran:
`pip3 install detect-secrets==0.13.1` as suggested by @heathd. 
this installs the same version used by the pre-commit hook into pyenv environment.
When generating the baseline I used
`detect-secrets scan --exclude-files package-lock.json > .secrets.baseline`
this avoids many false positives associated with package integrity hashes.
