### PR TITLE
Remove unnecessary <br> tags

### DIFF
--- a/app/templates/frameworks/start_declaration.html
+++ b/app/templates/frameworks/start_declaration.html
@@ -29,16 +29,13 @@
 {% endblock %}
 
 {% block mainContent %}
-  <div class="govuk-grid-row framework-dashboard">
+  <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-l">{{ self.page_title_inner() }}</h1>
 
       <p class="govuk-body">You must make the supplier declaration to confirm you’re eligible to provide services through {{ framework.name }}.</p>
-      <br>
       <p class="govuk-body">You can come back and change your answers before the application deadline at {{ framework.applicationsCloseAt | nbsp }}.</p>
-      <br>
       <p class="govuk-body">After the application deadline, the Crown Commercial Service will review your answers and let you know if your application has been successful.</p>
-      <br><br>
       {{ govukButton({
         "text": "Start your declaration",
         "href": url_for(".reuse_framework_supplier_declaration", framework_slug=framework.slug),


### PR DESCRIPTION
The combination of `govuk-body` styles mixed with `<br>` tags makes this page look odd:

![Screenshot 2021-02-16 at 15 04 08](https://user-images.githubusercontent.com/22524634/108081563-030d1c80-7069-11eb-8205-19ffdaabdcae.png)

So let's jettison the `<br>` tags. And as a happy side effect, we can get rid of the custom `framework-dashboard` style as well.

![Screenshot 2021-02-16 at 15 04 15](https://user-images.githubusercontent.com/22524634/108081894-5ed7a580-7069-11eb-9f05-5c5aad70481c.png)

