### PR TITLE
Make task buttons resemble the design system

### DIFF
--- a/app/assets/scss/overrides/_task-list.scss
+++ b/app/assets/scss/overrides/_task-list.scss
@@ -1,6 +1,5 @@
 // TODO: Remove when task lists incorporated into digitalmarketplace-govuk-frontend
 
-$indicator-colour: $black;
 
 %dm-task-list-indicator {
   @include bold-16;
@@ -10,7 +9,6 @@ $indicator-colour: $black;
   right: 0;
   top: $gutter - 2px;
   margin-top: -15px;
-  border: 2px solid $indicator-colour;
   pointer-events: none;
   z-index: 2;
   min-width: 20%;
@@ -62,7 +60,7 @@ $indicator-colour: $black;
 
   &-indicator-completed {
     @extend %dm-task-list-indicator;
-    background-color: $indicator-colour;
+    background-color: govuk-shade(govuk-colour("blue"), 30);
     color: $grey-4;
     // Just a pinch of letter spacing to make reversed-out text a bit
     // easier to read
@@ -71,8 +69,14 @@ $indicator-colour: $black;
 
   &-indicator-not-completed {
     @extend %dm-task-list-indicator;
-    background-color: $white;
-    color: $indicator-colour;
+    background-color: govuk-tint(govuk-colour("blue"), 80);
+    color: govuk-shade(govuk-colour("blue"), 30);
+  }
+
+  &-indicator-todo {
+    @extend %dm-task-list-indicator;
+    background-color: govuk-tint(govuk-colour("grey-1"), 90);
+    color: $black;
   }
 
 }

--- a/app/templates/frameworks/_framework_actions.html
+++ b/app/templates/frameworks/_framework_actions.html
@@ -55,7 +55,7 @@
         {# Supplier details exist from a previous framework application, but haven't yet been confirmed for this one #}
         <strong class="dm-task-list-indicator-completed" id="dm-companydetails-inprogress">In progress</strong>
       {% else %}
-        <strong class="dm-task-list-indicator-not-completed" id="dm-companydetails-todo">To do</strong>
+        <strong class="dm-task-list-indicator-todo" id="dm-companydetails-todo">To do</strong>
       {% endif %}
     </li>
     <li class="dm-task-list-item">
@@ -71,9 +71,9 @@
         {% endif %}
       </span>
       {% if not application_company_details_confirmed %}
-        <strong class="dm-task-list-indicator-not-completed" id="dm-declaration-cantstart">Can't start yet</strong>
+        <strong class="dm-task-list-indicator-todo" id="dm-declaration-cantstart">Can't start yet</strong>
       {% elif declaration_status == 'unstarted' %}
-        <strong class="dm-task-list-indicator-not-completed" id="dm-declaration-todo">To do</strong>
+        <strong class="dm-task-list-indicator-todo" id="dm-declaration-todo">To do</strong>
       {% elif declaration_status == 'started' %}
         <strong class="dm-task-list-indicator-not-completed" id="dm-declaration-inprogress">In progress</strong>
       {% elif declaration_status == 'complete' %}
@@ -91,9 +91,9 @@
         {% endif %}
       </span>
       {% if not application_company_details_confirmed %}
-        <strong class="dm-task-list-indicator-not-completed" id="dm-services-cantstart">Can't start yet</strong>
+        <strong class="dm-task-list-indicator-todo" id="dm-services-cantstart">Can't start yet</strong>
       {% elif not counts.draft and not counts.complete %}
-        <strong class="dm-task-list-indicator-not-completed" id="dm-services-todo">To do</strong>
+        <strong class="dm-task-list-indicator-todo" id="dm-services-todo">To do</strong>
       {% elif counts.draft %}
         <strong class="dm-task-list-indicator-not-completed" id="dm-services-inprogress">In progress</strong>
       {% else %}


### PR DESCRIPTION
Trello: https://trello.com/c/WlpUAQZe/327-1-update-supplier-fe-content-for-dos5-application-journey

Ultimately, we will migrate over to Design System 3 and use the native task list pages (see https://design-system.service.gov.uk/patterns/task-list-pages/). In the interim, though, update the button colours to make them look more like the design system.

New:

![image](https://user-images.githubusercontent.com/15256121/93874843-e3491680-fccb-11ea-83ae-0ac27aa0c804.png)

Old:

![image](https://user-images.githubusercontent.com/15256121/93875112-4cc92500-fccc-11ea-88ee-745158737f53.png)
