### PR TITLE
Validate declaration questions for DOS 5

### DIFF
--- a/app/main/helpers/validation.py
+++ b/app/main/helpers/validation.py
@@ -300,6 +300,25 @@ class DOS5Validator(SharedValidator):
     email_validation_fields = {"contactEmailContractNotice", "contactEmail"}
     percentage_fields = ["subcontractingInvoicesPaid"]
 
+    optional_fields = SharedValidator.optional_fields.union({
+        "subcontracting30DayPayments",
+        "subcontractingInvoicesPaid"}
+    )
+
+    def get_required_fields(self):
+        req_fields = super(DOS5Validator, self).get_required_fields()
+
+        # as per subcontracting configuration on digitalmarketplace-frameworks
+        if self.answers.get("subcontracting") in [
+            "as a prime contractor, using third parties (subcontractors) to provide some services",
+            "as part of a consortium or special purpose vehicle, using third parties (subcontractors) to provide some "
+            "services"
+        ]:
+            req_fields.add("subcontracting30DayPayments")
+            req_fields.add("subcontractingInvoicesPaid")
+
+        return req_fields
+
     def formatting_errors(self, answers):
         error_map = super(DOS5Validator, self).formatting_errors(answers)
 

--- a/app/main/helpers/validation.py
+++ b/app/main/helpers/validation.py
@@ -282,33 +282,31 @@ class G12Validator(SharedValidator):
         return errors_map
 
 
+def is_valid_percentage(value):
+    # Design System guidance is that we should allow users to provide answers with or without units.
+    if isinstance(value, str):
+        value = value.rstrip('%')
+
+    try:
+        number = float(value)
+    except ValueError:
+        return False
+    else:
+        return 0 <= number <= 100
+
+
 class DOS5Validator(SharedValidator):
     """Following an accessibility review, a number of questions and answers were changed for DOS 5"""
     email_validation_fields = {"contactEmailContractNotice", "contactEmail"}
     percentage_fields = ["subcontractingInvoicesPaid"]
 
-    def is_valid_percentage(self, field):
-        value = self.answers.get(field)
-
-        # Design System guidance is that we should allow users to provide answers with or without units.
-        if isinstance(value, str):
-            value = value.rstrip('%')
-
-        try:
-            number = float(value)
-        except ValueError:
-            return False
-        else:
-            return 0 <= number <= 100
-
     def formatting_errors(self, answers):
         error_map = super(DOS5Validator, self).formatting_errors(answers)
 
-        error_map.update({
-            field: 'invalid_format'
-            for field in self.percentage_fields
-            if not self.is_valid_percentage(field)
-        })
+        for field in self.percentage_fields:
+            value = self.answers.get(field)
+            if value is not None and not is_valid_percentage(value):
+                error_map[field] = 'invalid_format'
 
         return error_map
 

--- a/app/main/helpers/validation.py
+++ b/app/main/helpers/validation.py
@@ -293,4 +293,5 @@ VALIDATORS = {
     "g-cloud-11": SharedValidator,
     "digital-outcomes-and-specialists-4": SharedValidator,
     "g-cloud-12": G12Validator,
+    "digital-outcomes-and-specialists-5": SharedValidator,
 }

--- a/app/main/helpers/validation.py
+++ b/app/main/helpers/validation.py
@@ -290,6 +290,10 @@ class DOS5Validator(SharedValidator):
     def is_valid_percentage(self, field):
         value = self.answers.get(field)
 
+        # Design System guidance is that we should allow users to provide answers with or without units.
+        if isinstance(value, str):
+            value = value.rstrip('%')
+
         try:
             number = float(value)
         except ValueError:

--- a/app/main/helpers/validation.py
+++ b/app/main/helpers/validation.py
@@ -286,6 +286,22 @@ class DOS5Validator(SharedValidator):
     """Following an accessibility review, a number of questions and answers were changed for DOS 5"""
     email_validation_fields = {"contactEmailContractNotice", "contactEmail"}
 
+    number_fields = [("subcontracting30DayPayments", 0, 100)]
+
+    def formatting_errors(self, answers):
+        error_map = super(DOS5Validator, self).formatting_errors(answers)
+
+        for field, minimum, maximum in self.number_fields:
+            try:
+                number = float(self.answers.get(field))
+            except ValueError:
+                error_map[field] = 'invalid_format'
+            else:
+                if number > maximum or number < minimum:
+                    error_map[field] = 'invalid_format'
+
+        return error_map
+
 
 VALIDATORS = {
     "g-cloud-7": G7Validator,

--- a/app/main/helpers/validation.py
+++ b/app/main/helpers/validation.py
@@ -286,7 +286,7 @@ class DOS5Validator(SharedValidator):
     """Following an accessibility review, a number of questions and answers were changed for DOS 5"""
     email_validation_fields = {"contactEmailContractNotice", "contactEmail"}
 
-    number_fields = [("subcontracting30DayPayments", 0, 100)]
+    number_fields = [("subcontractingInvoicesPaid", 0, 100)]
 
     def formatting_errors(self, answers):
         error_map = super(DOS5Validator, self).formatting_errors(answers)

--- a/app/main/helpers/validation.py
+++ b/app/main/helpers/validation.py
@@ -306,7 +306,7 @@ class DOS5Validator(SharedValidator):
         for field in self.percentage_fields:
             value = self.answers.get(field)
             if value is not None and not is_valid_percentage(value):
-                error_map[field] = 'invalid_format'
+                error_map[field] = 'not_a_number'
 
         return error_map
 

--- a/app/main/helpers/validation.py
+++ b/app/main/helpers/validation.py
@@ -285,20 +285,26 @@ class G12Validator(SharedValidator):
 class DOS5Validator(SharedValidator):
     """Following an accessibility review, a number of questions and answers were changed for DOS 5"""
     email_validation_fields = {"contactEmailContractNotice", "contactEmail"}
+    percentage_fields = ["subcontractingInvoicesPaid"]
 
-    number_fields = [("subcontractingInvoicesPaid", 0, 100)]
+    def is_valid_percentage(self, field):
+        value = self.answers.get(field)
+
+        try:
+            number = float(value)
+        except ValueError:
+            return False
+        else:
+            return 0 <= number <= 100
 
     def formatting_errors(self, answers):
         error_map = super(DOS5Validator, self).formatting_errors(answers)
 
-        for field, minimum, maximum in self.number_fields:
-            try:
-                number = float(self.answers.get(field))
-            except ValueError:
-                error_map[field] = 'invalid_format'
-            else:
-                if number > maximum or number < minimum:
-                    error_map[field] = 'invalid_format'
+        error_map.update({
+            field: 'invalid_format'
+            for field in self.percentage_fields
+            if not self.is_valid_percentage(field)
+        })
 
         return error_map
 

--- a/app/main/helpers/validation.py
+++ b/app/main/helpers/validation.py
@@ -282,6 +282,11 @@ class G12Validator(SharedValidator):
         return errors_map
 
 
+class DOS5Validator(SharedValidator):
+    """Following an accessibility review, a number of questions and answers were changed for DOS 5"""
+    email_validation_fields = {"contactEmailContractNotice", "contactEmail"}
+
+
 VALIDATORS = {
     "g-cloud-7": G7Validator,
     "g-cloud-8": SharedValidator,
@@ -293,5 +298,5 @@ VALIDATORS = {
     "g-cloud-11": SharedValidator,
     "digital-outcomes-and-specialists-4": SharedValidator,
     "g-cloud-12": G12Validator,
-    "digital-outcomes-and-specialists-5": SharedValidator,
+    "digital-outcomes-and-specialists-5": DOS5Validator,
 }

--- a/tests/app/main/helpers/validation/test_dos5_declaration.py
+++ b/tests/app/main/helpers/validation/test_dos5_declaration.py
@@ -49,6 +49,8 @@ def test_invalid_email_addresses_cause_errors(content, submission):
     "0",
     "100",
     "3.14159",
+    "50%",
+    40,
 ])
 def test_subcontracting_payment_percent_is_valid(content, submission, number_field_value):
     submission['subcontractingInvoicesPaid'] = number_field_value

--- a/tests/app/main/helpers/validation/test_dos5_declaration.py
+++ b/tests/app/main/helpers/validation/test_dos5_declaration.py
@@ -19,7 +19,7 @@ def submission():
     dos5["outsideIR35"] = True
     dos5["employmentStatus"] = True
     dos5['contact'] = "Blah"
-    dos5['subcontracting30DayPayments'] = True
+    dos5['subcontracting30DayPayments'] = "100"
     dos5['subcontractingInvoicesPaid'] = True
     dos5['contactEmail'] = 'Blah@example.com'
 
@@ -43,3 +43,23 @@ def test_invalid_email_addresses_cause_errors(content, submission):
         'contactEmail': 'invalid_format',
         'contactEmailContractNotice': 'invalid_format',
     }
+
+
+@pytest.mark.parametrize("number_field_value", [
+    "0",
+    "100",
+    "3.14159",
+])
+def test_subcontracting_payment_percent_is_valid(content, submission, number_field_value):
+    submission['subcontracting30DayPayments'] = number_field_value
+    assert DOS5Validator(content, submission).errors() == {}
+
+
+@pytest.mark.parametrize("number_field_value", [
+    "-42",
+    "1000",
+    "not a number",
+])
+def test_subcontracting_payment_percent_is_invalid(content, submission, number_field_value):
+    submission['subcontracting30DayPayments'] = number_field_value
+    assert DOS5Validator(content, submission).errors() == {'subcontracting30DayPayments': 'invalid_format'}

--- a/tests/app/main/helpers/validation/test_dos5_declaration.py
+++ b/tests/app/main/helpers/validation/test_dos5_declaration.py
@@ -19,6 +19,7 @@ def submission():
     dos5["outsideIR35"] = True
     dos5["employmentStatus"] = True
     dos5['contact'] = "Blah"
+    dos5['subcontracting'] = 'as a prime contractor, using third parties (subcontractors) to provide some services'
     dos5['subcontracting30DayPayments'] = True
     dos5['subcontractingInvoicesPaid'] = "100"
     dos5['contactEmail'] = 'Blah@example.com'
@@ -67,6 +68,17 @@ def test_subcontracting_payment_percent_is_invalid(content, submission, number_f
     assert DOS5Validator(content, submission).errors() == {'subcontractingInvoicesPaid': 'not_a_number'}
 
 
-def test_subcontracting_payment_fails_when_absent(content, submission):
+def test_subcontracting_payment_fails_when_absent_and_required(content, submission):
+    submission['subcontracting30DayPayments'] = None
     submission['subcontractingInvoicesPaid'] = None
-    assert DOS5Validator(content, submission).errors() == {'subcontractingInvoicesPaid': 'answer_required'}
+    assert DOS5Validator(content, submission).errors() == {
+        'subcontractingInvoicesPaid': 'answer_required',
+        'subcontracting30DayPayments': 'answer_required'
+    }
+
+
+def test_subcontracting_payment_passes_when_absent_and_not_required(content, submission):
+    submission['subcontracting'] = 'yourself without the use of third parties (subcontractors)'
+    submission['subcontracting30DayPayments'] = None
+    submission['subcontractingInvoicesPaid'] = None
+    assert DOS5Validator(content, submission).errors() == {}

--- a/tests/app/main/helpers/validation/test_dos5_declaration.py
+++ b/tests/app/main/helpers/validation/test_dos5_declaration.py
@@ -19,8 +19,8 @@ def submission():
     dos5["outsideIR35"] = True
     dos5["employmentStatus"] = True
     dos5['contact'] = "Blah"
-    dos5['subcontracting30DayPayments'] = "100"
-    dos5['subcontractingInvoicesPaid'] = True
+    dos5['subcontracting30DayPayments'] = True
+    dos5['subcontractingInvoicesPaid'] = "100"
     dos5['contactEmail'] = 'Blah@example.com'
 
     return dos5
@@ -51,7 +51,7 @@ def test_invalid_email_addresses_cause_errors(content, submission):
     "3.14159",
 ])
 def test_subcontracting_payment_percent_is_valid(content, submission, number_field_value):
-    submission['subcontracting30DayPayments'] = number_field_value
+    submission['subcontractingInvoicesPaid'] = number_field_value
     assert DOS5Validator(content, submission).errors() == {}
 
 
@@ -61,5 +61,5 @@ def test_subcontracting_payment_percent_is_valid(content, submission, number_fie
     "not a number",
 ])
 def test_subcontracting_payment_percent_is_invalid(content, submission, number_field_value):
-    submission['subcontracting30DayPayments'] = number_field_value
-    assert DOS5Validator(content, submission).errors() == {'subcontracting30DayPayments': 'invalid_format'}
+    submission['subcontractingInvoicesPaid'] = number_field_value
+    assert DOS5Validator(content, submission).errors() == {'subcontractingInvoicesPaid': 'invalid_format'}

--- a/tests/app/main/helpers/validation/test_dos5_declaration.py
+++ b/tests/app/main/helpers/validation/test_dos5_declaration.py
@@ -65,3 +65,8 @@ def test_subcontracting_payment_percent_is_valid(content, submission, number_fie
 def test_subcontracting_payment_percent_is_invalid(content, submission, number_field_value):
     submission['subcontractingInvoicesPaid'] = number_field_value
     assert DOS5Validator(content, submission).errors() == {'subcontractingInvoicesPaid': 'invalid_format'}
+
+
+def test_subcontracting_payment_fails_when_absent(content, submission):
+    submission['subcontractingInvoicesPaid'] = None
+    assert DOS5Validator(content, submission).errors() == {'subcontractingInvoicesPaid': 'answer_required'}

--- a/tests/app/main/helpers/validation/test_dos5_declaration.py
+++ b/tests/app/main/helpers/validation/test_dos5_declaration.py
@@ -64,7 +64,7 @@ def test_subcontracting_payment_percent_is_valid(content, submission, number_fie
 ])
 def test_subcontracting_payment_percent_is_invalid(content, submission, number_field_value):
     submission['subcontractingInvoicesPaid'] = number_field_value
-    assert DOS5Validator(content, submission).errors() == {'subcontractingInvoicesPaid': 'invalid_format'}
+    assert DOS5Validator(content, submission).errors() == {'subcontractingInvoicesPaid': 'not_a_number'}
 
 
 def test_subcontracting_payment_fails_when_absent(content, submission):

--- a/tests/app/main/helpers/validation/test_dos5_declaration.py
+++ b/tests/app/main/helpers/validation/test_dos5_declaration.py
@@ -1,0 +1,45 @@
+from app.main.helpers.validation import DOS5Validator
+from app.main import content_loader
+from .test_dos_declaration import FULL_DOS_SUBMISSION
+import pytest
+
+
+@pytest.fixture
+def submission():
+    dos5 = FULL_DOS_SUBMISSION.copy()
+
+    dos5["mitigatingFactors3"] = ""
+    dos5["modernSlaveryTurnover"] = True
+    dos5["modernSlaveryReportingRequirements"] = True
+    dos5["modernSlaveryStatement"] = "/path/to/document"
+    dos5["dunsNumber"] = "123456789"
+    dos5["conspiracy"] = False
+    dos5["corruptionBribery"] = False
+    dos5["helpBuyersComplyTechnologyCodesOfPractice"] = True
+    dos5["outsideIR35"] = True
+    dos5["employmentStatus"] = True
+    dos5['contact'] = "Blah"
+    dos5['subcontracting30DayPayments'] = True
+    dos5['subcontractingInvoicesPaid'] = True
+    dos5['contactEmail'] = 'Blah@example.com'
+
+    return dos5
+
+
+@pytest.fixture
+def content():
+    return content_loader.get_builder('digital-outcomes-and-specialists-5', 'declaration')
+
+
+def test_no_error_if_correct(content, submission):
+    assert DOS5Validator(content, submission).errors() == {}
+
+
+def test_invalid_email_addresses_cause_errors(content, submission):
+    submission['contactEmail'] = 'not an email'
+    submission['contactEmailContractNotice'] = "not an email"
+
+    assert DOS5Validator(content, submission).errors() == {
+        'contactEmail': 'invalid_format',
+        'contactEmailContractNotice': 'invalid_format',
+    }


### PR DESCRIPTION
Trello: https://trello.com/c/Oqg9AUup/328-3-update-conditional-logic-for-declaration-question-q53-for-dos5

For DOS 5, we've renamed `primaryContactEmail` to `contactEmail`. Add a new validator for DOS 5 (+?) to handle this renamed field.

Also add validation for the new percent question - it's a number between 0 and 100. We need a new validator because the existing one used for the DUNS number validates numbers with a fixed length, which is not right for a percentage.