### PR TITLE
Always fail open if D&B API errors

### DIFF
--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -551,7 +551,7 @@ def duns_number():
                 organization = direct_plus_client.get_organization_by_duns_number(form.duns_number.data)
                 if organization is not None:
                     company_name = organization['primaryName']
-            except KeyError:
+            except (KeyError, ValueError):
                 # An unexpected error. Something other than supplier data in the response.
                 # Allow the user to proceed with the entered duns numer and skip this part of sign up.
                 session[form.duns_number.name] = form.duns_number.data

--- a/requirements.in
+++ b/requirements.in
@@ -7,6 +7,6 @@ Flask-WTF==0.14.3
 itsdangerous==1.1.0
 
 digitalmarketplace-content-loader
-git+https://github.com/alphagov/digitalmarketplace-utils.git@56.0.0#egg=digitalmarketplace-utils==56.0.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@56.1.1#egg=digitalmarketplace-utils==56.1.1
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.8.0#egg=digitalmarketplace-apiclient==21.8.0
 git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.2-alpha#egg=govuk-frontend-jinja==0.5.2-alpha

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,7 @@ git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.8.0#egg=digi
     # via -r requirements.in
 digitalmarketplace-content-loader==7.28.1
     # via -r requirements.in
-git+https://github.com/alphagov/digitalmarketplace-utils.git@56.0.0#egg=digitalmarketplace-utils==56.0.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@56.1.1#egg=digitalmarketplace-utils==56.1.1
     # via
     #   -r requirements.in
     #   digitalmarketplace-content-loader


### PR DESCRIPTION
Trello: https://trello.com/c/bZ4XlASA/617-1-log-directplusclient-errors-instead-of-swallowing-them

At the moment, we allow users to create an account if the D&B API produces an error that is valid JSON, but not if it's not valid JSON. This is odd and inconsistent. And I think it's unintentional - looking at utils, it looks as if the original author didn't know that about the different error for invalid JSON.

Change the behaviour to be consistent by always failing open. The behaviour now fully matches the intents of the comments.

Also pull in alphagov/digitalmarketplace-utils#596, which improves logging of D&B API errors.