### PR TITLE
Remove banner from 'Your G-Cloud-12 services' page

### DIFF
--- a/app/templates/services/list_all_services.html
+++ b/app/templates/services/list_all_services.html
@@ -31,14 +31,14 @@
     </div>
   </div>
 
+  <p>You have {{ g12_recovery.time_remaining }} left to finish your application.</p>
+  <p>You need to mark your draft services as complete to finish your application.</p>
+
   {{ summary.heading("Draft services") }}
   {% if framework.status == 'open' %}
     {{ summary.top_link("Add a service", url_for(".start_new_draft_service", framework_slug=framework.slug, lot_slug=lot.slug)) }}
   {% elif framework.status == 'pending' %}
     <p class="hint">These services were not completed</p>
-  {% endif %}
-  {% if drafts %}
-    <p>You have {{ g12_recovery.time_remaining }} left to finish your application. You need to mark your draft services as complete to finish your application.</p>
   {% endif %}
   {% call(draft) summary.list_table(
     drafts,
@@ -70,9 +70,7 @@
   {% endcall %}
 
   {{ summary.heading("Complete services") }}
-  {% if complete_drafts %}
-    <p>Your completed draft services will be automatically submitted in {{ g12_recovery.time_remaining }}. You may edit them until then.</p>
-  {% endif %}
+  <p class="hint">Services will appear here when you mark them complete. These services are not live.</p>
   {% call(draft) summary.list_table(
     complete_drafts,
     caption="Complete services",

--- a/app/templates/services/list_all_services.html
+++ b/app/templates/services/list_all_services.html
@@ -25,7 +25,6 @@
 {% endblock %}
 
 {% block mainContent %}
-{% include "partials/g12_recovery_information.html" %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-l">Your {{ framework.name }} services</h1>
@@ -37,6 +36,9 @@
     {{ summary.top_link("Add a service", url_for(".start_new_draft_service", framework_slug=framework.slug, lot_slug=lot.slug)) }}
   {% elif framework.status == 'pending' %}
     <p class="hint">These services were not completed</p>
+  {% endif %}
+  {% if drafts %}
+    <p>You have {{ g12_recovery.time_remaining }} left to finish your application. You need to mark your draft services as complete to finish your application.</p>
   {% endif %}
   {% call(draft) summary.list_table(
     drafts,
@@ -68,6 +70,9 @@
   {% endcall %}
 
   {{ summary.heading("Complete services") }}
+  {% if complete_drafts %}
+    <p>Your completed draft services will be automatically submitted in {{ g12_recovery.time_remaining }}. You may edit them until then.</p>
+  {% endif %}
   {% call(draft) summary.list_table(
     complete_drafts,
     caption="Complete services",

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -324,13 +324,14 @@ class TestListServices(BaseApplicationTest):
         )
 
 
-def assert_table(doc, name, expected_contents, table_paragraph=False):
+def assert_table(doc, name, expected_contents, has_hint_text=False):
     table_header = doc.xpath(
         "//h2[normalize-space(string())=$t]",
         t=name,
     )[0]
     if expected_contents:
-        if table_paragraph:
+        if has_hint_text:
+            # Skip hint text
             assert table_header.getnext().tag == "p"
             table_header = table_header.getnext()
 
@@ -427,8 +428,8 @@ class TestG12RecoveryListServices(BaseApplicationTest):
         res = self.client.get("/suppliers/frameworks/g-cloud-12/all-services")
         document = html.fromstring(res.get_data(as_text=True))
 
-        assert_table(document, "Draft services", draft_services, table_paragraph=bool(draft_services))
-        assert_table(document, "Complete services", completed_services, table_paragraph=bool(completed_services))
+        assert_table(document, "Draft services", draft_services)
+        assert_table(document, "Complete services", completed_services, has_hint_text=True)
         assert_table(document, "Live services", [])
 
     def test_page_shows_live_services(self, g12_recovery_supplier_id):
@@ -500,7 +501,7 @@ class TestG12RecoveryListServices(BaseApplicationTest):
         draft_services_table = document.xpath(
             "//h2[normalize-space(string())=$t]",
             t="Draft services",
-        )[0].getnext().getnext()
+        )[0].getnext()
 
         assert "74 unanswered questions" in draft_services_table.text_content()
 
@@ -531,7 +532,7 @@ class TestG12RecoveryListServices(BaseApplicationTest):
         draft_services_table = document.xpath(
             "//h2[normalize-space(string())=$t]",
             t="Draft services",
-        )[0].getnext().getnext()
+        )[0].getnext()
 
         draft_service_progress = draft_services_table.cssselect("tbody tr")[0].cssselect("td")[1]
 


### PR DESCRIPTION
Trello: https://trello.com/c/BbcYnioH/759-2-move-g12-recovery-information-out-of-your-g12-services-banner

In our user research, we found that the banner caused problems for some users on this page. The banner confused users because it linked back to the same page, and caused them to miss the green flash messages.

Remove the banner text and put it into paragraphs above the appropriate tables.
