### PR TITLE
Add link to framework documents to pending services card

### DIFF
--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -73,6 +73,7 @@ $govuk-global-styles: true;
 @import "overrides/_notifications_banner";
 @import "overrides/_temporary-messages";
 @import "overrides/_task-list";
+@import "overrides/_pending-services-table";
 
 // Misc styles
 .authorisation-form-wrapper {

--- a/app/assets/scss/overrides/_pending-services-table.scss
+++ b/app/assets/scss/overrides/_pending-services-table.scss
@@ -1,0 +1,29 @@
+// Expand borders of summary table incomplete rows to fill the whole row, rather than just the text span
+
+.pending-services-table {
+  table {
+    border-collapse: separate;
+    border-spacing: 0 5px;
+    border-top: 1px solid $govuk-border-colour;
+    border-bottom: 1px solid $govuk-border-colour;
+    thead {
+      @include govuk-visually-hidden;
+    }
+    .summary-item-row-incomplete .summary-item-field-first {
+      border-left: 3px solid $govuk-error-colour;
+    }
+    .summary-item-row-incomplete .summary-item-field-first span {
+      border-left: none;
+    }
+    tbody::before {
+      height: 0px;
+      display: table-row;
+      content: ''
+    }
+    tbody::after {
+      height: 4px;
+      display: table-row;
+      content: '';
+    }
+  }
+}

--- a/app/templates/suppliers/_frameworks_standstill.html
+++ b/app/templates/suppliers/_frameworks_standstill.html
@@ -27,8 +27,13 @@
           <p class="govuk-body">
             {{ framework.complete_drafts_count }} service{{ 's' if framework.complete_drafts_count != 1 }} {{ 'submitted' if not framework.onFramework }}
           </p>
+          <p class="govuk-body">
+          <a class="govuk-link" href="{{ url_for('.framework_dashboard', framework_slug=framework.slug) }}">
+            View your services
+          </a>
+          </p>
           {% if framework.needs_to_complete_declaration %}
-            <p class="second-line">
+            <p class="govuk-body">
             {% set sign_agreement_route = url_for('.legal_authority', framework_slug=framework.slug) if framework.is_e_signature_supported else url_for('.framework_agreement', framework_slug=framework.slug) %}
               <a class="govuk-link" href="{{ sign_agreement_route }}">
                 You must sign the framework agreement to sell these services
@@ -36,12 +41,6 @@
             </p>
           {% endif %}
         {% endcall %}
-        {% if not framework.needs_to_complete_declaration %}
-          {{ summary.edit_link('View your documents', url_for('.framework_dashboard', framework_slug=framework.slug)) }}
-        {% else %}
-          {% call summary.field() %}
-          {% endcall %}
-        {% endif %}
       {% endcall %}
     {% endcall %}
   </div>

--- a/tests/app/main/test_suppliers.py
+++ b/tests/app/main/test_suppliers.py
@@ -502,7 +502,7 @@ class TestSuppliersDashboard(BaseApplicationTest):
         assert u"Live from Monday 23 November 2015" not in first_row
         assert u"99 services submitted" in first_row
         assert u"You must sign the framework agreement to sell these services" not in first_row
-        assert u"View your documents" in first_row
+        assert u"View your services" in first_row
 
     def test_shows_gcloud_7_in_standstill_application_passed(self):
         self.data_api_client.get_supplier.side_effect = get_supplier


### PR DESCRIPTION
https://trello.com/c/xGMqeI71/1895-ccsrequests-g-cloud-12-service-visibility-query

We want suppliers to be able to see their framework documents before signing. This commit changes the card so that there is always a "view your documents" link.

### Screenshots

#### After

<img width="665" alt="Screenshot 2020-09-18 at 09 34 37" src="https://user-images.githubusercontent.com/503614/93575960-305a7f00-f992-11ea-980b-9a54d95088e7.png">

#### Before

<img width="653" alt="Screenshot 2020-09-15 at 15 57 26" src="https://user-images.githubusercontent.com/503614/93572125-4ade2980-f98d-11ea-93b7-1bc1b870211f.png">
