### PR TITLE
Show services and documents links on dashboard

### DIFF
--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -31,7 +31,7 @@ from ..helpers.frameworks import (
     get_frameworks_by_status,
     get_frameworks_closed_and_open_for_applications,
     get_unconfirmed_open_supplier_frameworks,
-    is_e_signature_supported_framework
+    is_e_signature_supported_framework,
 )
 from ..helpers.suppliers import (
     COUNTRY_TUPLE,
@@ -92,7 +92,7 @@ def dashboard():
             'needs_to_return_agreement': (
                 framework.get('onFramework') and framework.get('agreementReturned') is False
             ),
-            'is_e_signature_supported': is_e_signature_supported_framework(framework['slug'])
+            'is_e_signature_supported': is_e_signature_supported_framework(framework['slug']),
         })
 
     if "currently_applying_to" in session:

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -89,7 +89,7 @@ def dashboard():
                 and framework['declaration'].get('status') == 'complete'
                 and framework.get('complete_drafts_count') > 0
             ),
-            'needs_to_complete_declaration': (
+            'needs_to_return_agreement': (
                 framework.get('onFramework') and framework.get('agreementReturned') is False
             ),
             'is_e_signature_supported': is_e_signature_supported_framework(framework['slug'])

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -108,7 +108,7 @@ def dashboard():
             'open': get_frameworks_by_status(all_frameworks, 'open'),
             'pending': get_frameworks_by_status(all_frameworks, 'pending'),
             'standstill': get_frameworks_by_status(all_frameworks, 'standstill', 'made_application'),
-            'live': get_frameworks_by_status(all_frameworks, 'live', 'services_count'),
+            'live': get_frameworks_by_status(all_frameworks, 'live', 'onFramework'),
             'dos3': [
                 f for f in all_frameworks if f['slug'] == 'digital-outcomes-and-specialists-3' and f.get('onFramework')
             ],

--- a/app/templates/suppliers/_frameworks_live.html
+++ b/app/templates/suppliers/_frameworks_live.html
@@ -1,25 +1,38 @@
 {% for framework in frameworks.dos3 + frameworks.live %}
-{% if framework.onFramework %}
-  <h3 class="heading-xmedium">{{ framework.name }}</h3>
-  <p class="govuk-body">
-  {% if framework.needs_to_complete_declaration %}
-    {% set sign_agreement_route = url_for('.legal_authority', framework_slug=framework.slug) if framework.is_e_signature_supported else url_for('.framework_agreement', framework_slug=framework.slug) %}
-    <a class="govuk-link" href="{{ sign_agreement_route }}">
-      You must sign the framework agreement to sell these services
-    </a>
-  {% else %}
-    {% if framework.framework == 'digital-outcomes-and-specialists' %}
-      <a class="govuk-link" href="{{ url_for('external.opportunities_dashboard', framework_slug=framework.slug) }}">View your opportunities</a><br>
+  {% if framework.onFramework %}
+    <h3 class="heading-xmedium">{{ framework.name }}</h3>
+    {% if framework.needs_to_return_agreement %}
+      {% set sign_agreement_route = url_for('.legal_authority', framework_slug=framework.slug) if framework.is_e_signature_supported else url_for('.framework_agreement', framework_slug=framework.slug) %}
+      <p class="govuk-body">
+        <a class="govuk-link" href="{{ sign_agreement_route }}">
+        You must sign the framework agreement to sell these services
+        </a>
+      </p>
     {% endif %}
-    {% if not framework.slug == 'digital-outcomes-and-specialists-3' %}
-      <a class="govuk-link" href="{{ url_for('.list_services', framework_slug=framework.slug) }}">View services</a><br>
-      <a class="govuk-link" href="{{ url_for('.framework_dashboard', framework_slug=framework.slug) }}">View documents and ask a question</a>
-    {% endif %}
+    <ul class="govuk-list">
+      {% if framework.framework == 'digital-outcomes-and-specialists' %}
+      <li>
+        <a class="govuk-link" href="{{ url_for('external.opportunities_dashboard', framework_slug=framework.slug) }}">
+          View your opportunities
+        </a>
+      </li>
+      {% endif %}
+      {% if not framework.slug == 'digital-outcomes-and-specialists-3' %}
+      <li>
+        <a class="govuk-link" href="{{ url_for('.list_services', framework_slug=framework.slug) }}">
+        View services
+        </a>
+      </li>
+      <li>
+        <a class="govuk-link" href="{{ url_for('.framework_dashboard', framework_slug=framework.slug) }}">
+        View documents
+        </a>
+      </li>
+    </ul>
   {% endif %}
-  </p>
-{% endif %}
 {% else %}
   <p class="govuk-body">
     You don't have any services on the Digital Marketplace
   </p>
+{% endif %}
 {% endfor %}

--- a/app/templates/suppliers/_frameworks_standstill.html
+++ b/app/templates/suppliers/_frameworks_standstill.html
@@ -12,7 +12,7 @@
       ],
       field_headings_visible=False
     ) %}
-      {% call summary.row(complete=not framework.needs_to_complete_declaration) %}
+      {% call summary.row(complete=not framework.needs_to_return_agreement) %}
         {% call summary.field(first=True) %}
           <p class="govuk-body">
             {{ framework.name }}
@@ -32,7 +32,7 @@
             View your services
           </a>
           </p>
-          {% if framework.needs_to_complete_declaration %}
+          {% if framework.needs_to_return_agreement %}
             <p class="govuk-body">
             {% set sign_agreement_route = url_for('.legal_authority', framework_slug=framework.slug) if framework.is_e_signature_supported else url_for('.framework_agreement', framework_slug=framework.slug) %}
               <a class="govuk-link" href="{{ sign_agreement_route }}">

--- a/requirements.in
+++ b/requirements.in
@@ -7,6 +7,6 @@ Flask-WTF==0.14.3
 itsdangerous==1.1.0
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@52.10.0#egg=digitalmarketplace-utils==52.10.0
-git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.3.0#egg=digitalmarketplace-content-loader==7.3.0
+git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.22.0#egg=digitalmarketplace-content-loader==7.22.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.8.0#egg=digitalmarketplace-apiclient==21.8.0
 git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.2-alpha#egg=govuk-frontend-jinja==0.5.2-alpha

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ contextlib2==0.6.0.post1  # via digitalmarketplace-utils
 cryptography==2.3.1       # via digitalmarketplace-utils
 defusedxml==0.6.0         # via odfpy
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.8.0#egg=digitalmarketplace-apiclient==21.8.0  # via -r requirements.in
-git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.3.0#egg=digitalmarketplace-content-loader==7.3.0  # via -r requirements.in
+git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.22.0#egg=digitalmarketplace-content-loader==7.22.0  # via -r requirements.in
 git+https://github.com/alphagov/digitalmarketplace-utils.git@52.10.0#egg=digitalmarketplace-utils==52.10.0  # via -r requirements.in, digitalmarketplace-content-loader
 docopt==0.6.2             # via notifications-python-client
 docutils==0.15.2          # via botocore
@@ -33,7 +33,7 @@ git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.2-alpha#egg=govuk-
 idna==2.9                 # via cryptography, requests
 inflection==0.3.1         # via digitalmarketplace-content-loader
 itsdangerous==1.1.0       # via -r requirements.in, flask, flask-wtf
-jinja2==2.10.3            # via digitalmarketplace-content-loader, flask, govuk-frontend-jinja
+jinja2==2.11.2            # via digitalmarketplace-content-loader, flask, govuk-frontend-jinja
 jmespath==0.9.4           # via boto3, botocore
 mailchimp3==3.0.6         # via digitalmarketplace-utils
 markdown==2.6.11          # via digitalmarketplace-content-loader

--- a/tests/app/main/test_suppliers.py
+++ b/tests/app/main/test_suppliers.py
@@ -249,7 +249,7 @@ class TestSuppliersDashboard(BaseApplicationTest):
                 "//h3[normalize-space(string())=$f]"
                 "/..//a[normalize-space(string())=$t1]",
                 f="Digital Outcomes and Specialists 3",
-                t1="View documents and ask a question",
+                t1="View documents",
             )
         else:
             assert not document.xpath("//h3[normalize-space(string())='Digital Outcomes and Specialists 3']")
@@ -1105,7 +1105,7 @@ class TestSupplierOpportunitiesDashboardLink(BaseApplicationTest):
             u1="/suppliers/opportunities/frameworks/digital-outcomes-and-specialists-4",
             t2="View services",
             u2="/suppliers/frameworks/digital-outcomes-and-specialists-4/services",
-            t3="View documents and ask a question",
+            t3="View documents",
             u3="/suppliers/frameworks/digital-outcomes-and-specialists-4",
         )
 
@@ -1113,7 +1113,6 @@ class TestSupplierOpportunitiesDashboardLink(BaseApplicationTest):
         'incorrect_data',
         (
             {'onFramework': False},
-            {'services_count': 0},
             {'frameworkSlug': 'not-dos'}
         )
     )


### PR DESCRIPTION
https://trello.com/c/ZUgsBovZ/361-2-prep-and-test-buying-journey-for-g12-on-preview

When a framework is live, we want users to be able to view their services and documents, even if they have an agreement signature outstanding.