### PR TITLE
Show only selected drafts for the G12 recovery

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "package-lock.json",
     "lines": null
   },
-  "generated_at": "2021-01-21T10:50:48Z",
+  "generated_at": "2021-01-22T17:45:19Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -58,22 +58,6 @@
     }
   ],
   "results": {
-    "config.py": [
-      {
-        "hashed_secret": "6ece33acdf8a843e90915a2b661ab55941348059",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 164,
-        "type": "Secret Keyword"
-      },
-      {
-        "hashed_secret": "e9dcc6d93c625c72f0c2e7197e80fe49760d5c75",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 168,
-        "type": "Secret Keyword"
-      }
-    ],
     "tests/app/main/test_frameworks.py": [
       {
         "hashed_secret": "6955d0539c7ae97361ab63d21bc2bb730edbce7a",

--- a/app/main/helpers/suppliers.py
+++ b/app/main/helpers/suppliers.py
@@ -1,6 +1,6 @@
 import os
 import json
-from typing import Union
+from typing import Union, Set
 from datetime import datetime, timedelta
 
 from flask import current_app
@@ -84,6 +84,18 @@ def is_g12_recovery_supplier(supplier_id: Union[str, int]) -> bool:
         return False
 
     return int(supplier_id) in supplier_ids
+
+
+def get_g12_recovery_draft_ids() -> Set[int]:
+    draft_ids_string = current_app.config.get('DM_G12_RECOVERY_DRAFT_IDS') or ''
+
+    try:
+        return {int(s) for s in draft_ids_string.split(sep=',')}
+    except AttributeError as e:
+        current_app.logger.error("DM_G12_RECOVERY_DRAFT_IDS not a string", extra={'error': str(e)})
+    except ValueError as e:
+        current_app.logger.error("DM_G12_RECOVERY_DRAFT_IDS not a list of draft IDs", extra={'error': str(e)})
+    return set()
 
 
 G12_RECOVERY_DEADLINE = datetime(year=1970, month=1, day=1, hour=17)

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -14,7 +14,7 @@ from dmutils.flask import timed_render_template as render_template
 from dmutils.forms.helpers import get_errors_from_wtform
 from dmutils.errors import render_error_page
 
-from ..helpers.suppliers import is_g12_recovery_supplier, g12_recovery_time_remaining
+from ..helpers.suppliers import is_g12_recovery_supplier, g12_recovery_time_remaining, get_g12_recovery_draft_ids
 from ... import data_api_client
 from ...main import main, content_loader
 from ..helpers import login_required
@@ -97,6 +97,10 @@ def list_all_services(framework_slug):
     )["services"]
 
     drafts, complete_drafts = get_drafts(data_api_client, framework_slug)
+
+    g12_draft_allow_list = get_g12_recovery_draft_ids()
+    drafts = [draft for draft in drafts if draft["id"] in g12_draft_allow_list]
+    complete_drafts = [draft for draft in complete_drafts if draft["id"] in g12_draft_allow_list]
 
     service_sections = content_loader.get_manifest(
         framework_slug,

--- a/config.py
+++ b/config.py
@@ -93,6 +93,7 @@ class Config(object):
     DM_APP_NAME = 'supplier-frontend'
 
     DM_G12_RECOVERY_SUPPLIER_IDS = None
+    DM_G12_RECOVERY_DRAFT_IDS = None
 
     @staticmethod
     def init_app(app):
@@ -121,7 +122,7 @@ class Test(Config):
     SHARED_EMAIL_KEY = "KEY"
 
     DM_MAILCHIMP_USERNAME = 'not_a_real_username'
-    DM_MAILCHIMP_API_KEY = 'not_a_real_key'
+    DM_MAILCHIMP_API_KEY = 'not_a_real_key'  # pragma: allowlist secret
     DM_MAILCHIMP_OPEN_FRAMEWORK_NOTIFICATION_MAILING_LIST_ID = "not_a_real_mailing_list"
 
     DM_DATA_API_AUTH_TOKEN = 'myToken'
@@ -131,6 +132,7 @@ class Test(Config):
     DM_ASSETS_URL = 'http://asset-host'
 
     DM_G12_RECOVERY_SUPPLIER_IDS = "577184"
+    DM_G12_RECOVERY_DRAFT_IDS = ""
 
 
 class Development(Config):
@@ -163,13 +165,14 @@ class Development(Config):
     SECRET_KEY = 'verySecretKey'
 
     DM_MAILCHIMP_USERNAME = 'not_a_real_username'
-    DM_MAILCHIMP_API_KEY = 'not_a_real_key'
+    DM_MAILCHIMP_API_KEY = 'not_a_real_key'  # pragma: allowlist secret
     DM_MAILCHIMP_OPEN_FRAMEWORK_NOTIFICATION_MAILING_LIST_ID = "not_a_real_mailing_list"
 
     DM_DNB_API_USERNAME = 'not_a_real_username'
-    DM_DNB_API_PASSWORD = 'not_a_real_password'
+    DM_DNB_API_PASSWORD = 'not_a_real_password'  # pragma: allowlist secret
 
     DM_G12_RECOVERY_SUPPLIER_IDS = "577184"
+    DM_G12_RECOVERY_DRAFT_IDS = ""
 
 
 class Live(Config):

--- a/config.py
+++ b/config.py
@@ -132,7 +132,7 @@ class Test(Config):
     DM_ASSETS_URL = 'http://asset-host'
 
     DM_G12_RECOVERY_SUPPLIER_IDS = "577184"
-    DM_G12_RECOVERY_DRAFT_IDS = ""
+    DM_G12_RECOVERY_DRAFT_IDS = "123456"
 
 
 class Development(Config):
@@ -172,7 +172,7 @@ class Development(Config):
     DM_DNB_API_PASSWORD = 'not_a_real_password'  # pragma: allowlist secret
 
     DM_G12_RECOVERY_SUPPLIER_IDS = "577184"
-    DM_G12_RECOVERY_DRAFT_IDS = ""
+    DM_G12_RECOVERY_DRAFT_IDS = "123456"
 
 
 class Live(Config):

--- a/tests/app/main/helpers/test_suppliers.py
+++ b/tests/app/main/helpers/test_suppliers.py
@@ -67,6 +67,8 @@ class TestG12RecoverySupplier(BaseApplicationTest):
             ([123456, 789012], False),
             ('123456', True),
             ('123456,789012', True),
+            ('123456, 789012', True),
+            ('123456,\n789012', True),
         ]
     )
     def test_returns_expected_value_for_input(self, g12_recovery_supplier_ids, expected_result):
@@ -86,6 +88,8 @@ class TestG12RecoveryDrafts(BaseApplicationTest):
             ([123456, 789012], set()),
             ('123456', {123456}),
             ('123456,789012', {123456, 789012}),
+            ('123456, 789012', {123456, 789012}),
+            ('123456,\n789012', {123456, 789012}),
         ]
     )
     def test_returns_expected_value_for_input(self, draft_ids_config, expected_result):

--- a/tests/app/main/helpers/test_suppliers.py
+++ b/tests/app/main/helpers/test_suppliers.py
@@ -5,7 +5,7 @@ from flask_wtf import FlaskForm
 from wtforms import StringField
 from wtforms.validators import Length
 from app.main.helpers.suppliers import get_country_name_from_country_code, supplier_company_details_are_complete, \
-    is_g12_recovery_supplier, format_g12_recovery_time_remaining
+    is_g12_recovery_supplier, format_g12_recovery_time_remaining, get_g12_recovery_draft_ids
 
 from dmtestutils.api_model_stubs import SupplierStub
 
@@ -73,6 +73,25 @@ class TestG12RecoverySupplier(BaseApplicationTest):
         with self.app.app_context():
             self.app.config['DM_G12_RECOVERY_SUPPLIER_IDS'] = g12_recovery_supplier_ids
             assert is_g12_recovery_supplier('123456') is expected_result
+
+
+class TestG12RecoveryDrafts(BaseApplicationTest):
+    @pytest.mark.parametrize(
+        'draft_ids_config, expected_result',
+        [
+            (None, set()),
+            ('', set()),
+            (42, set()),
+            ('12:32', set()),
+            ([123456, 789012], set()),
+            ('123456', {123456}),
+            ('123456,789012', {123456, 789012}),
+        ]
+    )
+    def test_returns_expected_value_for_input(self, draft_ids_config, expected_result):
+        with self.app.app_context():
+            self.app.config['DM_G12_RECOVERY_DRAFT_IDS'] = draft_ids_config
+            assert get_g12_recovery_draft_ids() == expected_result
 
 
 class TestG12TimeRemainingFormatting:


### PR DESCRIPTION
Trello: https://trello.com/c/13Ryt5o5/679-5-as-a-supplier-i-cannot-see-submit-any-draft-services-that-ccs-will-not-consider

As part of the G12 recovery process, users are only able to submit certain drafts. To avoid confusion and unnecessary work, we're going to hide all other drafts from the G12 recovery process for suppliers.

Only show drafts that are in the allow-list - both submitted and un-submitted.

Tests prove that this is working.

This PR is very similar to https://github.com/alphagov/digitalmarketplace-supplier-frontend/pull/1288.