### PR TITLE
Add tests for legal text

### DIFF
--- a/app/templates/frameworks/_framework_agreement_legal_text_g-cloud-12.html
+++ b/app/templates/frameworks/_framework_agreement_legal_text_g-cloud-12.html
@@ -15,7 +15,7 @@
 
 
 <p>
-    registered address: {{ [company_details.address.get('street_address_line_1'), company_details.address.get('locality'), company_details.address.get('postcode'), company_details.address.get('country')|sub_country_codes] | join(', ') }}
+    registered address: {{ [company_details.address.get('street_address_line_1'), company_details.address.get('locality'), company_details.address.get('postcode')] | join(', ') }}
 </p>
 
 

--- a/app/templates/frameworks/_framework_agreement_legal_text_g-cloud-12.html
+++ b/app/templates/frameworks/_framework_agreement_legal_text_g-cloud-12.html
@@ -15,7 +15,7 @@
 
 
 <p>
-    registered address: {{ [company_details.address.get('street_address_line_1'), company_details.address.get('locality'), company_details.address.get('postcode')] | join(', ') }}
+    registered address: {{ [company_details.address.get('street_address_line_1'), company_details.address.get('locality'), company_details.address.get('postcode'), company_details.address.get('country')|sub_country_codes] | join(', ') }}
 </p>
 
 

--- a/app/templates/frameworks/sign_framework_agreement.html
+++ b/app/templates/frameworks/sign_framework_agreement.html
@@ -31,10 +31,10 @@
     {% include 'toolkit/forms/validation.html' %}
     <span class="govuk-caption-xl">{{ framework.name }} {{ contract_title }}</span>
     <h1 class="govuk-heading-xl">Supplier appointment terms</h1>
-    {% with company_details=company_details %}
         <p class="govuk-!-font-weight-bold">
             If any of the information about your company is incorrect contact <a href="mailto:cloud_digital@crowncommercial.gov.uk">cloud_digital@crowncommercial.gov.uk</a> before signing.
         </p>
+    {% with company_details=company_details %}
         {% include "frameworks/_framework_agreement_legal_text_{0}.html".format(framework_slug) %}
         <p class="govuk-clearfix">
             <a href="{{ framework_pdf_url }}">

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -6004,7 +6004,6 @@ class TestSignFrameworkAgreement(BaseApplicationTest):
 
         self.data_api_client.get_supplier.return_value = {'suppliers': {'registeredName': 'Acme Company',
                                                                         'companiesHouseNumber': '87654321',
-                                                                        'registrationCountry': 'country:GB',
                                                                         'contactInformation':
                                                                             [{'address1': '10 Downing Street',
                                                                               'city': 'London',
@@ -6017,4 +6016,4 @@ class TestSignFrameworkAgreement(BaseApplicationTest):
         assert "Cloud hosting, Cloud software, Cloud support" in text
         assert "Acme Company" in text
         assert "87654321" in text
-        assert "10 Downing Street, London, SW1A 2AA, United Kingdom" in text
+        assert "10 Downing Street, London, SW1A 2AA" in text

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -6004,6 +6004,7 @@ class TestSignFrameworkAgreement(BaseApplicationTest):
 
         self.data_api_client.get_supplier.return_value = {'suppliers': {'registeredName': 'Acme Company',
                                                                         'companiesHouseNumber': '87654321',
+                                                                        'registrationCountry': 'country:GB',
                                                                         'contactInformation':
                                                                             [{'address1': '10 Downing Street',
                                                                               'city': 'London',
@@ -6016,4 +6017,4 @@ class TestSignFrameworkAgreement(BaseApplicationTest):
         assert "Cloud hosting, Cloud software, Cloud support" in text
         assert "Acme Company" in text
         assert "87654321" in text
-        assert "10 Downing Street, London, SW1A 2AA" in text
+        assert "10 Downing Street, London, SW1A 2AA, United Kingdom" in text


### PR DESCRIPTION
Follow-up after #1239

adds test for legal text.

Thought it better to add these as unit tests than adding to https://github.com/alphagov/digitalmarketplace-functional-tests/pull/788
