### PR TITLE
Fix company details page for new suppliers 

### DIFF
--- a/app/templates/suppliers/details.html
+++ b/app/templates/suppliers/details.html
@@ -120,7 +120,7 @@
                 'text': "Registered company address"
               },
               'value': {
-                'html': '<br />'.join([supplier.contact.get("address1"), supplier.contact.get("city"), supplier.contact.get("postcode"), country_name])
+                'html': '<br />'.join([supplier.contact.get("address1"), supplier.contact.get("city"), supplier.contact.get("postcode"), country_name]|select)
               },
               'actions': {
                     'items': [{

--- a/tests/app/main/test_suppliers.py
+++ b/tests/app/main/test_suppliers.py
@@ -855,6 +855,19 @@ class TestSupplierDetails(BaseApplicationTest):
         assert "11 AB" in address[2]
         assert "United Kingdom" in address[3]
 
+    def test_handles_supplier_with_no_address_details(self):
+        supplier = get_supplier()
+        supplier_contact_information = supplier["suppliers"]["contactInformation"][0]
+        del supplier_contact_information["address1"]
+        del supplier_contact_information["city"]
+        del supplier_contact_information["postcode"]
+        self.data_api_client.get_supplier.return_value = supplier
+
+        self.login()
+
+        res = self.client.get("/suppliers/details")
+        assert res.status_code == 200
+
     @pytest.mark.parametrize(
         "question,null_attribute,link_address",
         [


### PR DESCRIPTION
Fixes https://trello.com/c/0z4CtYQu/2172-bug-in-company-details-page-on-production

When a supplier is created they have no address. This was causing a 500 on the company details page because it was trying to join instances of `None` into a string. This commit fixes this with the Jinja2 filter `select` which drops false-y values from an iterable.