### PR TITLE
Stop showing broken link to sign agreement

### DIFF
--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -86,8 +86,6 @@ def dashboard():
             if g12:
                 supplier_frameworks["g-cloud-12"] = g12
             del g12
-        if "g-cloud-12" in supplier_frameworks:
-            supplier_frameworks["g-cloud-12"]["onFramework"] = True
 
     for framework in all_frameworks:
         framework.update(
@@ -108,6 +106,8 @@ def dashboard():
             ),
             'is_e_signature_supported': is_e_signature_supported_framework(framework['slug']),
         })
+        if framework['slug'] == 'g-cloud-12' and supplier["g12_recovery"]:
+            framework['onFramework'] = True
 
     if "currently_applying_to" in session:
         del session["currently_applying_to"]


### PR DESCRIPTION
Trello: https://trello.com/c/e3KDduMm/652-fix-broken-links-for-g12-recovery-suppliers-without-live-services

Previously, we were showing this link to G12 recovery suppliers who were not on the framework. If these suppliers tried to follow the link, they would get an error page.

We still want to pretend to be on the framework for the purposes of getting the right things displayed elsewhere. However, by doing the hack just a little later, we can avoid messing up the determination of whether the supplier needs to sign the framework agreement.

Extend the test to test this.