### PR TITLE
Automatically close G12 recovery at deadline

### DIFF
--- a/app/main/helpers/suppliers.py
+++ b/app/main/helpers/suppliers.py
@@ -102,6 +102,10 @@ def get_g12_recovery_draft_ids() -> Set[int]:
 G12_RECOVERY_DEADLINE = datetime(year=2021, month=2, day=25, hour=14)
 
 
+def is_g12_recovery_open() -> bool:
+    return datetime.now() <= G12_RECOVERY_DEADLINE
+
+
 def g12_recovery_time_remaining() -> str:
     return format_g12_recovery_time_remaining(G12_RECOVERY_DEADLINE - datetime.now())
 

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -18,7 +18,7 @@ from ..helpers.suppliers import (
     is_g12_recovery_supplier,
     g12_recovery_time_remaining,
     get_g12_recovery_draft_ids,
-    count_g12_recovery_drafts_by_status, G12_RECOVERY_DEADLINE,
+    count_g12_recovery_drafts_by_status, G12_RECOVERY_DEADLINE, is_g12_recovery_open,
 )
 from ... import data_api_client
 from ...main import main, content_loader
@@ -499,7 +499,7 @@ def copy_draft_service(framework_slug, lot_slug, service_id):
 @EnsureApplicationCompanyDetailsHaveBeenConfirmed(data_api_client)
 @return_404_if_applications_closed(lambda: data_api_client)
 def complete_draft_service(framework_slug, lot_slug, service_id):
-    if framework_slug == "g-cloud-12" and is_g12_recovery_supplier(current_user.supplier_id):
+    if framework_slug == "g-cloud-12" and is_g12_recovery_open() and is_g12_recovery_supplier(current_user.supplier_id):
         framework, lot = get_framework_and_lot_or_404(data_api_client, framework_slug, lot_slug,
                                                       allowed_statuses=['open', 'live'])
     else:
@@ -665,7 +665,7 @@ def edit_service_submission(framework_slug, lot_slug, service_id, section_id, qu
         Also accepts URL parameter `force_continue_button` which will allow rendering of a 'Save and continue' button,
         used for when copying services.
     """
-    if framework_slug == 'g-cloud-12' and is_g12_recovery_supplier(current_user.supplier_id):
+    if framework_slug == 'g-cloud-12' and is_g12_recovery_open() and is_g12_recovery_supplier(current_user.supplier_id):
         framework, lot = get_framework_and_lot_or_404(data_api_client, framework_slug, lot_slug,
                                                       allowed_statuses=['open', 'live'])
     else:


### PR DESCRIPTION
Trello: https://trello.com/c/mhab9cpq/826-1-as-a-developer-i-can-stop-suppliers-submitting-draft-services-after-the-deadline

Once the deadline arrives, we want to stop suppliers involved in the recovery from being able to edit and submit their draft services.

Make a simple change to implement this - suppliers will now get 404s if they try to do either after the deadline.

After the deadline, we can tidy up all the other G12 recovery code still lying around.

Supersedes: https://github.com/alphagov/digitalmarketplace-supplier-frontend/pull/1346