### PR TITLE
Remove G12 recovery placeholder

### DIFF
--- a/app/templates/suppliers/_frameworks_coming.html
+++ b/app/templates/suppliers/_frameworks_coming.html
@@ -1,14 +1,3 @@
 {% for framework in frameworks.coming %}
   {# add banners/cards here for messages to suppliers about upcoming frameworks #}
 {% endfor %}
-
-{% if supplier.g12_recovery %}
-  {% with
-    main = true,
-    header_level = "h2",
-    messages = ['This is a placeholder'],
-    heading = "G-Cloud 12 recovery"
-  %}
-    {% include "toolkit/temporary-message.html" %}
-  {% endwith %}
-{% endif %}

--- a/tests/app/main/test_suppliers.py
+++ b/tests/app/main/test_suppliers.py
@@ -606,26 +606,6 @@ class TestSuppliersDashboard(BaseApplicationTest):
         assert continue_link
         assert continue_link[0].values()[0] == "/suppliers/frameworks/digital-outcomes-and-specialists"
 
-    def test_shows_placeholder_to_recovery_supplier(self):
-        self.data_api_client.get_supplier.return_value = get_supplier(id='577184')  # Test.DM_G12_RECOVERY_SUPPLIER_IDS
-        self.login()
-
-        with self.app.app_context():
-            response = self.client.get("/suppliers")
-            document = html.fromstring(response.get_data(as_text=True))
-
-            assert document.xpath("//h2[normalize-space(string())='G-Cloud 12 recovery']")
-
-    def test_does_not_show_placeholder(self):
-        self.data_api_client.get_supplier.return_value = get_supplier(id='123456')
-        self.login()
-
-        with self.app.app_context():
-            response = self.client.get("/suppliers")
-            document = html.fromstring(response.get_data(as_text=True))
-
-            assert not document.xpath("//h2[normalize-space(string())='G-Cloud 12 recovery']")
-
     @pytest.mark.parametrize("framework_interest, on_framework", (
         (False, False),
         (True, False),


### PR DESCRIPTION
Trello: https://trello.com/c/NhWv5iIk/647-1-remove-extraneous-g12-recovery-stuff

We now have the G12 banners, so we no longer need the placeholder to prove that the G12 allow-list is working.

This partially reverts 51be819e134c0e24f57f0b32de7e8eda9dbc27e6.