### PR TITLE
Replace validation banner with GOV.UK Frontend error summary component

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "package-lock.json",
     "lines": null
   },
-  "generated_at": "2021-01-22T17:45:19Z",
+  "generated_at": "2021-02-12T17:02:59Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -63,35 +63,35 @@
         "hashed_secret": "6955d0539c7ae97361ab63d21bc2bb730edbce7a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3823,
+        "line_number": 3839,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "5b10c4aa69a96ad5a1a11ff1add1a37cdc71fb20",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3839,
+        "line_number": 3855,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "b818bf7ee968a5c29d4436a8243c223576f1d75a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3840,
+        "line_number": 3856,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "e5223482a22578724452e2315f44d0bc5fc457a3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4564,
+        "line_number": 4580,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "82cae5b1d77db4d964804f85ef2c818c6bec2614",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4589,
+        "line_number": 4605,
         "type": "Base64 High Entropy String"
       }
     ]

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -9,7 +9,6 @@
 //= require ../../../node_modules/jquery/dist/jquery.js
 //= require ../../../node_modules/digitalmarketplace-frontend-toolkit/toolkit/javascripts/list-entry.js
 //= require ../../../node_modules/digitalmarketplace-frontend-toolkit/toolkit/javascripts/word-counter.js
-//= require ../../../node_modules/digitalmarketplace-frontend-toolkit/toolkit/javascripts/validation.js
 //= require ../../../node_modules/govuk_frontend_toolkit/javascripts/govuk/selection-buttons.js
 //= require ../../../node_modules/govuk_frontend_toolkit/javascripts/govuk/shim-links-with-button-role.js
 //= require ../../../node_modules/govuk_frontend_toolkit/javascripts/govuk/stick-at-top-when-scrolling.js

--- a/app/main/forms/suppliers.py
+++ b/app/main/forms/suppliers.py
@@ -91,11 +91,13 @@ class AddCompanyRegisteredNameForm(FlaskForm):
 class AddCompanyRegistrationNumberForm(FlaskForm):
     has_companies_house_number = RadioField(
         "Are you registered with Companies House?",
+        id="input-has_companies_house_number-1",
         validators=[InputRequired(message="You need to answer this question.")],
         choices=[('Yes', 'Yes'), ('No', 'No')]
     )
     companies_house_number = DMStripWhitespaceStringField(
         'Companies House number',
+        id="input-has_companies_house_number-1-companies_house_number",
         default='',
         validators=[
             Optional(),
@@ -106,6 +108,7 @@ class AddCompanyRegistrationNumberForm(FlaskForm):
     )
     other_company_registration_number = DMStripWhitespaceStringField(
         'Other company registration number',
+        id="input-has_companies_house_number-2-other_company_registration_number",
         default='',
         validators=[
             Optional(),

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -840,6 +840,12 @@ def framework_updates(framework_slug, error_message=None, default_textbox_value=
         file['path'] = '/'.join(path_parts[2:])
         files[path_parts[3]].append(file)
 
+    errors = {CLARIFICATION_QUESTION_NAME: {
+        "text": error_message,
+        "href": "#" + CLARIFICATION_QUESTION_NAME,
+        "errorMessage": error_message,
+    }} if error_message else {}
+
     return render_template(
         "frameworks/updates.html",
         framework=framework,
@@ -847,6 +853,8 @@ def framework_updates(framework_slug, error_message=None, default_textbox_value=
         clarification_question_name=CLARIFICATION_QUESTION_NAME,
         clarification_question_value=default_textbox_value,
         error_message=error_message,
+        errors=errors,
+        error_title="There was a problem with your submitted question",
         files=files,
         agreement_countersigned=bool(supplier_framework_info and supplier_framework_info['countersignedPath']),
     ), 200 if not error_message else 400
@@ -867,7 +875,7 @@ def framework_updates_email_clarification_question(framework_slug):
     clarification_question = request.form.get(CLARIFICATION_QUESTION_NAME, '').strip()
 
     if not clarification_question:
-        return framework_updates(framework_slug, "Add text if you want to ask a question.")
+        return framework_updates(framework_slug, error_message="Add text if you want to ask a question.")
     elif len(clarification_question) > 5000:
         return framework_updates(
             framework_slug,

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -5,6 +5,7 @@ from datetime import datetime, timedelta
 from dmutils.errors import render_error_page
 from itertools import chain
 
+from dmutils.forms.errors import govuk_errors
 from flask import request, abort, flash, redirect, url_for, current_app, session
 from flask_login import current_user
 
@@ -710,7 +711,7 @@ def framework_supplier_declaration_edit(framework_slug, section_id):
             )
 
             if document_errors:
-                errors = section.get_error_messages(document_errors, question_descriptor_from="question")
+                errors = govuk_errors(section.get_error_messages(document_errors, question_descriptor_from="question"))
             else:
                 submitted_answers.update(uploaded_documents)
 
@@ -719,7 +720,7 @@ def framework_supplier_declaration_edit(framework_slug, section_id):
         # TODO: combine document errors with other validation errors
         # If no document errors, look for other errors
         if not errors:
-            errors = validator.get_error_messages_for_page(section)
+            errors = govuk_errors(validator.get_error_messages_for_page(section))
             # Handle bug for pre-existing files - the filepath value is not included in the POST data,
             # so this fails validation if the user has resubmitted without changes (or changed a different field).
             # If the user *does* change the file, any errors will be picked up by the 'document_errors' section above

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timedelta
 
+from dmutils.forms.errors import govuk_errors
 from flask import request, redirect, url_for, abort, flash, current_app, Markup
 from flask_login import current_user
 
@@ -727,7 +728,7 @@ def edit_service_submission(framework_slug, lot_slug, service_id, section_id, qu
                 )
             except HTTPError as e:
                 update_data = section.unformat_data(update_data)
-                errors = section.get_error_messages(e.message, question_descriptor_from="question")
+                errors = govuk_errors(section.get_error_messages(e.message, question_descriptor_from="question"))
 
         if not errors:
             if next_question and not force_return_to_summary:

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -580,12 +580,22 @@ def duns_number():
                 'duns_errors': ",".join(form.duns_number.errors)})
 
     errors = get_errors_from_wtform(form)
+    error_title = None
+    error_description = None
+    if errors.get("duns_number", {}).get("message", None) == 'DUNS number already used':
+        error_title = "A supplier account already exists with that DUNS number"
+        support_email_address = current_app.config['SUPPORT_EMAIL_ADDRESS']
+        error_description = Markup(
+            'If you no longer have your account details, or if you think this may be an error, '
+            f'email <a class="govuk-link" href="mailto:{support_email_address}?subject=DUNS%20number%20question" '
+            f'title="Please contact {support_email_address}">{support_email_address}</a>')
 
     return render_template(
         "suppliers/create_duns_number.html",
         form=form,
         errors=errors,
-        support_email_address=current_app.config['SUPPORT_EMAIL_ADDRESS']
+        error_title=error_title,
+        error_description=error_description
     ), 200 if not errors else 400
 
 

--- a/app/templates/_base_page.html
+++ b/app/templates/_base_page.html
@@ -63,6 +63,14 @@
       {% endfor %}
     {% endwith %}
   {% endblock flashMessages %}
+  {% block errorSummary %}
+    {% if errors %}
+      {{ govukErrorSummary({
+      "titleText": "There is a problem",
+      "errorList": errors.values(),
+    }) }}
+    {% endif %}
+  {% endblock %}
   {% block mainContent %}{% endblock %}
 {% endblock %}
 

--- a/app/templates/_base_page.html
+++ b/app/templates/_base_page.html
@@ -66,7 +66,8 @@
   {% block errorSummary %}
     {% if errors %}
       {{ govukErrorSummary({
-      "titleText": "There is a problem",
+      "titleText": error_title or "There is a problem",
+      "descriptionText": error_description or None,
       "errorList": errors.values(),
     }) }}
     {% endif %}

--- a/app/templates/_base_page.html
+++ b/app/templates/_base_page.html
@@ -66,10 +66,10 @@
   {% block errorSummary %}
     {% if errors %}
       {{ govukErrorSummary({
-      "titleText": error_title or "There is a problem",
-      "descriptionText": error_description or None,
-      "errorList": errors.values(),
-    }) }}
+        "titleText": error_title or "There is a problem",
+        "descriptionText": error_description or None,
+        "errorList": errors.values(),
+      }) }}
     {% endif %}
   {% endblock %}
   {% block mainContent %}{% endblock %}

--- a/app/templates/auth/submit_email_address.html
+++ b/app/templates/auth/submit_email_address.html
@@ -29,7 +29,6 @@
 {% endblock %}
 
 {% block mainContent %}
-{% include "toolkit/forms/validation.html" %}
 
 <h1 class="govuk-heading-l">Invite a contributor</h1>
 

--- a/app/templates/frameworks/edit_declaration_section.html
+++ b/app/templates/frameworks/edit_declaration_section.html
@@ -32,8 +32,6 @@
 {% endblock %}
 
 {% block mainContent %}
-  {% include "toolkit/forms/validation.html" %}
-
   {% if name_of_framework_that_section_has_been_prefilled_from %}
     {% with
        message = "Answers on this page are from an earlier declaration and need review.",

--- a/app/templates/frameworks/reuse_declaration.html
+++ b/app/templates/frameworks/reuse_declaration.html
@@ -29,8 +29,6 @@
 {% endblock %}
 
 {% block mainContent %}
-  {% include 'toolkit/forms/validation.html' %}
-
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-l">{{ self.page_title_inner() }}</h1>

--- a/app/templates/frameworks/sign_framework_agreement.html
+++ b/app/templates/frameworks/sign_framework_agreement.html
@@ -28,7 +28,6 @@
 
 
 {% block mainContent %}
-    {% include 'toolkit/forms/validation.html' %}
     <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
     <span class="govuk-caption-xl"><span style="white-space:nowrap">{{ framework.name }}</span> <span style="white-space:nowrap">{{ contract_title }}</span></span>

--- a/app/templates/frameworks/updates.html
+++ b/app/templates/frameworks/updates.html
@@ -27,22 +27,6 @@
 {% endblock %}
 
 {% block mainContent %}
-
-  {% if error_message %}
-    {%
-      with
-      errors = {
-        "clarification_question_name": {
-          "input_name": clarification_question_name,
-          "question": "Ask a {} clarification question".format(framework.name)
-        }
-      },
-      lede = "There was a problem with your submitted question"
-    %}
-      {% include "toolkit/forms/validation.html" %}
-    {% endwith %}
-  {% endif %}
-
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-l">{{ framework.name }} updates</h1>

--- a/app/templates/services/_base_edit_section_page.html
+++ b/app/templates/services/_base_edit_section_page.html
@@ -6,7 +6,6 @@
 {% endblock %}
 
 {% block mainContent %}
-  {% include 'toolkit/forms/validation.html' %}
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/app/templates/services/previous_services.html
+++ b/app/templates/services/previous_services.html
@@ -38,7 +38,6 @@
 
 {% block mainContent %}
   {% if lot.oneServiceLimit %}
-    {% include 'toolkit/forms/validation.html' %}
 
     {% include "partials/service_warning.html" %}
 

--- a/app/templates/services/service.html
+++ b/app/templates/services/service.html
@@ -71,16 +71,6 @@
       </div>
     </div>
   {% endif %}
-  {% if error %}
-    <div class="govuk-grid-column-full">
-      {% with
-        lede = error,
-        errors = {}
-      %}
-        {% include "toolkit/forms/validation.html" %}
-      {% endwith %}
-    </div>
-  {% endif %}
 {% endblock %}
 
 {% block edit_link %}

--- a/app/templates/suppliers/create_company_details.html
+++ b/app/templates/suppliers/create_company_details.html
@@ -27,8 +27,6 @@
 {% endblock %}
 
 {% block mainContent %}
-  {% include 'toolkit/forms/validation.html' %}
-
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
 

--- a/app/templates/suppliers/create_confirm_company.html
+++ b/app/templates/suppliers/create_confirm_company.html
@@ -28,11 +28,6 @@
 
 {% block mainContent %}
   <div class="govuk-grid-row">
-
-  {% if errors %}
-    {% include 'toolkit/forms/validation.html' %}
-  {% endif %}
-
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-l">We found these details</h1>
 

--- a/app/templates/suppliers/create_duns_number.html
+++ b/app/templates/suppliers/create_duns_number.html
@@ -28,16 +28,6 @@
 
 {% block mainContent %}
 <div class="govuk-grid-row">
-  {% if errors.get("duns_number", {}).get("message", None) == 'DUNS number already used' %}
-    {% with lede = "A supplier account already exists with that DUNS number",
-            description = 'If you no longer have your account details, or if you think this may be an error, email <a class="govuk-link" href="mailto:{support_email_address}?subject=DUNS%20number%20question" title="Please contact {support_email_address}">{support_email_address}</a>'.format(support_email_address=support_email_address)|safe
-    %}
-      {% include 'toolkit/forms/validation.html' %}
-    {% endwith %}
-  {% elif errors %}
-    {% include 'toolkit/forms/validation.html' %}
-  {% endif %}
-
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">Enter your DUNS number</h1>
 

--- a/app/templates/suppliers/create_your_account.html
+++ b/app/templates/suppliers/create_your_account.html
@@ -28,7 +28,6 @@
 {% endblock %}
 
 {% block mainContent %}
-{% include "toolkit/forms/validation.html" %}
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/templates/suppliers/edit_company_registration_number.html
+++ b/app/templates/suppliers/edit_company_registration_number.html
@@ -27,7 +27,6 @@
 {% endblock %}
 
 {% block mainContent %}
-{% include "toolkit/forms/validation.html" %}
 
 <div class="single-question-page">
   <div class="govuk-grid-row">

--- a/app/templates/suppliers/edit_registered_name.html
+++ b/app/templates/suppliers/edit_registered_name.html
@@ -27,7 +27,6 @@
 {% endblock %}
 
 {% block mainContent %}
-{% include "toolkit/forms/validation.html" %}
 <div class="single-question-page">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/app/templates/suppliers/edit_supplier_organisation_size.html
+++ b/app/templates/suppliers/edit_supplier_organisation_size.html
@@ -27,8 +27,6 @@
 {% endblock %}
 
 {% block mainContent %}
-  {% include 'toolkit/forms/validation.html' %}
-
 <div class="single-question-page">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/app/templates/suppliers/edit_supplier_trading_status.html
+++ b/app/templates/suppliers/edit_supplier_trading_status.html
@@ -27,7 +27,6 @@
 {% endblock %}
 
 {% block mainContent %}
-{% include "toolkit/forms/validation.html" %}
 
 <div class="single-question-page">
   <div class="govuk-grid-row">

--- a/app/templates/suppliers/edit_what_buyers_will_see.html
+++ b/app/templates/suppliers/edit_what_buyers_will_see.html
@@ -28,7 +28,6 @@
 {% endblock %}
 
 {% block mainContent %}
-{% include "toolkit/forms/validation.html" %}
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">

--- a/app/templates/suppliers/join_open_framework_notification_mailing_list.html
+++ b/app/templates/suppliers/join_open_framework_notification_mailing_list.html
@@ -23,7 +23,6 @@
 {% endblock %}
 
 {% block mainContent %}
-{% include "toolkit/forms/validation.html" %}
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/templates/suppliers/registered_address.html
+++ b/app/templates/suppliers/registered_address.html
@@ -33,8 +33,6 @@
 
 
 {% block mainContent %}
-  {% include 'toolkit/forms/validation.html' %}
-
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
       <h1 class="govuk-heading-l">What is your registered office address?</h1>

--- a/tests/app/helpers.py
+++ b/tests/app/helpers.py
@@ -542,13 +542,14 @@ class BaseApplicationTest:
 
     def assert_single_question_page_validation_errors(self,
                                                       res,
-                                                      title="There was a problem with your answer to:",
+                                                      title="There is a problem",
                                                       question_name="",
                                                       validation_message=""
                                                       ):
         doc = html.fromstring(res.get_data(as_text=True))
-        masthead_heading = doc.xpath('normalize-space(//h2[@class="validation-masthead-heading"]/text())')
-        masthead_link_text = doc.xpath('normalize-space(string(//a[@class="validation-masthead-link"]))')
+        masthead_heading = doc.xpath('normalize-space(//h2[@class="govuk-error-summary__title"]/text())')
+        masthead_link_text = doc.xpath(
+            "normalize-space(//ul[contains(@class, 'govuk-error-summary__list')]/li/a/text())")
         validation_text = doc.xpath('normalize-space(//span[@class="validation-message"]/text())')
 
         assert res.status_code == 400

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -3625,6 +3625,22 @@ class TestFrameworkUpdatesPage(BaseApplicationTest):
         assert response.status_code == 200
         assert ('Contact the support team' in data) == contact_link_shown
 
+    def test_clarification_question_validation_errors_appear(self, s3):
+        self.data_api_client.get_framework.return_value = self.framework('live', clarification_questions_open=True)
+        self.login()
+        form_data = {
+            "clarification_question": None
+        }
+        response = self.client.post("suppliers/frameworks/g-cloud-7/updates", data=form_data)
+        data = response.get_data(as_text=True)
+        assert response.status_code == 400
+        assert "There was a problem with your submitted question" in data
+        doc = html.fromstring(data)
+        error_links = doc.xpath("//ul[contains(@class, 'govuk-error-summary__list')]/li/a")
+        assert len(error_links) == 1
+        assert error_links[0].text_content() == "Add text if you want to ask a question."
+        assert error_links[0].get("href") == "#clarification_question"
+
 
 @mock.patch('app.main.views.frameworks.DMNotifyClient.send_email', autospec=True)
 class TestSendClarificationQuestionEmail(BaseApplicationTest):

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -1555,7 +1555,7 @@ class TestCreateDraftService(BaseApplicationTest, MockEnsureApplicationCompanyDe
     def setup_method(self, method):
         super().setup_method(method)
         self._answer_required = 'Answer is required'
-        self._validation_error = 'There was a problem with your answer to:'
+        self._validation_error = 'There is a problem'
         self.data_api_client_patch = mock.patch('app.main.views.services.data_api_client', autospec=True)
         self.data_api_client = self.data_api_client_patch.start()
         self.login()
@@ -2183,12 +2183,12 @@ class TestEditDraftService(BaseApplicationTest, MockEnsureApplicationCompanyDeta
         )[0].strip()
 
     @pytest.mark.parametrize("field,error,expected_message", (
-        ('priceMin', 'answer_required', 'Error: Minimum price requires an answer.',),
+        ('priceMin', 'answer_required', 'Minimum price requires an answer.',),
         ('priceUnit', 'answer_required',
-            u"Error: Pricing unit requires an answer. If none of the provided units apply, please choose ‘Unit’."),
-        ('priceMin', 'not_money_format', 'Error: Minimum price must be a number, without units, eg 99.95',),
-        ('priceMax', 'not_money_format', 'Error: Maximum price must be a number, without units, eg 99.95',),
-        ('priceMax', 'max_less_than_min', 'Error: Minimum price must be less than maximum price.',),
+            "Pricing unit requires an answer. If none of the provided units apply, please choose ‘Unit’."),
+        ('priceMin', 'not_money_format', 'Minimum price must be a number, without units, eg 99.95',),
+        ('priceMax', 'not_money_format', 'Maximum price must be a number, without units, eg 99.95',),
+        ('priceMax', 'max_less_than_min', 'Minimum price must be less than maximum price.',),
     ))
     def test_update_with_pricing_errors(self, s3, field, error, expected_message):
         self.data_api_client.get_framework.return_value = self.framework(slug='g-cloud-9', status='open')
@@ -2202,9 +2202,9 @@ class TestEditDraftService(BaseApplicationTest, MockEnsureApplicationCompanyDeta
 
         assert res.status_code == 200
         document = html.fromstring(res.get_data(as_text=True))
-        assert document.xpath("normalize-space(string(//*[@class='govuk-error-message']))") == expected_message
-        assert document.xpath("normalize-space(string(//*[@class='validation-masthead']//a))") == \
-            "How much does the service cost (excluding VAT)?"
+        assert document.xpath(
+            "normalize-space(string(//*[@class='govuk-error-message']))") == f"Error: {expected_message}"
+        assert document.xpath("normalize-space(string(//*[@class='govuk-error-summary']//a))") == expected_message
 
     def test_update_non_existent_draft_service_returns_404(self, s3):
         self.data_api_client.get_draft_service.side_effect = HTTPError(mock.Mock(status_code=404))

--- a/tests/app/main/test_suppliers.py
+++ b/tests/app/main/test_suppliers.py
@@ -3030,6 +3030,11 @@ class TestSupplierAddRegistrationNumber(BaseApplicationTest):
         )
         assert self.data_api_client.update_supplier.call_args_list == []
 
+        # Assert the links in the error summary point to elements on the page
+        doc = html.fromstring(res.get_data(as_text=True))
+        summary_link = doc.xpath("//ul[contains(@class, 'govuk-error-summary__list')]/li/a/@href")[0]
+        assert doc.cssselect(summary_link)
+
     @pytest.mark.parametrize(
         'complete_data, expected_post',
         (

--- a/tests/app/main/test_suppliers.py
+++ b/tests/app/main/test_suppliers.py
@@ -1492,18 +1492,16 @@ class TestSupplierUpdate(BaseApplicationTest):
 
         doc = html.fromstring(response)
 
-        for content in [
-            ("validation-masthead-link", "Contact name"),
-            ("validation-masthead-link", "Contact email address"),
-            ("validation-masthead-link", "Contact phone number"),
-            ("validation-message", "Enter a contact name."),
-            ("validation-message", "Enter an email address."),
-            ("validation-message", "Enter a phone number."),
+        for xpath_selector, expected_content in [
+            ("[contains(@class, 'govuk-error-summary__list')]/li/a", "Enter a contact name."),
+            ("[contains(@class, 'govuk-error-summary__list')]/li/a", "Enter an email address."),
+            ("[contains(@class, 'govuk-error-summary__list')]/li/a", "Enter a phone number."),
+            ("[@class='validation-message']", "Enter a contact name."),
+            ("[@class='validation-message']", "Enter an email address."),
+            ("[@class='validation-message']", "Enter a phone number."),
         ]:
             assert doc.xpath(
-                "//*[@class=$t][normalize-space(string())=$c]",
-                t=content[0],
-                c=content[1],
+                f"//*{xpath_selector}[normalize-space(string())='{expected_content}']"
             )
 
         assert self.data_api_client.update_supplier.called is False
@@ -1522,16 +1520,14 @@ class TestSupplierUpdate(BaseApplicationTest):
 
         doc = html.fromstring(response)
 
-        for content in [
-            ("validation-masthead-link", "Contact phone number"),
-            ("validation-masthead-link", "Contact name"),
-            ("validation-message", "Enter a phone number under 20 characters."),
-            ("validation-message", "Enter a contact name under 256 characters."),
+        for xpath_selector, expected_content in [
+            ("[contains(@class, 'govuk-error-summary__list')]/li/a", "Enter a phone number under 20 characters."),
+            ("[contains(@class, 'govuk-error-summary__list')]/li/a", "Enter a contact name under 256 characters."),
+            ("[@class='validation-message']", "Enter a contact name under 256 characters."),
+            ("[@class='validation-message']", "Enter a phone number under 20 characters."),
         ]:
             assert doc.xpath(
-                "//*[@class=$t][normalize-space(string())=$c]",
-                t=content[0],
-                c=content[1],
+                f"//*{xpath_selector}[normalize-space(string())='{expected_content}']"
             )
 
         assert self.data_api_client.update_supplier.called is False
@@ -1547,14 +1543,12 @@ class TestSupplierUpdate(BaseApplicationTest):
 
         doc = html.fromstring(response)
 
-        for content in [
-            ("validation-masthead-link", "Contact email address"),
-            ("validation-message", "Enter a valid email address."),
+        for xpath_selector, expected_content in [
+            ("[contains(@class, 'govuk-error-summary__list')]/li/a", "Enter a valid email address."),
+            ("[@class='validation-message']", "Enter a valid email address."),
         ]:
             assert doc.xpath(
-                "//*[@class=$t][normalize-space(string())=$c]",
-                t=content[0],
-                c=content[1],
+                f"//*{xpath_selector}[normalize-space(string())='{expected_content}']"
             )
 
         assert self.data_api_client.update_supplier.called is False
@@ -1851,7 +1845,7 @@ class TestCreateSupplier(BaseApplicationTest):
 
         self.assert_single_question_page_validation_errors(
             res,
-            question_name="DUNS Number",
+            question_name="Enter your 9 digit DUNS number.",
             validation_message="Enter your 9 digit DUNS number."
         )
 
@@ -2754,7 +2748,7 @@ class TestSupplierEditOrganisationSize(BaseApplicationTest):
 
         self.assert_single_question_page_validation_errors(
             res,
-            question_name="What size is your organisation?",
+            question_name=expected_error,
             validation_message=expected_error
         )
 
@@ -2817,7 +2811,7 @@ class TestSupplierAddRegisteredCompanyName(BaseApplicationTest):
 
         self.assert_single_question_page_validation_errors(
             res,
-            question_name="Registered company name",
+            question_name="Enter your registered company name.",
             validation_message="Enter your registered company name."
         )
         assert self.data_api_client.update_supplier.call_args_list == []
@@ -2914,7 +2908,7 @@ class TestSupplierEditTradingStatus(BaseApplicationTest):
         assert error[0].text.strip() == expected_error, 'The validation message is not as anticipated.'
 
         self.assert_single_question_page_validation_errors(res,
-                                                           question_name="What’s your trading status?",
+                                                           question_name=expected_error,
                                                            validation_message=expected_error)
 
     @pytest.mark.parametrize('trading_status', (None, 'limited company (LTD)', 'other'))
@@ -2989,7 +2983,7 @@ class TestSupplierAddRegistrationNumber(BaseApplicationTest):
                  'companies_house_number': '',
                  'other_company_registration_number': ''
                  },
-                'Are you registered with Companies House?',
+                'You need to answer this question.',
                 'You need to answer this question.'
             ),
             (
@@ -2997,7 +2991,7 @@ class TestSupplierAddRegistrationNumber(BaseApplicationTest):
                  'companies_house_number': '',
                  'other_company_registration_number': ''
                  },
-                'Companies House number',
+                'Enter a Companies House number.',
                 'Enter a Companies House number.'
             ),
             (
@@ -3005,7 +2999,7 @@ class TestSupplierAddRegistrationNumber(BaseApplicationTest):
                  'companies_house_number': '123456789',
                  'other_company_registration_number': ''
                  },
-                'Companies House number',
+                'Enter your 8 digit Companies House number.',
                 'Enter your 8 digit Companies House number.'
             ),
             (
@@ -3013,7 +3007,7 @@ class TestSupplierAddRegistrationNumber(BaseApplicationTest):
                  'companies_house_number': '',
                  'other_company_registration_number': 'a' * 256
                  },
-                'Other company registration number',
+                'Enter a registration number under 256 characters.',
                 'Enter a registration number under 256 characters.'
             )
         )

--- a/tests/app/main/test_suppliers.py
+++ b/tests/app/main/test_suppliers.py
@@ -1865,6 +1865,7 @@ class TestCreateSupplier(BaseApplicationTest):
         page = res.get_data(as_text=True)
         assert "A supplier account already exists with that DUNS number" in page
         assert "DUNS number already used" in page
+        assert "If you no longer have your account details, or if you think this may be an error," in page
 
     def test_direct_plus_api_call(self):
         with self.app.app_context(), mock.patch(self.direct_plus_api_method, return_value=None) as client_call_mock:


### PR DESCRIPTION
As part of migrating our apps to use GOV.UK Design System styles and components, we want to use the [error summary component](https://design-system.service.gov.uk/components/error-summary/) to replace our existing validation banners.

To do this, we add an instance of the error summary component to the app base page template. This ensures that the error summary (if present) is in a consistent location across all pages in the app.

https://trello.com/c/WVjA4w66/771-2-replace-validation-banner-with-govuk-frontend-error-summary-component-in-the-supplier-frontend