### PR TITLE
Make the Framework Application task list more like the Design System task list

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "package-lock.json",
     "lines": null
   },
-  "generated_at": "2021-02-12T17:02:59Z",
+  "generated_at": "2021-02-22T17:17:54Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -63,35 +63,35 @@
         "hashed_secret": "6955d0539c7ae97361ab63d21bc2bb730edbce7a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3839,
+        "line_number": 3851,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "5b10c4aa69a96ad5a1a11ff1add1a37cdc71fb20",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3855,
+        "line_number": 3867,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "b818bf7ee968a5c29d4436a8243c223576f1d75a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3856,
+        "line_number": 3868,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "e5223482a22578724452e2315f44d0bc5fc457a3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4580,
+        "line_number": 4592,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "82cae5b1d77db4d964804f85ef2c818c6bec2614",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4605,
+        "line_number": 4617,
         "type": "Base64 High Entropy String"
       }
     ]

--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -74,6 +74,7 @@ $govuk-global-styles: true;
 @import "overrides/_notifications_banner";
 @import "overrides/_temporary-messages";
 @import "overrides/_task-list";
+@import "overrides/_tags";
 @import "overrides/_pending-services-table";
 
 // Misc styles

--- a/app/assets/scss/overrides/_tags.scss
+++ b/app/assets/scss/overrides/_tags.scss
@@ -1,0 +1,21 @@
+/**
+ * Newer versions of the design system replace .govuk-tag--inactive with .govuk-tag--grey.
+ * In addition, there are other tag colours available.
+ *
+ * .govuk-tag--inactive is deprecated
+ *
+ * Other tag colours are used at least in the Task List pattern.
+ *
+ * TODO: When we update the Design System to 3.x.x, we should remove these overrides
+ */
+
+ .govuk-tag--grey,
+ .govuk-tag--inactive {
+     color: govuk-shade(govuk-colour("grey-1"), 30);
+     background: govuk-tint(govuk-colour("grey-1"), 90);
+ }
+ 
+ .govuk-tag--blue {
+     color: govuk-shade(govuk-colour("blue"), 30);
+     background: govuk-tint(govuk-colour("blue"), 80);
+ }

--- a/app/assets/scss/overrides/_task-list.scss
+++ b/app/assets/scss/overrides/_task-list.scss
@@ -1,82 +1,104 @@
 // TODO: Remove when task lists incorporated into digitalmarketplace-govuk-frontend
 
-
-%dm-task-list-indicator {
-  @include bold-16;
-  display: inline-block;
-  padding: 3px 8px 1px 8px;
-  position: absolute;
-  right: 0;
-  top: $gutter - 2px;
-  margin-top: -15px;
-  pointer-events: none;
-  z-index: 2;
-  min-width: 20%;
-  text-align: center;
-}
-
 .dm-task-list {
+  list-style-type: none;
+  padding-left: 0;
+  margin-top: 0;
+  margin-bottom: 0;
+  
+  h2:first-of-type {
+    margin-top: 0;
+  }
 
-  border-top: 1px solid $border-colour;
-  margin: $gutter 0;
+  &__section {
+    @include govuk-responsive-margin(7, "bottom");
 
-  &-item {
+    h2 {
+      display: table;
+      @include govuk-font($size:24, $weight: bold);
+      @include govuk-responsive-margin(4, "bottom");
+    }
+  }
 
-    position: relative;
+  &__section-number {
+      display: table-cell;
 
-    a {
-      border-bottom: 1px solid $border-colour;
-      display: block;
-      padding: $gutter-half 0;
-      padding-right: 20%;
-      position: relative;
-
-      &:hover {
-        color: $link-hover-colour;
+      @include govuk-media-query($from: tablet) {
+          min-width: govuk-spacing(6);
+          padding-right: 0;
       }
+  }
 
-      &:focus {
-        outline: none;
-        color: $black;
-        box-shadow: -3px 0 0 0 $focus-colour, 3px 0 0 0 $focus-colour;
-        border-color: transparent;
-        top: -1px;
-        margin-bottom: -2px;
-        padding-top: $gutter-half + 1px;
-        padding-bottom: $gutter-half + 1px;
-      }
+  &__text {
+    @include govuk-font($size: 19);
+    padding-left: 0;
+    @include govuk-media-query($from: tablet) {
+      padding-left: govuk-spacing(6);
+    }
+  }
 
+  &__links {
+    padding-left: 0;
+    @include govuk-media-query($from: tablet) {
+      padding-left: govuk-spacing(6);
+    }
+  }
+
+  &__link {
+    display: inline-block;
+    @include govuk-font($size: 19);
+  }
+
+  &__items {
+    @include govuk-font($size: 19);
+    list-style: none;
+    padding-left: 0;
+    @include govuk-media-query($from: tablet) {
+      padding-left: govuk-spacing(6);
+    }
+  }
+
+  &__items.dm-task-list {
+    @include govuk-media-query($from: tablet) {
+      padding-left: 0;
     }
 
-    span.dm-task-list__text {
-      border-bottom: 1px solid $border-colour;
-      display: block;
-      padding: $gutter-half 0;
-      padding-right: 20%;
-      position: relative;
+    .dm-task-list__text {
+      @include govuk-media-query($from: tablet) {
+        padding-left: 0;
+      }
     }
 
+    padding-bottom: govuk-spacing(6);
   }
 
-  &-indicator-completed {
-    @extend %dm-task-list-indicator;
-    background-color: govuk-shade(govuk-colour("blue"), 30);
-    color: $grey-4;
-    // Just a pinch of letter spacing to make reversed-out text a bit
-    // easier to read
-    letter-spacing: 0.02em;
+  &__item {
+    border-bottom: 1px solid $govuk-border-colour;
+    margin-bottom: 0 !important;
+    padding-top: govuk-spacing(2);
+    padding-bottom: govuk-spacing(2);
+    @include govuk-clearfix;
   }
 
-  &-indicator-not-completed {
-    @extend %dm-task-list-indicator;
-    background-color: govuk-tint(govuk-colour("blue"), 80);
-    color: govuk-shade(govuk-colour("blue"), 30);
+  &__item:first-child {
+    border-top: 1px solid $govuk-border-colour;
   }
 
-  &-indicator-todo {
-    @extend %dm-task-list-indicator;
-    background-color: govuk-tint(govuk-colour("grey-1"), 90);
-    color: $black;
+  &__task-name {
+    display: block;
+    @include govuk-media-query($from: 450px) {
+      float: left;
+    }
   }
 
+  &__tag {
+    margin-top: govuk-spacing(2);
+    margin-bottom: govuk-spacing(1);
+  
+    @include govuk-media-query($from: 450px) {
+      float: right;
+      margin-top: 0;
+      margin-bottom: 0;
+    }
+  }
 }

--- a/app/templates/frameworks/_framework_actions.html
+++ b/app/templates/frameworks/_framework_actions.html
@@ -42,23 +42,24 @@
       }}
     {% endif %}
   {% endif %}
-  <ul class="dm-task-list">
-    <li class="dm-task-list-item">
+  <h2 class="govuk-heading-m">Application progress</h2>
+  <ul class="dm-task-list dm-task-list__items">
+    <li class="dm-task-list__item">
       <span class="dm-task-list__task-name">
         <a href="{{ url_for('.supplier_details') }}">
           Confirm your company details
         </a>
       </span>
       {% if application_company_details_confirmed %}
-        <strong class="dm-task-list-indicator-completed" id="dm-companydetails-done">Done</strong>
+        <strong class="govuk-tag dm-task-list__tag" id="dm-companydetails-done">Completed</strong>
       {% elif supplier_company_details_complete %}
         {# Supplier details exist from a previous framework application, but haven't yet been confirmed for this one #}
-        <strong class="dm-task-list-indicator-completed" id="dm-companydetails-inprogress">In progress</strong>
+        <strong class="govuk-tag govuk-tag--blue dm-task-list__tag" id="dm-companydetails-inprogress">In progress</strong>
       {% else %}
-        <strong class="dm-task-list-indicator-todo" id="dm-companydetails-todo">To do</strong>
+        <strong class="govuk-tag govuk-tag--grey dm-task-list__tag" id="dm-companydetails-todo">Not started</strong>
       {% endif %}
     </li>
-    <li class="dm-task-list-item">
+    <li class="dm-task-list__item">
       <span class="dm-task-list__task-name">
         {% if application_company_details_confirmed %}
           {% if declaration_status == 'unstarted' %}
@@ -71,16 +72,16 @@
         {% endif %}
       </span>
       {% if not application_company_details_confirmed %}
-        <strong class="dm-task-list-indicator-todo" id="dm-declaration-cantstart">Can't start yet</strong>
+        <strong class="govuk-tag govuk-tag--grey dm-task-list__tag" id="dm-declaration-cantstart">Cannot start yet</strong>
       {% elif declaration_status == 'unstarted' %}
-        <strong class="dm-task-list-indicator-todo" id="dm-declaration-todo">To do</strong>
+        <strong class="govuk-tag govuk-tag--grey dm-task-list__tag" id="dm-declaration-todo">Not started</strong>
       {% elif declaration_status == 'started' %}
-        <strong class="dm-task-list-indicator-not-completed" id="dm-declaration-inprogress">In progress</strong>
+        <strong class="govuk-tag govuk-tag--blue dm-task-list__tag" id="dm-declaration-inprogress">In progress</strong>
       {% elif declaration_status == 'complete' %}
-        <strong class="dm-task-list-indicator-completed" id="dm-declaration-done">Done</strong>
+        <strong class="govuk-tag dm-task-list__tag" id="dm-declaration-done">Completed</strong>
       {% endif %}
     </li>
-    <li class="dm-task-list-item">
+    <li class="dm-task-list__item">
       <span class="dm-task-list__task-name">
         {% if application_company_details_confirmed %}
         <a href="{{ url_for('.framework_submission_lots', framework_slug=framework.slug) }}">
@@ -91,13 +92,13 @@
         {% endif %}
       </span>
       {% if not application_company_details_confirmed %}
-        <strong class="dm-task-list-indicator-todo" id="dm-services-cantstart">Can't start yet</strong>
+        <strong class="govuk-tag govuk-tag--grey dm-task-list__tag" id="dm-services-cantstart">Cannot start yet</strong>
       {% elif not counts.draft and not counts.complete %}
-        <strong class="dm-task-list-indicator-todo" id="dm-services-todo">To do</strong>
+        <strong class="govuk-tag govuk-tag--grey dm-task-list__tag" id="dm-services-todo">Not started</strong>
       {% elif counts.draft %}
-        <strong class="dm-task-list-indicator-not-completed" id="dm-services-inprogress">In progress</strong>
+        <strong class="govuk-tag govuk-tag--blue dm-task-list__tag" id="dm-services-inprogress">In progress</strong>
       {% else %}
-        <strong class="dm-task-list-indicator-completed" id="dm-services-done">{{ counts.complete }} {{ pluralize(counts.complete, 'service', 'services') }}</strong>
+        <strong class="govuk-tag dm-task-list__tag" id="dm-services-done">{{ counts.complete }} {{ pluralize(counts.complete, 'service', 'services') }}</strong>
       {% endif %}
     </li>
   </ul>

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -79,7 +79,13 @@ def _extract_guidance_links(doc):
                 for item_li in section_li.xpath(".//p[.//a] | .//h3[.//a]")
             ),
         )
-        for section_li in doc.xpath("//main//*[./h2][.//p//a | .//section[@class='dm-attachment']//a]")
+        for section_li in doc.xpath(
+            (
+                "//main//*[./h2[not(text()='Application progress')]][.//p//a"
+                "|"
+                "//section[@class='dm-attachment']//a]"
+            )
+        )
     )
 
 
@@ -241,7 +247,7 @@ class TestFrameworksDashboardOpenApplications(BaseApplicationTest):
         assert res.status_code == 200
 
         doc = html.fromstring(res.get_data(as_text=True))
-        assert len(doc.xpath('//main//strong[@id="dm-declaration-done"][contains(text(), "Done")]')) == 1
+        assert len(doc.xpath('//main//strong[@id="dm-declaration-done"][contains(text(), "Completed")]')) == 1
 
     def test_declaration_status_when_started_for_open_framework(self, s3):
         self.login()


### PR DESCRIPTION
https://trello.com/c/0q1IRSSf/819-2-rewrite-framework-application-task-list

We want our task lists to look more like the [GOV.UK Design system task list pattern](https://design-system.service.gov.uk/patterns/task-list-pages/).

This means a few CSS and HTML changes.

![Screenshot 2021-02-22 at 14 53 58](https://user-images.githubusercontent.com/22524634/108744656-1cfba300-7532-11eb-89c6-760b2d6144ea.png)

![Screenshot 2021-02-22 at 14 54 53](https://user-images.githubusercontent.com/22524634/108744671-1f5dfd00-7532-11eb-9620-a68dff464420.png)

![Screenshot 2021-02-22 at 14 53 00](https://user-images.githubusercontent.com/22524634/108744683-2127c080-7532-11eb-8a79-38d2940a8077.png)
