### PR TITLE
use contract title on dashboard

### DIFF
--- a/app/main/helpers/frameworks.py
+++ b/app/main/helpers/frameworks.py
@@ -508,3 +508,10 @@ def return_404_if_applications_closed(data_api_client_callable):
 def check_framework_supports_e_signature_or_404(framework):
     if not framework['isESignatureSupported']:
         abort(404)
+
+
+def get_framework_contract_title(framework):
+    if framework['isESignatureSupported']:
+        return content_loader.get_message(framework['slug'], 'e-signature', 'framework_contract_title')
+    else:
+        return 'Framework Agreement'

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -54,7 +54,7 @@ from ..helpers.frameworks import (
     returned_agreement_email_recipients,
     return_404_if_applications_closed,
     check_framework_supports_e_signature_or_404,
-    get_completed_lots
+    get_completed_lots, get_framework_contract_title
 )
 from ..helpers.services import (
     get_drafts,
@@ -224,10 +224,7 @@ def framework_dashboard(framework_slug):
         )
         for label, d in base_communications_files.items()
     }
-    if framework['isESignatureSupported']:
-        contract_title = content_loader.get_message(framework_slug, 'e-signature', 'framework_contract_title')
-    else:
-        contract_title = 'framework agreement'
+    contract_title = get_framework_contract_title(framework)
 
     return render_template(
         "frameworks/dashboard.html",

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -31,7 +31,7 @@ from ..helpers.frameworks import (
     get_frameworks_by_status,
     get_frameworks_closed_and_open_for_applications,
     get_most_recent_expired_dos_framework,
-    get_unconfirmed_open_supplier_frameworks,
+    get_unconfirmed_open_supplier_frameworks, get_framework_contract_title,
 )
 from ..helpers.suppliers import (
     COUNTRY_TUPLE,
@@ -103,6 +103,7 @@ def dashboard():
             'needs_to_return_agreement': (
                 framework.get('onFramework') and framework.get('agreementReturned') is False
             ),
+            'contract_title': get_framework_contract_title(framework)
         })
         if framework['slug'] == 'g-cloud-12' and supplier["g12_recovery"]:
             framework['onFramework'] = True

--- a/app/templates/frameworks/_agreement_returned_legal.html
+++ b/app/templates/frameworks/_agreement_returned_legal.html
@@ -8,7 +8,7 @@
         {% if countersigned_agreement_file %}
           <p class="govuk-body">
             {% if framework['isESignatureSupported'] %}
-            Your signed framework agreement forms a complete legal contract.
+            Your signed {{ contract_title | lower }} forms a complete legal contract.
             {% else %}
             Your original and counterpart signature pages, and the standard framework
             agreement, form a complete, legal contract.
@@ -17,7 +17,7 @@
         {% else %}
           <p class="govuk-body">
               {% if framework['isESignatureSupported'] %}
-              Your signed {{ contract_title }} will be sent to Crown Commercial Service (<abbr title="Crown Commercial Service">CCS</abbr>) to be countersigned.
+              Your signed {{ contract_title | lower }} will be sent to Crown Commercial Service (<abbr title="Crown Commercial Service">CCS</abbr>) to be countersigned.
               We'll email you when the countersigned agreement is available.
               You'll need to wait for <abbr title="Crown Commercial Service">CCS</abbr> to countersign your agreement before you can sell services.
               {% else %}
@@ -71,7 +71,7 @@
     {# newer frameworks should have the final agreement published as a web page #}
     <p class="govuk-body">
       <a class="govuk-link" href="{{ framework_urls.framework_agreement_url }}">
-        Read the standard {{ contract_title }}
+        Read the standard {{ contract_title | lower }}
       </a>
     </p>
   {% elif communications_files.final_agreement.last_modified %}

--- a/app/templates/frameworks/_framework_actions.html
+++ b/app/templates/frameworks/_framework_actions.html
@@ -17,9 +17,9 @@
   {% set sign_agreement_route = url_for('.legal_authority', framework_slug=framework.slug) if framework['isESignatureSupported'] else url_for('.framework_agreement', framework_slug=framework.slug) %}
   <li class="browse-list-item">
     <a class="browse-list-item-link" href="{{ sign_agreement_route }}">
-      <span>Sign and return your framework agreement</span>
+      <span>Sign and return your {{ contract_title | lower }}</span>
     </a>
-    <p class="govuk-body">Your agreement will need to be signed by both you and the Crown Commercial Service before you can sell {{framework.name}} services.</p>
+    <p class="govuk-body">Your {{ contract_title | lower }} will need to be signed by both you and the Crown Commercial Service before you can sell {{framework.name}} services.</p>
   </li>
   {% endif %}
 {% endif %}

--- a/app/templates/suppliers/_frameworks_live.html
+++ b/app/templates/suppliers/_frameworks_live.html
@@ -5,7 +5,7 @@
       {% set sign_agreement_route = url_for('.legal_authority', framework_slug=framework.slug) if framework['isESignatureSupported'] else url_for('.framework_agreement', framework_slug=framework.slug) %}
       <p class="govuk-body">
         <a class="govuk-link" href="{{ sign_agreement_route }}">
-        You must sign the framework agreement to sell these services
+        You must sign the {{ framework.contract_title | lower }} to sell these services
         </a>
       </p>
     {% endif %}

--- a/app/templates/suppliers/_frameworks_standstill.html
+++ b/app/templates/suppliers/_frameworks_standstill.html
@@ -36,7 +36,7 @@
             <p class="govuk-body">
             {% set sign_agreement_route = url_for('.legal_authority', framework_slug=framework.slug) if framework['isESignatureSupported'] else url_for('.framework_agreement', framework_slug=framework.slug) %}
               <a class="govuk-link" href="{{ sign_agreement_route }}">
-                You must sign the framework agreement to sell these services
+                You must sign the {{ framework.contract_title | lower }} to sell these services
               </a>
             </p>
           {% endif %}


### PR DESCRIPTION
https://trello.com/c/75hbcRW8/607-2-implement-dos-5-e-signature
@NoraGDS spotted we should be using the contract title variable on the frameworks dashboard, as it now varies between frameworks.