### PR TITLE
Set G12 recovery closing date

### DIFF
--- a/app/main/helpers/suppliers.py
+++ b/app/main/helpers/suppliers.py
@@ -99,7 +99,7 @@ def get_g12_recovery_draft_ids() -> Set[int]:
     return set()
 
 
-G12_RECOVERY_DEADLINE = datetime(year=1970, month=1, day=1, hour=17)
+G12_RECOVERY_DEADLINE = datetime(year=2021, month=2, day=25, hour=14)
 
 
 def g12_recovery_time_remaining() -> str:


### PR DESCRIPTION
We now have a confirmed closing date for the G12 recovery phase of 2pm on 25th February 2021. Set this so we show the correct date in the reminder banner.

When we set this previously, the countdown in the banner caused the visual regression tests to fail the first time they were run everyday. However, the banner logic was changed in #1331 and our test supplier in Preview and Staging has one G12 draft service marked as complete. This means they'll see the banner content `You have marked 1
service as complete...` and won't get the countdown.

Since #1331 is already released, this commit should not cause any further visual regression test failures.

https://trello.com/c/LyhdZKkZ/724-1-agree-g12-recovery-dates-and-times

This is how the reminder banner now looks for a supplier with no submitted G12 recovery draft services:

![image](https://user-images.githubusercontent.com/6362602/106757584-6ee29480-6628-11eb-9dd1-adad97b2bb54.png)
