### PR TITLE
Update G12 recovery banner with final content

### DIFF
--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -18,7 +18,7 @@ from ..helpers.suppliers import (
     is_g12_recovery_supplier,
     g12_recovery_time_remaining,
     get_g12_recovery_draft_ids,
-    count_unsubmitted_g12_recovery_drafts,
+    count_g12_recovery_drafts_by_status,
 )
 from ... import data_api_client
 from ...main import main, content_loader
@@ -129,9 +129,12 @@ def list_all_services(framework_slug):
     ]
 
     # Only G12 recovery suppliers can access this route, so always show the banner
+    not_submitted_count, submitted_count = count_g12_recovery_drafts_by_status(data_api_client,
+                                                                               current_user.supplier_id)
     g12_recovery = {
         'time_remaining': g12_recovery_time_remaining(),
-        'drafts_remaining': count_unsubmitted_g12_recovery_drafts(data_api_client, current_user.supplier_id)
+        'not_submitted_drafts': not_submitted_count,
+        'submitted_drafts': submitted_count
     }
 
     return render_template(
@@ -607,9 +610,12 @@ def view_service_submission(framework_slug, lot_slug, service_id):
     ):
         # we want this page to appear as it would if g12 were open
         framework["status"] = "open"
+        not_submitted_count, submitted_count = count_g12_recovery_drafts_by_status(data_api_client,
+                                                                                   current_user.supplier_id)
         g12_recovery = {
             'time_remaining': g12_recovery_time_remaining(),
-            'drafts_remaining': count_unsubmitted_g12_recovery_drafts(data_api_client, current_user.supplier_id)
+            'not_submitted_drafts': not_submitted_count,
+            'submitted_drafts': submitted_count
         }
 
     try:

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -38,7 +38,7 @@ from ..helpers.suppliers import (
     get_country_name_from_country_code,
     supplier_company_details_are_complete,
     is_g12_recovery_supplier, g12_recovery_time_remaining,
-    count_unsubmitted_g12_recovery_drafts,
+    count_g12_recovery_drafts_by_status,
 )
 from ..helpers import login_required
 
@@ -114,9 +114,12 @@ def dashboard():
 
     g12_recovery = None
     if supplier['g12_recovery']:
+        not_submitted_count, submitted_count = count_g12_recovery_drafts_by_status(data_api_client,
+                                                                                   current_user.supplier_id)
         g12_recovery = {
             'time_remaining': g12_recovery_time_remaining(),
-            'drafts_remaining': count_unsubmitted_g12_recovery_drafts(data_api_client, current_user.supplier_id)
+            'not_submitted_drafts': not_submitted_count,
+            'submitted_drafts': submitted_count
         }
 
     return render_template(

--- a/app/templates/partials/g12_recovery_information.html
+++ b/app/templates/partials/g12_recovery_information.html
@@ -1,13 +1,23 @@
 {% if g12_recovery %}
   <div class="wrapper">
     {# TODO: replace with govukNotificationBanner #}
-    {% if g12_recovery.drafts_remaining == 0 %}
+    {% if g12_recovery.not_submitted_drafts == 0 %}
       {%
         with
-        message = 'Thank you for completing your application.',
+        message = 'You have marked all your services as complete. Your services will be automatically submitted on 25 February.',
         type = 'success'
       %}
         {% include 'toolkit/notification-banner.html' %}
+      {% endwith %}
+    {% elif g12_recovery.submitted_drafts > 0 %}
+      {% with service = " service" if g12_recovery.submitted_drafts == 1 else " services" %}
+        {%
+          with
+          message = "You have marked " + g12_recovery.submitted_drafts|string + service + " as complete. Your services will be automatically submitted on 25 February."|safe,
+          type = 'success'
+        %}
+          {% include 'toolkit/notification-banner.html' %}
+        {% endwith %}
       {% endwith %}
     {% else %}
       {%

--- a/app/templates/partials/g12_recovery_information.html
+++ b/app/templates/partials/g12_recovery_information.html
@@ -4,7 +4,7 @@
     {% if g12_recovery.not_submitted_drafts == 0 %}
       {%
         with
-        message = 'You have marked all your services as complete. Your services will be automatically submitted on 25 February.',
+        message = 'You have marked all your services as complete. Your services will be automatically submitted at 2pm on 25 February 2021.',
         type = 'success'
       %}
         {% include 'toolkit/notification-banner.html' %}
@@ -13,7 +13,7 @@
       {% with service = " service" if g12_recovery.submitted_drafts == 1 else " services" %}
         {%
           with
-          message = "You have marked " + g12_recovery.submitted_drafts|string + service + " as complete. Your services will be automatically submitted on 25 February."|safe,
+          message = "You have marked " + g12_recovery.submitted_drafts|string + service + " as complete. Your services will be automatically submitted at 2pm on 25 February 2021."|safe,
           type = 'success'
         %}
           {% include 'toolkit/notification-banner.html' %}

--- a/config.py
+++ b/config.py
@@ -132,7 +132,7 @@ class Test(Config):
     DM_ASSETS_URL = 'http://asset-host'
 
     DM_G12_RECOVERY_SUPPLIER_IDS = "577184"
-    DM_G12_RECOVERY_DRAFT_IDS = "123456"
+    DM_G12_RECOVERY_DRAFT_IDS = "123456,123457"
 
 
 class Development(Config):

--- a/tests/app/main/test_suppliers.py
+++ b/tests/app/main/test_suppliers.py
@@ -117,6 +117,10 @@ class TestSuppliersDashboard(BaseApplicationTest):
     def g12_recovery_supplier_id(self):
         return 577184
 
+    @pytest.fixture
+    def g12_recovery_draft_ids(self):
+        return 123456, 123457
+
     def test_error_and_success_flashed_messages_only_are_shown_in_banner_messages(self):
         with self.client.session_transaction() as session:
             session['_flashes'] = [

--- a/tests/app/main/test_suppliers.py
+++ b/tests/app/main/test_suppliers.py
@@ -673,7 +673,7 @@ class TestSuppliersDashboard(BaseApplicationTest):
 
     def test_recovery_supplier_sees_banner(self, g12_recovery_supplier_id):
         self.data_api_client.get_supplier.return_value = get_supplier(id=g12_recovery_supplier_id)
-        self.data_api_client.find_draft_services_by_framework_iter.return_value = [
+        self.data_api_client.find_draft_services_iter.return_value = [
             DraftServiceStub(id=123456, status="not-submitted").response()
         ]
         self.login()
@@ -693,6 +693,67 @@ class TestSuppliersDashboard(BaseApplicationTest):
         doc = html.fromstring(response.get_data(as_text=True))
 
         assert not doc.cssselect("p.banner-message:contains('You need to mark your services as complete')")
+
+    def test_recovery_supplier_with_one_submitted_draft_sees_x_completed_banner(self, g12_recovery_supplier_id,
+                                                                                g12_recovery_draft_ids):
+        self.login(supplier_id=g12_recovery_supplier_id)
+
+        self.data_api_client.find_draft_services_iter.return_value = [
+            DraftServiceStub(id=g12_recovery_draft_ids[0], status="submitted").response(),
+            DraftServiceStub(id=g12_recovery_draft_ids[0], status="not-submitted").response(),
+        ]
+        self.data_api_client.find_services.return_value = {"services": []}
+
+        res = self.client.get("/suppliers")
+
+        document = html.fromstring(res.get_data(as_text=True))
+
+        assert document.cssselect("p.banner-message:contains('You have marked 1 service as complete')")
+
+    def test_recovery_supplier_with_two_submitted_drafts_sees_x_completed_banner(self, g12_recovery_supplier_id,
+                                                                                 g12_recovery_draft_ids):
+        self.login(supplier_id=g12_recovery_supplier_id)
+
+        self.data_api_client.find_draft_services_iter.return_value = [
+            DraftServiceStub(id=g12_recovery_draft_ids[0], status="submitted").response(),
+            DraftServiceStub(id=g12_recovery_draft_ids[1], status="submitted").response(),
+            DraftServiceStub(id=g12_recovery_draft_ids[0], status="not-submitted").response(),
+        ]
+        self.data_api_client.find_services.return_value = {"services": []}
+
+        res = self.client.get("/suppliers")
+
+        document = html.fromstring(res.get_data(as_text=True))
+
+        assert document.cssselect("p.banner-message:contains('You have marked 2 services as complete')")
+
+    def test_recovery_supplier_with_all_submitted_drafts_sees_all_completed_banner(self, g12_recovery_supplier_id,
+                                                                                   g12_recovery_draft_ids):
+        self.login(supplier_id=g12_recovery_supplier_id)
+
+        self.data_api_client.find_draft_services_iter.return_value = [
+            DraftServiceStub(id=g12_recovery_draft_ids[0], status="submitted").response()
+        ]
+        self.data_api_client.find_services.return_value = {"services": []}
+
+        res = self.client.get("/suppliers")
+
+        document = html.fromstring(res.get_data(as_text=True))
+
+        assert document.cssselect("p.banner-message:contains('You have marked all your services as complete')")
+
+    def test_recovery_supplier_with_no_completed_drafts_sees_reminder_banner(self, g12_recovery_supplier_id,
+                                                                             g12_recovery_draft_ids):
+        self.data_api_client.find_draft_services_iter.return_value = [
+            DraftServiceStub(id=g12_recovery_draft_ids[0], status="not-submitted").response()
+        ]
+        self.login(supplier_id=g12_recovery_supplier_id)
+
+        res = self.client.get("/suppliers")
+        document = html.fromstring(res.get_data(as_text=True))
+
+        assert document.cssselect("p.banner-message:contains('You have')")
+        assert document.cssselect("p.banner-message:contains('left to finish your application')")
 
 
 class TestSupplierDetails(BaseApplicationTest):


### PR DESCRIPTION
In #1329 we added logic to the banner so it showed a different message if the supplier had submitted all their draft services. We hadn't decided what the content should be at that time.

In content review, we decided that this behaviour wasn't quite what we wanted.

Update the banner with the final content, and add more logic so the banner tells the supplier how many services they've marked as complete as they go. If the supplier completes all their services, show a third message.

Note the nested `{% with %}` in the template. Putting `"service" if g12_recovery.submitted_drafts == 1 else " services"`
in the string concatenation for `message` caused Jinja to only render the string up to and including service(s). I don't like this solution very much, but it's the only one I was able to get working. If there is a better way, please let me know.

https://trello.com/c/p3BVSpj6/740-2-change-banner-when-all-drafts-complete

![image](https://user-images.githubusercontent.com/6362602/106737519-afcdaf80-660e-11eb-9c22-c9939fef0bc1.png)
