### PR TITLE
Update GitHub Actions cache

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: venv
-        key: venv-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('**/requirements-dev.txt') }}
+        key: venv-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('**/requirements*.txt') }}
 
     - name: Run python tests
       run: |


### PR DESCRIPTION
The python cache for GitHub Actions should depend on requirements.txt as well as requirements-dev.txt