### PR TITLE
Update content in G12 recovery banner

### DIFF
--- a/app/main/helpers/suppliers.py
+++ b/app/main/helpers/suppliers.py
@@ -1,6 +1,7 @@
 import os
 import json
 from typing import Union
+from datetime import datetime, timedelta
 
 from flask import current_app
 
@@ -83,3 +84,28 @@ def is_g12_recovery_supplier(supplier_id: Union[str, int]) -> bool:
         return False
 
     return int(supplier_id) in supplier_ids
+
+
+G12_RECOVERY_DEADLINE = datetime(year=2025, month=1, day=1, hour=17)
+
+
+def g12_recovery_time_remaining() -> str:
+    return format_g12_recovery_time_remaining(G12_RECOVERY_DEADLINE - datetime.now())
+
+
+def format_g12_recovery_time_remaining(time_to_deadline: timedelta) -> str:
+    if time_to_deadline.days > 0:
+        number, unit = time_to_deadline.days, 'day'
+    elif time_to_deadline.seconds / 3600 >= 1:
+        number, unit = int(time_to_deadline.seconds / 3600), 'hour'
+    elif time_to_deadline.seconds / 60 >= 1:
+        number, unit = int(time_to_deadline.seconds / 60), 'minute'
+    elif time_to_deadline.seconds >= 0:
+        number, unit = time_to_deadline.seconds, 'second'
+    else:
+        number, unit = 0, 'second'
+
+    if number != 1:
+        unit += 's'
+
+    return f'{number} {unit}'

--- a/app/main/helpers/suppliers.py
+++ b/app/main/helpers/suppliers.py
@@ -86,7 +86,7 @@ def is_g12_recovery_supplier(supplier_id: Union[str, int]) -> bool:
     return int(supplier_id) in supplier_ids
 
 
-G12_RECOVERY_DEADLINE = datetime(year=2025, month=1, day=1, hour=17)
+G12_RECOVERY_DEADLINE = datetime(year=2525, month=1, day=1, hour=17)
 
 
 def g12_recovery_time_remaining() -> str:

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -38,7 +38,7 @@ from ..helpers.suppliers import (
     COUNTRY_TUPLE,
     get_country_name_from_country_code,
     supplier_company_details_are_complete,
-    is_g12_recovery_supplier,
+    is_g12_recovery_supplier, g12_recovery_time_remaining,
 )
 from ..helpers import login_required
 
@@ -112,6 +112,10 @@ def dashboard():
     if "currently_applying_to" in session:
         del session["currently_applying_to"]
 
+    g12_recovery = None
+    if supplier['g12_recovery']:
+        g12_recovery = {'time_remaining': g12_recovery_time_remaining()}
+
     return render_template(
         "suppliers/dashboard.html",
         supplier=supplier,
@@ -122,7 +126,8 @@ def dashboard():
             'standstill': get_frameworks_by_status(all_frameworks, 'standstill', 'made_application'),
             'live': get_frameworks_by_status(all_frameworks, 'live', 'onFramework'),
             'last_dos': get_most_recent_expired_dos_framework(all_frameworks),
-        }
+        },
+        g12_recovery=g12_recovery,
     ), 200
 
 

--- a/app/templates/partials/g12_recovery_information.html
+++ b/app/templates/partials/g12_recovery_information.html
@@ -1,9 +1,9 @@
-{% if supplier.g12_recovery %}
+{% if g12_recovery %}
   <div class="wrapper">
     {# TODO: replace with govukNotificationBanner #}
     {%
       with
-      message = 'You have until 23:59 on 1 January 2525 to complete <a href="'|safe + url_for('.list_services', framework_slug='g-cloud-12') + '">your additional G12 services</a>.'|safe,
+      message = 'You have ' + g12_recovery.time_remaining + ' left to finish your application.<br>You need to mark your services as complete to finish your application. <a href="'|safe + url_for('.list_services', framework_slug='g-cloud-12') + '">View your services.</a>'|safe,
       type = 'information'
     %}
       {% include 'toolkit/notification-banner.html' %}

--- a/tests/app/main/helpers/test_suppliers.py
+++ b/tests/app/main/helpers/test_suppliers.py
@@ -1,9 +1,11 @@
+from datetime import timedelta
+
 import pytest
 from flask_wtf import FlaskForm
 from wtforms import StringField
 from wtforms.validators import Length
 from app.main.helpers.suppliers import get_country_name_from_country_code, supplier_company_details_are_complete, \
-    is_g12_recovery_supplier
+    is_g12_recovery_supplier, format_g12_recovery_time_remaining
 
 from dmtestutils.api_model_stubs import SupplierStub
 
@@ -71,3 +73,21 @@ class TestG12RecoverySupplier(BaseApplicationTest):
         with self.app.app_context():
             self.app.config['DM_G12_RECOVERY_SUPPLIER_IDS'] = g12_recovery_supplier_ids
             assert is_g12_recovery_supplier('123456') is expected_result
+
+
+class TestG12TimeRemainingFormatting:
+    @pytest.mark.parametrize(
+        'time_to_deadline, expected_result', [
+            (timedelta(days=10, hours=10), '10 days'),
+            (timedelta(days=1, hours=10), '1 day'),
+            (timedelta(hours=10, minutes=10), '10 hours'),
+            (timedelta(hours=1, minutes=10), '1 hour'),
+            (timedelta(minutes=10, seconds=10), '10 minutes'),
+            (timedelta(minutes=1, seconds=10), '1 minute'),
+            (timedelta(seconds=10), '10 seconds'),
+            (timedelta(seconds=1), '1 second'),
+            (timedelta(days=-1), '0 seconds'),
+        ]
+    )
+    def test_returns_expected_value_for_input(self, time_to_deadline, expected_result):
+        assert format_g12_recovery_time_remaining(time_to_deadline) == expected_result

--- a/tests/app/main/test_suppliers.py
+++ b/tests/app/main/test_suppliers.py
@@ -670,7 +670,7 @@ class TestSuppliersDashboard(BaseApplicationTest):
             response = self.client.get("/suppliers")
         doc = html.fromstring(response.get_data(as_text=True))
 
-        assert doc.cssselect("p.banner-message:contains('You have until')")
+        assert doc.cssselect("p.banner-message:contains('You need to mark your services as complete')")
 
     def test_supplier_cannot_see_banner(self):
         self.data_api_client.get_supplier.return_value = get_supplier(id=1)
@@ -680,7 +680,7 @@ class TestSuppliersDashboard(BaseApplicationTest):
             response = self.client.get("/suppliers")
         doc = html.fromstring(response.get_data(as_text=True))
 
-        assert not doc.cssselect("p.banner-message:contains('You have until')")
+        assert not doc.cssselect("p.banner-message:contains('You need to mark your services as complete')")
 
 
 class TestSupplierDetails(BaseApplicationTest):


### PR DESCRIPTION
Trello: https://trello.com/c/n2Eop9FB/644-2-as-a-supplier-i-know-when-the-deadline-is

The G12 recovery process is for suppliers who were affected by the outage during G12 closing. We will give these suppliers an opportunity to submit the services that the outage disrupted.

In https://github.com/alphagov/digitalmarketplace-supplier-frontend/pull/1297, we created a banner that we will display to suppliers involved in the G12 recovery - and none others. It will help them understand when the deadline is for the recovery process and what they need to do.

This PR updates the banner with the content from @NoraGDS 

(Note that the deadline is currently hardcoded to a placeholder in 2525. We'll need to update when we know the actual date.)

![image](https://user-images.githubusercontent.com/15256121/102359382-9b731c00-3fa8-11eb-80e6-d96e1e6cfdbb.png)
