### PR TITLE
Fix G12 recovery all services view to remove live services from completed services

### DIFF
--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -112,6 +112,13 @@ def list_all_services(framework_slug):
             'unanswered_optional': unanswered_optional,
         })
 
+    # We only want drafts that they have completed as part of G12 recovery to
+    # show up in "Complete services" table (live services go in a separate table)
+    complete_drafts = [
+        draft for draft in complete_drafts
+        if "serviceId" not in complete_drafts
+    ]
+
     # Only G12 recovery suppliers can access this route, so always show the banner
     g12_recovery = {'time_remaining': g12_recovery_time_remaining()}
 


### PR DESCRIPTION
Part of https://trello.com/c/13Ryt5o5/

The G12 recovery all services page should have three tables, currently called "Draft services", "Complete services", and "Live services". We want "Complete services" to show submitted draft services that are not live, so we need to filter out submitted draft services that have been published. This commit does that.