### PR TITLE
Hide 'Remove draft service' button for G12 recovery suppliers

### DIFF
--- a/app/templates/services/service_submission.html
+++ b/app/templates/services/service_submission.html
@@ -199,7 +199,7 @@
             {% include "partials/complete_service.html" %}
           </div>
         {% endif %}
-        {% if framework.status == 'open' %}
+        {% if framework.status == 'open' and not g12_recovery %}
         <form action="{{ url_for('.delete_draft_service', framework_slug=framework.slug, lot_slug=service_data.lot, service_id=service_id ) }}" method="POST">
           <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
           {{ govukButton({

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -2483,6 +2483,26 @@ class TestShowDraftService(BaseApplicationTest, MockEnsureApplicationCompanyDeta
         doc = html.fromstring(res.get_data(as_text=True))
         assert not doc.xpath("//form//button[normalize-space(string())=$t]", t="Mark as complete")
 
+    def test_no_remove_draft_service_button_for_g12_recovery_supplier(self):
+        g12_recovery_supplier_id = 577184
+        self.login(supplier_id=g12_recovery_supplier_id)
+        self.data_api_client.get_framework.return_value = self.framework(status="live", slug="g-cloud-12")
+
+        g12_draft_service = DraftServiceStub(
+            service_name="My draft service",
+            framework_slug="g-cloud-12",
+            supplier_id=g12_recovery_supplier_id
+        ).single_result_response()
+        g12_draft_service["auditEvents"] = None
+        g12_draft_service["validationErrors"] = None
+        self.data_api_client.get_draft_service.return_value = g12_draft_service
+
+        res = self.client.get("/suppliers/frameworks/g-cloud-12/submissions/cloud-software/1")
+        doc = html.fromstring(res.get_data(as_text=True))
+
+        assert res.status_code == 200
+        assert not doc.xpath("//form//button[normalize-space(string())=$t]", t="Remove draft service")
+
     @mock.patch('app.main.views.services.count_unanswered_questions')
     def test_shows_g7_message_if_pending_and_service_is_in_draft(self, count_unanswered):
         self.data_api_client.get_framework.return_value = self.framework(status='pending')


### PR DESCRIPTION
We're going to stop G12 recovery suppliers from creating new draft services other than the ones they've already submitted in previous recovery phases, so we need to prevent a supplier from accidentally deleting a draft and needing to contact support to get it re-added.

This PR hides the 'Remove draft service' button on the service submission page for G12 recovery suppliers. I've checked other pages and can't see any other method for a supplier to delete a draft service, so I think hiding this button is enough to finish the below story.

https://trello.com/c/1Jgs4nZ4/684-1-stop-users-being-able-to-delete-draft-services