### PR TITLE
Bump govuk-country-and-territory-autocomplete to 0.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1755,9 +1755,9 @@
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "corejs-typeahead": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/corejs-typeahead/-/corejs-typeahead-1.2.1.tgz",
-      "integrity": "sha1-NFqK/mZMxJQHW1m2R3eAfws/Eys=",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/corejs-typeahead/-/corejs-typeahead-1.3.1.tgz",
+      "integrity": "sha512-fyNlBNWJNL6EQUnJyAunEzBzRcwR2cEHtZXBi2pndHPOJ/wpOf3wbS+/Oh+kYYS5sKowQcs0LFwMSl6Y2Xeqkw==",
       "requires": {
         "jquery": ">=1.11"
       }
@@ -4024,13 +4024,13 @@
       }
     },
     "govuk-country-and-territory-autocomplete": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/govuk-country-and-territory-autocomplete/-/govuk-country-and-territory-autocomplete-0.4.0.tgz",
-      "integrity": "sha512-MOYGPpC6TsAesWK/LDC+scKpJxzdHSROBxtA5CSRbasWU4HnzUltCK7Eg9Nq7gIAR3WIkBGLaSX1al70eKZN7g==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/govuk-country-and-territory-autocomplete/-/govuk-country-and-territory-autocomplete-0.5.0.tgz",
+      "integrity": "sha512-MVIpYL0DfaYZxZyLZ7qpjyffDiAoMTdV3St1iAep0W0HMRjoJ5yrBvM5mggx4dYcCm+IXi44rbeyPO6yF6abhw==",
       "requires": {
         "accessible-autocomplete": "^1.6.1",
         "openregister-picker-engine": "^1.2.1",
-        "webpack-sources": "^1.0.1"
+        "webpack-sources": "^1.3.0"
       }
     },
     "govuk-elements-sass": {
@@ -7818,9 +7818,9 @@
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
     },
     "preact": {
-      "version": "8.5.2",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-8.5.2.tgz",
-      "integrity": "sha512-37tlDJGq5IQKqGUbqPZ7qPtsTOWFyxe+ojAOFfzKo0dEPreenqrqgJuS83zGpeGAqD9h9L9Yr7QuxH2W4ZrKxg=="
+      "version": "8.5.3",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-8.5.3.tgz",
+      "integrity": "sha512-O3kKP+1YdgqHOFsZF2a9JVdtqD+RPzCQc3rP+Ualf7V6rmRDchZ9MJbiGTT7LuyqFKZqlHSOyO/oMFmI2lVTsw=="
     },
     "prelude-ls": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "digitalmarketplace-frameworks": "github:alphagov/digitalmarketplace-frameworks#v18.1.6",
     "digitalmarketplace-frontend-toolkit": "^36.1.2",
     "digitalmarketplace-govuk-frontend": "^2.8.0",
-    "govuk-country-and-territory-autocomplete": "0.4.0",
+    "govuk-country-and-territory-autocomplete": "0.5.0",
     "govuk-elements-sass": "3.0.3",
     "govuk-frontend": "2.13.0",
     "govuk_frontend_toolkit": "5.0.3",


### PR DESCRIPTION
https://trello.com/c/Hey9OS9t/805-2-mitigate-registers-switch-off

This appears to be the last version which is compatible with the functional tests. 

It appears later versions use different javascript which requires a further interaction after entering a value e.g. click on dropdown value or press return key for the input to be accepted. It is unclear why this was implemented or if it is intentional. I can make an enter keypress to get this to work using Firefox/geckodriver however, I was unable to get it to work using PhantomJS. 

So this PR changes to the latest version as supported by the current tests
