### PR TITLE
Take latest version of frameworks dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2087,8 +2087,8 @@
       "dev": true
     },
     "digitalmarketplace-frameworks": {
-      "version": "github:alphagov/digitalmarketplace-frameworks#cc761a16132d079e92fa7356e4aa50b6033f6f6c",
-      "from": "github:alphagov/digitalmarketplace-frameworks#v17.12.1"
+      "version": "github:alphagov/digitalmarketplace-frameworks#8f8ade44e099f11288b0a12a094d59ece159fc7d",
+      "from": "github:alphagov/digitalmarketplace-frameworks#v17.16.0"
     },
     "digitalmarketplace-frontend-toolkit": {
       "version": "git+https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#323b3d4b704e33782df6cdae7b105a2a9237a594",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "colors": "1.1.2",
     "del": "^5.1.0",
-    "digitalmarketplace-frameworks": "github:alphagov/digitalmarketplace-frameworks#v17.12.1",
+    "digitalmarketplace-frameworks": "github:alphagov/digitalmarketplace-frameworks#v17.16.0",
     "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v36.1.0",
     "digitalmarketplace-govuk-frontend": "^2.1.0",
     "govuk-country-and-territory-autocomplete": "0.4.0",


### PR DESCRIPTION
Trello: https://trello.com/c/yWkgqyPL/325-2-update-dos5-application-content-in-the-frameworks-repo

This will pull in various bits of DOS 5 content, so we can start testing them in preview.