### PR TITLE
Revert caching of lists of IDs from environment variables

### DIFF
--- a/app/main/helpers/suppliers.py
+++ b/app/main/helpers/suppliers.py
@@ -72,11 +72,11 @@ def get_company_details_from_supplier(supplier):
 
 
 def is_g12_recovery_supplier(supplier_id: Union[str, int]) -> bool:
-    return int(supplier_id) in current_app.config['G12_RECOVERY_SUPPLIER_IDS']
+    return int(supplier_id) in current_app.config['DM_G12_RECOVERY_SUPPLIER_IDS']
 
 
 def is_g12_recovery_draft(draft_id: Union[str, int]) -> bool:
-    return int(draft_id) in current_app.config['G12_RECOVERY_DRAFT_IDS']
+    return int(draft_id) in current_app.config['DM_G12_RECOVERY_DRAFT_IDS']
 
 
 G12_RECOVERY_DEADLINE = datetime(year=1970, month=1, day=1, hour=17)

--- a/app/main/helpers/suppliers.py
+++ b/app/main/helpers/suppliers.py
@@ -1,6 +1,6 @@
 import os
 import json
-from typing import Union
+from typing import Union, Set
 from datetime import datetime, timedelta
 
 from flask import current_app
@@ -72,11 +72,30 @@ def get_company_details_from_supplier(supplier):
 
 
 def is_g12_recovery_supplier(supplier_id: Union[str, int]) -> bool:
-    return int(supplier_id) in current_app.config['DM_G12_RECOVERY_SUPPLIER_IDS']
+    supplier_ids_string = current_app.config.get('DM_G12_RECOVERY_SUPPLIER_IDS') or ''
+
+    try:
+        supplier_ids = [int(s) for s in supplier_ids_string.split(sep=',')]
+    except AttributeError as e:
+        current_app.logger.error("DM_G12_RECOVERY_SUPPLIER_IDS not a string", extra={'error': str(e)})
+        return False
+    except ValueError as e:
+        current_app.logger.error("DM_G12_RECOVERY_SUPPLIER_IDS not a list of supplier IDs", extra={'error': str(e)})
+        return False
+
+    return int(supplier_id) in supplier_ids
 
 
-def is_g12_recovery_draft(draft_id: Union[str, int]) -> bool:
-    return int(draft_id) in current_app.config['DM_G12_RECOVERY_DRAFT_IDS']
+def get_g12_recovery_draft_ids() -> Set[int]:
+    draft_ids_string = current_app.config.get('DM_G12_RECOVERY_DRAFT_IDS') or ''
+
+    try:
+        return {int(s) for s in draft_ids_string.split(sep=',')}
+    except AttributeError as e:
+        current_app.logger.error("DM_G12_RECOVERY_DRAFT_IDS not a string", extra={'error': str(e)})
+    except ValueError as e:
+        current_app.logger.error("DM_G12_RECOVERY_DRAFT_IDS not a list of draft IDs", extra={'error': str(e)})
+    return set()
 
 
 G12_RECOVERY_DEADLINE = datetime(year=1970, month=1, day=1, hour=17)

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -14,7 +14,7 @@ from dmutils.flask import timed_render_template as render_template
 from dmutils.forms.helpers import get_errors_from_wtform
 from dmutils.errors import render_error_page
 
-from ..helpers.suppliers import is_g12_recovery_draft, g12_recovery_time_remaining, is_g12_recovery_supplier
+from ..helpers.suppliers import is_g12_recovery_supplier, g12_recovery_time_remaining, get_g12_recovery_draft_ids
 from ... import data_api_client
 from ...main import main, content_loader
 from ..helpers import login_required
@@ -98,8 +98,9 @@ def list_all_services(framework_slug):
 
     drafts, complete_drafts = get_drafts(data_api_client, framework_slug)
 
-    drafts = [draft for draft in drafts if is_g12_recovery_draft(draft["id"])]
-    complete_drafts = [draft for draft in complete_drafts if is_g12_recovery_draft(draft["id"])]
+    g12_draft_allow_list = get_g12_recovery_draft_ids()
+    drafts = [draft for draft in drafts if draft["id"] in g12_draft_allow_list]
+    complete_drafts = [draft for draft in complete_drafts if draft["id"] in g12_draft_allow_list]
 
     service_sections = content_loader.get_manifest(
         framework_slug,

--- a/config.py
+++ b/config.py
@@ -2,26 +2,9 @@
 # type: ignore
 
 import os
-from typing import Set
-
 import jinja2
 from dmutils.status import get_version_label
 from dmutils.asset_fingerprint import AssetFingerprinter
-
-
-def extract_list_of_ids(current_app, config_key) -> Set[int]:
-    """
-    Lists of IDs are provided as comma-separated strings to allow them to be passed in via environment variables.
-    """
-    ids_string = current_app.config.get(config_key) or ''
-
-    try:
-        return {int(s) for s in ids_string.split(sep=',')}
-    except AttributeError as e:
-        current_app.logger.error(f"{config_key} not a string", extra={'error': str(e)})
-    except ValueError as e:
-        current_app.logger.error(f"{config_key} not a list of IDs", extra={'error': str(e)})
-    return set()
 
 
 class Config(object):
@@ -127,9 +110,6 @@ class Config(object):
             jinja2.PrefixLoader({'govuk': jinja2.FileSystemLoader(govuk_frontend)})
         ])
         app.jinja_loader = jinja_loader
-
-        app.config["DM_G12_RECOVERY_SUPPLIER_IDS"] = extract_list_of_ids(app, "DM_G12_RECOVERY_SUPPLIER_IDS")
-        app.config["DM_G12_RECOVERY_DRAFT_IDS"] = extract_list_of_ids(app, "DM_G12_RECOVERY_DRAFT_IDS")
 
 
 class Test(Config):

--- a/config.py
+++ b/config.py
@@ -128,8 +128,8 @@ class Config(object):
         ])
         app.jinja_loader = jinja_loader
 
-        app.config["G12_RECOVERY_SUPPLIER_IDS"] = extract_list_of_ids(app, "DM_G12_RECOVERY_SUPPLIER_IDS")
-        app.config["G12_RECOVERY_DRAFT_IDS"] = extract_list_of_ids(app, "DM_G12_RECOVERY_DRAFT_IDS")
+        app.config["DM_G12_RECOVERY_SUPPLIER_IDS"] = extract_list_of_ids(app, "DM_G12_RECOVERY_SUPPLIER_IDS")
+        app.config["DM_G12_RECOVERY_DRAFT_IDS"] = extract_list_of_ids(app, "DM_G12_RECOVERY_DRAFT_IDS")
 
 
 class Test(Config):


### PR DESCRIPTION
I'm not sure what's wrong, but the caching seems not to be working. When deployed to Preview, our test supplier was incorrectly no longer recognised as a G12 recovery supplier.

So I'm going to revert this to get back to a working state. We can think about whether the caching is necessary and, if so, how to do it correctly.

Reverts https://github.com/alphagov/digitalmarketplace-supplier-frontend/pull/1326 and https://github.com/alphagov/digitalmarketplace-supplier-frontend/pull/1327