### PR TITLE
Show G12 recovery banner on service pages

### DIFF
--- a/app/templates/services/list_services.html
+++ b/app/templates/services/list_services.html
@@ -24,6 +24,8 @@
 {% endblock %}
 
 {% block mainContent %}
+  {% include "partials/g12_recovery_information.html" %}
+
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-l">Your {{ framework.name }} services</h1>

--- a/app/templates/services/service_submission.html
+++ b/app/templates/services/service_submission.html
@@ -41,6 +41,8 @@
     {% endif %}
   {% endwith %}
 
+  {% include "partials/g12_recovery_information.html" %}
+
   {% if service_data.status == 'submitted' and declaration_status != 'complete' and framework.status == 'open' %}
     <div class="wrapper">
       {%


### PR DESCRIPTION
Trello: https://trello.com/c/n2Eop9FB/644-2-as-a-supplier-i-know-when-the-deadline-is

The G12 recovery process is for suppliers who were affected by the outage during G12 closing. We will give these suppliers an opportunity to submit the services that the outage disrupted.

Show [the banner telling suppliers how long they've got](https://github.com/alphagov/digitalmarketplace-supplier-frontend/pull/1298) on two new pages: 'Your G-Cloud 12 services' and the submission summary

![image](https://user-images.githubusercontent.com/15256121/102370037-8603ef00-3fb4-11eb-9ec8-7992a4bb82be.png)

![image](https://user-images.githubusercontent.com/15256121/102370094-96b46500-3fb4-11eb-98d1-79241d2f9fd5.png)
