### PR TITLE
Prevent Chrome autofilling company name

### DIFF
--- a/app/templates/suppliers/create_company_details.html
+++ b/app/templates/suppliers/create_company_details.html
@@ -47,6 +47,7 @@
             question = "Company name",
             name = "company_name",
             value = form.company_name.data,
+            autocomplete = "new-supplier-organisation",
             error = errors.get("company_name", {}).get("message", None),
             hint = "This is how buyers will see your company’s name on the Digital&nbsp;Marketplace"|safe
         %}


### PR DESCRIPTION
https://trello.com/c/XGSVuDnG/

We need to explicitly disable autocomplete for this field - Chrome appears to be inferring that this is a Title field because the following field is Contact Name.

[Chrome does not support `autocomplete="off"`](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete) so I've gone for a dummy value instead.