### PR TITLE
Revert "Show G12 recovery suppliers link to 'add services'"

### DIFF
--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -69,25 +69,15 @@ def dashboard():
 
     supplier['g12_recovery'] = is_g12_recovery_supplier(supplier['id'])
 
-    all_frameworks = list(sorted(
+    all_frameworks = sorted(
         data_api_client.find_frameworks()['frameworks'],
         key=lambda framework: framework['slug'],
         reverse=True
-    ))
+    )
     supplier_frameworks = {
         framework['frameworkSlug']: framework
         for framework in data_api_client.get_supplier_frameworks(current_user.supplier_id)['frameworkInterest']
     }
-
-    # g12 should always be in frameworks.live for recovery suppliers
-    if supplier["g12_recovery"]:
-        if "g-cloud-12" not in supplier_frameworks:
-            g12 = next(filter(lambda f: f["slug"] == "g-cloud-12", all_frameworks), None)
-            if g12:
-                supplier_frameworks["g-cloud-12"] = g12
-            del g12
-        if "g-cloud-12" in supplier_frameworks:
-            supplier_frameworks["g-cloud-12"]["onFramework"] = True
 
     for framework in all_frameworks:
         framework.update(

--- a/app/templates/suppliers/_frameworks_live.html
+++ b/app/templates/suppliers/_frameworks_live.html
@@ -18,13 +18,6 @@
       </li>
       {% endif %}
       {% if framework in frameworks.live %}
-      {% if framework.slug == "g-cloud-12" and supplier.g12_recovery %}
-      <li>
-        <a class="govuk-link" href="{{ url_for('.g12_recovery_draft_services', framework_slug='g-cloud-12') }}">
-        Add a service
-        </a>
-      </li>
-      {% endif %}
       <li>
         <a class="govuk-link" href="{{ url_for('.list_services', framework_slug=framework.slug) }}">
         View services

--- a/tests/app/main/test_suppliers.py
+++ b/tests/app/main/test_suppliers.py
@@ -606,42 +606,6 @@ class TestSuppliersDashboard(BaseApplicationTest):
         assert continue_link
         assert continue_link[0].values()[0] == "/suppliers/frameworks/digital-outcomes-and-specialists"
 
-    @pytest.mark.parametrize("framework_interest, on_framework", (
-        (False, False),
-        (True, False),
-        (True, True),
-    ))
-    def test_recovery_supplier_sees_g12_links(self, framework_interest, on_framework):
-        g12 = FrameworkStub(status="live", slug="g-cloud-12").response()
-        g12["frameworkSlug"] = "g-cloud-12"
-        self.data_api_client.get_supplier_frameworks.return_value = {
-            "frameworkInterest": [{**g12, "onFramework": on_framework}] if framework_interest else []
-        }
-        self.data_api_client.find_frameworks.return_value = {
-            "frameworks": [g12]
-        }
-
-        self.data_api_client.get_supplier.return_value = get_supplier(id='577184')  # Test.DM_G12_RECOVERY_SUPPLIER_IDS
-        self.login()
-
-        with self.app.app_context():
-            response = self.client.get("/suppliers")
-            doc = html.fromstring(response.get_data(as_text=True))
-
-            assert doc.xpath(
-                "//h3[normalize-space(string())=$f]"
-                "[(following::a)[1][normalize-space(string())=$t1][@href=$u1]]"
-                "[(following::a)[2][normalize-space(string())=$t2][@href=$u2]]"
-                "[(following::a)[3][normalize-space(string())=$t3][@href=$u3]]",
-                f="G-Cloud 12",
-                t1="Add a service",
-                u1="/suppliers/frameworks/g-cloud-12/draft-services",
-                t2="View services",
-                u2="/suppliers/frameworks/g-cloud-12/services",
-                t3="View documents",
-                u3="/suppliers/frameworks/g-cloud-12",
-            )
-
     def test_recovery_supplier_sees_banner(self):
         self.data_api_client.get_supplier.return_value = get_supplier(id=577184)  # Test.DM_G12_RECOVERY_SUPPLIER_IDS
         self.login()


### PR DESCRIPTION
Trello: https://trello.com/c/NhWv5iIk/647-1-remove-extraneous-g12-recovery-stuff

This reverts commit ed72149f6687691ea4ecbcbee16e28236059021a from https://github.com/alphagov/digitalmarketplace-supplier-frontend/pull/1292.

We have since chosen to add the draft services to the 'Your G-Cloud 12 services' page instead of having a stand-alone page for the draft services. So we can now remove this link, which is not needed.