### PR TITLE
Add extra line break in G12 recovery banner

### DIFF
--- a/app/templates/partials/g12_recovery_information.html
+++ b/app/templates/partials/g12_recovery_information.html
@@ -3,7 +3,7 @@
     {# TODO: replace with govukNotificationBanner #}
     {%
       with
-      message = 'You have ' + g12_recovery.time_remaining + ' left to finish your application.<br>You need to mark your services as complete to finish your application. <a href="'|safe + url_for('.list_services', framework_slug='g-cloud-12') + '">View your services.</a>'|safe,
+      message = 'You have ' + g12_recovery.time_remaining + ' left to finish your application.<br><br>You need to mark your services as complete to finish your application. <a href="'|safe + url_for('.list_services', framework_slug='g-cloud-12') + '">View your services.</a>'|safe,
       type = 'information'
     %}
       {% include 'toolkit/notification-banner.html' %}


### PR DESCRIPTION
From https://trello.com/c/Kox43DLs/653-1-space-the-banner-text

Before
![image](https://user-images.githubusercontent.com/6362602/103531868-1336b700-4e82-11eb-95f8-43d83400b545.png)

After
![image](https://user-images.githubusercontent.com/6362602/103531904-2184d300-4e82-11eb-9aee-7d0942e11ae2.png)
