### PR TITLE
Add DM_S3_ENDPOINT_URL to Development config

### DIFF
--- a/config.py
+++ b/config.py
@@ -137,11 +137,20 @@ class Development(Config):
     DM_DATA_API_AUTH_TOKEN = "myToken"
     DM_API_AUTH_TOKEN = "myToken"
 
+    DM_S3_ENDPOINT_URL = (  # use envvars to set this, defaults to using AWS
+        f"http://localhost:{os.environ['DM_S3_ENDPOINT_PORT']}"
+        if os.getenv("DM_S3_ENDPOINT_PORT") else None
+    )
+
     DM_SUBMISSIONS_BUCKET = "digitalmarketplace-dev-uploads"
     DM_COMMUNICATIONS_BUCKET = "digitalmarketplace-dev-uploads"
     DM_AGREEMENTS_BUCKET = "digitalmarketplace-dev-uploads"
     DM_DOCUMENTS_BUCKET = "digitalmarketplace-dev-uploads"
-    DM_ASSETS_URL = "https://{}.s3-eu-west-1.amazonaws.com".format(DM_SUBMISSIONS_BUCKET)
+    DM_ASSETS_URL = (
+        f"{DM_S3_ENDPOINT_URL}"
+        if DM_S3_ENDPOINT_URL else
+        f"https://{DM_SUBMISSIONS_BUCKET}.s3-eu-west-1.amazonaws.com"
+    )
 
     DM_NOTIFY_API_KEY = "not_a_real_key-00000000-fake-uuid-0000-000000000000"
 

--- a/requirements.in
+++ b/requirements.in
@@ -6,7 +6,7 @@ Flask-Login==0.5.0
 Flask-WTF==0.14.3
 itsdangerous==1.1.0
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@54.0.0#egg=digitalmarketplace-utils==54.0.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@54.1.0#egg=digitalmarketplace-utils==54.1.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.25.0#egg=digitalmarketplace-content-loader==7.25.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.8.0#egg=digitalmarketplace-apiclient==21.8.0
 git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.2-alpha#egg=govuk-frontend-jinja==0.5.2-alpha

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ cryptography==2.3.1       # via digitalmarketplace-utils
 defusedxml==0.6.0         # via odfpy
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.8.0#egg=digitalmarketplace-apiclient==21.8.0  # via -r requirements.in
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.25.0#egg=digitalmarketplace-content-loader==7.25.0  # via -r requirements.in
-git+https://github.com/alphagov/digitalmarketplace-utils.git@54.0.0#egg=digitalmarketplace-utils==54.0.0  # via -r requirements.in, digitalmarketplace-content-loader
+git+https://github.com/alphagov/digitalmarketplace-utils.git@54.1.0#egg=digitalmarketplace-utils==54.1.0  # via -r requirements.in, digitalmarketplace-content-loader
 docopt==0.6.2             # via notifications-python-client
 docutils==0.15.2          # via botocore
 flask-gzip==0.2           # via digitalmarketplace-utils


### PR DESCRIPTION
For development instances we want developers to be able to use a tool like [localstack] instead of real AWS endpoints. The Flask configuration variable DM_S3_ENDPOINT_URL can be used (if set) by dmutils.s3.S3 to connect to a localstack instance (see alphagov/digitalmarketplace-utils#580).

This commit adds DM_S3_ENDPOINT_URL to the Development configuration only, and makes it dependant on an environment variable, DM_S3_ENDPOINT_PORT (so we can set the port only, or the port and hostname, using envvars).

[localstack]: https://github.com/localstack/localstack