### PR TITLE
Show G12 recovery users their number of draft services

### DIFF
--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -297,6 +297,11 @@ def framework_submission_lots(framework_slug):
         application_made=application_made
     ), 200
 
+@main.route('/frameworks/g-cloud-12/draft-services', methods=['GET'])
+@login_required
+@EnsureApplicationCompanyDetailsHaveBeenConfirmed(data_api_client)
+def g12_recovery_draft_services():
+    abort(503)
 
 @main.route('/frameworks/<framework_slug>/submissions/<lot_slug>', methods=['GET'])
 @login_required

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -301,6 +301,7 @@ def framework_submission_lots(framework_slug):
         application_made=application_made
     ), 200
 
+
 @main.route('/frameworks/<framework_slug>/draft-services', methods=['GET'])
 @login_required
 @EnsureApplicationCompanyDetailsHaveBeenConfirmed(data_api_client)
@@ -356,6 +357,7 @@ def g12_recovery_draft_services(framework_slug):
         lots=lots,
         application_made=application_made
     ), 200
+
 
 @main.route('/frameworks/<framework_slug>/submissions/<lot_slug>', methods=['GET'])
 @login_required

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -340,7 +340,7 @@ def g12_recovery_draft_services(framework_slug):
             lot['draft_count'],
             lot['complete_count'],
             declaration_status,
-            framework['status'],
+            "open",  # we want the statuses as if the framework were open
             lot['name'],
             lot['unitSingular'],
             lot['unitPlural']

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -301,11 +301,13 @@ def framework_submission_lots(framework_slug):
         application_made=application_made
     ), 200
 
-@main.route('/frameworks/g-cloud-12/draft-services', methods=['GET'])
+@main.route('/frameworks/<framework_slug>/draft-services', methods=['GET'])
 @login_required
 @EnsureApplicationCompanyDetailsHaveBeenConfirmed(data_api_client)
-def g12_recovery_draft_services():
-    framework_slug = 'g-cloud-12'
+def g12_recovery_draft_services(framework_slug):
+    if framework_slug != "g-cloud-12":
+        abort(404)
+
     framework = get_framework_or_404(data_api_client, framework_slug)
 
     drafts, complete_drafts = get_drafts(data_api_client, framework_slug)

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -69,15 +69,25 @@ def dashboard():
 
     supplier['g12_recovery'] = is_g12_recovery_supplier(supplier['id'])
 
-    all_frameworks = sorted(
+    all_frameworks = list(sorted(
         data_api_client.find_frameworks()['frameworks'],
         key=lambda framework: framework['slug'],
         reverse=True
-    )
+    ))
     supplier_frameworks = {
         framework['frameworkSlug']: framework
         for framework in data_api_client.get_supplier_frameworks(current_user.supplier_id)['frameworkInterest']
     }
+
+    # g12 should always be in frameworks.live for recovery suppliers
+    if supplier["g12_recovery"]:
+        if "g-cloud-12" not in supplier_frameworks:
+            g12 = next(filter(lambda f: f["slug"] == "g-cloud-12", all_frameworks), None)
+            if g12:
+                supplier_frameworks["g-cloud-12"] = g12
+            del g12
+        if "g-cloud-12" in supplier_frameworks:
+            supplier_frameworks["g-cloud-12"]["onFramework"] = True
 
     for framework in all_frameworks:
         framework.update(

--- a/app/templates/suppliers/_frameworks_live.html
+++ b/app/templates/suppliers/_frameworks_live.html
@@ -18,6 +18,13 @@
       </li>
       {% endif %}
       {% if framework in frameworks.live %}
+      {% if framework.slug == "g-cloud-12" and supplier.g12_recovery %}
+      <li>
+        <a class="govuk-link" href="{{ url_for('.g12_recovery_draft_services') }}">
+        Add a service
+        </a>
+      </li>
+      {% endif %}
       <li>
         <a class="govuk-link" href="{{ url_for('.list_services', framework_slug=framework.slug) }}">
         View services

--- a/app/templates/suppliers/_frameworks_live.html
+++ b/app/templates/suppliers/_frameworks_live.html
@@ -20,7 +20,7 @@
       {% if framework in frameworks.live %}
       {% if framework.slug == "g-cloud-12" and supplier.g12_recovery %}
       <li>
-        <a class="govuk-link" href="{{ url_for('.g12_recovery_draft_services') }}">
+        <a class="govuk-link" href="{{ url_for('.g12_recovery_draft_services', framework_slug='g-cloud-12') }}">
         Add a service
         </a>
       </li>

--- a/tests/app/helpers.py
+++ b/tests/app/helpers.py
@@ -473,10 +473,10 @@ class BaseApplicationTest:
         if self.get_user_patch is not None:
             self.get_user_patch.stop()
 
-    def login(self, supplier_organisation_size="small", user_research_opted_in=True, active=True):
+    def login(self, supplier_organisation_size="small", user_research_opted_in=True, active=True, supplier_id=1234):
         with patch('app.main.views.login.data_api_client') as login_api_client:
             supplier_user_json = self.user(
-                123, "email@email.com", 1234, u'Supplier NĀme', u'Năme',
+                123, "email@email.com", supplier_id, u'Supplier NĀme', u'Năme',
                 supplier_organisation_size=supplier_organisation_size,
                 userResearchOptedIn=user_research_opted_in,
                 active=active

--- a/tests/app/main/helpers/test_frameworks.py
+++ b/tests/app/main/helpers/test_frameworks.py
@@ -766,6 +766,7 @@ class TestEnsureApplicationCompanyDetailsHaveBeenConfirmed(BaseApplicationTest):
             'main.framework_supplier_declaration_overview',
             'main.framework_supplier_declaration_submit',
             'main.framework_supplier_declaration_edit',
+            'main.g12_recovery_draft_services'
         }
 
         from app.main.helpers.frameworks import EnsureApplicationCompanyDetailsHaveBeenConfirmed as decorator_class

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -4183,6 +4183,21 @@ class TestG12RecoveryDraftServices(BaseApplicationTest, MockEnsureApplicationCom
             response = self.client.get('/suppliers/frameworks/g-cloud-12/draft-services')
         assert response.status_code == response_code
 
+    def test_page_renders(self, count_unanswered):
+        self.login(supplier_id=577184)
+        self.data_api_client.get_framework.return_value = FrameworkStub(slug="g-cloud-12", status="live").single_result_response()
+
+        with self.app.app_context():
+            response = self.client.get('/suppliers/frameworks/g-cloud-12/draft-services')
+
+        doc = html.fromstring(response.get_data(as_text=True))
+
+        assert doc.cssselect("h1:contains('Your G-Cloud 12 services')")
+        assert [el.text for el in doc.cssselect(".browse-list a")] == [
+            "Cloud hosting", "Cloud software", "Cloud support"
+        ]
+
+
 
 @mock.patch('app.main.views.frameworks.count_unanswered_questions')
 class TestFrameworkSubmissionServices(BaseApplicationTest, MockEnsureApplicationCompanyDetailsHaveBeenConfirmedMixin):

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -4141,7 +4141,7 @@ class TestFrameworkSubmissionLots(BaseApplicationTest, MockEnsureApplicationComp
         assert u'Submitted' in submissions.get_data(as_text=True)
         assert u'Apply to provide' not in submissions.get_data(as_text=True)
 
- 
+
 @mock.patch('app.main.views.frameworks.count_unanswered_questions')
 class TestG12RecoveryDraftServices(BaseApplicationTest, MockEnsureApplicationCompanyDetailsHaveBeenConfirmedMixin):
 
@@ -4185,7 +4185,8 @@ class TestG12RecoveryDraftServices(BaseApplicationTest, MockEnsureApplicationCom
 
     def test_page_renders(self, count_unanswered):
         self.login(supplier_id=577184)
-        self.data_api_client.get_framework.return_value = FrameworkStub(slug="g-cloud-12", status="live").single_result_response()
+        self.data_api_client.get_framework.return_value = FrameworkStub(slug="g-cloud-12", status="live")\
+            .single_result_response()
 
         with self.app.app_context():
             response = self.client.get('/suppliers/frameworks/g-cloud-12/draft-services')
@@ -4199,7 +4200,8 @@ class TestG12RecoveryDraftServices(BaseApplicationTest, MockEnsureApplicationCom
 
     def test_lot_status_includes_number_of_draft_and_completed_services(self, count_unanswered):
         self.login(supplier_id=577184)
-        self.data_api_client.get_framework.return_value = FrameworkStub(slug="g-cloud-12", status="live").single_result_response()
+        self.data_api_client.get_framework.return_value = FrameworkStub(slug="g-cloud-12", status="live")\
+            .single_result_response()
 
         self.data_api_client.get_supplier_declaration.return_value = {'declaration': {'status': 'complete'}}
         self.data_api_client.find_draft_services_iter.return_value = [

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -4167,6 +4167,13 @@ class TestG12RecoveryDraftServices(BaseApplicationTest, MockEnsureApplicationCom
             response = self.client.get('/suppliers/frameworks/g-cloud-12/draft-services')
         assert response.status_code == response_code
 
+    def test_page_exists_only_for_g_cloud_12(self, count_unanswered):
+        self.login(supplier_id=577184)
+
+        with self.app.app_context():
+            response = self.client.get('/suppliers/frameworks/g-cloud-11/draft-services')
+        assert response.status_code == 404
+
     @pytest.mark.parametrize('supplier_id, response_code', [(1, 404), (577184, 200)])
     def test_page_exists_for_recovery_suppliers_only(self, count_unanswered, supplier_id, response_code):
         self.login(supplier_id=supplier_id)

--- a/tests/app/main/test_suppliers.py
+++ b/tests/app/main/test_suppliers.py
@@ -647,6 +647,42 @@ class TestSuppliersDashboard(BaseApplicationTest):
 
             assert not document.xpath("//h2[normalize-space(string())='G-Cloud 12 recovery']")
 
+    @pytest.mark.parametrize("framework_interest, on_framework", (
+        (False, False),
+        (True, False),
+        (True, True),
+    ))
+    def test_recovery_supplier_sees_g12_links(self, framework_interest, on_framework):
+        g12 = FrameworkStub(status="live", slug="g-cloud-12").response()
+        g12["frameworkSlug"] = "g-cloud-12"
+        self.data_api_client.get_supplier_frameworks.return_value = {
+            "frameworkInterest": [{**g12, "onFramework": on_framework}] if framework_interest else []
+        }
+        self.data_api_client.find_frameworks.return_value = {
+            "frameworks": [g12]
+        }
+
+        self.data_api_client.get_supplier.return_value = get_supplier(id='577184')  # Test.DM_G12_RECOVERY_SUPPLIER_IDS
+        self.login()
+
+        with self.app.app_context():
+            response = self.client.get("/suppliers")
+            doc = html.fromstring(response.get_data(as_text=True))
+
+            assert doc.xpath(
+                "//h3[normalize-space(string())=$f]"
+                "[(following::a)[1][normalize-space(string())=$t1][@href=$u1]]"
+                "[(following::a)[2][normalize-space(string())=$t2][@href=$u2]]"
+                "[(following::a)[3][normalize-space(string())=$t3][@href=$u3]]",
+                f="G-Cloud 12",
+                t1="Add a service",
+                u1="/suppliers/frameworks/g-cloud-12/draft-services",
+                t2="View services",
+                u2="/suppliers/frameworks/g-cloud-12/services",
+                t3="View documents",
+                u3="/suppliers/frameworks/g-cloud-12",
+            )
+
 
 class TestSupplierDetails(BaseApplicationTest):
 


### PR DESCRIPTION
Trello: https://trello.com/c/B05l52YO/612-2-as-a-g12-recovery-supplier-i-can-see-how-many-draft-g12-services-i-have

In [the last PR](https://github.com/alphagov/digitalmarketplace-supplier-frontend/pull/1288), we gave supplier-frontend knowledge of which suppliers are part of the G12 recovery.

Allow these suppliers to see the 'Your services' page for G12, which shows all their draft services for G12.

We've not tested whether the links on the page work - the next story will cover sorting them out.

![your-services](https://user-images.githubusercontent.com/15256121/101154956-610b9580-361e-11eb-9b81-ffdf53c346d0.png)
