### PR TITLE
bump lxml and remove apt get dependenices from github action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,9 +9,6 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Install Ubuntu packages
-      run: sudo apt-get install libxml2-dev libxslt1-dev python-dev
-
     - name: Install Node dependencies
       shell: bash -l {0}
       run: |

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -5,7 +5,7 @@ pip-tools>=5.4.0
 cssselect==1.0.3
 flake8==3.7.7
 freezegun==0.3.12
-lxml==4.4.1
+lxml==4.6.2
 mock==3.0.5
 pytest==4.6.3
 python-dotenv==0.10.3  # used to load .flaskenv

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -17,7 +17,7 @@ flake8==3.7.7             # via -r requirements-dev.in
 freezegun==0.3.12         # via -r requirements-dev.in
 idna==2.9                 # via -c requirements.txt, requests
 importlib-metadata==1.5.0  # via pluggy, pytest
-lxml==4.4.1               # via -r requirements-dev.in
+lxml==4.6.2               # via -r requirements-dev.in
 mccabe==0.6.1             # via flake8
 mock==3.0.5               # via -r requirements-dev.in
 more-itertools==8.2.0     # via pytest


### PR DESCRIPTION
With this change we no longer need to install lxml dependencies in ubuntu