### PR TITLE
Set the G12 recovery deadline in the past 

### DIFF
--- a/app/main/helpers/suppliers.py
+++ b/app/main/helpers/suppliers.py
@@ -94,13 +94,13 @@ def g12_recovery_time_remaining() -> str:
 
 
 def format_g12_recovery_time_remaining(time_to_deadline: timedelta) -> str:
-    if time_to_deadline.days > 0:
+    if time_to_deadline / timedelta(days=1) >= 1:
         number, unit = time_to_deadline.days, 'day'
-    elif time_to_deadline.seconds / 3600 >= 1:
+    elif time_to_deadline / timedelta(hours=1) >= 1:
         number, unit = int(time_to_deadline.seconds / 3600), 'hour'
-    elif time_to_deadline.seconds / 60 >= 1:
+    elif time_to_deadline / timedelta(minutes=1) >= 1:
         number, unit = int(time_to_deadline.seconds / 60), 'minute'
-    elif time_to_deadline.seconds >= 0:
+    elif time_to_deadline / timedelta(seconds=1) >= 0:
         number, unit = time_to_deadline.seconds, 'second'
     else:
         number, unit = 0, 'second'

--- a/app/main/helpers/suppliers.py
+++ b/app/main/helpers/suppliers.py
@@ -86,7 +86,7 @@ def is_g12_recovery_supplier(supplier_id: Union[str, int]) -> bool:
     return int(supplier_id) in supplier_ids
 
 
-G12_RECOVERY_DEADLINE = datetime(year=2525, month=1, day=1, hour=17)
+G12_RECOVERY_DEADLINE = datetime(year=1970, month=1, day=1, hour=17)
 
 
 def g12_recovery_time_remaining() -> str:

--- a/tests/app/main/helpers/test_suppliers.py
+++ b/tests/app/main/helpers/test_suppliers.py
@@ -87,6 +87,8 @@ class TestG12TimeRemainingFormatting:
             (timedelta(seconds=10), '10 seconds'),
             (timedelta(seconds=1), '1 second'),
             (timedelta(days=-1), '0 seconds'),
+            (timedelta(days=-1, hours=10), '0 seconds'),
+            (timedelta(hours=-1, minutes=10), '0 seconds'),
         ]
     )
     def test_returns_expected_value_for_input(self, time_to_deadline, expected_result):


### PR DESCRIPTION
Trello: https://trello.com/c/n2Eop9FB/644-2-as-a-supplier-i-know-when-the-deadline-is

We don't yet know when the deadline is, so set it to a dummy date in the far future. However, this means that the number of days remaining decrements every day and breaks the visual regression tests.

Switch to a dummy date in the far past. The banner will now always read '0 seconds remaining'.

Also fix a bug I found with dates more than 1 day in the past.