### PR TITLE
Show the correct closing date to G12 recovery suppliers

### DIFF
--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -9,7 +9,7 @@ from dmcontent.utils import count_unanswered_questions
 from dmutils import s3
 from dmutils.dates import update_framework_with_formatted_dates
 from dmutils.documents import upload_service_documents
-from dmutils.formats import displaytimeformat
+from dmutils.formats import displaytimeformat, utctoshorttimelongdateformat
 from dmutils.flask import timed_render_template as render_template
 from dmutils.forms.helpers import get_errors_from_wtform
 from dmutils.errors import render_error_page
@@ -18,7 +18,7 @@ from ..helpers.suppliers import (
     is_g12_recovery_supplier,
     g12_recovery_time_remaining,
     get_g12_recovery_draft_ids,
-    count_g12_recovery_drafts_by_status,
+    count_g12_recovery_drafts_by_status, G12_RECOVERY_DEADLINE,
 )
 from ... import data_api_client
 from ...main import main, content_loader
@@ -610,6 +610,7 @@ def view_service_submission(framework_slug, lot_slug, service_id):
     ):
         # we want this page to appear as it would if g12 were open
         framework["status"] = "open"
+        framework["applicationsCloseAt"] = utctoshorttimelongdateformat(G12_RECOVERY_DEADLINE)
         not_submitted_count, submitted_count = count_g12_recovery_drafts_by_status(data_api_client,
                                                                                    current_user.supplier_id)
         g12_recovery = {


### PR DESCRIPTION
Override the G12 closing date with the recovery closing date for recovery suppliers only.

https://trello.com/c/SHoFSoXG/786-1-fix-date-on-submitted-g12-service-summary-pages

The complete service page now looks like: 

![image](https://user-images.githubusercontent.com/6362602/106904764-7ae75880-66f3-11eb-99df-9873e904470f.png)
