### PR TITLE
Distinguish G12 recovery suppliers

### DIFF
--- a/app/main/helpers/suppliers.py
+++ b/app/main/helpers/suppliers.py
@@ -1,5 +1,8 @@
 import os
 import json
+from typing import Union
+
+from flask import current_app
 
 
 def load_countries():
@@ -65,3 +68,9 @@ def get_company_details_from_supplier(supplier):
         "registered_name": supplier.get("registeredName"),
         "address": address
     }
+
+
+def is_g12_recovery_supplier(supplier_id: Union[str, int]) -> bool:
+    supplier_ids = current_app.config.get('DM_G12_RECOVERY_SUPPLIER_IDS') or ''
+
+    return str(supplier_id) in supplier_ids.split(sep=',')

--- a/app/main/helpers/suppliers.py
+++ b/app/main/helpers/suppliers.py
@@ -71,6 +71,15 @@ def get_company_details_from_supplier(supplier):
 
 
 def is_g12_recovery_supplier(supplier_id: Union[str, int]) -> bool:
-    supplier_ids = current_app.config.get('DM_G12_RECOVERY_SUPPLIER_IDS') or ''
+    supplier_ids_string = current_app.config.get('DM_G12_RECOVERY_SUPPLIER_IDS') or ''
 
-    return str(supplier_id) in supplier_ids.split(sep=',')
+    try:
+        supplier_ids = [int(s) for s in supplier_ids_string.split(sep=',')]
+    except AttributeError as e:
+        current_app.logger.error("DM_G12_RECOVERY_SUPPLIER_IDS not a string", extra={'error': str(e)})
+        return False
+    except ValueError as e:
+        current_app.logger.error("DM_G12_RECOVERY_SUPPLIER_IDS not a list of supplier IDs", extra={'error': str(e)})
+        return False
+
+    return int(supplier_id) in supplier_ids

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -38,6 +38,7 @@ from ..helpers.suppliers import (
     COUNTRY_TUPLE,
     get_country_name_from_country_code,
     supplier_company_details_are_complete,
+    is_g12_recovery_supplier,
 )
 from ..helpers import login_required
 
@@ -65,6 +66,8 @@ def dashboard():
         current_user.supplier_id
     )['suppliers']
     supplier['contact'] = supplier['contactInformation'][0]
+
+    supplier['g12_recovery'] = is_g12_recovery_supplier(supplier['id'])
 
     all_frameworks = sorted(
         data_api_client.find_frameworks()['frameworks'],

--- a/app/templates/suppliers/_frameworks_coming.html
+++ b/app/templates/suppliers/_frameworks_coming.html
@@ -1,3 +1,14 @@
 {% for framework in frameworks.coming %}
   {# add banners/cards here for messages to suppliers about upcoming frameworks #}
 {% endfor %}
+
+{% if supplier.g12_recovery %}
+  {% with
+    main = true,
+    header_level = "h2",
+    messages = ['This is a placeholder'],
+    heading = "G-Cloud 12 recovery"
+  %}
+    {% include "toolkit/temporary-message.html" %}
+  {% endwith %}
+{% endif %}

--- a/config.py
+++ b/config.py
@@ -94,6 +94,8 @@ class Config(object):
     DM_LOG_PATH = None
     DM_APP_NAME = 'supplier-frontend'
 
+    DM_G12_RECOVERY_SUPPLIER_IDS = None
+
     @staticmethod
     def init_app(app):
         repo_root = os.path.abspath(os.path.dirname(__file__))
@@ -129,6 +131,8 @@ class Test(Config):
     SECRET_KEY = 'not_very_secret'
 
     DM_ASSETS_URL = 'http://asset-host'
+
+    DM_G12_RECOVERY_SUPPLIER_IDS = "577184"
 
 
 class Development(Config):
@@ -166,6 +170,8 @@ class Development(Config):
 
     DM_DNB_API_USERNAME = 'not_a_real_username'
     DM_DNB_API_PASSWORD = 'not_a_real_password'
+
+    DM_G12_RECOVERY_SUPPLIER_IDS = "577184"
 
 
 class Live(Config):

--- a/tests/app/main/helpers/test_suppliers.py
+++ b/tests/app/main/helpers/test_suppliers.py
@@ -2,9 +2,12 @@ import pytest
 from flask_wtf import FlaskForm
 from wtforms import StringField
 from wtforms.validators import Length
-from app.main.helpers.suppliers import get_country_name_from_country_code, supplier_company_details_are_complete
+from app.main.helpers.suppliers import get_country_name_from_country_code, supplier_company_details_are_complete, \
+    is_g12_recovery_supplier
 
 from dmtestutils.api_model_stubs import SupplierStub
+
+from tests.app.helpers import BaseApplicationTest
 
 
 class TestGetCountryNameFromCountryCode:
@@ -49,3 +52,22 @@ class FormForTest(FlaskForm):
     field_three = StringField('Field three?', validators=[
         Length(max=5, message="Field three must be under 5 characters.")
     ])
+
+
+class TestG12RecoverySupplier(BaseApplicationTest):
+    @pytest.mark.parametrize(
+        'g12_recovery_supplier_ids, expected_result',
+        [
+            (None, False),
+            ('', False),
+            (42, False),
+            ('12:32', False),
+            ([123456, 789012], False),
+            ('123456', True),
+            ('123456,789012', True),
+        ]
+    )
+    def test_returns_expected_value_for_input(self, g12_recovery_supplier_ids, expected_result):
+        with self.app.app_context():
+            self.app.config['DM_G12_RECOVERY_SUPPLIER_IDS'] = g12_recovery_supplier_ids
+            assert is_g12_recovery_supplier('123456') is expected_result

--- a/tests/app/main/test_suppliers.py
+++ b/tests/app/main/test_suppliers.py
@@ -627,6 +627,26 @@ class TestSuppliersDashboard(BaseApplicationTest):
         assert continue_link
         assert continue_link[0].values()[0] == "/suppliers/frameworks/digital-outcomes-and-specialists"
 
+    def test_shows_placeholder_to_recovery_supplier(self):
+        self.data_api_client.get_supplier.return_value = get_supplier(id='577184')  # Test.DM_G12_RECOVERY_SUPPLIER_IDS
+        self.login()
+
+        with self.app.app_context():
+            response = self.client.get("/suppliers")
+            document = html.fromstring(response.get_data(as_text=True))
+
+            assert document.xpath("//h2[normalize-space(string())='G-Cloud 12 recovery']")
+
+    def test_does_not_show_placeholder(self):
+        self.data_api_client.get_supplier.return_value = get_supplier(id='123456')
+        self.login()
+
+        with self.app.app_context():
+            response = self.client.get("/suppliers")
+            document = html.fromstring(response.get_data(as_text=True))
+
+            assert not document.xpath("//h2[normalize-space(string())='G-Cloud 12 recovery']")
+
 
 class TestSupplierDetails(BaseApplicationTest):
 


### PR DESCRIPTION
Trello: https://trello.com/c/KikQx3R2/593-as-a-g12-recovery-supplier-i-can-see-something-other-suppliers-cannot

We had an outage during G12 closing. Some suppliers will be involved in a recovery process to account for the outage causing them to fail to submit their services in time.

We have previously provided a list of the affected supplier IDs via the environment - see https://github.com/alphagov/digitalmarketplace-credentials/pull/359 and https://github.com/alphagov/digitalmarketplace-aws/pull/797. This PR proves that this all works by displaying a placeholder to the affected suppliers.

Currently, the only supplier so configured is our test supplier, so this will not be shown to any real users and is therefore safe for production. The two tests check this.

![image](https://user-images.githubusercontent.com/15256121/100758757-c7f33980-33e7-11eb-863f-9d2640eecfa0.png)
