### PR TITLE
add intellij flask run configuration

### DIFF
--- a/.idea/runConfigurations/Flask__application_py_.xml
+++ b/.idea/runConfigurations/Flask__application_py_.xml
@@ -1,0 +1,18 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Flask (application.py)" type="Python.FlaskServer" nameIsGenerated="true">
+    <option name="flaskDebug" value="true" />
+    <module name="digitalmarketplace-supplier-frontend" />
+    <option name="target" value="$PROJECT_DIR$/application.py" />
+    <option name="targetType" value="PATH" />
+    <option name="INTERPRETER_OPTIONS" value="" />
+    <option name="PARENT_ENVS" value="true" />
+    <option name="SDK_HOME" value="$PROJECT_DIR$/venv/bin/python" />
+    <option name="WORKING_DIRECTORY" value="" />
+    <option name="IS_MODULE_SDK" value="false" />
+    <option name="ADD_CONTENT_ROOTS" value="true" />
+    <option name="ADD_SOURCE_ROOTS" value="true" />
+    <EXTENSION ID="PythonCoverageRunConfigurationExtension" runner="coverage.py" />
+    <option name="launchJavascriptDebuger" value="false" />
+    <method v="2" />
+  </configuration>
+</component>


### PR DESCRIPTION
https://trello.com/c/fwLv6sMf/61-work-out-and-document-how-to-attach-dmp-apps-to-an-ide-debugger

This adds a run configuration using the [Share configurations](https://www.jetbrains.com/help/idea/run-debug-configuration.html#share-configurations) feature of IntelliJ.

## How to use
* Before using this ensure the `dmrunner` process has been killed: from `dmrunner` do `k supplier-frontend`
* Open the project in IntelliJ you should see a Run configuration called _Flask (application.py)_ which you should be able to Run or Debug.

## Known issues
* Credentials are not injected so any route relying on credentials currently fails

## Questions
* Does this work in Pycharm?
* Does this work in the free versions of IntelliJ or Pycharm? (I think it may not as it uses a premium plugin, but not sure?)