### PR TITLE
e-signature signing page tweaks

### DIFF
--- a/app/main/forms/frameworks.py
+++ b/app/main/forms/frameworks.py
@@ -120,6 +120,6 @@ class SignFrameworkAgreementForm(FlaskForm):
     signer_terms_and_conditions = DMBooleanField(
         "I accept the terms and conditions of the Framework Agreement",
         validators=[
-            DataRequired(message="You must accept the terms and conditions of the Framework Agreement.")
+            DataRequired(message="Accept the terms and conditions of the Framework Agreement.")
         ]
     )

--- a/app/templates/frameworks/sign_framework_agreement.html
+++ b/app/templates/frameworks/sign_framework_agreement.html
@@ -46,15 +46,18 @@
         </p>
     {% endwith %}
 
-
-    <form method="POST" novalidate action="{{ url_for(".sign_framework_agreement", framework_slug=framework_slug) }}">
-        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
-        {{ form.signerName }}
-        {{ form.signerRole }}
-        {{ form.signer_terms_and_conditions }}
-        {{ govukButton({
-          "text": "Sign agreement"
-        }) }}
-    </form>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <form method="POST" novalidate action="{{ url_for(".sign_framework_agreement", framework_slug=framework_slug) }}">
+                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+                {{ form.signerName }}
+                {{ form.signerRole }}
+                {{ form.signer_terms_and_conditions }}
+                {{ govukButton({
+                  "text": "Sign agreement"
+                }) }}
+            </form>
+        </div>
+    </div>
 {% endblock %}
 

--- a/app/templates/frameworks/sign_framework_agreement.html
+++ b/app/templates/frameworks/sign_framework_agreement.html
@@ -29,6 +29,8 @@
 
 {% block mainContent %}
     {% include 'toolkit/forms/validation.html' %}
+    <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
     <span class="govuk-caption-xl">{{ framework.name }} {{ contract_title }}</span>
     <h1 class="govuk-heading-xl">Supplier appointment terms</h1>
         <p class="govuk-!-font-weight-bold">
@@ -45,9 +47,6 @@
             <span class="govuk-body-s"><abbr title="Portable Document Format">PDF</abbr>, {{ framework_pdf_metadata.file_size }}, {{ framework_pdf_metadata.page_count }} pages</span>
         </p>
     {% endwith %}
-
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
             <form method="POST" novalidate action="{{ url_for(".sign_framework_agreement", framework_slug=framework_slug) }}">
                 <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
                 {{ form.signerName }}
@@ -58,6 +57,6 @@
                 }) }}
             </form>
         </div>
-    </div>
+        </div>
 {% endblock %}
 

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -5929,7 +5929,7 @@ class TestSignFrameworkAgreement(BaseApplicationTest):
         text = res.get_data(as_text=True)
         assert 'Enter your full name.' in text
         assert 'Enter your role in the company.' in text
-        assert 'You must accept the terms and conditions of the Framework Agreement.' in text
+        assert 'Accept the terms and conditions of the Framework Agreement.' in text
 
     def test_post_signs_agreement(self):
         self.data_api_client.create_framework_agreement.return_value = {"agreement": {"id": 789}}


### PR DESCRIPTION
Another couple of fixes from: https://trello.com/c/NutOcwCP/342-2-placeholder-triage-and-fix-e-signature-issues
* Updated error message suggested by @NoraGDS 
* Make form two thirds column
![Screenshot 2020-09-30 at 13 57 39](https://user-images.githubusercontent.com/1764158/94690350-e9707000-0327-11eb-8e82-8d406b9e7d6a.png)
