### PR TITLE
Stop DOS5 text clipping

### DIFF
--- a/app/templates/frameworks/sign_framework_agreement_confirmation.html
+++ b/app/templates/frameworks/sign_framework_agreement_confirmation.html
@@ -14,7 +14,7 @@
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
       {{ govukPanel({
-        "titleHtml": "You’ve signed the <span style=\"white-space: nowrap\">{}</span> {}".format(framework.name, contract_title),
+        "titleText": "You’ve signed the {} {}".format(framework.name, contract_title),
       }) }}
 
             <p class="govuk-body">We have sent you a confirmation email.</p>


### PR DESCRIPTION
https://trello.com/c/75hbcRW8/607-3-implement-dos-5-e-signature
Previously on the e-signature confirmation page the framework name was clipping as it the `nowrap` style prevented it from wrapping. For now this just removes this so it doesn't clip. Although it will wrap for G-Cloud-12.
**Before**
 ![Screenshot 2020-12-21 at 14 26 14](https://user-images.githubusercontent.com/1764158/102795805-3acb5100-43a5-11eb-903e-a0a35aed474f.png)
**After**
![Screenshot 2020-12-21 at 16 05 23](https://user-images.githubusercontent.com/1764158/102796552-5be07180-43a6-11eb-98d6-9dd8bb9b1d50.png)