### PR TITLE
Replace flash messages with alerts

### DIFF
--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -637,8 +637,6 @@ def framework_supplier_declaration_submit(framework_slug):
         current_user.email_address,
     )
 
-    flash_key = "{}/declaration_complete".format(url_for('.framework_dashboard', framework_slug=framework['slug']))
-    flash(flash_key, "track-page-view")
     return redirect(url_for('.framework_dashboard', framework_slug=framework['slug']))
 
 

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -449,11 +449,6 @@ def complete_draft_service(framework_slug, lot_slug, service_id):
     )
 
     flash(SERVICE_COMPLETED_MESSAGE.format(service_name=draft.get('serviceName') or draft.get('lotName')), "success")
-    flash("/".join((
-        url_for(".framework_submission_lots", framework_slug=framework['slug']),
-        lot_slug,
-        "complete",
-    )), "track-page-view")
 
     if lot['oneServiceLimit']:
         return redirect(url_for(".framework_submission_lots", framework_slug=framework['slug']))
@@ -711,17 +706,6 @@ def remove_subsection(framework_slug, lot_slug, service_id, section_id, question
             section_name=containing_section.name.lower(),
             service_name=(draft.get("serviceName") or draft.get("lotName")).lower(),
         ), "error")
-        flash("/".join((
-            url_for(
-                ".remove_subsection",
-                framework_slug=framework_slug,
-                lot_slug=lot_slug,
-                service_id=service_id,
-                section_id=section_id,
-                question_slug=question_slug,
-            ),
-            "remove-last-subsection-attempt",
-        )), "track-page-view")
 
     if request.args.get("confirm") and request.method == "POST":
         # Remove the section

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -153,7 +153,7 @@ def remove_service(framework_slug, service_id):
 
         updated_service = updated_service.get('services')
 
-        flash(SERVICE_REMOVED_MESSAGE.format(service_name=updated_service.get('serviceName')), 'remove_service')
+        flash(SERVICE_REMOVED_MESSAGE.format(service_name=updated_service.get('serviceName')), "success")
 
         return redirect(url_for(".list_services", framework_slug=service["frameworkSlug"]))
 

--- a/app/templates/_base_page.html
+++ b/app/templates/_base_page.html
@@ -49,7 +49,20 @@
 {% endblock %}
 
 {% block content %}
-  {% include "toolkit/flash_messages.html" %}
+  {% block flashMessages %}
+    {% with
+       messages = get_flashed_messages(with_categories=True),
+       titles = {"error": "There is a problem"}
+    %}
+      {% for category, message in messages %}
+        {{ dmAlert({
+          "titleHtml": titles.get(category) or message,
+          "html": message if category in titles else None,
+          "type": category,
+        }) }}
+      {% endfor %}
+    {% endwith %}
+  {% endblock flashMessages %}
   {% block mainContent %}{% endblock %}
 {% endblock %}
 

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -2952,12 +2952,6 @@ class TestDeclarationSubmit(BaseApplicationTest, MockEnsureApplicationCompanyDet
 
         # this will be the response from the redirected-to view
         assert response.status_code == 200
-        doc = html.fromstring(response.get_data(as_text=True))
-
-        assert doc.xpath(
-            "//*[@data-analytics='trackPageView'][@data-url=$k]",
-            k="/suppliers/frameworks/g-cloud-9/declaration_complete",
-        )
 
     @pytest.mark.parametrize("framework_status", ("standstill", "pending", "live", "expired",))
     def test_closed_framework_state(self, framework_status):

--- a/tests/app/main/test_suppliers.py
+++ b/tests/app/main/test_suppliers.py
@@ -118,7 +118,6 @@ class TestSuppliersDashboard(BaseApplicationTest):
             session['_flashes'] = [
                 ('error', 'This is an error'),
                 ('success', 'This is a success'),
-                ('track-page-view', '/suppliers?account-created=true')
             ]
 
         self.data_api_client.get_framework.return_value = self.framework('open')
@@ -133,26 +132,7 @@ class TestSuppliersDashboard(BaseApplicationTest):
 
         assert '<pclass="banner-message">Thisisanerror</p>' in data
         assert '<pclass="banner-message">Thisisasuccess</p>' in data
-        assert '<pclass="banner-message">account-created</p>' not in data
 
-    def test_data_analytics_track_page_view_is_shown_if_account_created_flag_flash_message(self):
-        with self.client.session_transaction() as session:
-            session['_flashes'] = [('track-page-view', '/suppliers?account-created=true')]
-
-        self.login()
-
-        res = self.client.get("/suppliers")
-        data = res.get_data(as_text=True)
-
-        assert 'data-analytics="trackPageView" data-url="/suppliers?account-created=true"' in data
-
-    def test_data_analytics_track_page_view_is_not_shown_if_no_account_created_flag_flash_message(self):
-        self.login()
-
-        res = self.client.get("/suppliers")
-        data = res.get_data(as_text=True)
-
-        assert 'data-analytics="trackPageView" data-url="/suppliers?account-created=true"' not in data
 
     def test_shows_edit_buttons(self):
         self.data_api_client.get_supplier.side_effect = get_supplier


### PR DESCRIPTION
Ticket: https://trello.com/c/Vp3FZhKc/289-replace-flash-messages-with-digital-marketplace-govuk-frontend-alert-component-in-supplier-frontend

We want to use the dmAlerts macro instead of the old flash-messages 
template, as dmAlert is based on GOV.UK Design System styles and guidance.