### PR TITLE
Change submissions and service submissions pages to redirect to all services page for G12 recovery suppliers

### DIFF
--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -259,6 +259,10 @@ def framework_dashboard(framework_slug):
 def framework_submission_lots(framework_slug):
     framework = get_framework_or_404(data_api_client, framework_slug)
 
+    if is_g12_recovery_supplier(current_user.supplier_id) and framework_slug == "g-cloud-12":
+        # this page will 404 if g12 recovery suppliers try to visit it, so let's avoid that
+        return redirect(url_for(".list_all_services", framework_slug=framework_slug))
+
     drafts, complete_drafts = get_drafts(data_api_client, framework_slug)
     declaration_status = get_declaration_status(data_api_client, framework_slug)
     application_made = len(complete_drafts) > 0 and declaration_status == 'complete'
@@ -366,13 +370,10 @@ def g12_recovery_draft_services(framework_slug):
 def framework_submission_services(framework_slug, lot_slug):
     framework, lot = get_framework_and_lot_or_404(data_api_client, framework_slug, lot_slug)
 
-    if (
-        framework_slug == "g-cloud-12"
-        and framework["status"] == "live"
-        and is_g12_recovery_supplier(current_user.supplier_id)
-    ):
-        # we want this page to appear as it would if g12 were open
-        framework["status"] = "open"
+    if is_g12_recovery_supplier(current_user.supplier_id) and framework_slug == "g-cloud-12":
+        # g12 recovery suppliers should not be able to add new services,
+        # so they have no need to see this page
+        return redirect(url_for(".list_all_services", framework_slug=framework_slug))
 
     drafts, complete_drafts = get_lot_drafts(data_api_client, framework_slug, lot_slug)
     declaration_status = get_declaration_status(data_api_client, framework_slug)


### PR DESCRIPTION
Ticket: https://trello.com/c/QBCaiojj/698-fix-mark-as-complete-redirect-in-g12-recovery-flow

For G12 recovery suppliers we need to fix breadcrumbs that link to the "Services" and lot page, and also change where the user ends up after marking a service as complete.

This commit does this in a fairly brute-force way, by making those urls always redirect to the `all_services` route; however I think this should be fine because they will not need to see the pages we are redirecting away from anyway.