### PR TITLE
Remove 'Add a service' link without also removing other links

### DIFF
--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -69,15 +69,25 @@ def dashboard():
 
     supplier['g12_recovery'] = is_g12_recovery_supplier(supplier['id'])
 
-    all_frameworks = sorted(
+    all_frameworks = list(sorted(
         data_api_client.find_frameworks()['frameworks'],
         key=lambda framework: framework['slug'],
         reverse=True
-    )
+    ))
     supplier_frameworks = {
         framework['frameworkSlug']: framework
         for framework in data_api_client.get_supplier_frameworks(current_user.supplier_id)['frameworkInterest']
     }
+
+    # g12 should always be in frameworks.live for recovery suppliers
+    if supplier["g12_recovery"]:
+        if "g-cloud-12" not in supplier_frameworks:
+            g12 = next(filter(lambda f: f["slug"] == "g-cloud-12", all_frameworks), None)
+            if g12:
+                supplier_frameworks["g-cloud-12"] = g12
+            del g12
+        if "g-cloud-12" in supplier_frameworks:
+            supplier_frameworks["g-cloud-12"]["onFramework"] = True
 
     for framework in all_frameworks:
         framework.update(

--- a/app/templates/suppliers/_frameworks_live.html
+++ b/app/templates/suppliers/_frameworks_live.html
@@ -18,6 +18,13 @@
       </li>
       {% endif %}
       {% if framework in frameworks.live %}
+      {% if framework.slug == "g-cloud-12" and supplier.g12_recovery %}
+      <li>
+        <a class="govuk-link" href="{{ url_for('.g12_recovery_draft_services', framework_slug='g-cloud-12') }}">
+        Add a service
+        </a>
+      </li>
+      {% endif %}
       <li>
         <a class="govuk-link" href="{{ url_for('.list_services', framework_slug=framework.slug) }}">
         View services

--- a/app/templates/suppliers/_frameworks_live.html
+++ b/app/templates/suppliers/_frameworks_live.html
@@ -18,13 +18,6 @@
       </li>
       {% endif %}
       {% if framework in frameworks.live %}
-      {% if framework.slug == "g-cloud-12" and supplier.g12_recovery %}
-      <li>
-        <a class="govuk-link" href="{{ url_for('.g12_recovery_draft_services', framework_slug='g-cloud-12') }}">
-        Add a service
-        </a>
-      </li>
-      {% endif %}
       <li>
         <a class="govuk-link" href="{{ url_for('.list_services', framework_slug=framework.slug) }}">
         View services

--- a/tests/app/main/test_suppliers.py
+++ b/tests/app/main/test_suppliers.py
@@ -631,15 +631,12 @@ class TestSuppliersDashboard(BaseApplicationTest):
             assert doc.xpath(
                 "//h3[normalize-space(string())=$f]"
                 "[(following::a)[1][normalize-space(string())=$t1][@href=$u1]]"
-                "[(following::a)[2][normalize-space(string())=$t2][@href=$u2]]"
-                "[(following::a)[3][normalize-space(string())=$t3][@href=$u3]]",
+                "[(following::a)[2][normalize-space(string())=$t2][@href=$u2]]",
                 f="G-Cloud 12",
-                t1="Add a service",
-                u1="/suppliers/frameworks/g-cloud-12/draft-services",
-                t2="View services",
-                u2="/suppliers/frameworks/g-cloud-12/services",
-                t3="View documents",
-                u3="/suppliers/frameworks/g-cloud-12",
+                t1="View services",
+                u1="/suppliers/frameworks/g-cloud-12/services",
+                t2="View documents",
+                u2="/suppliers/frameworks/g-cloud-12",
             )
 
     def test_recovery_supplier_sees_banner(self):


### PR DESCRIPTION
Trello: https://trello.com/c/NhWv5iIk/647-1-remove-extraneous-g12-recovery-stuff

Reverts https://github.com/alphagov/digitalmarketplace-supplier-frontend/pull/1302

I was over-eager when reverting. Yes, I removed the 'Add a service' link, which was what I meant to do. However, I also removed the special case handling of the other links. This ensures that G12 recovery suppliers see the link to 'Your G-Cloud 12 services' even if they have no live G12 services.

#1301 depends on this link existing. So revert the revert so that the link to 'Your G-Cloud 12 services' appears for all G12 recovery suppliers once more.

Then perform a surgical removal of only the 'Add a service' link. Update the tests to check all G12 recovery suppliers can still see the other links.