### PR TITLE
Un-hard-code previous DOS framework

### DIFF
--- a/app/main/helpers/frameworks.py
+++ b/app/main/helpers/frameworks.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from functools import wraps
 from itertools import chain, islice, groupby
 import re
-from typing import Optional, Container
+from typing import Optional, Container, Dict, List
 
 from flask import abort, current_app, render_template, request
 from flask_login import current_user
@@ -199,10 +199,26 @@ def question_references(data, get_question):
     return data.__class__(references)
 
 
-def get_frameworks_by_status(frameworks, status, extra_condition=False):
+def get_frameworks_by_status(
+        frameworks: List[Dict],
+        status: str,
+        extra_condition: Optional[str] = None
+) -> List[Dict]:
     return list(
         filter(lambda i: i['status'] == status and (i.get(extra_condition) if extra_condition else True), frameworks)
     )
+
+
+def get_most_recent_expired_dos_framework(all_frameworks: List[Dict]) -> List[Dict]:
+    expired_dos = [
+        f for f in get_frameworks_by_status(all_frameworks, 'expired', 'onFramework')
+        if f['family'] == 'digital-outcomes-and-specialists'
+    ]
+
+    if expired_dos:
+        return [sorted(expired_dos, key=lambda f: f['frameworkExpiresAtUTC'], reverse=True)[0]]
+
+    return []
 
 
 def count_drafts_by_lot(drafts, lotSlug):

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -30,6 +30,7 @@ from ..forms.suppliers import (
 from ..helpers.frameworks import (
     get_frameworks_by_status,
     get_frameworks_closed_and_open_for_applications,
+    get_most_recent_expired_dos_framework,
     get_unconfirmed_open_supplier_frameworks,
     is_e_signature_supported_framework,
 )
@@ -98,8 +99,6 @@ def dashboard():
     if "currently_applying_to" in session:
         del session["currently_applying_to"]
 
-    # TODO remove the `dos3` key from the frameworks dict below. It's a temporary fix until a better designed solution
-    # can be implemented.
     return render_template(
         "suppliers/dashboard.html",
         supplier=supplier,
@@ -109,9 +108,7 @@ def dashboard():
             'pending': get_frameworks_by_status(all_frameworks, 'pending'),
             'standstill': get_frameworks_by_status(all_frameworks, 'standstill', 'made_application'),
             'live': get_frameworks_by_status(all_frameworks, 'live', 'onFramework'),
-            'dos3': [
-                f for f in all_frameworks if f['slug'] == 'digital-outcomes-and-specialists-3' and f.get('onFramework')
-            ],
+            'last_dos': get_most_recent_expired_dos_framework(all_frameworks),
         }
     ), 200
 

--- a/app/templates/suppliers/_frameworks_live.html
+++ b/app/templates/suppliers/_frameworks_live.html
@@ -1,4 +1,4 @@
-{% for framework in frameworks.dos3 + frameworks.live %}
+{% for framework in frameworks.last_dos + frameworks.live %}
   {% if framework.onFramework %}
     <h3 class="heading-xmedium">{{ framework.name }}</h3>
     {% if framework.needs_to_return_agreement %}
@@ -17,7 +17,7 @@
         </a>
       </li>
       {% endif %}
-      {% if not framework.slug == 'digital-outcomes-and-specialists-3' %}
+      {% if framework in frameworks.live %}
       <li>
         <a class="govuk-link" href="{{ url_for('.list_services', framework_slug=framework.slug) }}">
         View services

--- a/tests/app/main/test_suppliers.py
+++ b/tests/app/main/test_suppliers.py
@@ -254,6 +254,39 @@ class TestSuppliersDashboard(BaseApplicationTest):
         else:
             assert not document.xpath("//h3[normalize-space(string())='Digital Outcomes and Specialists 3']")
 
+    def test_shows_correct_expired_framework(self):
+        self.data_api_client.get_supplier.side_effect = get_supplier
+        self.data_api_client.find_frameworks.return_value = {
+            "frameworks": [
+                FrameworkStub(
+                    status='expired',
+                    slug='digital-outcomes-and-specialists-2',
+                    frameworkExpiresAtUTC='2000-01-01T01:00:00.000000Z'
+                ).response(),
+                FrameworkStub(
+                    status='expired',
+                    slug='digital-outcomes-and-specialists-1',
+                    frameworkExpiresAtUTC='2001-01-01T01:00:00.000000Z'
+                ).response(),
+            ]
+        }
+        self.data_api_client.get_supplier_frameworks.return_value = {
+            'frameworkInterest': [
+                {'frameworkSlug': 'digital-outcomes-and-specialists-1', 'onFramework': True},
+                {'frameworkSlug': 'digital-outcomes-and-specialists-2', 'onFramework': True},
+            ]
+        }
+
+        self.login()
+
+        response = self.client.get("/suppliers")
+        assert response.status_code == 200
+
+        document = html.fromstring(response.get_data(as_text=True))
+
+        assert document.xpath("//h3[normalize-space(string())='Digital Outcomes and Specialists 1']")
+        assert not document.xpath("//h3[normalize-space(string())='Digital Outcomes and Specialists 2']")
+
     def test_shows_gcloud_7_application_button(self):
         self.data_api_client.get_framework_interest.return_value = {'frameworks': []}
         self.data_api_client.get_supplier.side_effect = get_supplier


### PR DESCRIPTION
Fulfil [Kat's vow](https://github.com/alphagov/digitalmarketplace-supplier-frontend/pull/1123). We need to show the previous DOS framework so that suppliers can see their applications on the previous DOS framework. Previously, we did this by hard coding the last DOS framework in the code.

Now do it by choosing the expired DOS framework with the latest expiry date. This will save us from needing to remember to update this manually when we make DOS 5 live.