### PR TITLE
Use mypy to test typing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ htmlcov/
 .cache
 nosetests.xml
 coverage.xml
+.mypy_cache
 
 # Translations
 *.mo

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "package-lock.json",
     "lines": null
   },
-  "generated_at": "2020-09-29T15:40:25Z",
+  "generated_at": "2020-11-27T13:08:13Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -63,14 +63,14 @@
         "hashed_secret": "6ece33acdf8a843e90915a2b661ab55941348059",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 153,
+        "line_number": 164,
         "type": "Secret Keyword"
       },
       {
         "hashed_secret": "e9dcc6d93c625c72f0c2e7197e80fe49760d5c75",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 157,
+        "line_number": 168,
         "type": "Secret Keyword"
       }
     ],

--- a/Makefile
+++ b/Makefile
@@ -45,11 +45,15 @@ frontend-build: npm-install
 	npm run --silent frontend-build:${GULP_ENVIRONMENT}
 
 .PHONY: test
-test: show-environment frontend-build test-flake8 test-python test-javascript
+test: show-environment frontend-build test-flake8 test-mypy test-python test-javascript
 
 .PHONY: test-flake8
 test-flake8: virtualenv requirements-dev
 	${VIRTUALENV_ROOT}/bin/flake8 .
+
+.PHONY: test-mypy
+test-mypy: virtualenv requirements-dev
+	${VIRTUALENV_ROOT}/bin/mypy app/
 
 .PHONY: test-python
 test-python: virtualenv requirements-dev

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -10,7 +10,7 @@ from dmutils.user import User
 
 from govuk_frontend_jinja.flask_ext import init_govuk_frontend
 
-from config import configs
+from config import configs  # type: ignore
 
 data_api_client = dmapiclient.DataAPIClient()
 login_manager = LoginManager()

--- a/app/main/helpers/validation.py
+++ b/app/main/helpers/validation.py
@@ -1,7 +1,7 @@
 from functools import reduce
 from operator import add
 import re
-from typing import Any, List, Dict, Set, Tuple
+from typing import Any, List, Dict, Set, Tuple, Optional
 
 from werkzeug.datastructures import ImmutableOrderedMultiDict
 
@@ -20,11 +20,11 @@ def get_validator(framework, content, answers):
 
 
 class DeclarationValidator(object):
-    email_validation_fields = []
-    number_string_fields = []
-    character_limit = None
-    word_limit = None
-    optional_fields = set([])
+    email_validation_fields: Set[str] = set()
+    number_string_fields: List[Tuple[str, int]] = []
+    character_limit: Optional[int] = None
+    word_limit: Optional[int] = None
+    optional_fields: Set[str] = set()
 
     def __init__(self, content, answers):
         self.content = content
@@ -33,8 +33,7 @@ class DeclarationValidator(object):
     def get_error_messages_for_page(self, section) -> ImmutableOrderedMultiDict:
         all_errors = self.get_error_messages()
         page_ids = section.get_question_ids()
-        page_errors = ImmutableOrderedMultiDict(filter(lambda err: err[0] in page_ids, all_errors))
-        return page_errors
+        return ImmutableOrderedMultiDict(filter(lambda err: err[0] in page_ids, all_errors))
 
     def get_error_messages(self) -> List[Tuple[str, dict]]:
         raw_errors_map = self.errors()
@@ -55,7 +54,7 @@ class DeclarationValidator(object):
     def get_error_message(self, question_id: str, message_key: str) -> str:
         for validation in self.content.get_question(question_id).get('validations', []):
             if validation['name'] == message_key:
-                return validation['message']
+                return validation['message']  # type: ignore
         default_messages = {
             'answer_required': 'You need to answer this question.',
             'under_character_limit': 'Your answer must be no more than {} characters.'.format(self.character_limit),
@@ -129,7 +128,7 @@ class DeclarationValidator(object):
 
     def get_required_fields(self) -> Set[str]:
         try:
-            req_fields = self.required_fields
+            req_fields = self.required_fields  # type: ignore
         except AttributeError:
             req_fields = set(self.all_fields())
 
@@ -137,7 +136,7 @@ class DeclarationValidator(object):
         if self.optional_fields is not None:
             req_fields -= set(self.optional_fields)
 
-        return req_fields
+        return req_fields  # type: ignore
 
 
 class G7Validator(DeclarationValidator):

--- a/app/status/views.py
+++ b/app/status/views.py
@@ -6,7 +6,7 @@ from dmutils.status import get_app_status
 
 
 @status.route('/_status')
-def status():
+def show_status():
     return get_app_status(data_api_client=data_api_client,
                           search_api_client=None,
                           ignore_dependencies='ignore-dependencies' in request.args)

--- a/config.py
+++ b/config.py
@@ -1,4 +1,5 @@
 # coding=utf-8
+# type: ignore
 
 import os
 import jinja2

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,24 @@
+[mypy]
+python_version = 3.6
+warn_return_any = True
+
+[mypy-dmutils.*]
+ignore_missing_imports = True
+
+[mypy-dmapiclient.*]
+ignore_missing_imports = True
+
+[mypy-dmcontent.*]
+ignore_missing_imports = True
+
+[mypy-flask_login.*]
+ignore_missing_imports = True
+
+[mypy-flask_wtf.*]
+ignore_missing_imports = True
+
+[mypy-govuk_frontend_jinja.*]
+ignore_missing_imports = True
+
+[mypy-wtforms.*]
+ignore_missing_imports = True

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -14,6 +14,6 @@ pytest-cov==2.7.1
 python-dotenv==0.10.3  # used to load .flaskenv
 requests-mock==1.6.0
 watchdog==0.9.0
-mypy==0.790
+mypy==0.782
 
 git+https://github.com/alphagov/digitalmarketplace-test-utils.git@2.8.0#egg=digitalmarketplace-test-utils==2.8.0

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -14,5 +14,6 @@ pytest-cov==2.7.1
 python-dotenv==0.10.3  # used to load .flaskenv
 requests-mock==1.6.0
 watchdog==0.9.0
+mypy==0.790
 
 git+https://github.com/alphagov/digitalmarketplace-test-utils.git@2.8.0#egg=digitalmarketplace-test-utils==2.8.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -25,7 +25,7 @@ mccabe==0.6.1             # via flake8
 mock==3.0.5               # via -r requirements-dev.in
 more-itertools==8.2.0     # via pytest
 mypy-extensions==0.4.3    # via mypy
-mypy==0.790               # via -r requirements-dev.in
+mypy==0.782               # via -r requirements-dev.in
 packaging==20.1           # via pytest
 pathtools==0.1.2          # via watchdog
 pip-tools==5.4.0          # via -r requirements-dev.in

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -24,6 +24,8 @@ lxml==4.4.1               # via -r requirements-dev.in
 mccabe==0.6.1             # via flake8
 mock==3.0.5               # via -r requirements-dev.in
 more-itertools==8.2.0     # via pytest
+mypy-extensions==0.4.3    # via mypy
+mypy==0.790               # via -r requirements-dev.in
 packaging==20.1           # via pytest
 pathtools==0.1.2          # via watchdog
 pip-tools==5.4.0          # via -r requirements-dev.in
@@ -40,6 +42,8 @@ pyyaml==5.3.1             # via -c requirements.txt, watchdog
 requests-mock==1.6.0      # via -r requirements-dev.in
 requests==2.23.0          # via -c requirements.txt, coveralls, requests-mock
 six==1.14.0               # via -c requirements.txt, freezegun, mock, packaging, pip-tools, pytest, python-dateutil, requests-mock
+typed-ast==1.4.1          # via mypy
+typing-extensions==3.7.4.3  # via mypy
 urllib3==1.25.10          # via -c requirements.txt, requests
 watchdog==0.9.0           # via -r requirements-dev.in
 wcwidth==0.1.8            # via pytest


### PR DESCRIPTION
This PR adds [`mypy`](http://mypy-lang.org/) static type checking to the checks performed on `make test` and on Travis CI (but not on commit).

I've also fixed/ignored the issues mypy picked up as appropriate.

I copied the approach from [dmrunner](https://github.com/alphagov/digitalmarketplace-runner/pull/51), which we did first.