### PR TITLE
Load DOS 5 manifests

### DIFF
--- a/app/main/__init__.py
+++ b/app/main/__init__.py
@@ -79,6 +79,13 @@ def _make_content_loader_factory():
     master_cl.load_messages('g-cloud-12', ['urls', 'advice'])
     master_cl.load_metadata('g-cloud-12', ['copy_services', 'following_framework'])
 
+    master_cl.load_manifest('digital-outcomes-and-specialists-5', 'declaration', 'declaration')
+    master_cl.load_manifest('digital-outcomes-and-specialists-5', 'services', 'edit_submission')
+    master_cl.load_manifest('digital-outcomes-and-specialists-5', 'services', 'edit_service')
+    master_cl.load_manifest('digital-outcomes-and-specialists-5', 'briefs', 'edit_brief')
+    master_cl.load_messages('digital-outcomes-and-specialists-5', ['urls'])
+    master_cl.load_metadata('digital-outcomes-and-specialists-5', ['copy_services', 'following_framework'])
+
     # seal master_cl in a closure by returning a function which will only ever return an independent copy of it
     return lambda: deepcopy(master_cl)
 


### PR DESCRIPTION
Trello: https://trello.com/c/WlpUAQZe/327-1-update-supplier-fe-content-for-dos5-application-journey

This should unblock testing of the DOS 5 content changes.