### PR TITLE
Remove uses of secondary action link template

### DIFF
--- a/app/assets/scss/_view-service-link.scss
+++ b/app/assets/scss/_view-service-link.scss
@@ -1,3 +1,0 @@
-.view-service-link {
-  margin-bottom: 30px;
-}

--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -24,7 +24,6 @@ $path: "/suppliers/static/images/";
 @import "toolkit/_instruction-list.scss";
 @import "toolkit/_notification-banners.scss";
 @import "toolkit/_proposition-header.scss";
-@import "toolkit/_secondary-action-link.scss";
 @import "toolkit/_service-id.scss";
 @import "toolkit/_temporary-message.scss";
 @import "toolkit/_text-diff.scss";
@@ -66,7 +65,6 @@ $govuk-global-styles: true;
 @import "_single-summary-page.scss";
 @import "_supplier-declaration.scss";
 @import "_updates.scss";
-@import "_view-service-link.scss";
 
 // Overrides
 @import "overrides/_list-entry";

--- a/app/templates/errors/applications_closed.html
+++ b/app/templates/errors/applications_closed.html
@@ -19,11 +19,11 @@
       </p>
     {% endif %}
   </div>
-  <div class="secondary-action-link">
-    <p class="govuk-body">
-      <a class="govuk-link" href="{{ url_for('.dashboard') }}">Return to your account</a>.
-    </p>
-  </div>
+
+  <p class="govuk-body">
+    <a class="govuk-link" href="{{ url_for('.dashboard') }}">Return to your account</a>
+  </p>
+
 </div>
 
 {% endblock %}

--- a/app/templates/frameworks/contract_variation.html
+++ b/app/templates/frameworks/contract_variation.html
@@ -145,18 +145,17 @@
 
           {% else %}
 
-            <p class="padding-bottom-small">&nbsp;</p>
+            <p class="govuk-body">
+              <a class="govuk-link govuk-link--no-visited-state"
+                 href="{{ url_for('.framework_dashboard', framework_slug=framework.slug) }}"
+              >
+                Return to your documents page
+              </a>
+            </p>
 
-            {%
-              with
-                url = url_for(".framework_dashboard", framework_slug=framework.slug),
-                text = "Return to your documents page"
-            %}
-              {% include "toolkit/secondary-action-link.html" %}
-            {% endwith %}
           {% endif %}
 
-          </div>
+        </div>
       </div>
 
 {% endblock %}

--- a/app/templates/frameworks/declaration_overview.html
+++ b/app/templates/frameworks/declaration_overview.html
@@ -123,19 +123,21 @@
           {% endcall %}
         {% endcall %}
       {% endfor %}
-    </div>
-  </div>
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
+
+      <hr class="govuk-section-break govuk-section-break--m">
+
       {{ make_declaration_button_block() }}
+
+      <p class="govuk-body">
+        <a class="govuk-link govuk-link--no-visited-state"
+           href="{{ url_for('.framework_dashboard', framework_slug=framework.slug) }}"
+        >
+          Return to application
+        </a>
+      </p>
+
     </div>
   </div>
 
-  {%
-    with
-    url = url_for(".framework_dashboard", framework_slug=framework.slug),
-    text = "Return to application"
-  %}
-    {% include "toolkit/secondary-action-link.html" %}
-  {% endwith %}
+
 {% endblock %}

--- a/app/templates/frameworks/services.html
+++ b/app/templates/frameworks/services.html
@@ -149,11 +149,14 @@
     {% endcall %}
   {% endcall %}
 
-  {%
-    with
-    url = url_for(".framework_submission_lots", framework_slug=framework.slug),
-    text = "Back to application"
-  %}
-    {% include "toolkit/secondary-action-link.html" %}
-  {% endwith %}
+  <hr class="govuk-section-break govuk-section-break--m">
+
+  <p class="govuk-body">
+    <a class="govuk-link govuk-link--no-visited-state"
+       href="{{ url_for('.framework_submission_lots', framework_slug=framework.slug) }}"
+    >
+      Back to application
+    </a>
+  </p>
+
 {% endblock %}

--- a/app/templates/services/previous_services.html
+++ b/app/templates/services/previous_services.html
@@ -126,13 +126,16 @@
       {% endcall %}
     {% endcall %}
 
-    {%
-      with
-      url = url_for(".framework_submission_services", framework_slug=framework.slug, lot_slug=lot.slug),
-      text = "Back to services"
-    %}
-      {% include "toolkit/secondary-action-link.html" %}
-    {% endwith %}
+    <hr class="govuk-section-break govuk-section-break--m">
+
+    <p class="govuk-body">
+      <a class="govuk-link govuk-link--no-visited-state"
+         href="{{ url_for('.framework_submission_services', framework_slug=framework.slug, lot_slug=lot.slug) }}"
+      >
+      Back to services
+      </a>
+    </p>
+
   {% endif %}
 
 {% endblock %}

--- a/app/templates/services/service.html
+++ b/app/templates/services/service.html
@@ -57,18 +57,17 @@
 {% block before_sections %}
   {% if service_data.frameworkFamily != "digital-outcomes-and-specialists" %}
     <div class="govuk-grid-column-two-thirds">
-      <div class="view-service-link">
-        {%
-          with
-          url = "/g-cloud/services/{}".format(service_id),
-          text = "View service page on the Digital Marketplace"
-        %}
-          {% include "toolkit/secondary-action-link.html" %}
-        {% endwith %}
-      </div>
-      <div class="dmspeak">
-        <p class="govuk-body">You can edit how you describe your service but you can’t change the service itself or how it works.</p>
-      </div>
+
+      <p class="govuk-body govuk-!-margin-bottom-6">
+        <a class="govuk-link" href="/g-cloud/services/{{service_id}}">
+          View service page on the Digital Marketplace
+        </a>
+      </p>
+
+      <p class="govuk-body">
+        You can edit how you describe your service but you can’t change the service itself or how it works.
+      </p>
+
     </div>
   {% endif %}
 {% endblock %}

--- a/app/templates/services/service_submission.html
+++ b/app/templates/services/service_submission.html
@@ -207,21 +207,24 @@
         </form>
         {% endif %}
       </div>
-      {% if lot.oneServiceLimit %}
-        {% set back_to_service_url = url_for(".framework_submission_lots", framework_slug=framework.slug) %}
-        {% set back_to_service_link_text = 'Back to application' %}
-      {% else %}
-        {% set back_to_service_url = url_for(".framework_submission_services", framework_slug=framework.slug, lot_slug=service_data.lot) %}
-        {% set back_to_service_link_text = 'Back to {}'.format(service_data['lotName']|lower) %}
-      {% endif %}
+
       <div class="govuk-grid-column-two-thirds">
-          {%
-            with
-            url = back_to_service_url,
-            text = back_to_service_link_text
-          %}
-            {% include "toolkit/secondary-action-link.html" %}
-          {% endwith %}
+        {% if lot.oneServiceLimit %}
+          {% set back_to_service_url = url_for(".framework_submission_lots", framework_slug=framework.slug) %}
+          {% set back_to_service_link_text = 'Back to application' %}
+        {% else %}
+          {% set back_to_service_url = url_for(".framework_submission_services", framework_slug=framework.slug, lot_slug=service_data.lot) %}
+          {% set back_to_service_link_text = 'Back to {}'.format(service_data['lotName']|lower) %}
+        {% endif %}
+
+        <p class="govuk-body">
+          <a class="govuk-link govuk-link--no-visited-state"
+             href="{{ back_to_service_url }}"
+          >
+            {{ back_to_service_link_text }}
+          </a>
+        </p>
+
       </div>
 
   {% endif %}

--- a/app/templates/suppliers/already_completed.html
+++ b/app/templates/suppliers/already_completed.html
@@ -47,13 +47,13 @@
         if you want to change your {{ completed_data_description }}.</p>
       </div>
 
-      {%
-        with
-        url = url_for('.supplier_details'),
-        text = "Return to company details"
-      %}
-        {% include "toolkit/secondary-action-link.html" %}
-      {% endwith %}
+      <p class="govuk-body">
+        <a class="govuk-link govuk-link--no-visited-state"
+           href="{{ url_for('.supplier_details') }}"
+        >
+          Return to company details
+        </a>
+      </p>
 
     </div>
   </div>

--- a/app/templates/suppliers/become_a_supplier.html
+++ b/app/templates/suppliers/become_a_supplier.html
@@ -33,13 +33,13 @@
           </div>
         {% endfor %}
 
-        {%
-          with
-          url = url_for("main.create_new_supplier"),
-          text = "Create a supplier account"
-        %}
-          {% include "toolkit/secondary-action-link.html" %}
-        {% endwith %}
+        <p class="govuk-body">
+          <a class="govuk-link"
+             href="{{ url_for('main.create_new_supplier') }}"
+          >
+            Create a supplier account
+          </a>
+        </p>
 
         {% if closed_fwks %}
 
@@ -68,13 +68,13 @@
       {% endif %}
 
       {% if closed_fwks %}
-        {%
-          with
-          url = url_for("main.join_open_framework_notification_mailing_list"),
-          text = "Get notifications when applications are opening"
-        %}
-          {% include "toolkit/secondary-action-link.html" %}
-        {% endwith %}
+        <p class="govuk-body">
+          <a class="govuk-link"
+             href="{{ url_for('main.join_open_framework_notification_mailing_list') }}"
+          >
+            Get notifications when applications are opening
+          </a>
+        </p>
       {% endif %}
     </div>
   </div>

--- a/app/templates/suppliers/details.html
+++ b/app/templates/suppliers/details.html
@@ -230,14 +230,13 @@
   {% if currently_applying_to %}
   <div class='govuk-grid-row'>
     <div class='govuk-grid-column-two-thirds'>
-    {%
-       with
-       url = url_for(".framework_dashboard", framework_slug=currently_applying_to.slug),
-       text = "Return to your {} application".format(currently_applying_to.name),
-       bigger = false
-     %}
-       {% include "toolkit/secondary-action-link.html" %}
-    {% endwith %}
+      <p class="govuk-body">
+        <a class="govuk-link govuk-link--no-visited-state"
+           href="{{ url_for('.framework_dashboard', framework_slug=currently_applying_to.slug) }}"
+        >
+          Return to your {{ currently_applying_to.name }} application
+        </a>
+      </p>
     </div>
   </div>
   {% endif %}

--- a/tests/app/main/test_suppliers.py
+++ b/tests/app/main/test_suppliers.py
@@ -877,9 +877,9 @@ class TestSupplierDetails(BaseApplicationTest):
 
         page_html = response.get_data(as_text=True)
         document = html.fromstring(page_html)
-        return_link = (document.xpath("//a[text()='Return to your {} application']".format(framework_name)))
+        return_link = (document.xpath(f"//a[contains(text(), 'Return to your {framework_name} application')]"))
         assert return_link
-        assert return_link[0].values()[0] == link_address
+        assert return_link[0].attrib["href"] == link_address
 
     def test_back_to_application_link_not_visible_if_currently_applying_to_not_in_session(self):
         self.data_api_client.get_supplier.return_value = get_supplier()


### PR DESCRIPTION
Ticket: https://trello.com/c/MBn0LIOB/852-2-remove-secondary-action-link-component-from-supplier-frontend

We don't want to use a template for these simple links.

Also remove some unneeded CSS styles.