### PR TITLE
Remove unnecessary <br> on Reuse Declaration form

### DIFF
--- a/app/templates/frameworks/reuse_declaration.html
+++ b/app/templates/frameworks/reuse_declaration.html
@@ -37,14 +37,11 @@
 
       <p class="govuk-body">In {{ old_framework_application_close_date|nbsp }}, your organisation completed a declaration for {{ old_framework.name }}.</p>
       <p class="govuk-body">You can reuse some of the answers from that declaration.</p>
-      <br>
       <p class="govuk-body">You’ll need to:</p>
       <ul class="govuk-list govuk-list--bullet">
         <li>review the answers you gave before and make sure they’re still correct</li>
         <li>provide some new answers for this declaration</li>
       </ul>
-      <br>
-      <br>
 
       <form method="POST" action="{{ url_for(".reuse_framework_supplier_declaration_post", framework_slug=current_framework.slug) }}">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>


### PR DESCRIPTION
Another case of `govuk-body` styles and `<br>` not working well together. This looks like the last instance of this on the Make a Supplier Declaration journey.

Before:
![Screenshot 2021-02-16 at 15 43 48](https://user-images.githubusercontent.com/22524634/108087995-e1636380-706f-11eb-8f11-f00a084a63d6.png)

After:
![Screenshot 2021-02-16 at 15 43 34](https://user-images.githubusercontent.com/22524634/108088005-e45e5400-706f-11eb-9c0d-4b3dab42feb6.png)
