### PR TITLE
 switch company details to use Summary List component

### DIFF
--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -38,7 +38,7 @@ from ..helpers.suppliers import (
     get_country_name_from_country_code,
     supplier_company_details_are_complete,
     is_g12_recovery_supplier, g12_recovery_time_remaining,
-    count_g12_recovery_drafts_by_status,
+    count_g12_recovery_drafts_by_status, get_company_details_from_supplier,
 )
 from ..helpers import login_required
 
@@ -169,6 +169,7 @@ def supplier_details():
         unconfirmed_open_supplier_framework_names=[
             fw['frameworkName'] for fw in unconfirmed_open_supplier_frameworks
         ],
+        company_details=get_company_details_from_supplier(supplier)
     ), 200
 
 

--- a/app/templates/suppliers/details.html
+++ b/app/templates/suppliers/details.html
@@ -166,7 +166,7 @@
             'items': [{
                 'href': url_for(".edit_supplier_registration_number"),
                 'text': 'Change' if company_details.get('registration_number') else 'Answer required',
-                'visuallyHiddenText': 'registration number'
+                'visuallyHiddenText': 'registration number' if company_details.get('registration_number') else 'for registration number'
                 }
             ]
         }

--- a/app/templates/suppliers/details.html
+++ b/app/templates/suppliers/details.html
@@ -38,139 +38,191 @@
     <div class='govuk-grid-column-full{% if currently_applying_to or (supplier_company_details_complete and not supplier_company_details_confirmed) %} padding-bottom-small{% endif %}'>
       <h1 class="govuk-heading-l">Your company details</h1>
 
-{{ summary.heading("What buyers will see", id="what_buyers_will_see") }}
-{{ summary.top_link('Edit', url_for('.edit_what_buyers_will_see')) }}
-{% call(item) summary.mapping_table(
-  caption='What buyers will see',
-  field_headings=[
-    'Label',
-    'Value',
-    'Optional'
-  ],
-  field_headings_visible=False
-) %}
-  {% call summary.row() %}
-    {{ summary.field_name('Contact name') }}
-    {{ summary.text(supplier.contact.contactName) }}
-    {{ summary.text("") }}
-  {% endcall %}
-  {% call summary.row() %}
-    {{ summary.field_name('Contact email') }}
-    {{ summary.text(supplier.contact.email) }}
-    {{ summary.text("") }}
-  {% endcall %}
-  {% call summary.row() %}
-    {{ summary.field_name('Contact phone number') }}
-    {{ summary.text(supplier.contact.phoneNumber) }}
-    {{ summary.text("") }}
-  {% endcall %}
-  {% call summary.row() %}
-    {{ summary.field_name('Summary') }}
-    {{ summary.text(supplier.description) }}
-    {% call summary.field(action=True) %}
-      {% if not supplier.description %}
-        Optional
-      {% endif %}
-    {% endcall %}
-  {% endcall %}
-{% endcall %}
+<h2 class="govuk-heading-m" id="what_buyers_will_see">What buyers will see</h2>
+{{ govukSummaryList({
+  'rows': [
+    {
+      'key': {
+        'text': "Contact name"
+      },
+      'value': {
+        'text': supplier.contact.contactName
+      },
+      'actions': {
+          'items': [{
+            'href': url_for('.edit_what_buyers_will_see', _anchor = 'contactName'),
+            'text': 'Change',
+            'visuallyHiddenText': 'contact name'
+            }
+        ]
+      }
+    },
 
-{{ summary.heading("Company details for your framework applications", id="registration_information") }}
-{% call(item) summary.mapping_table(
-  caption='Registration information',
-  field_headings=[
-    'Label',
-    'Value',
-    'Edit'
-  ],
-  field_headings_visible=False
-) %}
-{% call summary.row() %}
-  {{ summary.field_name('Registered company name') }}
-  {% if supplier.registeredName %}
-    {{ summary.text(supplier.registeredName) }}
-    {{ summary.edit_link(label="Edit", link=url_for(".edit_supplier_registered_name"), hidden_text="Registered company name") }}
-  {% else %}
-    {{ summary.link(link_title="Answer required", link=url_for(".edit_supplier_registered_name"), hidden_text="for registered company name") }}
-    {{ summary.text("") }}
-  {% endif %}
-{% endcall %}
+    {
+      'key': {
+        'text': "Contact email"
+      },
+      'value': {
+        'text': supplier.contact.email
+      },
 
-{% set postcode = supplier.contact.get("postcode") %}
-{% set street_address_line_1 = supplier.contact.get("address1") %}
-{% set locality = supplier.contact.get("city") %}
-{% call summary.row() %}
-  {{ summary.field_name('Registered company address') }}
-  {% if postcode and street_address_line_1 and locality and supplier.registrationCountry %}
-    {% call summary.field() %}
-      {%
-        with
-        without_spacing = true,
-        postcode = postcode,
-        street_address = True,
-        street_address_line_1 = street_address_line_1,
-        locality = locality,
-        country = country_name
-      %}
-        {% include "toolkit/contact-details.html" %}
-      {% endwith %}
-    {% endcall %}
-    {{ summary.edit_link(label="Edit", link=url_for(".edit_registered_address"), hidden_text="Registered company address") }}
-  {% else %}
-    {{ summary.link(link_title="Answer required", link=url_for(".edit_registered_address"), hidden_text=" for registered company address") }}
-    {{ summary.text("") }}
-  {% endif %}
-{% endcall %}
+      'actions': {
+            'items': [{
+                'href': url_for('.edit_what_buyers_will_see', _anchor = 'email'),
+                'text': 'Change',
+                'visuallyHiddenText': 'contact email'
+                }
+            ]
+        }
+    },
 
-{% call summary.row() %}
-  {{ summary.field_name('Registration number') }}
-  {% if supplier.companiesHouseNumber %}
-    {{ summary.text(supplier.companiesHouseNumber) }}
-    {{ summary.edit_link(label="Edit", link=url_for(".edit_supplier_registration_number"), hidden_text="Registration number") }}
-  {% elif supplier.otherCompanyRegistrationNumber %}
-    {{ summary.text(supplier.otherCompanyRegistrationNumber) }}
-    {{ summary.edit_link(label="Edit", link=url_for(".edit_supplier_registration_number"), hidden_text="Registration number") }}
-  {% else %}
-    {{ summary.link(link_title="Answer required", link=url_for(".edit_supplier_registration_number"), hidden_text="for registration number") }}
-    {{ summary.text("") }}
-  {% endif %}
-{% endcall %}
+    {
+      'key': {
+        'text': "Contact phone number"
+      },
+      'value': {
+        'text': supplier.contact.phoneNumber
+      },
 
-{% call summary.row() %}
-  {{ summary.field_name('Trading status') }}
-  {% if supplier.tradingStatus %}
-    {{ summary.text(supplier.tradingStatus|capitalize_first) }}
-    {{ summary.edit_link(label="Edit", link=url_for(".edit_supplier_trading_status"), hidden_text="Trading status") }}
-  {% else %}
-    {{ summary.link(link_title="Answer required", link=url_for(".edit_supplier_trading_status"), hidden_text="for trading status") }}
-    {{ summary.text("") }}
-  {% endif %}
-{% endcall %}
 
-{% call summary.row() %}
-  {{ summary.field_name('Company size') }}
-  {% if supplier.organisationSize %}
-    {{ summary.text(supplier.organisationSize|capitalize_first) }}
-    {{ summary.edit_link(label="Edit", link=url_for(".edit_supplier_organisation_size"), hidden_text="Company size") }}
-  {% else %}
-    {{ summary.link(link_title="Answer required", link=url_for(".edit_supplier_organisation_size"), hidden_text="for company size") }}
-    {{ summary.text("") }}
-  {% endif %}
-{% endcall %}
+      'actions': {
+            'items': [{
+                'href': url_for('.edit_what_buyers_will_see', _anchor = 'phoneNumber'),
+                'text': 'Change',
+                'visuallyHiddenText': 'contact phone number'
+                }
+            ]
+        }
+    },
 
-{% call summary.row() %}
-  {{ summary.field_name('DUNS number') }}
-   {% if supplier.dunsNumber %}
-    {{ summary.text(supplier.dunsNumber) }}
-    {{ summary.edit_link(label="Edit", link=url_for(".edit_supplier_duns_number"), hidden_text="DUNS number") }}
-  {% else %}
-    {{ summary.link(link_title="Answer required", link=url_for(".edit_supplier_duns_number"), hidden_text="for DUNS number") }}
-    {{ summary.text("") }}
-  {% endif %}
-{% endcall %}
+    {
+      'key': {
+        'text': "Summary"
+      },
+      'value': {
+        'text': supplier.description
+      },
+      'actions': {
+            'items': [
+            {
+                'href': url_for('.edit_what_buyers_will_see', _anchor = 'description'),
+                'text': 'Change (optional)' if not supplier.description else 'Change',
+                'visuallyHiddenText': 'summary'
+                }]
+        }
+    },
+]
+}) }}
 
-{% endcall %}
+<h2 class="govuk-heading-m" id="registration_information">Company details for your framework applications</h2>
+{%  set has_address = supplier.contact.get("postcode") and supplier.contact.get("address1") and supplier.contact.get("city") and country_name %}
 
+{{ govukSummaryList({
+  'rows': [
+    {
+      'key': {
+        'text': "Registered company name"
+      },
+      'value': {
+        'text': supplier.registeredName
+      },
+      'actions': {
+          'items': [{
+            'href': url_for('.edit_supplier_registered_name'),
+            'text': 'Change' if supplier.registeredName else 'Answer required',
+            'visuallyHiddenText': 'registered company name' if supplier.registeredName else 'for registered company name'
+            }
+        ]
+      }
+    },
+
+    {
+      'key': {
+        'text': "Registered company address"
+      },
+      'value': {
+        'html': '<br />'.join([supplier.contact.get("address1"), supplier.contact.get("city"), supplier.contact.get("postcode"), country_name])
+      },
+
+      'actions': {
+            'items': [{
+                'href': url_for(".edit_registered_address"),
+                'text': 'Change' if has_address else 'Answer required',
+                'visuallyHiddenText': 'registered company address' if has_address else 'for registered company address'
+                }
+            ]
+        }
+    },
+
+    {
+      'key': {
+        'text': "Registration number"
+      },
+      'value': {
+        'text': company_details.get('registration_number')
+      },
+
+
+      'actions': {
+            'items': [{
+                'href': url_for(".edit_supplier_registration_number"),
+                'text': 'Change' if company_details.get('registration_number') else 'Answer required',
+                'visuallyHiddenText': 'registration number'
+                }
+            ]
+        }
+    },
+
+    {
+      'key': {
+        'text': "Trading status"
+      },
+      'value': {
+        'text': supplier.tradingStatus|capitalize_first
+      },
+      'actions': {
+            'items': [
+            {
+                'href': url_for(".edit_supplier_trading_status"),
+                'text': 'Change' if supplier.tradingStatus else 'Answer required',
+                'visuallyHiddenText': 'trading status' if supplier.tradingStatus else 'for trading status'
+                }]
+        }
+    },
+    {
+      'key': {
+        'text': "Company size"
+      },
+      'value': {
+        'text': supplier.organisationSize|capitalize_first
+      },
+      'actions': {
+            'items': [
+            {
+                'href': url_for(".edit_supplier_organisation_size"),
+                'text': 'Change' if supplier.organisationSize else 'Answer required',
+                'visuallyHiddenText': 'company size' if supplier.organisationSize else 'for company size'
+                }]
+        }
+    },
+    {
+      'key': {
+        'text': "DUNS number"
+      },
+      'value': {
+        'text': supplier.dunsNumber
+      },
+      'actions': {
+            'items': [
+            {
+                'href': url_for(".edit_supplier_duns_number"),
+                'text': 'Change' if supplier.dunsNumber else 'Answer required',
+                'visuallyHiddenText': 'DUNS number' if supplier.dunsNumber else 'for DUNS number'
+                }]
+        }
+    },
+]
+}) }}
     </div>
   </div>
 

--- a/app/templates/suppliers/details.html
+++ b/app/templates/suppliers/details.html
@@ -1,5 +1,4 @@
 {% extends "_base_page.html" %}
-{% import "toolkit/summary-table.html" as summary %}
 {% block pageTitle %}
   Your company details – Digital Marketplace
 {% endblock %}

--- a/app/templates/suppliers/details.html
+++ b/app/templates/suppliers/details.html
@@ -49,7 +49,7 @@
               'actions': {
                   'items': [{
                     'href': url_for('.edit_what_buyers_will_see', _anchor = 'contactName'),
-                    'text': 'Change',
+                    'text': 'Edit',
                     'visuallyHiddenText': 'contact name'
                     }]}
             },
@@ -63,7 +63,7 @@
               'actions': {
                     'items': [{
                         'href': url_for('.edit_what_buyers_will_see', _anchor = 'email'),
-                        'text': 'Change',
+                        'text': 'Edit',
                         'visuallyHiddenText': 'contact email'
                         }]}
                 },
@@ -77,7 +77,7 @@
               'actions': {
                     'items': [{
                         'href': url_for('.edit_what_buyers_will_see', _anchor = 'phoneNumber'),
-                        'text': 'Change',
+                        'text': 'Edit',
                         'visuallyHiddenText': 'contact phone number'
                         }]}
             },
@@ -92,7 +92,7 @@
                     'items': [
                     {
                         'href': url_for('.edit_what_buyers_will_see', _anchor = 'description'),
-                        'text': 'Change (optional)' if not supplier.description else 'Change',
+                        'text': 'Change (optional)' if not supplier.description else 'Edit',
                         'visuallyHiddenText': 'summary'
                         }]}
             },
@@ -111,7 +111,7 @@
               'actions': {
                   'items': [{
                     'href': url_for('.edit_supplier_registered_name'),
-                    'text': 'Change' if supplier.registeredName else 'Answer required',
+                    'text': 'Edit' if supplier.registeredName else 'Answer required',
                     'visuallyHiddenText': 'registered company name' if supplier.registeredName else 'for registered company name'
                     }]}
                 },
@@ -125,7 +125,7 @@
               'actions': {
                     'items': [{
                         'href': url_for(".edit_registered_address"),
-                        'text': 'Change' if has_address else 'Answer required',
+                        'text': 'Edit' if has_address else 'Answer required',
                         'visuallyHiddenText': 'registered company address' if has_address else 'for registered company address'
                         }]}
             },
@@ -139,7 +139,7 @@
               'actions': {
                     'items': [{
                         'href': url_for(".edit_supplier_registration_number"),
-                        'text': 'Change' if company_details.get('registration_number') else 'Answer required',
+                        'text': 'Edit' if company_details.get('registration_number') else 'Answer required',
                         'visuallyHiddenText': 'registration number' if company_details.get('registration_number') else 'for registration number'
                         }]}
                 },
@@ -154,7 +154,7 @@
                     'items': [
                     {
                         'href': url_for(".edit_supplier_trading_status"),
-                        'text': 'Change' if supplier.tradingStatus else 'Answer required',
+                        'text': 'Edit' if supplier.tradingStatus else 'Answer required',
                         'visuallyHiddenText': 'trading status' if supplier.tradingStatus else 'for trading status'
                         }]}
             },
@@ -169,7 +169,7 @@
                     'items': [
                     {
                         'href': url_for(".edit_supplier_organisation_size"),
-                        'text': 'Change' if supplier.organisationSize else 'Answer required',
+                        'text': 'Edit' if supplier.organisationSize else 'Answer required',
                         'visuallyHiddenText': 'company size' if supplier.organisationSize else 'for company size'
                         }]}
             },
@@ -184,7 +184,7 @@
                     'items': [
                     {
                         'href': url_for(".edit_supplier_duns_number"),
-                        'text': 'Change' if supplier.dunsNumber else 'Answer required',
+                        'text': 'Edit' if supplier.dunsNumber else 'Answer required',
                         'visuallyHiddenText': 'DUNS number' if supplier.dunsNumber else 'for DUNS number'
                         }]}
                 },

--- a/app/templates/suppliers/details.html
+++ b/app/templates/suppliers/details.html
@@ -83,7 +83,7 @@
             },
             {
               'key': {
-                'text': "Summary"
+                'text': "Summary" if supplier.description else "Summary (optional)"
               },
               'value': {
                 'text': supplier.description
@@ -92,7 +92,7 @@
                     'items': [
                     {
                         'href': url_for('.edit_what_buyers_will_see', _anchor = 'description'),
-                        'text': 'Change (optional)' if not supplier.description else 'Edit',
+                        'text': 'Edit',
                         'visuallyHiddenText': 'summary'
                         }]}
             },

--- a/app/templates/suppliers/details.html
+++ b/app/templates/suppliers/details.html
@@ -36,192 +36,160 @@
   <div class='govuk-grid-row'>
     <div class='govuk-grid-column-full{% if currently_applying_to or (supplier_company_details_complete and not supplier_company_details_confirmed) %} padding-bottom-small{% endif %}'>
       <h1 class="govuk-heading-l">Your company details</h1>
-
-<h2 class="govuk-heading-m" id="what_buyers_will_see">What buyers will see</h2>
-{{ govukSummaryList({
-  'rows': [
-    {
-      'key': {
-        'text': "Contact name"
-      },
-      'value': {
-        'text': supplier.contact.contactName
-      },
-      'actions': {
-          'items': [{
-            'href': url_for('.edit_what_buyers_will_see', _anchor = 'contactName'),
-            'text': 'Change',
-            'visuallyHiddenText': 'contact name'
-            }
-        ]
-      }
-    },
-
-    {
-      'key': {
-        'text': "Contact email"
-      },
-      'value': {
-        'text': supplier.contact.email
-      },
-
-      'actions': {
-            'items': [{
-                'href': url_for('.edit_what_buyers_will_see', _anchor = 'email'),
-                'text': 'Change',
-                'visuallyHiddenText': 'contact email'
-                }
-            ]
-        }
-    },
-
-    {
-      'key': {
-        'text': "Contact phone number"
-      },
-      'value': {
-        'text': supplier.contact.phoneNumber
-      },
-
-
-      'actions': {
-            'items': [{
-                'href': url_for('.edit_what_buyers_will_see', _anchor = 'phoneNumber'),
-                'text': 'Change',
-                'visuallyHiddenText': 'contact phone number'
-                }
-            ]
-        }
-    },
-
-    {
-      'key': {
-        'text': "Summary"
-      },
-      'value': {
-        'text': supplier.description
-      },
-      'actions': {
-            'items': [
+        <h2 class="govuk-heading-m" id="what_buyers_will_see">What buyers will see</h2>
+        {{ govukSummaryList({
+          'rows': [
             {
-                'href': url_for('.edit_what_buyers_will_see', _anchor = 'description'),
-                'text': 'Change (optional)' if not supplier.description else 'Change',
-                'visuallyHiddenText': 'summary'
-                }]
-        }
-    },
-]
-}) }}
-
-<h2 class="govuk-heading-m" id="registration_information">Company details for your framework applications</h2>
-{%  set has_address = supplier.contact.get("postcode") and supplier.contact.get("address1") and supplier.contact.get("city") and country_name %}
-
-{{ govukSummaryList({
-  'rows': [
-    {
-      'key': {
-        'text': "Registered company name"
-      },
-      'value': {
-        'text': supplier.registeredName
-      },
-      'actions': {
-          'items': [{
-            'href': url_for('.edit_supplier_registered_name'),
-            'text': 'Change' if supplier.registeredName else 'Answer required',
-            'visuallyHiddenText': 'registered company name' if supplier.registeredName else 'for registered company name'
-            }
-        ]
-      }
-    },
-
-    {
-      'key': {
-        'text': "Registered company address"
-      },
-      'value': {
-        'html': '<br />'.join([supplier.contact.get("address1"), supplier.contact.get("city"), supplier.contact.get("postcode"), country_name])
-      },
-
-      'actions': {
-            'items': [{
-                'href': url_for(".edit_registered_address"),
-                'text': 'Change' if has_address else 'Answer required',
-                'visuallyHiddenText': 'registered company address' if has_address else 'for registered company address'
-                }
+              'key': {
+                'text': "Contact name"
+              },
+              'value': {
+                'text': supplier.contact.contactName
+              },
+              'actions': {
+                  'items': [{
+                    'href': url_for('.edit_what_buyers_will_see', _anchor = 'contactName'),
+                    'text': 'Change',
+                    'visuallyHiddenText': 'contact name'
+                    }]}
+            },
+            {
+              'key': {
+                'text': "Contact email"
+              },
+              'value': {
+                'text': supplier.contact.email
+              },
+              'actions': {
+                    'items': [{
+                        'href': url_for('.edit_what_buyers_will_see', _anchor = 'email'),
+                        'text': 'Change',
+                        'visuallyHiddenText': 'contact email'
+                        }]}
+                },
+            {
+              'key': {
+                'text': "Contact phone number"
+              },
+              'value': {
+                'text': supplier.contact.phoneNumber
+              },
+              'actions': {
+                    'items': [{
+                        'href': url_for('.edit_what_buyers_will_see', _anchor = 'phoneNumber'),
+                        'text': 'Change',
+                        'visuallyHiddenText': 'contact phone number'
+                        }]}
+            },
+            {
+              'key': {
+                'text': "Summary"
+              },
+              'value': {
+                'text': supplier.description
+              },
+              'actions': {
+                    'items': [
+                    {
+                        'href': url_for('.edit_what_buyers_will_see', _anchor = 'description'),
+                        'text': 'Change (optional)' if not supplier.description else 'Change',
+                        'visuallyHiddenText': 'summary'
+                        }]}
+            },
+        ]}) }}
+        <h2 class="govuk-heading-m" id="registration_information">Company details for your framework applications</h2>
+        {%  set has_address = supplier.contact.get("postcode") and supplier.contact.get("address1") and supplier.contact.get("city") and country_name %}
+        {{ govukSummaryList({
+          'rows': [
+            {
+              'key': {
+                'text': "Registered company name"
+              },
+              'value': {
+                'text': supplier.registeredName
+              },
+              'actions': {
+                  'items': [{
+                    'href': url_for('.edit_supplier_registered_name'),
+                    'text': 'Change' if supplier.registeredName else 'Answer required',
+                    'visuallyHiddenText': 'registered company name' if supplier.registeredName else 'for registered company name'
+                    }]}
+                },
+            {
+              'key': {
+                'text': "Registered company address"
+              },
+              'value': {
+                'html': '<br />'.join([supplier.contact.get("address1"), supplier.contact.get("city"), supplier.contact.get("postcode"), country_name])
+              },
+              'actions': {
+                    'items': [{
+                        'href': url_for(".edit_registered_address"),
+                        'text': 'Change' if has_address else 'Answer required',
+                        'visuallyHiddenText': 'registered company address' if has_address else 'for registered company address'
+                        }]}
+            },
+            {
+              'key': {
+                'text': "Registration number"
+              },
+              'value': {
+                'text': company_details.get('registration_number')
+              },
+              'actions': {
+                    'items': [{
+                        'href': url_for(".edit_supplier_registration_number"),
+                        'text': 'Change' if company_details.get('registration_number') else 'Answer required',
+                        'visuallyHiddenText': 'registration number' if company_details.get('registration_number') else 'for registration number'
+                        }]}
+                },
+            {
+              'key': {
+                'text': "Trading status"
+              },
+              'value': {
+                'text': supplier.tradingStatus|capitalize_first
+              },
+              'actions': {
+                    'items': [
+                    {
+                        'href': url_for(".edit_supplier_trading_status"),
+                        'text': 'Change' if supplier.tradingStatus else 'Answer required',
+                        'visuallyHiddenText': 'trading status' if supplier.tradingStatus else 'for trading status'
+                        }]}
+            },
+            {
+              'key': {
+                'text': "Company size"
+              },
+              'value': {
+                'text': supplier.organisationSize|capitalize_first
+              },
+              'actions': {
+                    'items': [
+                    {
+                        'href': url_for(".edit_supplier_organisation_size"),
+                        'text': 'Change' if supplier.organisationSize else 'Answer required',
+                        'visuallyHiddenText': 'company size' if supplier.organisationSize else 'for company size'
+                        }]}
+            },
+            {
+              'key': {
+                'text': "DUNS number"
+              },
+              'value': {
+                'text': supplier.dunsNumber
+              },
+              'actions': {
+                    'items': [
+                    {
+                        'href': url_for(".edit_supplier_duns_number"),
+                        'text': 'Change' if supplier.dunsNumber else 'Answer required',
+                        'visuallyHiddenText': 'DUNS number' if supplier.dunsNumber else 'for DUNS number'
+                        }]}
+                },
             ]
-        }
-    },
-
-    {
-      'key': {
-        'text': "Registration number"
-      },
-      'value': {
-        'text': company_details.get('registration_number')
-      },
-
-
-      'actions': {
-            'items': [{
-                'href': url_for(".edit_supplier_registration_number"),
-                'text': 'Change' if company_details.get('registration_number') else 'Answer required',
-                'visuallyHiddenText': 'registration number' if company_details.get('registration_number') else 'for registration number'
-                }
-            ]
-        }
-    },
-
-    {
-      'key': {
-        'text': "Trading status"
-      },
-      'value': {
-        'text': supplier.tradingStatus|capitalize_first
-      },
-      'actions': {
-            'items': [
-            {
-                'href': url_for(".edit_supplier_trading_status"),
-                'text': 'Change' if supplier.tradingStatus else 'Answer required',
-                'visuallyHiddenText': 'trading status' if supplier.tradingStatus else 'for trading status'
-                }]
-        }
-    },
-    {
-      'key': {
-        'text': "Company size"
-      },
-      'value': {
-        'text': supplier.organisationSize|capitalize_first
-      },
-      'actions': {
-            'items': [
-            {
-                'href': url_for(".edit_supplier_organisation_size"),
-                'text': 'Change' if supplier.organisationSize else 'Answer required',
-                'visuallyHiddenText': 'company size' if supplier.organisationSize else 'for company size'
-                }]
-        }
-    },
-    {
-      'key': {
-        'text': "DUNS number"
-      },
-      'value': {
-        'text': supplier.dunsNumber
-      },
-      'actions': {
-            'items': [
-            {
-                'href': url_for(".edit_supplier_duns_number"),
-                'text': 'Change' if supplier.dunsNumber else 'Answer required',
-                'visuallyHiddenText': 'DUNS number' if supplier.dunsNumber else 'for DUNS number'
-                }]
-        }
-    },
-]
-}) }}
+        })}}
     </div>
   </div>
 

--- a/tests/app/main/test_suppliers.py
+++ b/tests/app/main/test_suppliers.py
@@ -795,7 +795,7 @@ class TestSupplierDetails(BaseApplicationTest):
             assert document.xpath("//*[normalize-space(string())=$t]", t=property_str), property_str
             # Property has associated Change link
             assert document.xpath(f"//dd[normalize-space(text())='{property_str}']/following-sibling::dd/a/text()")[0]\
-                .strip() == 'Change'
+                .strip() == 'Edit'
 
         # Registration number not shown if Companies House ID exists
         assert "BEL153" not in page_html
@@ -962,7 +962,7 @@ class TestSupplierDetails(BaseApplicationTest):
     @pytest.mark.parametrize(
         "summary,link_text",
         [
-            ({"description": "Our company is the best for digital ponies."}, 'Change'),
+            ({"description": "Our company is the best for digital ponies."}, 'Edit'),
             ({"description": ""}, 'Change (optional)'),
         ]
     )

--- a/tests/app/main/test_suppliers.py
+++ b/tests/app/main/test_suppliers.py
@@ -960,13 +960,13 @@ class TestSupplierDetails(BaseApplicationTest):
         assert answer_required_link[0].values()[1] == link_address
 
     @pytest.mark.parametrize(
-        "summary,link_text",
+        "summary,expected_key",
         [
-            ({"description": "Our company is the best for digital ponies."}, 'Edit'),
-            ({"description": ""}, 'Change (optional)'),
+            ({"description": "Our company is the best for digital ponies."}, 'Summary'),
+            ({"description": ""}, 'Summary (optional)'),
         ]
     )
-    def test_hint_text_for_summary_only_visible_if_field_empty(self, summary, link_text):
+    def test_hint_text_for_summary_only_visible_if_field_empty(self, summary, expected_key):
         self.data_api_client.get_supplier.return_value = get_supplier(**summary)
 
         self.login()
@@ -975,9 +975,7 @@ class TestSupplierDetails(BaseApplicationTest):
         assert response.status_code == 200
         page_html = response.get_data(as_text=True)
         document = html.fromstring(page_html)
-        actual_link_text = document.xpath("//dt[normalize-space(text())='Summary']/following-sibling::dd[2]/a")[0].\
-            text.strip()
-        assert link_text == actual_link_text
+        assert document.xpath(f"*//dt[normalize-space(text())='{expected_key}']")
 
     @pytest.mark.parametrize(
         "framework_slug,framework_name,link_address",

--- a/tests/app/main/test_suppliers.py
+++ b/tests/app/main/test_suppliers.py
@@ -777,21 +777,12 @@ class TestSupplierDetails(BaseApplicationTest):
         page_html = res.get_data(as_text=True)
         document = html.fromstring(page_html)
 
-        assert document.xpath(
-            "//a[normalize-space(string())=$t][@href=$u][contains(@class, $c)]",
-            t="Edit",
-            u="/suppliers/what-buyers-will-see/edit",
-            c="summary-change-link",
-        )
-
         for property_str in (
             # "Company details" section at the top
+            # Address elements are tested separately in `test_shows_address_details()` due to HTML structure
             "Supplier Person",  # Contact name
             "supplier@user.dmdev",  # Contact email
             "0800123123",  # Phone number
-            "1 Street",  # Address: "2 Building" and "Supplierland" are not shown, even though in contactInformation
-            "Supplierville",  # Town or City
-            "11 AB",  # Postcode
             "Supplier Description",  # Supplier summary
             # "Registration information" section
             "Official Name Inc",  # Registered company name
@@ -817,7 +808,8 @@ class TestSupplierDetails(BaseApplicationTest):
         assert res.status_code == 200
         page_html = res.get_data(as_text=True)
         document = html.fromstring(page_html)
-        assert document.xpath("//span[text()='Registration number']/following::td[1]/span[text()='42, EARTH']")
+        assert document.xpath("//dt[normalize-space(text())='Registration number']/following-sibling::dd")[0]. \
+            text.strip() == '42, EARTH'
 
     def test_shows_united_kingdom_for_old_style_country_code(self):
         self.data_api_client.get_supplier.return_value = get_supplier(
@@ -829,7 +821,8 @@ class TestSupplierDetails(BaseApplicationTest):
         assert res.status_code == 200
         page_html = res.get_data(as_text=True)
         document = html.fromstring(page_html)
-        assert document.xpath("//*[normalize-space(string())='United Kingdom']")  # Country United Kingdom is shown
+        # Country United Kingdom is shown
+        assert document.xpath("//*/node()[normalize-space(string())='United Kingdom']")
 
     def test_handles_supplier_with_no_registration_country_key(self):
         supplier = get_supplier()
@@ -850,16 +843,13 @@ class TestSupplierDetails(BaseApplicationTest):
         assert response.status_code == 200
         page_html = response.get_data(as_text=True)
         document = html.fromstring(page_html)
+        address = (document.
+                   xpath("//dt[normalize-space(text())='Registered company address']/following-sibling::dd/text()"))
 
-        street = document.xpath("//span[text()='Registered company address']/following::td[1]/span/p/span[1]")
-        town = document.xpath("//span[text()='Registered company address']/following::td[1]/span/p/span[2]")
-        postcode = document.xpath("//span[text()='Registered company address']/following::td[1]/span/p/span[3]")
-        country = document.xpath("//span[text()='Registered company address']/following::td[1]/span/p/span[4]")
-
-        assert "1 Street" in street[0].text
-        assert "Supplierville" in town[0].text
-        assert "11 AB" in postcode[0].text
-        assert "United Kingdom" in country[0].text
+        assert "1 Street" in address[0]
+        assert "Supplierville" in address[1]
+        assert "11 AB" in address[2]
+        assert "United Kingdom" in address[3]
 
     @pytest.mark.parametrize(
         "question,null_attribute,link_address",
@@ -884,12 +874,11 @@ class TestSupplierDetails(BaseApplicationTest):
         assert response.status_code == 200
         page_html = response.get_data(as_text=True)
         document = html.fromstring(page_html)
-        answer_required_link = document.xpath(
-            "//span[text()='{}']/following::td[1]/span/a[text()='Answer required']".format(question)
-        )
+        answer_required_link = document.xpath(f"//dt[normalize-space(text())='{question}']/following-sibling::dd[2]/a")
 
         assert answer_required_link
-        assert answer_required_link[0].values()[0] == link_address
+        assert answer_required_link[0].values()[1] == link_address
+        assert answer_required_link[0].text.strip() == 'Answer required'
 
     @pytest.mark.parametrize(
         "question,filled_in_attribute,link_address",
@@ -960,20 +949,20 @@ class TestSupplierDetails(BaseApplicationTest):
         page_html = response.get_data(as_text=True)
         document = html.fromstring(page_html)
         answer_required_link = document.xpath(
-            "//span[text()='{}']/following::td[2]/span/a[text()='Edit']".format(question)
+            f"//dt[normalize-space(text())='{question}']/following-sibling::dd[2]/a"
         )
 
         assert answer_required_link
-        assert answer_required_link[0].values()[0] == link_address
+        assert answer_required_link[0].values()[1] == link_address
 
     @pytest.mark.parametrize(
-        "summary,is_hint_visible",
+        "summary,link_text",
         [
-            ({"description": "Our company is the best for digital ponies."}, False),
-            ({"description": ""}, True),
+            ({"description": "Our company is the best for digital ponies."}, 'Change'),
+            ({"description": ""}, 'Change (optional)'),
         ]
     )
-    def test_hint_text_for_summary_only_visible_if_field_empty(self, summary, is_hint_visible):
+    def test_hint_text_for_summary_only_visible_if_field_empty(self, summary, link_text):
         self.data_api_client.get_supplier.return_value = get_supplier(**summary)
 
         self.login()
@@ -982,8 +971,9 @@ class TestSupplierDetails(BaseApplicationTest):
         assert response.status_code == 200
         page_html = response.get_data(as_text=True)
         document = html.fromstring(page_html)
-        optional_hint_text = (document.xpath("//span[text()='Summary']/following::td[2]/span")[0].text).strip()
-        assert bool(optional_hint_text) == is_hint_visible
+        actual_link_text = document.xpath("//dt[normalize-space(text())='Summary']/following-sibling::dd[2]/a")[0].\
+            text.strip()
+        assert link_text == actual_link_text
 
     @pytest.mark.parametrize(
         "framework_slug,framework_name,link_address",

--- a/tests/app/main/test_suppliers.py
+++ b/tests/app/main/test_suppliers.py
@@ -791,7 +791,11 @@ class TestSupplierDetails(BaseApplicationTest):
             "Open for business",  # Trading status
             "Small",  # Size
         ):
+            # Property exists on page
             assert document.xpath("//*[normalize-space(string())=$t]", t=property_str), property_str
+            # Property has associated Change link
+            assert document.xpath(f"//dd[normalize-space(text())='{property_str}']/following-sibling::dd/a/text()")[0]\
+                .strip() == 'Change'
 
         # Registration number not shown if Companies House ID exists
         assert "BEL153" not in page_html


### PR DESCRIPTION
https://trello.com/c/seJqGqxD/772-2-replace-company-details-page-summary-table-with-summary-list
also fixes https://trello.com/c/7d0040to/233-2-inconsistent-font

Switches company details to use [Summary list](https://design-system.service.gov.uk/components/summary-list/) component.

## Notes
Some small changes were required to fit within the style of Summary list:
* _Edit_ link text becomes _Change_
* Anchor links for each item are used rather than a shared single link under _What buyers will see_
* Previously if summary was left unpopulated 'Optional' was displayed in plain text. This is no longer possible as the 'Actions' in the Summary list must be links, so I changed it to _Change (Optional)_:
### Before
![Screenshot 2021-02-09 at 13 33 44](https://user-images.githubusercontent.com/1764158/107370881-75b35080-6adb-11eb-8fa7-33583c29922b.png)
### After
![Screenshot 2021-02-09 at 13 34 22](https://user-images.githubusercontent.com/1764158/107370946-8a8fe400-6adb-11eb-8df0-93da9fbc00df.png)

 CC @NoraGDS to review these changes.

**I will update the functional tests once this PR is approved.**

-----------
## Before
![Screenshot_2020-10-20_at_11 47 21](https://user-images.githubusercontent.com/1764158/107369991-536d0300-6ada-11eb-980f-1f5dee1d2410.png)

## After
![Screenshot 2021-02-09 at 13 30 15](https://user-images.githubusercontent.com/1764158/107370550-09385180-6adb-11eb-9392-7d46f86ad99a.png)


