### PR TITLE
Extract ID lists to new keys

### DIFF
--- a/app/main/helpers/suppliers.py
+++ b/app/main/helpers/suppliers.py
@@ -72,11 +72,11 @@ def get_company_details_from_supplier(supplier):
 
 
 def is_g12_recovery_supplier(supplier_id: Union[str, int]) -> bool:
-    return int(supplier_id) in current_app.config['DM_G12_RECOVERY_SUPPLIER_IDS']
+    return int(supplier_id) in current_app.config['G12_RECOVERY_SUPPLIER_IDS']
 
 
 def is_g12_recovery_draft(draft_id: Union[str, int]) -> bool:
-    return int(draft_id) in current_app.config['DM_G12_RECOVERY_DRAFT_IDS']
+    return int(draft_id) in current_app.config['G12_RECOVERY_DRAFT_IDS']
 
 
 G12_RECOVERY_DEADLINE = datetime(year=1970, month=1, day=1, hour=17)

--- a/config.py
+++ b/config.py
@@ -128,8 +128,8 @@ class Config(object):
         ])
         app.jinja_loader = jinja_loader
 
-        app.config["DM_G12_RECOVERY_SUPPLIER_IDS"] = extract_list_of_ids(app, "DM_G12_RECOVERY_SUPPLIER_IDS")
-        app.config["DM_G12_RECOVERY_DRAFT_IDS"] = extract_list_of_ids(app, "DM_G12_RECOVERY_DRAFT_IDS")
+        app.config["G12_RECOVERY_SUPPLIER_IDS"] = extract_list_of_ids(app, "DM_G12_RECOVERY_SUPPLIER_IDS")
+        app.config["G12_RECOVERY_DRAFT_IDS"] = extract_list_of_ids(app, "DM_G12_RECOVERY_DRAFT_IDS")
 
 
 class Test(Config):


### PR DESCRIPTION
We've recently added functionality to get allow-lists of IDs from environment variables. We pass them in as environment variables, and then convert them from a comma-separated string into a `Set[int]`. However, it seems as if something is [going wrong](https://ci.marketplace.team/job/apps-are-up-preview/257100/smoke_20test_20report/). Either the extraction isn't happening, or the Set somehow gets overwritten with the original string.

My hypothesis is that it's the latter - our app init is somewhat complicated, so it seems plausible. If I'm right, we can fix it by writing to a new key so it won't get overwritten.

If I'm wrong, this won't fix Preview, and I'll just revert everything.

Fixes bug introduced by https://github.com/alphagov/digitalmarketplace-supplier-frontend/pull/1326