### PR TITLE
Change G12 banner when all drafts complete

### DIFF
--- a/app/main/helpers/suppliers.py
+++ b/app/main/helpers/suppliers.py
@@ -125,11 +125,10 @@ def format_g12_recovery_time_remaining(time_to_deadline: timedelta) -> str:
 
 
 def count_unsubmitted_g12_recovery_drafts(data_api_client: DataAPIClient, supplier_id: int) -> int:
-    unsubmitted_recovery_drafts = [
-        draft for draft in
+    unsubmitted_draft_ids = {
+        draft["id"] for draft in
         data_api_client.find_draft_services_by_framework_iter(
             framework_slug="g-cloud-12", supplier_id=supplier_id, status="not-submitted"
         )
-        if draft["id"] in get_g12_recovery_draft_ids()
-    ]
-    return len(unsubmitted_recovery_drafts)
+    }
+    return len(unsubmitted_draft_ids.intersection(get_g12_recovery_draft_ids()))

--- a/app/main/helpers/suppliers.py
+++ b/app/main/helpers/suppliers.py
@@ -4,6 +4,7 @@ from typing import Union, Set
 from datetime import datetime, timedelta
 
 from flask import current_app
+from dmapiclient import DataAPIClient
 
 
 def load_countries():
@@ -121,3 +122,14 @@ def format_g12_recovery_time_remaining(time_to_deadline: timedelta) -> str:
         unit += 's'
 
     return f'{number} {unit}'
+
+
+def count_unsubmitted_g12_recovery_drafts(data_api_client: DataAPIClient, supplier_id: int) -> int:
+    unsubmitted_recovery_drafts = [
+        draft for draft in
+        data_api_client.find_draft_services_by_framework_iter(
+            framework_slug="g-cloud-12", supplier_id=supplier_id, status="not-submitted"
+        )
+        if draft["id"] in get_g12_recovery_draft_ids()
+    ]
+    return len(unsubmitted_recovery_drafts)

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -14,7 +14,12 @@ from dmutils.flask import timed_render_template as render_template
 from dmutils.forms.helpers import get_errors_from_wtform
 from dmutils.errors import render_error_page
 
-from ..helpers.suppliers import is_g12_recovery_supplier, g12_recovery_time_remaining, get_g12_recovery_draft_ids
+from ..helpers.suppliers import (
+    is_g12_recovery_supplier,
+    g12_recovery_time_remaining,
+    get_g12_recovery_draft_ids,
+    count_unsubmitted_g12_recovery_drafts,
+)
 from ... import data_api_client
 from ...main import main, content_loader
 from ..helpers import login_required
@@ -124,7 +129,10 @@ def list_all_services(framework_slug):
     ]
 
     # Only G12 recovery suppliers can access this route, so always show the banner
-    g12_recovery = {'time_remaining': g12_recovery_time_remaining()}
+    g12_recovery = {
+        'time_remaining': g12_recovery_time_remaining(),
+        'drafts_remaining': count_unsubmitted_g12_recovery_drafts(data_api_client, current_user.supplier_id)
+    }
 
     return render_template(
         "services/list_all_services.html",
@@ -599,7 +607,10 @@ def view_service_submission(framework_slug, lot_slug, service_id):
     ):
         # we want this page to appear as it would if g12 were open
         framework["status"] = "open"
-        g12_recovery = {'time_remaining': g12_recovery_time_remaining()}
+        g12_recovery = {
+            'time_remaining': g12_recovery_time_remaining(),
+            'drafts_remaining': count_unsubmitted_g12_recovery_drafts(data_api_client, current_user.supplier_id)
+        }
 
     try:
         data = data_api_client.get_draft_service(service_id)

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -38,6 +38,7 @@ from ..helpers.suppliers import (
     get_country_name_from_country_code,
     supplier_company_details_are_complete,
     is_g12_recovery_supplier, g12_recovery_time_remaining,
+    count_unsubmitted_g12_recovery_drafts,
 )
 from ..helpers import login_required
 
@@ -113,7 +114,10 @@ def dashboard():
 
     g12_recovery = None
     if supplier['g12_recovery']:
-        g12_recovery = {'time_remaining': g12_recovery_time_remaining()}
+        g12_recovery = {
+            'time_remaining': g12_recovery_time_remaining(),
+            'drafts_remaining': count_unsubmitted_g12_recovery_drafts(data_api_client, current_user.supplier_id)
+        }
 
     return render_template(
         "suppliers/dashboard.html",

--- a/app/templates/partials/g12_recovery_information.html
+++ b/app/templates/partials/g12_recovery_information.html
@@ -1,12 +1,22 @@
 {% if g12_recovery %}
   <div class="wrapper">
     {# TODO: replace with govukNotificationBanner #}
-    {%
-      with
-      message = 'You have ' + g12_recovery.time_remaining + ' left to finish your application.<br><br>You need to mark your services as complete to finish your application. <a href="'|safe + url_for('.list_services', framework_slug='g-cloud-12') + '">View your services.</a>'|safe,
-      type = 'information'
-    %}
-      {% include 'toolkit/notification-banner.html' %}
-    {% endwith %}
+    {% if g12_recovery.drafts_remaining == 0 %}
+      {%
+        with
+        message = 'Thank you for completing your application.',
+        type = 'success'
+      %}
+        {% include 'toolkit/notification-banner.html' %}
+      {% endwith %}
+    {% else %}
+      {%
+        with
+        message = 'You have ' + g12_recovery.time_remaining + ' left to finish your application.<br><br>You need to mark your services as complete to finish your application. <a href="'|safe + url_for('.list_services', framework_slug='g-cloud-12') + '">View your services.</a>'|safe,
+        type = 'information'
+      %}
+        {% include 'toolkit/notification-banner.html' %}
+      {% endwith %}
+    {% endif %}
   </div>
 {% endif %}

--- a/tests/app/main/test_suppliers.py
+++ b/tests/app/main/test_suppliers.py
@@ -10,7 +10,7 @@ from werkzeug.exceptions import ServiceUnavailable
 
 from dmapiclient import APIError, HTTPError
 from dmapiclient.audit import AuditTypes
-from dmtestutils.api_model_stubs import FrameworkStub, SupplierFrameworkStub
+from dmtestutils.api_model_stubs import FrameworkStub, SupplierFrameworkStub, DraftServiceStub
 
 from tests.app.helpers import BaseApplicationTest, assert_args_and_return
 from app.main.forms.suppliers import CompanyOrganisationSizeForm, CompanyTradingStatusForm
@@ -669,6 +669,9 @@ class TestSuppliersDashboard(BaseApplicationTest):
 
     def test_recovery_supplier_sees_banner(self, g12_recovery_supplier_id):
         self.data_api_client.get_supplier.return_value = get_supplier(id=g12_recovery_supplier_id)
+        self.data_api_client.find_draft_services_by_framework_iter.return_value = [
+            DraftServiceStub(id=123456, status="not-submitted").response()
+        ]
         self.login()
 
         with self.app.app_context():


### PR DESCRIPTION
In our user research we discovered that users expected the banner to change when they had completed all their drafts.

Change the banner to a success message if the user has no unsubmitted G12 recovery drafts (see #1325).

Content on this banner is not final.

There is G12 recovery logic to show a banner on the `/frameworks/<string:framework_slug>/services` route, however I've not updated this as we've now added a new route (`/all-services`, see #1301) for the G12 recovery suppliers to see their services and therefore the banner will never be shown on the `/services` route.

![image](https://user-images.githubusercontent.com/6362602/106254421-985a8500-6210-11eb-8782-1288e1513203.png)

https://trello.com/c/p3BVSpj6/740-2-change-banner-when-all-drafts-complete