### PR TITLE
fix cache key by using correct variable

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: venv
-        key: venv-${{ runner.os }}-${{ steps.full-python-version.outputs.version }}-${{ hashFiles('**/requirements-dev.txt') }}
+        key: venv-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('**/requirements-dev.txt') }}
 
     - name: Run python tests
       run: |


### PR DESCRIPTION
Spotted this issue when reviewing https://github.com/alphagov/digitalmarketplace-scripts/pull/588 the second variable wasn't being resolved which made the cache key non-unique across matrix runs. 