### PR TITLE
Fix breadcrumbs for G12 recovery

### DIFF
--- a/app/templates/services/edit_submission_section.html
+++ b/app/templates/services/edit_submission_section.html
@@ -11,16 +11,8 @@
         "href": url_for('.dashboard')
       },
       {
-        "text": "Apply to " + framework.name,
-        "href": url_for(".framework_dashboard", framework_slug=framework.slug)
-      },
-      {
-        "text": "Services",
-        "href": url_for(".framework_submission_lots", framework_slug=framework.slug)
-      },
-      {
-        "text": lot.name,
-        "href": url_for(".framework_submission_services", framework_slug=framework.slug, lot_slug=lot.slug)
+        "text": "Your " + framework.name + " services",
+        "href": url_for(".list_all_services", framework_slug=framework.slug)
       }
     ]
   %}

--- a/app/templates/services/service_submission.html
+++ b/app/templates/services/service_submission.html
@@ -17,12 +17,8 @@
         "href": url_for('.dashboard')
       },
       {
-        "text": "Apply to " + framework.name,
-        "href": url_for(".framework_dashboard", framework_slug=framework.slug)
-      },
-      {
-        "text": "Services",
-        "href": url_for(".framework_submission_lots", framework_slug=framework.slug)
+        "text": "Your " + framework.name + " services",
+        "href": url_for(".list_all_services", framework_slug=framework.slug)
       }
     ]
   %}
@@ -30,10 +26,6 @@
       {{ govukBreadcrumbs({"items": items + [{"text": service_data.get('serviceName', service_data['lotName'])}]}) }}
     {% else %}
       {{ govukBreadcrumbs({"items": items + [
-        {
-          "text": service_data.lotName,
-          "href": url_for(".framework_submission_services", framework_slug=framework.slug, lot_slug=service_data.lot)
-          },
         {
           "text": service_data.get('serviceName', service_data['lotName'])
         }


### PR DESCRIPTION
Trello: https://trello.com/c/k4g4FDoX/787-2-odd-breadcrumbs-on-draft-service-page

The standard breadcrumbs don't work for the G12 recovery, because the user journey is different to normal. Mainly, we have the new 'Your G-Cloud 12 services' page that covers both the services and the lot page from a normal framework. So update the breadcrumbs accordingly.

This will break the breadcrumbs for non-G12 recovery suppliers. That's fine because no framework will be open during the G12 recovery. We will revert this code once the G12 recovery process has closed.

With changes:

![image](https://user-images.githubusercontent.com/15256121/107067693-9035b300-67d7-11eb-9626-8894cd29978e.png)
![image](https://user-images.githubusercontent.com/15256121/107067713-99268480-67d7-11eb-8403-8c18251dcdb5.png)