### PR TITLE
Add G12 recovery banner to supplier dashboard

### DIFF
--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -67,10 +67,14 @@ def list_services(framework_slug):
         framework=framework_slug,
     )["services"]
 
+    # We only need to know whether they are a G12 recovery supplier or not.
+    supplier = {'g12_recovery': is_g12_recovery_supplier(current_user.supplier_id)}
+
     return render_template(
         "services/list_services.html",
         services=suppliers_services,
         framework=framework,
+        supplier=supplier,
     ), 200
 
 

--- a/app/templates/partials/g12_recovery_information.html
+++ b/app/templates/partials/g12_recovery_information.html
@@ -1,0 +1,12 @@
+{% if supplier.g12_recovery %}
+  <div class="wrapper">
+    {# TODO: replace with govukNotificationBanner #}
+    {%
+      with
+      message = 'You have until 23:59 on 1 January 2525 to complete <a href="'|safe + url_for('.list_services', framework_slug='g-cloud-12') + '">your additional G12 services</a>.'|safe,
+      type = 'information'
+    %}
+      {% include 'toolkit/notification-banner.html' %}
+    {% endwith %}
+  </div>
+{% endif %}

--- a/app/templates/suppliers/dashboard.html
+++ b/app/templates/suppliers/dashboard.html
@@ -18,6 +18,7 @@
 {% endblock %}
 
 {% block mainContent %}
+  {% include "partials/g12_recovery_information.html" %}
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">

--- a/tests/app/main/test_suppliers.py
+++ b/tests/app/main/test_suppliers.py
@@ -662,6 +662,26 @@ class TestSuppliersDashboard(BaseApplicationTest):
                 u3="/suppliers/frameworks/g-cloud-12",
             )
 
+    def test_recovery_supplier_sees_banner(self):
+        self.data_api_client.get_supplier.return_value = get_supplier(id=577184)  # Test.DM_G12_RECOVERY_SUPPLIER_IDS
+        self.login()
+
+        with self.app.app_context():
+            response = self.client.get("/suppliers")
+        doc = html.fromstring(response.get_data(as_text=True))
+
+        assert doc.cssselect("p.banner-message:contains('You have until')")
+
+    def test_supplier_cannot_see_banner(self):
+        self.data_api_client.get_supplier.return_value = get_supplier(id=1)
+        self.login()
+
+        with self.app.app_context():
+            response = self.client.get("/suppliers")
+        doc = html.fromstring(response.get_data(as_text=True))
+
+        assert not doc.cssselect("p.banner-message:contains('You have until')")
+
 
 class TestSupplierDetails(BaseApplicationTest):
 


### PR DESCRIPTION
Trello: https://trello.com/c/n2Eop9FB/644-2-as-a-supplier-i-know-when-the-deadline-is

We show this banner to suppliers involved in the G12 recovery - and none others. It will help them understand when the deadline is for the recovery process and what they need to do.

Content is not final - just putting the banner into place for the moment.

Hard-code the closing date. This is fine because we're going to remove all this code after the recovery process is complete, so it doesn't need to be re-usable.

Add tests to check that this shows up iff the supplier is a recovery supplier.

![image](https://user-images.githubusercontent.com/15256121/102344144-60b2b900-3f93-11eb-8142-7ad9dc0080aa.png)
