### PR TITLE
Parse list of IDs from config only once

### DIFF
--- a/app/main/helpers/suppliers.py
+++ b/app/main/helpers/suppliers.py
@@ -1,6 +1,6 @@
 import os
 import json
-from typing import Union, Set
+from typing import Union
 from datetime import datetime, timedelta
 
 from flask import current_app
@@ -72,30 +72,11 @@ def get_company_details_from_supplier(supplier):
 
 
 def is_g12_recovery_supplier(supplier_id: Union[str, int]) -> bool:
-    supplier_ids_string = current_app.config.get('DM_G12_RECOVERY_SUPPLIER_IDS') or ''
-
-    try:
-        supplier_ids = [int(s) for s in supplier_ids_string.split(sep=',')]
-    except AttributeError as e:
-        current_app.logger.error("DM_G12_RECOVERY_SUPPLIER_IDS not a string", extra={'error': str(e)})
-        return False
-    except ValueError as e:
-        current_app.logger.error("DM_G12_RECOVERY_SUPPLIER_IDS not a list of supplier IDs", extra={'error': str(e)})
-        return False
-
-    return int(supplier_id) in supplier_ids
+    return int(supplier_id) in current_app.config['DM_G12_RECOVERY_SUPPLIER_IDS']
 
 
-def get_g12_recovery_draft_ids() -> Set[int]:
-    draft_ids_string = current_app.config.get('DM_G12_RECOVERY_DRAFT_IDS') or ''
-
-    try:
-        return {int(s) for s in draft_ids_string.split(sep=',')}
-    except AttributeError as e:
-        current_app.logger.error("DM_G12_RECOVERY_DRAFT_IDS not a string", extra={'error': str(e)})
-    except ValueError as e:
-        current_app.logger.error("DM_G12_RECOVERY_DRAFT_IDS not a list of draft IDs", extra={'error': str(e)})
-    return set()
+def is_g12_recovery_draft(draft_id: Union[str, int]) -> bool:
+    return int(draft_id) in current_app.config['DM_G12_RECOVERY_DRAFT_IDS']
 
 
 G12_RECOVERY_DEADLINE = datetime(year=1970, month=1, day=1, hour=17)

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -14,7 +14,7 @@ from dmutils.flask import timed_render_template as render_template
 from dmutils.forms.helpers import get_errors_from_wtform
 from dmutils.errors import render_error_page
 
-from ..helpers.suppliers import is_g12_recovery_supplier, g12_recovery_time_remaining, get_g12_recovery_draft_ids
+from ..helpers.suppliers import is_g12_recovery_draft, g12_recovery_time_remaining, is_g12_recovery_supplier
 from ... import data_api_client
 from ...main import main, content_loader
 from ..helpers import login_required
@@ -98,9 +98,8 @@ def list_all_services(framework_slug):
 
     drafts, complete_drafts = get_drafts(data_api_client, framework_slug)
 
-    g12_draft_allow_list = get_g12_recovery_draft_ids()
-    drafts = [draft for draft in drafts if draft["id"] in g12_draft_allow_list]
-    complete_drafts = [draft for draft in complete_drafts if draft["id"] in g12_draft_allow_list]
+    drafts = [draft for draft in drafts if is_g12_recovery_draft(draft["id"])]
+    complete_drafts = [draft for draft in complete_drafts if is_g12_recovery_draft(draft["id"])]
 
     service_sections = content_loader.get_manifest(
         framework_slug,

--- a/config.py
+++ b/config.py
@@ -2,9 +2,26 @@
 # type: ignore
 
 import os
+from typing import Set
+
 import jinja2
 from dmutils.status import get_version_label
 from dmutils.asset_fingerprint import AssetFingerprinter
+
+
+def extract_list_of_ids(current_app, config_key) -> Set[int]:
+    """
+    Lists of IDs are provided as comma-separated strings to allow them to be passed in via environment variables.
+    """
+    ids_string = current_app.config.get(config_key) or ''
+
+    try:
+        return {int(s) for s in ids_string.split(sep=',')}
+    except AttributeError as e:
+        current_app.logger.error(f"{config_key} not a string", extra={'error': str(e)})
+    except ValueError as e:
+        current_app.logger.error(f"{config_key} not a list of IDs", extra={'error': str(e)})
+    return set()
 
 
 class Config(object):
@@ -110,6 +127,9 @@ class Config(object):
             jinja2.PrefixLoader({'govuk': jinja2.FileSystemLoader(govuk_frontend)})
         ])
         app.jinja_loader = jinja_loader
+
+        app.config["DM_G12_RECOVERY_SUPPLIER_IDS"] = extract_list_of_ids(app, "DM_G12_RECOVERY_SUPPLIER_IDS")
+        app.config["DM_G12_RECOVERY_DRAFT_IDS"] = extract_list_of_ids(app, "DM_G12_RECOVERY_DRAFT_IDS")
 
 
 class Test(Config):

--- a/tests/app/main/helpers/test_suppliers.py
+++ b/tests/app/main/helpers/test_suppliers.py
@@ -5,10 +5,11 @@ from flask_wtf import FlaskForm
 from wtforms import StringField
 from wtforms.validators import Length
 from app.main.helpers.suppliers import get_country_name_from_country_code, supplier_company_details_are_complete, \
-    is_g12_recovery_supplier, format_g12_recovery_time_remaining, get_g12_recovery_draft_ids
+    format_g12_recovery_time_remaining
 
 from dmtestutils.api_model_stubs import SupplierStub
 
+from config import extract_list_of_ids
 from tests.app.helpers import BaseApplicationTest
 
 
@@ -56,30 +57,9 @@ class FormForTest(FlaskForm):
     ])
 
 
-class TestG12RecoverySupplier(BaseApplicationTest):
+class TestExtractListFromConfig(BaseApplicationTest):
     @pytest.mark.parametrize(
-        'g12_recovery_supplier_ids, expected_result',
-        [
-            (None, False),
-            ('', False),
-            (42, False),
-            ('12:32', False),
-            ([123456, 789012], False),
-            ('123456', True),
-            ('123456,789012', True),
-            ('123456, 789012', True),
-            ('123456,\n789012', True),
-        ]
-    )
-    def test_returns_expected_value_for_input(self, g12_recovery_supplier_ids, expected_result):
-        with self.app.app_context():
-            self.app.config['DM_G12_RECOVERY_SUPPLIER_IDS'] = g12_recovery_supplier_ids
-            assert is_g12_recovery_supplier('123456') is expected_result
-
-
-class TestG12RecoveryDrafts(BaseApplicationTest):
-    @pytest.mark.parametrize(
-        'draft_ids_config, expected_result',
+        'config_input, expected_result',
         [
             (None, set()),
             ('', set()),
@@ -92,10 +72,10 @@ class TestG12RecoveryDrafts(BaseApplicationTest):
             ('123456,\n789012', {123456, 789012}),
         ]
     )
-    def test_returns_expected_value_for_input(self, draft_ids_config, expected_result):
+    def test_returns_expected_value_for_input(self, config_input, expected_result):
         with self.app.app_context():
-            self.app.config['DM_G12_RECOVERY_DRAFT_IDS'] = draft_ids_config
-            assert get_g12_recovery_draft_ids() == expected_result
+            self.app.config['TEST'] = config_input
+            assert extract_list_of_ids(self.app, 'TEST') == expected_result
 
 
 class TestG12TimeRemainingFormatting:


### PR DESCRIPTION
Trello: https://trello.com/c/13Ryt5o5/679-5-as-a-supplier-i-cannot-see-submit-any-draft-services-that-ccs-will-not-consider

We have some lists of IDs that we use as allow-lists. These are needed every time certain pages are loaded.

Previously, we did the string parsing every time. Now, perform the string parsing during app initialisation and store the result. This should remove the performance impact of these new allowlists.

Follows on from https://github.com/alphagov/digitalmarketplace-supplier-frontend/pull/1325#discussion_r566014562