### PR TITLE
Close G12 recovery process

### DIFF
--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -499,12 +499,7 @@ def copy_draft_service(framework_slug, lot_slug, service_id):
 @EnsureApplicationCompanyDetailsHaveBeenConfirmed(data_api_client)
 @return_404_if_applications_closed(lambda: data_api_client)
 def complete_draft_service(framework_slug, lot_slug, service_id):
-    if framework_slug == "g-cloud-12" and is_g12_recovery_supplier(current_user.supplier_id):
-        framework, lot = get_framework_and_lot_or_404(data_api_client, framework_slug, lot_slug,
-                                                      allowed_statuses=['open', 'live'])
-    else:
-        framework, lot = get_framework_and_lot_or_404(data_api_client, framework_slug, lot_slug,
-                                                      allowed_statuses=['open'])
+    framework, lot = get_framework_and_lot_or_404(data_api_client, framework_slug, lot_slug, allowed_statuses=['open'])
 
     # Suppliers must have registered interest in a framework before they can complete draft services
     if not get_supplier_framework_info(data_api_client, framework_slug):
@@ -665,12 +660,7 @@ def edit_service_submission(framework_slug, lot_slug, service_id, section_id, qu
         Also accepts URL parameter `force_continue_button` which will allow rendering of a 'Save and continue' button,
         used for when copying services.
     """
-    if framework_slug == 'g-cloud-12' and is_g12_recovery_supplier(current_user.supplier_id):
-        framework, lot = get_framework_and_lot_or_404(data_api_client, framework_slug, lot_slug,
-                                                      allowed_statuses=['open', 'live'])
-    else:
-        framework, lot = get_framework_and_lot_or_404(data_api_client, framework_slug, lot_slug,
-                                                      allowed_statuses=['open'])
+    framework, lot = get_framework_and_lot_or_404(data_api_client, framework_slug, lot_slug, allowed_statuses=['open'])
 
     # Suppliers must have registered interest in a framework before they can edit draft services
     if not get_supplier_framework_info(data_api_client, framework_slug):

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -1728,7 +1728,7 @@ class TestCompleteDraft(BaseApplicationTest, MockEnsureApplicationCompanyDetails
         res = self.client.post('/suppliers/frameworks/g-cloud-7/submissions/scs/1/complete')
         assert res.status_code == 404
 
-    def test_g12_recovery_supplier_can_complete_draft(self):
+    def test_g12_recovery_supplier_cannot_complete_draft(self):
         recovery_supplier_id = 577184
         g12 = FrameworkStub(status="live", slug="g-cloud-12").single_result_response()
         g12_draft_service = empty_g9_draft_service()
@@ -1746,9 +1746,7 @@ class TestCompleteDraft(BaseApplicationTest, MockEnsureApplicationCompanyDetails
         }
 
         res = self.client.post('/suppliers/frameworks/g-cloud-12/submissions/cloud-hosting/1/complete')
-        assert res.status_code == 302
-        assert 'lot=cloud-hosting' in res.location
-        assert '/suppliers/frameworks/g-cloud-12/submissions' in res.location
+        assert res.status_code == 404
 
     def test_cannot_complete_draft_if_no_supplier_framework(self):
         self.data_api_client.get_supplier_framework_info.return_value = {'frameworkInterest': {}}
@@ -1855,7 +1853,7 @@ class TestEditDraftService(BaseApplicationTest, MockEnsureApplicationCompanyDeta
             })
         assert res.status_code == 404
 
-    def test_g12_recovery_supplier_can_edit_draft_service(self, s3):
+    def test_g12_recovery_supplier_cannot_edit_draft_service(self, s3):
         recovery_supplier_id = 577184
         self.login(supplier_id=recovery_supplier_id)
 
@@ -1876,13 +1874,7 @@ class TestEditDraftService(BaseApplicationTest, MockEnsureApplicationCompanyDeta
             }
         )
 
-        assert res.status_code == 302
-        self.data_api_client.update_draft_service.assert_called_once_with(
-            "1",
-            {"serviceDescription": "This is the service."},
-            "email@email.com",
-            page_questions=["serviceDescription"]
-        )
+        assert res.status_code == 404
 
     def test_draft_section_cannot_be_edited_if_not_open(self, s3):
         self.data_api_client.get_framework.return_value = self.framework(status='other')


### PR DESCRIPTION
Trello: https://trello.com/c/mhab9cpq/826-1-as-a-developer-i-can-stop-suppliers-submitting-draft-services-after-the-deadline

Once the deadline arrives, we want to stop suppliers involved in the recovery from being able to edit and submit their draft services.

Make the simplest possible change to implement this - suppliers will now get 404s if they try to do either.

This should be something small and low-risk we can deploy at the deadline. After the deadline, we can tidy up all the other G12 recovery code still lying around.

## How to deploy

Merge this to master on the day of the deadline and get it through to staging. Deploy to production when the deadline hits.