### PR TITLE
Replace notification banner on 'make a declaration' journey

### DIFF
--- a/app/templates/_base_page.html
+++ b/app/templates/_base_page.html
@@ -15,6 +15,7 @@
 {% from "digitalmarketplace/components/header/macro.njk" import dmHeader %}
 {% from "digitalmarketplace/components/attachment/macro.njk" import dmAttachment %}
 {% from "digitalmarketplace/components/footer/macro.njk" import dmFooter %}
+{% from "digitalmarketplace/components/banner/macro.njk" import dmBanner %}
 
 {% set assetPath = '/suppliers/static' %}
 

--- a/app/templates/frameworks/edit_declaration_section.html
+++ b/app/templates/frameworks/edit_declaration_section.html
@@ -33,12 +33,9 @@
 
 {% block mainContent %}
   {% if name_of_framework_that_section_has_been_prefilled_from %}
-    {% with
-       message = "Answers on this page are from an earlier declaration and need review.",
-       type = "information"
-    %}
-      {% include "toolkit/notification-banner.html" %}
-    {% endwith %}
+    {{ dmBanner({
+        "title": "Answers on this page are from an earlier declaration and need review.",
+    }) }}
   {% endif %}
 
   <form method="post" enctype="multipart/form-data" class="supplier-declaration" action="#" {# remove any fragment identifier as validation messages are at the top #}>

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -2984,7 +2984,7 @@ class TestSupplierDeclaration(BaseApplicationTest, MockEnsureApplicationCompanyD
         assert len(doc.xpath('//input[@id="input-organisedCrime-2"][@value="False"]/@checked')) == 1
 
         # Blue banner message is shown at top of page
-        assert doc.xpath('normalize-space(string(//div[@class="banner-information-without-action"]))') == \
+        assert doc.xpath('normalize-space(string(//section[@class="dm-banner"]))') == \
             "Answers on this page are from an earlier declaration and need review."
 
         # Blue information messages are shown next to each question
@@ -3051,7 +3051,7 @@ class TestSupplierDeclaration(BaseApplicationTest, MockEnsureApplicationCompanyD
         assert len(doc.xpath('//input[@id="input-terrorism-2"]/@checked')) == 0
 
         # Blue banner message is shown at top of page
-        assert doc.xpath('normalize-space(string(//div[@class="banner-information-without-action"]))') == \
+        assert doc.xpath('normalize-space(string(//section[@class="dm-banner"]))') == \
             "Answers on this page are from an earlier declaration and need review."
 
         # Blue information messages are shown next to pre-filled questions only


### PR DESCRIPTION
Replace the toolkit banner with the [banner component](https://github.com/alphagov/digitalmarketplace-govuk-frontend/tree/master/src/digitalmarketplace/components/banner) from the digitalmarketplace-govuk-frontend.

I have run the functional tests against this change and the [relevant scenario](https://github.com/alphagov/digitalmarketplace-functional-tests/blob/master/features/supplier/supplier_applies_to_a_framework.feature#L42) still passes as we don't check for the banner as part of that test.

https://trello.com/c/CQlT1KmX/853-2-replace-notification-banner-on-make-a-supplier-declaration-journey

Previous banner:
![image](https://user-images.githubusercontent.com/6362602/110315578-61427500-8001-11eb-8639-62c24f850211.png)


New banner:
![image](https://user-images.githubusercontent.com/6362602/110315473-3526f400-8001-11eb-9699-181ef9039937.png)