### PR TITLE
Add attachment component to Frameworks dashboard and updates pages

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "package-lock.json",
     "lines": null
   },
-  "generated_at": "2020-11-27T13:08:13Z",
+  "generated_at": "2020-11-30T15:37:04Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -79,35 +79,35 @@
         "hashed_secret": "6955d0539c7ae97361ab63d21bc2bb730edbce7a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3904,
+        "line_number": 3916,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "5b10c4aa69a96ad5a1a11ff1add1a37cdc71fb20",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3920,
+        "line_number": 3932,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "b818bf7ee968a5c29d4436a8243c223576f1d75a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3921,
+        "line_number": 3933,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "e5223482a22578724452e2315f44d0bc5fc457a3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 5428,
+        "line_number": 5440,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "82cae5b1d77db4d964804f85ef2c818c6bec2614",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 5453,
+        "line_number": 5465,
         "type": "Base64 High Entropy String"
       }
     ]

--- a/app/templates/_base_page.html
+++ b/app/templates/_base_page.html
@@ -13,6 +13,7 @@
 {% from "digitalmarketplace/components/cookie-banner/macro.njk" import dmCookieBanner %}
 {% from "digitalmarketplace/components/alert/macro.njk" import dmAlert %}
 {% from "digitalmarketplace/components/header/macro.njk" import dmHeader %}
+{% from "digitalmarketplace/components/attachment/macro.njk" import dmAttachment %}
 {% from "digitalmarketplace/components/footer/macro.njk" import dmFooter %}
 
 {% set assetPath = '/suppliers/static' %}

--- a/app/templates/frameworks/_agreement_returned_legal.html
+++ b/app/templates/frameworks/_agreement_returned_legal.html
@@ -84,7 +84,7 @@
       },
       "headingTag": "h3",
       "contentType": "application/pdf",
-      "alternativeFormatContactEmail": "help@digitalmarketplace.service.gov.uk"
+      "alternativeFormatContactEmail": "info@crowncommercial.gov.uk"
     })}}
   {% endif %}
   {% if signed_agreement_document_name %}
@@ -96,7 +96,7 @@
       },
       "headingTag": "h3",
       "contentType": "application/pdf",
-      "alternativeFormatContactEmail": "help@digitalmarketplace.service.gov.uk",
+      "alternativeFormatContactEmail": "info@crowncommercial.gov.uk",
       "description": {
         "text": "The agreement signed by your company"
       }
@@ -122,7 +122,7 @@
       },
       "headingTag": "h3",
       "contentType": "application/pdf",
-      "alternativeFormatContactEmail": "help@digitalmarketplace.service.gov.uk",
+      "alternativeFormatContactEmail": "info@crowncommercial.gov.uk",
       "description": {
         "text": "This agreement is signed by the Crown Commercial Service." if e_signature_supported_framework else "The agreement signed by the Crown Commercial Service."
       }
@@ -137,7 +137,7 @@
       },
       "headingTag": "h3",
       "contentType": "application/pdf",
-      "alternativeFormatContactEmail": "help@digitalmarketplace.service.gov.uk"
+      "alternativeFormatContactEmail": "info@crowncommercial.gov.uk"
     })}}
   {% endif %}
   {% for variation in framework.variations %}
@@ -149,7 +149,7 @@
       },
       "headingTag": "h3",
       "contentType": "application/pdf",
-      "alternativeFormatContactEmail": "help@digitalmarketplace.service.gov.uk"
+      "alternativeFormatContactEmail": "info@crowncommercial.gov.uk"
     })}}
   {% endfor %}
   {% if communications_files.final_call_off.last_modified %}
@@ -161,7 +161,7 @@
       },
       "headingTag": "h3",
       "contentType": "application/pdf",
-      "alternativeFormatContactEmail": "help@digitalmarketplace.service.gov.uk"
+      "alternativeFormatContactEmail": "info@crowncommercial.gov.uk"
     })}}
   {% endif %}
   {% if not countersigned_agreement_file %}

--- a/app/templates/frameworks/_agreement_returned_legal.html
+++ b/app/templates/frameworks/_agreement_returned_legal.html
@@ -1,35 +1,35 @@
 {% if supplier_is_on_framework and framework.status in ['standstill', 'live'] and supplier_framework.agreementReturned %}
-  <div>
-    <h2 class="summary-item-heading">Legal documents</h2>
+<div>
+  <h2 class="govuk-heading-m">Legal documents</h2>
 
   {% if framework.frameworkAgreementVersion %}
-      {# e-signature frameworks don't use signed_agreement_document_name but supplier_framework.agreementReturned check above should be sufficient #}
-      {% if signed_agreement_document_name or is_e_signature_supported_framework  %}
-            {% if countersigned_agreement_file %}
-              <p class="govuk-body">
-                {%  if is_e_signature_supported_framework %}
-                Your signed framework agreement forms a complete legal contract.
-                {% else %}
-                Your original and counterpart signature pages, and the standard framework
-                agreement, form a complete, legal contract.
-                {%  endif %}
-              </p>
+    {# e-signature frameworks don't use signed_agreement_document_name but supplier_framework.agreementReturned check above should be sufficient #}
+    {% if signed_agreement_document_name or is_e_signature_supported_framework  %}
+        {% if countersigned_agreement_file %}
+          <p class="govuk-body">
+            {% if is_e_signature_supported_framework %}
+            Your signed framework agreement forms a complete legal contract.
             {% else %}
-              <p class="govuk-body">
-                  {% if is_e_signature_supported_framework %}
-                  Your signed framework agreement will be sent to Crown Commercial Service (<abbr title="Crown Commercial Service">CCS</abbr>) to be countersigned.
-                  We'll email you when the countersigned agreement is available.
-                  You'll need to wait for <abbr title="Crown Commercial Service">CCS</abbr> to countersign your agreement before you can sell services.
-                  {% else %}
-                  Your framework agreement signature page has been sent to
-                  the Crown Commercial Service (<abbr title="Crown Commercial Service">CCS</abbr>).
-                  They’ll check and countersign the agreement, or contact you if there’s a
-                  problem. You don’t need to wait for <abbr title="Crown Commercial Service">CCS</abbr> to
-                  countersign your agreement before you start selling services.
-                  {% endif %}
-              </p>
+            Your original and counterpart signature pages, and the standard framework
+            agreement, form a complete, legal contract.
             {% endif %}
+          </p>
+        {% else %}
+          <p class="govuk-body">
+              {% if is_e_signature_supported_framework %}
+              Your signed framework agreement will be sent to Crown Commercial Service (<abbr title="Crown Commercial Service">CCS</abbr>) to be countersigned.
+              We'll email you when the countersigned agreement is available.
+              You'll need to wait for <abbr title="Crown Commercial Service">CCS</abbr> to countersign your agreement before you can sell services.
+              {% else %}
+              Your framework agreement signature page has been sent to
+              the Crown Commercial Service (<abbr title="Crown Commercial Service">CCS</abbr>).
+              They’ll check and countersign the agreement, or contact you if there’s a
+              problem. You don’t need to wait for <abbr title="Crown Commercial Service">CCS</abbr> to
+              countersign your agreement before you start selling services.
+              {% endif %}
+          </p>
         {% endif %}
+    {% endif %}
 
     {% if not countersigned_agreement_file %}
       {{ govukSummaryList({
@@ -66,85 +66,108 @@
       })}}
     {% endif %}
   {% endif %}
-
-    <div class="dmspeak">
-    {% if framework_urls.framework_agreement_url %}
-      {# newer frameworks should have the final agreement published as a web page #}
-      <p class="govuk-body">
-        <a class="govuk-link" href="{{ framework_urls.framework_agreement_url }}">
-          Read the standard framework agreement
-        </a>
-      </p>
-    {% elif communications_files.final_agreement.last_modified %}
-      {# older frameworks will still have to point to a file that came from the old supplier pack #}
-      <p class="govuk-body">
-        <a class="govuk-link" href="{{ url_for('.download_supplier_file', filepath=communications_files.final_agreement.filename, framework_slug=framework.slug) }}">
-          Download the standard framework agreement
-        </a>
-      </p>
-    {% endif %}
-    {% if signed_agreement_document_name %}
-      <p class="govuk-body">
-        <a class="govuk-link" href="{{ url_for('.download_agreement_file', framework_slug=framework.slug, document_name=signed_agreement_document_name) }}" target="_blank">
-          {% if framework.frameworkAgreementVersion %}
-            Download your ‘original’ framework agreement signature page
-          {% else %}
-            Download your signed framework agreement
-          {% endif %}
-        </a>
-        <br/>
-        The agreement signed by your company
-      </p>
-    {% endif %}
-    {% if countersigned_agreement_file %}
-      <p class="govuk-body">
-        <a class="govuk-link" href="{{ url_for('.download_agreement_file', framework_slug=framework.slug, document_name=countersigned_agreement_file) }}" target="_blank">
-          {% if framework.frameworkAgreementVersion %}
-                {% if is_e_signature_supported_framework %}
-                 Download your signed framework agreement
-                {% else %}
-                  Download your ‘counterpart’ framework agreement signature page
-                {% endif %}
-          {% else %}
-            Download your countersigned framework agreement
-          {% endif %}
-        </a>
-        <br/>
-        {% if e_signature_supported_framework %}
-        This agreement is signed by the Crown Commercial Service.
-        {% else %}
-        The agreement signed by the Crown Commercial Service.
-        {% endif %}
-      </p>
-    {% endif %}
-    {% if countersigned_agreement_file and not framework.frameworkAgreementVersion %}
-      <p class="govuk-body">
-        <a class="govuk-link" href="{{ url_for('.download_agreement_file', framework_slug=framework.slug, document_name=result_letter_filename) }}" target="_blank">
-          Download your application result letter
-        </a>
-      </p>
-    {% endif %}
-    {% for variation in framework.variations %}
+  
+  {% if framework_urls.framework_agreement_url %}
+    {# newer frameworks should have the final agreement published as a web page #}
     <p class="govuk-body">
-      <a class="govuk-link" href="{{ url_for('.view_contract_variation', framework_slug=framework.slug, variation_slug=variation) }}">
-      {% if framework.variations[variation].get('countersignedAt') and supplier_framework.agreedVariations.get(variation).agreedAt %}
-        View the signed contract variation
-      {% else %}
-        Read the proposed contract variation
-      {% endif %}
+      <a class="govuk-link" href="{{ framework_urls.framework_agreement_url }}">
+        Read the standard framework agreement
       </a>
     </p>
-    {% endfor %}
-    {% if communications_files.final_call_off.last_modified %}
-      <p class="govuk-body">
-        <a class="govuk-link" href="{{ url_for('.download_supplier_file', filepath=communications_files.final_call_off.filename, framework_slug=framework.slug) }}">Download the call-off contract template</a>
-      </p>
-    {% endif %}
-    {% if not countersigned_agreement_file %}
-      <p class="govuk-body">
-        You can start selling your {{ framework.name }} services on the Digital Marketplace from {{ framework.frameworkLiveAt }}.
-      </p>
-    {% endif %}
-    </div>
-  </div>
+  {% elif communications_files.final_agreement.last_modified %}
+    {# older frameworks will still have to point to a file that came from the old supplier pack #}
+    {{dmAttachment({
+      "link": {
+        "classes": "govuk-!-font-size-19",
+        "href": url_for('.download_supplier_file', filepath=communications_files.final_agreement.filename, framework_slug=framework.slug),
+        "text": "Download the standard framework agreement",
+      },
+      "headingTag": "h3",
+      "contentType": "application/pdf",
+      "alternativeFormatContactEmail": "help@digitalmarketplace.service.gov.uk"
+    })}}
+  {% endif %}
+  {% if signed_agreement_document_name %}
+    {{dmAttachment({
+      "link": {
+        "classes": "govuk-!-font-size-19",
+        "href": url_for('.download_agreement_file', framework_slug=framework.slug, document_name=signed_agreement_document_name),
+        "text": "Download your ‘original’ framework agreement signature page" if framework.frameworkAgreementVersion else "Download your signed framework agreement",
+      },
+      "headingTag": "h3",
+      "contentType": "application/pdf",
+      "alternativeFormatContactEmail": "help@digitalmarketplace.service.gov.uk",
+      "description": {
+        "text": "The agreement signed by your company"
+      }
+    })}}
+  {% endif %}
+  {% if countersigned_agreement_file %}
+    {% set signed_message %}
+      {% if framework.frameworkAgreementVersion %}
+        {% if is_e_signature_supported_framework %}
+          Download your signed framework agreement
+        {% else %}
+          Download your ‘counterpart’ framework agreement signature page
+        {% endif %}
+      {% else %}
+        Download your countersigned framework agreement
+      {% endif %}
+    {% endset %}
+    {{dmAttachment({
+      "link": {
+        "classes": "govuk-!-font-size-19",
+        "href": url_for('.download_agreement_file', framework_slug=framework.slug, document_name=countersigned_agreement_file),
+        "text": signed_message,
+      },
+      "headingTag": "h3",
+      "contentType": "application/pdf",
+      "alternativeFormatContactEmail": "help@digitalmarketplace.service.gov.uk",
+      "description": {
+        "text": "This agreement is signed by the Crown Commercial Service." if e_signature_supported_framework else "The agreement signed by the Crown Commercial Service."
+      }
+    })}}
+  {% endif %}
+  {% if countersigned_agreement_file and not framework.frameworkAgreementVersion %}
+    {{dmAttachment({
+      "link": {
+        "classes": "govuk-!-font-size-19",
+        "href": url_for('.download_agreement_file', framework_slug=framework.slug, document_name=result_letter_filename),
+        "text": "Download your application result letter",
+      },
+      "headingTag": "h3",
+      "contentType": "application/pdf",
+      "alternativeFormatContactEmail": "help@digitalmarketplace.service.gov.uk"
+    })}}
+  {% endif %}
+  {% for variation in framework.variations %}
+    {{dmAttachment({
+      "link": {
+        "classes": "govuk-!-font-size-19",
+        "href": url_for('.view_contract_variation', framework_slug=framework.slug, variation_slug=variation),
+        "text": "View the signed contract variation" if (framework.variations[variation].get('countersignedAt') and supplier_framework.agreedVariations.get(variation).agreedAt) else 'Read the proposed contract variation',
+      },
+      "headingTag": "h3",
+      "contentType": "application/pdf",
+      "alternativeFormatContactEmail": "help@digitalmarketplace.service.gov.uk"
+    })}}
+  {% endfor %}
+  {% if communications_files.final_call_off.last_modified %}
+    {{dmAttachment({
+      "link": {
+        "classes": "govuk-!-font-size-19",
+        "href": url_for('.download_supplier_file', filepath=communications_files.final_call_off.filename, framework_slug=framework.slug),
+        "text": "Download the call-off contract template",
+      },
+      "headingTag": "h3",
+      "contentType": "application/pdf",
+      "alternativeFormatContactEmail": "help@digitalmarketplace.service.gov.uk"
+    })}}
+  {% endif %}
+  {% if not countersigned_agreement_file %}
+    <p class="govuk-body">
+      You can start selling your {{ framework.name }} services on the Digital Marketplace from {{ framework.frameworkLiveAt }}.
+    </p>
+  {% endif %}
+</div>
 {% endif %}

--- a/app/templates/frameworks/_guidance_links.html
+++ b/app/templates/frameworks/_guidance_links.html
@@ -44,7 +44,7 @@
         "datetime": communications_files.final_agreement.last_modified,
         "text": communications_files.final_agreement.last_modified|dateformat
       },
-      "alternativeFormatContactEmail": "help@digitalmarketplace.service.gov.uk",
+      "alternativeFormatContactEmail": "info@crowncommercial.gov.uk",
       "description": {
         "html": 'Read the agreement between the Crown Commercial Service (<abbr title="Crown Commercial Service">CCS</abbr>) and suppliers.'
       }
@@ -62,7 +62,7 @@
         "datetime": communications_files.proposed_agreement.last_modified,
         "text": communications_files.proposed_agreement.last_modified|dateformat
       },
-      "alternativeFormatContactEmail": "help@digitalmarketplace.service.gov.uk",
+      "alternativeFormatContactEmail": "info@crowncommercial.gov.uk",
       "description": {
         "html": 'Read the proposed agreement between the Crown Commercial Service (<abbr title="Crown Commercial Service">CCS</abbr>) and suppliers.'
       }
@@ -82,7 +82,7 @@
         "datetime": communications_files.final_call_off.last_modified,
         "text": communications_files.final_call_off.last_modified|dateformat
       },
-      "alternativeFormatContactEmail": "help@digitalmarketplace.service.gov.uk",
+      "alternativeFormatContactEmail": "info@crowncommercial.gov.uk",
       "description": {
         "text": 'Read the contract between a buyer and a supplier.'
       }
@@ -100,7 +100,7 @@
         "datetime": communications_files.proposed_call_off.last_modified,
         "text": communications_files.proposed_call_off.last_modified|dateformat
       },
-      "alternativeFormatContactEmail": "help@digitalmarketplace.service.gov.uk",
+      "alternativeFormatContactEmail": "info@crowncommercial.gov.uk",
       "description": {
         "text": 'Read the proposed contract between a buyer and a supplier.'
       }
@@ -144,7 +144,7 @@
         "text": "Download the reporting template",
       },
       "headingTag": "h3",
-      "alternativeFormatContactEmail": "help@digitalmarketplace.service.gov.uk",
+      "alternativeFormatContactEmail": "info@crowncommercial.gov.uk",
       "description": {
         "text": 'You’ll need to send monthly ‘management information’ about the contracts you’ve been working on to CCS.'
       }

--- a/app/templates/frameworks/_guidance_links.html
+++ b/app/templates/frameworks/_guidance_links.html
@@ -1,6 +1,6 @@
-<div class="dmspeak">
+<div>
   <div>
-    <h2 id="guidance" class="heading-xmedium">Guidance</h2>
+    <h2 id="guidance" class="govuk-heading-m">Guidance</h2>
 
     {% if communications_files.invitation.last_modified %}
     <p class="govuk-body">
@@ -29,75 +29,87 @@
 #}
 {% if framework.status == 'pending' or not supplier_is_on_framework %}
   <div>
-    <h2 id="legal-documents" class="heading-xmedium">Legal documents</h2>
+    <h2 id="legal-documents" class="govuk-heading-m">Legal documents</h2>
 
     {% if communications_files.final_agreement.last_modified %}
-    <p class="govuk-body">
-      <a class="govuk-link" href="{{ url_for('.download_supplier_file', filepath=communications_files.final_agreement.filename, framework_slug=framework.slug) }}">
-        Download the framework agreement
-      </a>
-      <br/>
-      Read the agreement between the Crown Commercial Service (<abbr title="Crown Commercial Service">CCS</abbr>) and suppliers.
-      <br/>
-      <span class="hint">
-        Last updated
-        <time datetime="{{ communications_files.final_agreement.last_modified }}">
-          {{ communications_files.final_agreement.last_modified|dateformat }}
-        </time>
-      </span>
-    </p>
+    {{dmAttachment({
+      "link": {
+        "classes": "govuk-!-font-size-19",
+        "href": url_for('.download_supplier_file', filepath=communications_files.final_agreement.filename, framework_slug=framework.slug),
+        "text": "Download the framework agreement",
+      },
+      "headingTag": "h3",
+      "contentType": "application/pdf",
+      "lastUpdated": {
+        "datetime": communications_files.final_agreement.last_modified,
+        "text": communications_files.final_agreement.last_modified|dateformat
+      },
+      "alternativeFormatContactEmail": "help@digitalmarketplace.service.gov.uk",
+      "description": {
+        "html": 'Read the agreement between the Crown Commercial Service (<abbr title="Crown Commercial Service">CCS</abbr>) and suppliers.'
+      }
+    })}}
     {% elif communications_files.proposed_agreement.last_modified %}
-    <p class="govuk-body">
-      <a class="govuk-link" href="{{ url_for('.download_supplier_file', filepath=communications_files.proposed_agreement.filename, framework_slug=framework.slug) }}">
-        Download the proposed framework agreement
-      </a>
-      <br/>
-      Read the proposed agreement between the Crown Commercial Service (<abbr title="Crown Commercial Service">CCS</abbr>) and suppliers.
-      <br/>
-      <span class="hint">
-        Last updated
-        <time datetime="{{ communications_files.proposed_agreement.last_modified }}">
-          {{ communications_files.proposed_agreement.last_modified|dateformat }}
-        </time>
-      </span>
-    </p>
+    {{dmAttachment({
+      "link": {
+        "classes": "govuk-!-font-size-19",
+        "href": url_for('.download_supplier_file', filepath=communications_files.proposed_agreement.filename, framework_slug=framework.slug),
+        "text": "Download the proposed framework agreement",
+      },
+      "headingTag": "h3",
+      "contentType": "application/pdf",
+      "lastUpdated": {
+        "datetime": communications_files.proposed_agreement.last_modified,
+        "text": communications_files.proposed_agreement.last_modified|dateformat
+      },
+      "alternativeFormatContactEmail": "help@digitalmarketplace.service.gov.uk",
+      "description": {
+        "html": 'Read the proposed agreement between the Crown Commercial Service (<abbr title="Crown Commercial Service">CCS</abbr>) and suppliers.'
+      }
+    })}}
     {% endif %}
 
     {% if communications_files.final_call_off.last_modified %}
-    <p class="govuk-body">
-      <a class="govuk-link" href="{{ url_for('.download_supplier_file', filepath=communications_files.final_call_off.filename, framework_slug=framework.slug) }}">
-        Download the ‘call-off’ contract
-      </a>
-      <br/>
-      Read the contract between a buyer and a supplier.
-      <br/>
-      <span class="hint">
-        Last updated
-        <time datetime="{{ communications_files.final_call_off.last_modified }}">
-          {{ communications_files.final_call_off.last_modified|dateformat }}
-        </time>
-      </span>
-    </p>
+    {{dmAttachment({
+      "link": {
+        "classes": "govuk-!-font-size-19",
+        "href": url_for('.download_supplier_file', filepath=communications_files.final_call_off.filename, framework_slug=framework.slug),
+        "text": "Download the ‘call-off’ contract",
+      },
+      "headingTag": "h3",
+      "contentType": "application/pdf",
+      "lastUpdated": {
+        "datetime": communications_files.final_call_off.last_modified,
+        "text": communications_files.final_call_off.last_modified|dateformat
+      },
+      "alternativeFormatContactEmail": "help@digitalmarketplace.service.gov.uk",
+      "description": {
+        "text": 'Read the contract between a buyer and a supplier.'
+      }
+    })}}
     {% elif communications_files.proposed_call_off.last_modified %}
-    <p class="govuk-body">
-      <a class="govuk-link" href="{{ url_for('.download_supplier_file', filepath=communications_files.proposed_call_off.filename, framework_slug=framework.slug) }}">
-        Download the proposed ‘call-off’ contract
-      </a>
-      <br/>
-      Read the proposed contract between a buyer and a supplier.
-      <br/>
-      <span class="hint">
-        Last updated
-        <time datetime="{{ communications_files.proposed_call_off.last_modified }}">
-          {{ communications_files.proposed_call_off.last_modified|dateformat }}
-        </time>
-      </span>
-    </p>
+    {{dmAttachment({
+      "link": {
+        "classes": "govuk-!-font-size-19",
+        "href": url_for('.download_supplier_file', filepath=communications_files.proposed_call_off.filename, framework_slug=framework.slug),
+        "text": "Download the proposed ‘call-off’ contract",
+      },
+      "headingTag": "h3",
+      "contentType": "application/pdf",
+      "lastUpdated": {
+        "datetime": communications_files.proposed_call_off.last_modified,
+        "text": communications_files.proposed_call_off.last_modified|dateformat
+      },
+      "alternativeFormatContactEmail": "help@digitalmarketplace.service.gov.uk",
+      "description": {
+        "text": 'Read the proposed contract between a buyer and a supplier.'
+      }
+    })}}
     {% endif %}
   </div>
 {% endif %}
   <div>
-    <h2 id="communications" class="heading-xmedium" class="heading-xmedium">Communications</h2>
+    <h2 id="communications" class="govuk-heading-m">Communications</h2>
 
     {% if framework.status == "open" and framework.clarificationQuestionsOpen %}
     <p class="govuk-body">
@@ -113,7 +125,7 @@
         clarification questions
       </a>
       {% if communications_files.supplier_updates.last_modified %}
-      <span class="hint">
+      <span class="govuk-hint">
         Last updated
         <time datetime="{{ communications_files.supplier_updates.last_modified }}">
           {{ communications_files.supplier_updates.last_modified|dateformat }}
@@ -124,15 +136,19 @@
   </div>
 {% if communications_files.reporting_template.last_modified %}
   <div>
-  <h2 id="reporting" class="heading-xmedium">Reporting</h2>
-    <p class="govuk-body">
-      <a class="govuk-link" href="{{ url_for('.download_supplier_file', filepath=communications_files.reporting_template.filename, framework_slug=framework.slug) }}">
-        Download the reporting template
-      </a>
-      <br/>
-      You’ll need to send monthly ‘management information’ about the contracts
-      you’ve been working on to CCS.
-    </p>
+  <h2 id="reporting" class="govuk-heading-m">Reporting</h2>
+    {{dmAttachment({
+      "link": {
+        "classes": "govuk-!-font-size-19",
+        "href": url_for('.download_supplier_file', filepath=communications_files.reporting_template.filename, framework_slug=framework.slug),
+        "text": "Download the reporting template",
+      },
+      "headingTag": "h3",
+      "alternativeFormatContactEmail": "help@digitalmarketplace.service.gov.uk",
+      "description": {
+        "text": 'You’ll need to send monthly ‘management information’ about the contracts you’ve been working on to CCS.'
+      }
+    })}}
   </div>
 {% endif %}
 </div>

--- a/app/templates/frameworks/updates.html
+++ b/app/templates/frameworks/updates.html
@@ -1,5 +1,4 @@
 {% extends "_base_page.html" %}
-{% import "toolkit/summary-table.html" as summary %}
 
 {% block pageTitle %}
   {{ framework.name }} updates – Digital Marketplace
@@ -51,7 +50,7 @@
   </div>
 
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-full updates-document-tables">
+    <div class="govuk-grid-column-full">
       {% set sections = [
         {
           "heading": "Communications",
@@ -66,27 +65,41 @@
       ] %}
 
       {% for section in sections %}
-        {{ summary.heading(section.heading) }}
-        {% call(item) summary.list_table(
-          section.files,
-          caption=section.heading,
-          empty_message=section.empty_message,
-          field_headings=[
-            "Last modified",
-            "File"
-          ],
-          field_headings_visible=False
-        ) %}
-          {% call summary.row() %}
-            {{ summary.field_name(item.last_modified|dateformat) }}
-            {% call summary.field() %}
-              <a href="{{ url_for('.download_supplier_file', filepath=item.path, framework_slug=framework.slug) }}" class="document-link-with-icon">
-                <span class='document-icon'>{{ item.ext }}<span> document:</span></span>
-                {{ item.filename }}
-              </a>
-            {% endcall %}
-          {% endcall %}
-        {% endcall %}
+        {% if not section.files %}
+          <h2 class="govuk-heading-m">{{ section.heading }}</h2>
+          <p class="govuk-body">{{ section.empty_message }}</p>
+        {% else %}
+        <table class="govuk-table">
+          <caption class="govuk-table__caption govuk-heading-m">
+            <span>{{ section.heading }}</span>
+            {% if section.files %}
+            <p class="govuk-body">
+              If you use assistive technology (such as a screen reader) and need a version of these documents in a more accessible format, please email <a href="mailto:help@digitalmarketplace.service.gov.uk" target="_blank" class="govuk-link">help@digitalmarketplace.service.gov.uk</a>. Please tell us what format you need. It will help us if you say what assistive technology you use.
+            </p>
+            {% endif %}
+          </caption>
+          <tbody>
+            {% for file in section.files %}
+            <tr class="govuk-table__row">
+              <td class="govuk-table__cell">{{ file.last_modified|dateformat }}</td>
+              <td class="govuk-table__cell">
+                {{dmAttachment({
+                  "link": {
+                    "classes": "govuk-!-font-size-16",
+                    "href": url_for('.download_supplier_file', filepath=file.path, framework_slug=framework.slug),
+                    "text": file.filename
+                  },
+                  "contentType": file.ext | upper,
+                  "headingTag": 'p',
+                  "thumbnailSize": "small"
+                })}}
+              </td>
+            </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+        {% endif %}
+
       {% endfor %}
       <p class="hint">
         {% if framework.clarificationQuestionsOpen %}
@@ -106,17 +119,13 @@
         <div class="govuk-grid-row">
 
           <div class="govuk-grid-column-two-thirds">
-            {{ summary.heading("Ask a clarification question") }}
-            <br />
+            <h2 class="govuk-heading-m">Ask a clarification question</h2>
             <p class="govuk-body">Ask a clarification question if you need a better understanding of:</p>
-            <br />
             <ul class="govuk-list govuk-list--bullet">
               <li>the legal documents</li>
               <li>your responsibilities as a supplier</li>
             </ul>
-            <br />
             <p class="govuk-body">There’s a different way to:</p>
-            <br />
             <ul class="govuk-list govuk-list--bullet">
               <li>
                 <a class="govuk-link" href="{{ framework_urls.supplier_guide_url }}">find out about the application process and eligibility</a>
@@ -138,9 +147,7 @@
                 {% include "toolkit/forms/textbox.html" %}
               {% endwith %}
             <p class="govuk-body">You can ask clarification questions until {{ framework.clarificationsCloseAt }}.</p>
-            <br />
             <p class="govuk-body">Answers are published to this page around twice a week, alongside answers to questions from other suppliers.</p>
-            <br />
             <p class="govuk-body">All responses will be published by {{ framework.clarificationsPublishAt }}.</p>
               {{ govukButton({
                 "text": "Ask a question"
@@ -155,10 +162,9 @@
 
         <div class="govuk-grid-row">
           <div class="govuk-grid-column-two-thirds">
-            {{ summary.heading("Contact us") }}
+            <h2 class="govuk-heading-m">Contact us</h2>
 
             <p class="govuk-body">Contact the support team if <a class="govuk-link" href="{{ url_for('external.help') }}">there’s a problem with your account or to update your details</a>.</p>
-            <br />
             <p class="govuk-body"><a class="govuk-link" href="{{ url_for('.framework_dashboard', framework_slug=framework.slug) }}">Return to {{ framework.name }} application</a></p>
 
           </div>

--- a/app/templates/frameworks/updates.html
+++ b/app/templates/frameworks/updates.html
@@ -74,7 +74,7 @@
             <span>{{ section.heading }}</span>
             {% if section.files %}
             <p class="govuk-body">
-              If you use assistive technology (such as a screen reader) and need a version of these documents in a more accessible format, please email <a href="mailto:help@digitalmarketplace.service.gov.uk" target="_blank" class="govuk-link">help@digitalmarketplace.service.gov.uk</a>. Please tell us what format you need. It will help us if you say what assistive technology you use.
+              If you use assistive technology (such as a screen reader) and need a version of these documents in a more accessible format, please email <a href="mailto:info@crowncommercial.gov.uk" target="_blank" class="govuk-link">info@crowncommercial.gov.uk</a>. Please tell us what format you need. It will help us if you say what assistive technology you use.
             </p>
             {% endif %}
           </caption>

--- a/package-lock.json
+++ b/package-lock.json
@@ -2099,9 +2099,9 @@
       }
     },
     "digitalmarketplace-govuk-frontend": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/digitalmarketplace-govuk-frontend/-/digitalmarketplace-govuk-frontend-2.6.0.tgz",
-      "integrity": "sha512-ULLq/IutHK2/2f7nIBmq4N77zuwCapoqOTLd/HwH9pgYW53UOHkc5m/bkDI5uAc0z2qdxUAEKSk1E2/KFEIJPw=="
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/digitalmarketplace-govuk-frontend/-/digitalmarketplace-govuk-frontend-2.7.0.tgz",
+      "integrity": "sha512-A6P/nvDCkZfKwn0tpDLWcZsTamD1r5vhua2vKjK3V5ZRibPmYfEGhg8wpsEFBNM8028xiU30Bv85mrFbLtKkig=="
     },
     "dir-glob": {
       "version": "3.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2099,9 +2099,9 @@
       }
     },
     "digitalmarketplace-govuk-frontend": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/digitalmarketplace-govuk-frontend/-/digitalmarketplace-govuk-frontend-2.7.0.tgz",
-      "integrity": "sha512-A6P/nvDCkZfKwn0tpDLWcZsTamD1r5vhua2vKjK3V5ZRibPmYfEGhg8wpsEFBNM8028xiU30Bv85mrFbLtKkig=="
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/digitalmarketplace-govuk-frontend/-/digitalmarketplace-govuk-frontend-2.8.0.tgz",
+      "integrity": "sha512-IK4NRgSO7wZCPLZjrA66KDWRj1YwHDvXd/g3dtUCzvRv5TRksshLRa7hBSly+XhKjVUEmaqFYQJtlOlfOIbvNw=="
     },
     "dir-glob": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "del": "^5.1.0",
     "digitalmarketplace-frameworks": "github:alphagov/digitalmarketplace-frameworks#v17.17.9",
     "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v36.1.0",
-    "digitalmarketplace-govuk-frontend": "^2.6.0",
+    "digitalmarketplace-govuk-frontend": "^2.7.0",
     "govuk-country-and-territory-autocomplete": "0.4.0",
     "govuk-elements-sass": "3.0.3",
     "govuk-frontend": "2.13.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "del": "^5.1.0",
     "digitalmarketplace-frameworks": "github:alphagov/digitalmarketplace-frameworks#v17.17.9",
     "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v36.1.0",
-    "digitalmarketplace-govuk-frontend": "^2.7.0",
+    "digitalmarketplace-govuk-frontend": "^2.8.0",
     "govuk-country-and-territory-autocomplete": "0.4.0",
     "govuk-elements-sass": "3.0.3",
     "govuk-frontend": "2.13.0",

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -61,13 +61,25 @@ def _extract_guidance_links(doc):
                 (
                     item_li.xpath("normalize-space(string(.//a))") or None,
                     item_li.xpath("string(.//a/@href)") or None,
-                    item_li.xpath("normalize-space(string(.//time))") or None,
-                    item_li.xpath("string(.//time/@datetime)") or None,
+                    item_li.xpath(
+                        (
+                            "normalize-space(string(.//time"
+                            " | "
+                            "./following-sibling::p[@class='dm-attachment__metadata']//time))"
+                        )
+                    ) or None,
+                    item_li.xpath(
+                        (
+                            "string(.//time/@datetime"
+                            " | "
+                            "./following-sibling::p[@class='dm-attachment__metadata']//time/@datetime)"
+                        )
+                    ) or None,
                 )
-                for item_li in section_li.xpath(".//p[.//a]")
+                for item_li in section_li.xpath(".//p[.//a] | .//h3[.//a]")
             ),
         )
-        for section_li in doc.xpath("//main//*[./h2][.//p//a]")
+        for section_li in doc.xpath("//main//*[./h2][.//p//a | .//section[@class='dm-attachment']//a]")
     )
 
 

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -3544,14 +3544,14 @@ class TestFrameworkUpdatesPage(BaseApplicationTest):
 
         assert self.strip_all_whitespace('G-Cloud 7 updates') in self.strip_all_whitespace(doc.xpath('//h1')[0].text)
 
-        headers = doc.xpath('//div[contains(@class, "updates-document-tables")]/h2[@class="summary-item-heading"]')
+        headers = doc.xpath('//div[@class="govuk-grid-column-full"]//h2 | //table//caption//span')
         assert len(headers) == 2
 
         assert self.strip_all_whitespace(headers[0].text) == 'Communications'
         assert self.strip_all_whitespace(headers[1].text) == 'Clarificationquestionsandanswers'
 
         if check_for_tables:
-            table_captions = doc.xpath('//div[contains(@class, "updates-document-tables")]/table/caption')
+            table_captions = doc.xpath('//div/table/caption/span')
             assert len(table_captions) == 2
             assert self.strip_all_whitespace(table_captions[0].text) == 'Communications'
             assert self.strip_all_whitespace(table_captions[1].text) == 'Clarificationquestionsandanswers'
@@ -3586,12 +3586,12 @@ class TestFrameworkUpdatesPage(BaseApplicationTest):
         response_text = self.strip_all_whitespace(response.get_data(as_text=True))
 
         assert (
-            self.strip_all_whitespace('<p class="summary-item-no-content">No communications have been sent out.</p>')
+            self.strip_all_whitespace('<p class="govuk-body">No communications have been sent out.</p>')
             in response_text
         )
         assert (
             self.strip_all_whitespace(
-                '<p class="summary-item-no-content">No clarification questions and answers have been posted yet.</p>'
+                '<p class="govuk-body">No clarification questions and answers have been posted yet.</p>'
             )
             in response_text
         )


### PR DESCRIPTION
https://trello.com/c/tUd7Ck2w/275-5-replace-document-links-with-attachment-component-in-frontend-apps

## What
This PR uses the new Attachment component to display document downloads on these two pages:

`suppliers/frameworks/<framework>`
`suppliers/frameworks/<framework>/updates`

## Why
We currently don't offer a way to acquire more accessible versions of our documents. This makes it easier for users to request them, and provides a way to show more metadata about files once we have a way to extract that information on the backend.

## Issues
* We don't currently provide much metadata beyond file type and last modified date
* On the updates page, we're currently using the file extension to pass in type, when we should ideally be using MIME types like `application/pdf`
* Using a Details component (for the contact details) within a table creates all sorts of issues, so I've had to move the directions for accessible documents out of the tables - this at least makes the table cells less repetitive
* It's not the most intuitive task in the world to force these pages into different states to inspect changes - perhaps we can improve this
* There are still a few digitalmarketplace-frontend-toolkit elements on this page - these felt out of scope, but I did replace the summary-table as part of this PR

## Framework Dashboard page example
### Before
![Screenshot 2020-11-30 at 17 34 37](https://user-images.githubusercontent.com/22524634/100643789-6cb33f80-3332-11eb-9d43-078a0616fa99.png)
### After
![Screenshot 2020-11-30 at 17 23 24](https://user-images.githubusercontent.com/22524634/100642610-e1857a00-3330-11eb-969e-f4feeeb22e72.png)

## Framework Updates page example
### Before
![Screenshot 2020-11-30 at 17 34 06](https://user-images.githubusercontent.com/22524634/100643752-5dcc8d00-3332-11eb-8bc3-7871fc27a1c8.png)
## After
![Screenshot 2020-11-30 at 17 24 40](https://user-images.githubusercontent.com/22524634/100642678-ff52df00-3330-11eb-89ac-c8b15d5f28d1.png)
