### PR TITLE
Add page to view all services for G12 recovery suppliers

### DIFF
--- a/app/assets/scss/_list_all_services.scss
+++ b/app/assets/scss/_list_all_services.scss
@@ -1,0 +1,3 @@
+.app-text--can-be-marked-as-complete {
+    color: govuk-colour("green")
+}

--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -67,6 +67,7 @@ $govuk-global-styles: true;
 @import "_supplier-declaration.scss";
 @import "_updates.scss";
 @import "_view-service-link.scss";
+@import "_list_all_services.scss";
 
 // Overrides
 @import "overrides/_list-entry";

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -112,12 +112,16 @@ def list_all_services(framework_slug):
             'unanswered_optional': unanswered_optional,
         })
 
+    # Only G12 recovery suppliers can access this route, so always show the banner
+    g12_recovery = {'time_remaining': g12_recovery_time_remaining()}
+
     return render_template(
         "services/list_all_services.html",
         framework=framework,
         drafts=drafts,
         complete_drafts=complete_drafts,
         services=suppliers_services,
+        g12_recovery=g12_recovery
     ), 200
 
 

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -20,6 +20,7 @@ from ...main import main, content_loader
 from ..helpers import login_required
 from ..helpers.services import (
     copy_service_from_previous_framework,
+    get_drafts,
     get_lot_drafts,
     get_signed_document_url,
     is_service_associated_with_supplier,
@@ -60,6 +61,9 @@ ALL_SERVICES_ADDED_MESSAGE = (
 @main.route("/frameworks/<string:framework_slug>/services")
 @login_required
 def list_services(framework_slug):
+    if is_g12_recovery_supplier(current_user.supplier_id) and framework_slug == "g-cloud-12":
+        return redirect(url_for(".list_all_services", framework_slug=framework_slug))
+
     framework = get_framework_or_404(data_api_client, framework_slug, allowed_statuses=['live'])
 
     suppliers_services = data_api_client.find_services(
@@ -76,6 +80,44 @@ def list_services(framework_slug):
         services=suppliers_services,
         framework=framework,
         g12_recovery=g12_recovery,
+    ), 200
+
+
+@main.route("/frameworks/<string:framework_slug>/all-services")
+@login_required
+def list_all_services(framework_slug):
+    if not (is_g12_recovery_supplier(current_user.supplier_id) and framework_slug == "g-cloud-12"):
+        abort(404)
+
+    framework = get_framework_or_404(data_api_client, framework_slug, allowed_statuses=['live'])
+
+    suppliers_services = data_api_client.find_services(
+        supplier_id=current_user.supplier_id,
+        framework=framework_slug,
+    )["services"]
+
+    drafts, complete_drafts = get_drafts(data_api_client, framework_slug)
+
+    service_sections = content_loader.get_manifest(
+        framework_slug,
+        'edit_submission',
+    )
+
+    for draft in drafts:
+        sections = service_sections.filter(context={'lot': draft["lotSlug"]}).summary(draft, inplace_allowed=True)
+
+        unanswered_required, unanswered_optional = count_unanswered_questions(sections)
+        draft.update({
+            'unanswered_required': unanswered_required,
+            'unanswered_optional': unanswered_optional,
+        })
+
+    return render_template(
+        "services/list_all_services.html",
+        framework=framework,
+        drafts=drafts,
+        complete_drafts=complete_drafts,
+        services=suppliers_services,
     ), 200
 
 

--- a/app/templates/services/list_all_services.html
+++ b/app/templates/services/list_all_services.html
@@ -1,0 +1,127 @@
+{% extends "_base_page.html" %}
+{% import "toolkit/summary-table.html" as summary %}
+{% import "macros/submission.html" as submission %}
+
+{% block pageTitle %}
+  Current services – Digital Marketplace
+{% endblock %}
+
+{% block breadcrumb %}
+  {{ govukBreadcrumbs({
+    "items": [
+      {
+        "text": "Digital Marketplace",
+        "href": "/"
+      },
+      {
+        "text": "Your account",
+        "href": url_for('.dashboard')
+      },
+      {
+        "text": "Your " + framework.name + " services"
+      }
+    ]
+  }) }}
+{% endblock %}
+
+{% block mainContent %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-l">Your {{ framework.name }} services</h1>
+    </div>
+  </div>
+
+  {{ summary.heading("Draft services") }}
+  {% if framework.status == 'open' %}
+    {{ summary.top_link("Add a service", url_for(".start_new_draft_service", framework_slug=framework.slug, lot_slug=lot.slug)) }}
+  {% elif framework.status == 'pending' %}
+    <p class="hint">These services were not completed</p>
+  {% endif %}
+  {% call(draft) summary.list_table(
+    drafts,
+    caption="Draft services",
+    empty_message="You haven’t added any services yet." if framework.status == 'open' else "You didn’t add any services.",
+    field_headings=[
+        "Service name",
+        "Progress"
+    ],
+    field_headings_visible=False
+  ) %}
+    {% call summary.row() %}
+      {{ summary.service_link(draft.serviceName,
+                              url_for(".view_service_submission", framework_slug=framework.slug, lot_slug=draft.lot, service_id=draft.id)) }}
+
+      {{ summary.text(submission.multiline_string(
+        submission.can_be_completed_text(draft.unanswered_required, "open"),
+        submission.unanswered_required_text(draft.unanswered_required, draft.unanswered_optional),
+        submission.unanswered_optional_text(draft.unanswered_required, draft.unanswered_optional)
+      )) }}
+    {% endcall %}
+  {% endcall %}
+
+  {{ summary.heading("Complete services") }}
+  {% call(draft) summary.list_table(
+    complete_drafts,
+    caption="Complete services",
+    empty_message="You haven’t marked any services as complete yet." if framework.status == 'open' else "You didn’t mark any services as complete.",
+    field_headings=[
+        "Service name",
+        "Progress",
+        "Make a copy"
+    ],
+    field_headings_visible=False
+  ) %}
+    {% call summary.row() %}
+      {{ summary.service_link(
+          draft.serviceName,
+          url_for(".view_service_submission", framework_slug=framework.slug, lot_slug=draft.lot, service_id=draft.id)
+      ) }}
+      {% if framework.status == 'open' %}
+        {% call summary.field(action=True) %}
+          <form method="post" action="{{ url_for('.copy_draft_service', framework_slug=framework.slug, lot_slug=draft.lot, service_id=draft.id) }}">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token_value or csrf_token() }}" />
+            {{ govukButton({
+              "text": "Make a copy",
+              "classes": "govuk-!-margin-0",
+            }) }}
+          </form>
+        {% endcall %}
+      {% else %}
+        {{ summary.text() }}
+      {% endif %}
+    {% endcall %}
+  {% endcall %}
+
+  {{ summary.heading("Live services") }}
+  {% set empty_message %}
+    You don’t have any {{ framework.name }} services on the Digital Marketplace
+  {% endset %}
+  {% call(item) summary.list_table(
+    services,
+    caption='Current services',
+    field_headings=[
+      'Name',
+      'Lot',
+      summary.hidden_field_heading("Status")
+    ],
+    field_headings_visible=True,
+    empty_message=empty_message
+  ) %}
+    {% call summary.row() %}
+      {{ summary.service_link(
+          item.serviceName or item.lotName,
+          url_for('.edit_service', framework_slug=item.frameworkSlug, service_id=item.id)
+      ) }}
+
+      {{ summary.text(item.lotName or item.lot) }}
+
+      {% call summary.field(action=True) %}
+        {% if item.status == "published" %}
+          Live
+        {% else %}
+          Removed
+        {% endif %}
+      {% endcall %}
+    {% endcall %}
+  {% endcall %}
+{% endblock %}

--- a/app/templates/services/list_all_services.html
+++ b/app/templates/services/list_all_services.html
@@ -25,6 +25,7 @@
 {% endblock %}
 
 {% block mainContent %}
+{% include "partials/g12_recovery_information.html" %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-l">Your {{ framework.name }} services</h1>
@@ -50,12 +51,19 @@
     {% call summary.row() %}
       {{ summary.service_link(draft.serviceName,
                               url_for(".view_service_submission", framework_slug=framework.slug, lot_slug=draft.lot, service_id=draft.id)) }}
+      {% if draft.unanswered_required %}
+        {{ summary.text(submission.multiline_string(
+          submission.unanswered_required_text(draft.unanswered_required, draft.unanswered_optional),
+          submission.unanswered_optional_text(draft.unanswered_required, draft.unanswered_optional)
+        )) }}
+      {% else %}
+        <td class="summary-item-field">
+        <strong class="app-text--can-be-marked-as-complete">
+          {{ submission.can_be_completed_text(draft.unanswered_required, "open") }}
 
-      {{ summary.text(submission.multiline_string(
-        submission.can_be_completed_text(draft.unanswered_required, "open"),
-        submission.unanswered_required_text(draft.unanswered_required, draft.unanswered_optional),
-        submission.unanswered_optional_text(draft.unanswered_required, draft.unanswered_optional)
-      )) }}
+        </strong>
+        </td>
+      {% endif %}
     {% endcall %}
   {% endcall %}
 
@@ -65,9 +73,7 @@
     caption="Complete services",
     empty_message="You haven’t marked any services as complete yet." if framework.status == 'open' else "You didn’t mark any services as complete.",
     field_headings=[
-        "Service name",
-        "Progress",
-        "Make a copy"
+        "Service name"
     ],
     field_headings_visible=False
   ) %}
@@ -76,19 +82,6 @@
           draft.serviceName,
           url_for(".view_service_submission", framework_slug=framework.slug, lot_slug=draft.lot, service_id=draft.id)
       ) }}
-      {% if framework.status == 'open' %}
-        {% call summary.field(action=True) %}
-          <form method="post" action="{{ url_for('.copy_draft_service', framework_slug=framework.slug, lot_slug=draft.lot, service_id=draft.id) }}">
-            <input type="hidden" name="csrf_token" value="{{ csrf_token_value or csrf_token() }}" />
-            {{ govukButton({
-              "text": "Make a copy",
-              "classes": "govuk-!-margin-0",
-            }) }}
-          </form>
-        {% endcall %}
-      {% else %}
-        {{ summary.text() }}
-      {% endif %}
     {% endcall %}
   {% endcall %}
 

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -526,7 +526,24 @@ class TestG12RecoveryListServices(BaseApplicationTest):
             t="Draft services",
         )[0].getnext()
 
-        assert "Service can be marked as complete" in draft_services_table.text_content()
+        draft_service_progress = draft_services_table.cssselect("tbody tr")[0].cssselect("td")[1]
+
+        assert "Service can be marked as complete" in draft_service_progress.text_content()
+        assert draft_service_progress.cssselect("strong")
+        assert draft_service_progress.cssselect(".app-text--can-be-marked-as-complete")
+
+    def test_list_all_services_page_has_banner(self, g12_recovery_supplier_id):
+        self.login(supplier_id=g12_recovery_supplier_id)
+
+        self.data_api_client.find_draft_services_iter.return_value = []
+        self.data_api_client.find_services.return_value = {"services": []}
+
+        res = self.client.get("/suppliers/frameworks/g-cloud-12/all-services")
+
+        document = html.fromstring(res.get_data(as_text=True))
+
+        assert document.cssselect("p.banner-message:contains('You have')")
+        assert document.cssselect("p.banner-message:contains('left to finish your application')")
 
 
 class _BaseTestSupplierEditRemoveService(BaseApplicationTest):


### PR DESCRIPTION
https://trello.com/c/0igPI9kJ/

The G12 recovery process is for suppliers who were affected by the outage during G12 closing. We will give these suppliers an opportunity to submit the services that the outage disrupted.

We want G12 recovery suppliers to be able to see all live and draft (submitted or unsubmitted) services on one page; this PR adds a new route `/suppliers/frameworks/g-cloud-12/all-services` which does this. The typical list services route `/suppliers/frameworks/g-cloud-12/services` will redirect to this page if required, so we have fewer links and breadcrumbs to update.

![Screenshot of 'Your G-Cloud 12 services' page showing 'Draft services', 'Completed Services', and 'Live services'](https://user-images.githubusercontent.com/503614/102598786-713e6d00-4114-11eb-86fa-cd2342aadef8.png)
