### PR TITLE
Load old manifests lazily for faster app startup

### DIFF
--- a/app/main/__init__.py
+++ b/app/main/__init__.py
@@ -17,28 +17,48 @@ _local = Local()
 
 
 def _load_dos(master_cl):
-    master_cl.load_manifest('digital-outcomes-and-specialists', 'declaration', 'declaration')
-    master_cl.load_manifest('digital-outcomes-and-specialists', 'services', 'edit_submission')
-    master_cl.load_manifest('digital-outcomes-and-specialists', 'briefs', 'edit_brief')
+    master_cl.lazy_load_manifests(
+        'digital-outcomes-and-specialists',
+        {
+            'declaration': 'declaration',
+            'edit_submission': 'services',
+            'edit_brief': 'briefs',
+        },
+    )
     master_cl.load_messages('digital-outcomes-and-specialists', ['urls'])
 
-    master_cl.load_manifest('digital-outcomes-and-specialists-2', 'declaration', 'declaration')
-    master_cl.load_manifest('digital-outcomes-and-specialists-2', 'services', 'edit_submission')
-    master_cl.load_manifest('digital-outcomes-and-specialists-2', 'services', 'edit_service')
-    master_cl.load_manifest('digital-outcomes-and-specialists-2', 'briefs', 'edit_brief')
+    master_cl.lazy_load_manifests(
+        'digital-outcomes-and-specialists-2',
+        {
+            'declaration': 'declaration',
+            'edit_submission': 'services',
+            'edit_service': 'services',
+            'edit_brief': 'briefs',
+        },
+    )
     master_cl.load_messages('digital-outcomes-and-specialists-2', ['urls'])
 
-    master_cl.load_manifest('digital-outcomes-and-specialists-3', 'declaration', 'declaration')
-    master_cl.load_manifest('digital-outcomes-and-specialists-3', 'services', 'edit_submission')
-    master_cl.load_manifest('digital-outcomes-and-specialists-3', 'services', 'edit_service')
-    master_cl.load_manifest('digital-outcomes-and-specialists-3', 'briefs', 'edit_brief')
+    master_cl.lazy_load_manifests(
+        'digital-outcomes-and-specialists-3',
+        {
+            'declaration': 'declaration',
+            'edit_submission': 'services',
+            'edit_service': 'services',
+            'edit_brief': 'briefs',
+        },
+    )
     master_cl.load_messages('digital-outcomes-and-specialists-3', ['urls'])
     master_cl.load_metadata('digital-outcomes-and-specialists-3', ['copy_services', 'following_framework'])
 
-    master_cl.load_manifest('digital-outcomes-and-specialists-4', 'declaration', 'declaration')
-    master_cl.load_manifest('digital-outcomes-and-specialists-4', 'services', 'edit_submission')
-    master_cl.load_manifest('digital-outcomes-and-specialists-4', 'services', 'edit_service')
-    master_cl.load_manifest('digital-outcomes-and-specialists-4', 'briefs', 'edit_brief')
+    master_cl.lazy_load_manifests(
+        'digital-outcomes-and-specialists-4',
+        {
+            'declaration': 'declaration',
+            'edit_submission': 'services',
+            'edit_service': 'services',
+            'edit_brief': 'briefs',
+        },
+    )
     master_cl.load_messages('digital-outcomes-and-specialists-4', ['urls'])
     master_cl.load_metadata('digital-outcomes-and-specialists-4', ['copy_services', 'following_framework'])
 
@@ -51,33 +71,63 @@ def _load_dos(master_cl):
 
 
 def _load_g_cloud(master_cl):
-    master_cl.load_manifest('g-cloud-6', 'services', 'edit_service')
+    master_cl.lazy_load_manifests(
+        'g-cloud-6',
+        {
+            'edit_service': 'services',
+        },
+    )
     master_cl.load_messages('g-cloud-6', ['urls'])
 
-    master_cl.load_manifest('g-cloud-7', 'services', 'edit_service')
-    master_cl.load_manifest('g-cloud-7', 'services', 'edit_submission')
-    master_cl.load_manifest('g-cloud-7', 'declaration', 'declaration')
+    master_cl.lazy_load_manifests(
+        'g-cloud-7',
+        {
+            'edit_service': 'services',
+            'edit_submission': 'services',
+            'declaration': 'declaration',
+        },
+    )
     master_cl.load_messages('g-cloud-7', ['urls'])
 
-    master_cl.load_manifest('g-cloud-8', 'services', 'edit_service')
-    master_cl.load_manifest('g-cloud-8', 'services', 'edit_submission')
-    master_cl.load_manifest('g-cloud-8', 'declaration', 'declaration')
+    master_cl.lazy_load_manifests(
+        'g-cloud-8',
+        {
+            'edit_service': 'services',
+            'edit_submission': 'services',
+            'declaration': 'declaration',
+        },
+    )
     master_cl.load_messages('g-cloud-8', ['urls'])
 
-    master_cl.load_manifest('g-cloud-9', 'services', 'edit_service')
-    master_cl.load_manifest('g-cloud-9', 'services', 'edit_submission')
-    master_cl.load_manifest('g-cloud-9', 'declaration', 'declaration')
+    master_cl.lazy_load_manifests(
+        'g-cloud-9',
+        {
+            'edit_service': 'services',
+            'edit_submission': 'services',
+            'declaration': 'declaration',
+        },
+    )
     master_cl.load_messages('g-cloud-9', ['urls', 'advice'])
 
-    master_cl.load_manifest('g-cloud-10', 'services', 'edit_service')
-    master_cl.load_manifest('g-cloud-10', 'services', 'edit_submission')
-    master_cl.load_manifest('g-cloud-10', 'declaration', 'declaration')
+    master_cl.lazy_load_manifests(
+        'g-cloud-10',
+        {
+            'edit_service': 'services',
+            'edit_submission': 'services',
+            'declaration': 'declaration',
+        },
+    )
     master_cl.load_messages('g-cloud-10', ['urls', 'advice'])
     master_cl.load_metadata('g-cloud-10', ['copy_services'])
 
-    master_cl.load_manifest('g-cloud-11', 'services', 'edit_service')
-    master_cl.load_manifest('g-cloud-11', 'services', 'edit_submission')
-    master_cl.load_manifest('g-cloud-11', 'declaration', 'declaration')
+    master_cl.lazy_load_manifests(
+        'g-cloud-11',
+        {
+            'edit_service': 'services',
+            'edit_submission': 'services',
+            'declaration': 'declaration',
+        },
+    )
     master_cl.load_messages('g-cloud-11', ['urls', 'advice'])
     master_cl.load_metadata('g-cloud-11', ['copy_services', 'following_framework'])
 

--- a/app/main/__init__.py
+++ b/app/main/__init__.py
@@ -16,16 +16,7 @@ main = Blueprint('main', __name__)
 _local = Local()
 
 
-def _make_content_loader_factory():
-    master_cl = ContentLoader('app/content')
-    master_cl.load_manifest('g-cloud-6', 'services', 'edit_service')
-    master_cl.load_messages('g-cloud-6', ['urls'])
-
-    master_cl.load_manifest('g-cloud-7', 'services', 'edit_service')
-    master_cl.load_manifest('g-cloud-7', 'services', 'edit_submission')
-    master_cl.load_manifest('g-cloud-7', 'declaration', 'declaration')
-    master_cl.load_messages('g-cloud-7', ['urls'])
-
+def _load_dos(master_cl):
     master_cl.load_manifest('digital-outcomes-and-specialists', 'declaration', 'declaration')
     master_cl.load_manifest('digital-outcomes-and-specialists', 'services', 'edit_submission')
     master_cl.load_manifest('digital-outcomes-and-specialists', 'briefs', 'edit_brief')
@@ -36,6 +27,37 @@ def _make_content_loader_factory():
     master_cl.load_manifest('digital-outcomes-and-specialists-2', 'services', 'edit_service')
     master_cl.load_manifest('digital-outcomes-and-specialists-2', 'briefs', 'edit_brief')
     master_cl.load_messages('digital-outcomes-and-specialists-2', ['urls'])
+
+    master_cl.load_manifest('digital-outcomes-and-specialists-3', 'declaration', 'declaration')
+    master_cl.load_manifest('digital-outcomes-and-specialists-3', 'services', 'edit_submission')
+    master_cl.load_manifest('digital-outcomes-and-specialists-3', 'services', 'edit_service')
+    master_cl.load_manifest('digital-outcomes-and-specialists-3', 'briefs', 'edit_brief')
+    master_cl.load_messages('digital-outcomes-and-specialists-3', ['urls'])
+    master_cl.load_metadata('digital-outcomes-and-specialists-3', ['copy_services', 'following_framework'])
+
+    master_cl.load_manifest('digital-outcomes-and-specialists-4', 'declaration', 'declaration')
+    master_cl.load_manifest('digital-outcomes-and-specialists-4', 'services', 'edit_submission')
+    master_cl.load_manifest('digital-outcomes-and-specialists-4', 'services', 'edit_service')
+    master_cl.load_manifest('digital-outcomes-and-specialists-4', 'briefs', 'edit_brief')
+    master_cl.load_messages('digital-outcomes-and-specialists-4', ['urls'])
+    master_cl.load_metadata('digital-outcomes-and-specialists-4', ['copy_services', 'following_framework'])
+
+    master_cl.load_manifest('digital-outcomes-and-specialists-5', 'declaration', 'declaration')
+    master_cl.load_manifest('digital-outcomes-and-specialists-5', 'services', 'edit_submission')
+    master_cl.load_manifest('digital-outcomes-and-specialists-5', 'services', 'edit_service')
+    master_cl.load_manifest('digital-outcomes-and-specialists-5', 'briefs', 'edit_brief')
+    master_cl.load_messages('digital-outcomes-and-specialists-5', ['urls', 'e-signature'])
+    master_cl.load_metadata('digital-outcomes-and-specialists-5', ['copy_services', 'following_framework'])
+
+
+def _load_g_cloud(master_cl):
+    master_cl.load_manifest('g-cloud-6', 'services', 'edit_service')
+    master_cl.load_messages('g-cloud-6', ['urls'])
+
+    master_cl.load_manifest('g-cloud-7', 'services', 'edit_service')
+    master_cl.load_manifest('g-cloud-7', 'services', 'edit_submission')
+    master_cl.load_manifest('g-cloud-7', 'declaration', 'declaration')
+    master_cl.load_messages('g-cloud-7', ['urls'])
 
     master_cl.load_manifest('g-cloud-8', 'services', 'edit_service')
     master_cl.load_manifest('g-cloud-8', 'services', 'edit_submission')
@@ -53,25 +75,11 @@ def _make_content_loader_factory():
     master_cl.load_messages('g-cloud-10', ['urls', 'advice'])
     master_cl.load_metadata('g-cloud-10', ['copy_services'])
 
-    master_cl.load_manifest('digital-outcomes-and-specialists-3', 'declaration', 'declaration')
-    master_cl.load_manifest('digital-outcomes-and-specialists-3', 'services', 'edit_submission')
-    master_cl.load_manifest('digital-outcomes-and-specialists-3', 'services', 'edit_service')
-    master_cl.load_manifest('digital-outcomes-and-specialists-3', 'briefs', 'edit_brief')
-    master_cl.load_messages('digital-outcomes-and-specialists-3', ['urls'])
-    master_cl.load_metadata('digital-outcomes-and-specialists-3', ['copy_services', 'following_framework'])
-
     master_cl.load_manifest('g-cloud-11', 'services', 'edit_service')
     master_cl.load_manifest('g-cloud-11', 'services', 'edit_submission')
     master_cl.load_manifest('g-cloud-11', 'declaration', 'declaration')
     master_cl.load_messages('g-cloud-11', ['urls', 'advice'])
     master_cl.load_metadata('g-cloud-11', ['copy_services', 'following_framework'])
-
-    master_cl.load_manifest('digital-outcomes-and-specialists-4', 'declaration', 'declaration')
-    master_cl.load_manifest('digital-outcomes-and-specialists-4', 'services', 'edit_submission')
-    master_cl.load_manifest('digital-outcomes-and-specialists-4', 'services', 'edit_service')
-    master_cl.load_manifest('digital-outcomes-and-specialists-4', 'briefs', 'edit_brief')
-    master_cl.load_messages('digital-outcomes-and-specialists-4', ['urls'])
-    master_cl.load_metadata('digital-outcomes-and-specialists-4', ['copy_services', 'following_framework'])
 
     master_cl.load_manifest('g-cloud-12', 'services', 'edit_service')
     master_cl.load_manifest('g-cloud-12', 'services', 'edit_submission')
@@ -79,12 +87,12 @@ def _make_content_loader_factory():
     master_cl.load_messages('g-cloud-12', ['urls', 'advice', 'e-signature'])
     master_cl.load_metadata('g-cloud-12', ['copy_services', 'following_framework'])
 
-    master_cl.load_manifest('digital-outcomes-and-specialists-5', 'declaration', 'declaration')
-    master_cl.load_manifest('digital-outcomes-and-specialists-5', 'services', 'edit_submission')
-    master_cl.load_manifest('digital-outcomes-and-specialists-5', 'services', 'edit_service')
-    master_cl.load_manifest('digital-outcomes-and-specialists-5', 'briefs', 'edit_brief')
-    master_cl.load_messages('digital-outcomes-and-specialists-5', ['urls', 'e-signature'])
-    master_cl.load_metadata('digital-outcomes-and-specialists-5', ['copy_services', 'following_framework'])
+
+def _make_content_loader_factory():
+    master_cl = ContentLoader('app/content')
+
+    _load_dos(master_cl)
+    _load_g_cloud(master_cl)
 
     # seal master_cl in a closure by returning a function which will only ever return an independent copy of it
     return lambda: deepcopy(master_cl)

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ defusedxml==0.6.0
     # via odfpy
 digitalmarketplace-apiclient==21.13.0
     # via -r requirements.in
-digitalmarketplace-content-loader==7.30.1
+digitalmarketplace-content-loader==7.31.0
     # via -r requirements.in
 digitalmarketplace-utils==56.1.2
     # via


### PR DESCRIPTION
We've added [the ability to lazily load manifests](https://github.com/alphagov/digitalmarketplace-content-loader/pull/137). Use this for old frameworks to dramatically reduce startup time. This should only affect a small number of user requests, where they'll be about 1s slower. See the previous experiment for numbers: #1348

Keep the newest frameworks eagerly loaded. This is because I think these frameworks receive substantial traffic. So by eagerly loading we avoid slow user requests that are otherwise highly likely. We also want to load these frameworks during app startup so that the app fails to start if the manifests are malformed. We don't typically change old framework data so they're at much lower risk of being broken.

If this works and doesn't break things, we can roll out these changes to the other frontend apps that load manifests as well.