### PR TITLE
New choose a lot page in create a service journey

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "package-lock.json",
     "lines": null
   },
-  "generated_at": "2021-03-12T10:20:51Z",
+  "generated_at": "2021-03-08T14:16:08Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -100,14 +100,14 @@
         "hashed_secret": "e5223482a22578724452e2315f44d0bc5fc457a3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4517,
+        "line_number": 4644,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "82cae5b1d77db4d964804f85ef2c818c6bec2614",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4542,
+        "line_number": 4669,
         "type": "Base64 High Entropy String"
       }
     ]

--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -74,6 +74,7 @@ $govuk-global-styles: true;
 @import "overrides/_temporary-messages";
 @import "overrides/_task-list";
 @import "overrides/_tags";
+@import "overrides/_table";
 @import "overrides/_pending-services-table";
 
 // Misc styles

--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -71,6 +71,7 @@ $govuk-global-styles: true;
 @import "overrides/_list-entry";
 @import "overrides/_notifications_banner";
 @import "overrides/_summary-list";
+@import "overrides/_radios";
 @import "overrides/_temporary-messages";
 @import "overrides/_task-list";
 @import "overrides/_tags";

--- a/app/assets/scss/overrides/_radios.scss
+++ b/app/assets/scss/overrides/_radios.scss
@@ -1,0 +1,12 @@
+/*
+ * On the What type of service do you want to add? page, we want to display the question
+ * description as hint text, but it's already got classes applied to the HTML. So we want
+ * to reinstate the govuk-hint colour to conform with other hints.
+ *
+ * It may be better to remove these classes in the content loader before they get into
+ * this app.
+ */
+.dm-radios--description-hint .govuk-radios__hint .govuk-body,
+.dm-radios--description-hint .govuk-radios__hint .govuk-list {
+    color: $govuk-secondary-text-colour;
+}

--- a/app/assets/scss/overrides/_table.scss
+++ b/app/assets/scss/overrides/_table.scss
@@ -6,3 +6,18 @@
 .dm-action-link {
     text-align: right;
 }
+
+/*
+ * On /frameworks/<framework_slug>/submissions we override the table width
+ * in order to make the multiple tables on the page look consistent.
+ * The GOV.UK Design System width overrides default to 100%, so on small screens,
+ * the override ends up making things go wonky.
+ * This overrides THAT override.
+ */
+
+ .dm-table {
+    .govuk-\!-width-one-third {
+        width: 33.33% !important;
+    }
+ }
+

--- a/app/assets/scss/overrides/_table.scss
+++ b/app/assets/scss/overrides/_table.scss
@@ -1,0 +1,8 @@
+/*
+ * On the services submissions page, we use a table with action links.
+ * We want to style all the action links to be right-aligned.
+ */
+
+.dm-action-link {
+    text-align: right;
+}

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -295,6 +295,61 @@ def framework_submission_lots(framework_slug):
     ), 200
 
 
+@main.route('/frameworks/<framework_slug>/submissions/service-type', methods=['GET', 'POST'])
+@login_required
+@EnsureApplicationCompanyDetailsHaveBeenConfirmed(data_api_client)
+def choose_draft_service_lot(framework_slug):
+    framework = get_framework_or_404(data_api_client, framework_slug)
+
+    if framework['status'] not in ["open"]:
+        abort(404)
+
+    errors = {}
+    status_code = 200
+
+    lot_question = {
+        option["value"]: option
+        for option in ContentQuestion(content_loader.get_question(framework_slug, 'services', 'lot')).get('options')
+    }
+
+    lots = [
+        {
+            "text": lot_question[lot['slug']]['label'] if framework["status"] == "open" else lot["name"],
+            "value": lot['slug'],
+            "hint": {
+                "html": lot_question[lot['slug']]['description']
+            }
+        } for lot in framework['lots']
+        if framework["status"] == "open" or (lot['draft_count'] + lot['complete_count']) > 0
+    ]
+
+    if request.method == 'POST':
+        if "lot_slug" in request.form:
+            return redirect(
+                url_for(
+                    ".framework_submission_services",
+                    framework_slug=framework['slug'],
+                    lot_slug=request.form['lot_slug']
+                )
+            )
+        else:
+            errors = {
+                "lot_slug": {
+                    "text": "Select a type of service",
+                    "href": "#lot_slug-1",
+                    "errorMessage": "Select a type of service"
+                }
+            }
+            status_code = 400
+
+    return render_template(
+        "frameworks/choose_service_lot.html",
+        framework=framework,
+        lots=lots,
+        errors=errors
+    ), status_code
+
+
 @main.route('/frameworks/<framework_slug>/submissions/<lot_slug>', methods=['GET'])
 @login_required
 @EnsureApplicationCompanyDetailsHaveBeenConfirmed(data_api_client)

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -269,6 +269,7 @@ def framework_submission_lots(framework_slug):
 
     lots = [{
         "title": lot_question[lot['slug']]['label'] if framework["status"] == "open" else lot["name"],
+        "slug": lot['slug'],
         'body': lot_question[lot['slug']]['description'],
         "link": url_for('.framework_submission_services', framework_slug=framework_slug, lot_slug=lot['slug']),
         "statuses": get_statuses_for_lot(

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -6,7 +6,6 @@ from flask_login import current_user
 
 from dmapiclient import HTTPError
 from dmcontent.content_loader import ContentNotFoundError
-from dmcontent.questions import ContentQuestion
 from dmcontent.utils import count_unanswered_questions
 from dmutils import s3
 from dmutils.dates import update_framework_with_formatted_dates
@@ -306,61 +305,6 @@ def redirect_direct_service_urls(service_id, trailing_path):
 
 
 #  ####################  CREATING NEW DRAFT SERVICES ##########################
-
-@main.route('/frameworks/<framework_slug>/submissions/service-type', methods=['GET', 'POST'])
-@login_required
-@EnsureApplicationCompanyDetailsHaveBeenConfirmed(data_api_client)
-def choose_draft_service_lot(framework_slug):
-    framework = get_framework_or_404(data_api_client, framework_slug)
-
-    if framework['status'] not in ["open", "pending", "standstill"]:
-        abort(404)
-
-    errors = {}
-    status_code = 200
-
-    lot_question = {
-        option["value"]: option
-        for option in ContentQuestion(content_loader.get_question(framework_slug, 'services', 'lot')).get('options')
-    }
-
-    lots = [
-        {
-            "text": lot_question[lot['slug']]['label'] if framework["status"] == "open" else lot["name"],
-            "value": lot['slug'],
-            "hint": {
-                "html": lot_question[lot['slug']]['description']
-            }
-        } for lot in framework['lots']
-        if framework["status"] == "open" or (lot['draft_count'] + lot['complete_count']) > 0
-    ]
-
-    if request.method == 'POST':
-        if "lot_slug" in request.form:
-            return redirect(
-                url_for(
-                    ".framework_submission_services",
-                    framework_slug=framework['slug'],
-                    lot_slug=request.form['lot_slug']
-                )
-            )
-        else:
-            errors = {
-                "lot_slug": {
-                    "text": "Select a type of service",
-                    "href": "#lot_slug-1",
-                    "errorMessage": "Select a type of service"
-                }
-            }
-            status_code = 400
-
-    return render_template(
-        "services/choose_service_lot.html",
-        framework=framework,
-        lots=lots,
-        errors=errors
-    ), status_code
-
 
 @main.route('/frameworks/<framework_slug>/submissions/<lot_slug>/create', methods=['GET', 'POST'])
 @login_required

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -326,12 +326,14 @@ def choose_draft_service_lot(framework_slug):
 
     lots = [
         {
-        "text": lot_question[lot['slug']]['label'] if framework["status"] == "open" else lot["name"],
-        "value": lot['slug'],
-        "hint": {
-            "html": lot_question[lot['slug']]['description']
-        }
-        } for lot in framework['lots'] if framework["status"] == "open" or (lot['draft_count'] + lot['complete_count']) > 0]
+            "text": lot_question[lot['slug']]['label'] if framework["status"] == "open" else lot["name"],
+            "value": lot['slug'],
+            "hint": {
+                "html": lot_question[lot['slug']]['description']
+            }
+        } for lot in framework['lots']
+        if framework["status"] == "open" or (lot['draft_count'] + lot['complete_count']) > 0
+    ]
 
     if request.method == 'POST':
         if "lot_slug" in request.form:

--- a/app/templates/_base_page.html
+++ b/app/templates/_base_page.html
@@ -6,6 +6,7 @@
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
+{% from "govuk/components/table/macro.njk" import govukTable %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 

--- a/app/templates/frameworks/choose_service_lot.html
+++ b/app/templates/frameworks/choose_service_lot.html
@@ -1,7 +1,7 @@
 {% extends "_base_page.html" %}
 
 {% block pageTitle %}
-  Your {{ framework.name }} services – Digital Marketplace
+  {% if errors %} Error: {% endif %}Your {{ framework.name }} services – Digital Marketplace
 {% endblock %}
 
 {% block breadcrumb %}
@@ -18,6 +18,10 @@
       {
         "text": ("Apply to " + framework.name) if framework.status == "open" else ("Your " + framework.name + " application"),
         "href": url_for(".framework_dashboard", framework_slug=framework.slug)
+      },
+      {
+        "text": ("Your " + framework.name + " services"),
+        "href": url_for(".framework_submission_lots", framework_slug=framework.slug)
       },
       {
         "text": "Choose a service type"
@@ -55,7 +59,7 @@
       })}}
     </form>
     <p class="govuk-body">
-      <a class="govuk-link" href="{{ url_for('.framework_dashboard', framework_slug=framework.slug) }}">Back to {{ framework.name }} application</a>
+      <a class="govuk-link" href="{{ url_for('.framework_submission_lots', framework_slug=framework.slug) }}">Back to your {{ framework.name }} services</a>
     </p>
   </div>
 </div>

--- a/app/templates/frameworks/submission_lots.html
+++ b/app/templates/frameworks/submission_lots.html
@@ -37,31 +37,25 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-l">Your {{ framework.name }} services</h1>
-        {% if framework.family == 'g-cloud' %}
-          <div class="use-of-service-data">
-            {% if framework.status == 'pending' and not application_made %}
-              <p class="govuk-body">The services below were not submitted.</p>
-            {% else %}
-            <p class="govuk-body">The service information you provide here:</p>
-            <ul class="govuk-list govuk-list--bullet">
-              <li>will be public</li>
-              <li>may be used as filters</li>
-              <li>will appear on your service description page </li>
-              <li>should help buyers review and compare services</li>
-            </ul>
-            {% endif %}
-          </div>
-        {% endif %}
-    </div>
-  </div>
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds framework-lots-table">
-      {% with items = lots %}
-        {% include "toolkit/browse-list.html" %}
-      {% endwith %}
-<p class="govuk-body">&nbsp;</p>
-    <a class="govuk-link" href="{{ url_for('.framework_dashboard', framework_slug=framework.slug) }}">Back to {{ framework.name }} application</a>
-
+      {% if framework.family == 'g-cloud' %}
+        <div class="use-of-service-data">
+          {% if framework.status == 'pending' and not application_made %}
+            <p class="govuk-body">The services below were not submitted.</p>
+          {% else %}
+          <p class="govuk-body">The service information you provide here:</p>
+          <ul class="govuk-list govuk-list--bullet">
+            <li>will be public</li>
+            <li>may be used as filters</li>
+            <li>will appear on your service description page </li>
+            <li>should help buyers review and compare services</li>
+          </ul>
+          {% endif %}
+        </div>
+      {% endif %}
+      {{ govukButton({
+        "text": "Add a service",
+        "href": url_for('.choose_draft_service_lot', framework_slug=framework.slug)
+      })}}
     </div>
   </div>
 

--- a/app/templates/frameworks/submission_lots.html
+++ b/app/templates/frameworks/submission_lots.html
@@ -68,9 +68,9 @@
         {% if framework.family == "g-cloud" %}
 
           {% set head = [
-            {"text": "Name", "classes": "govuk-!-width-one-half"},
-            {"text": "Lot", "classes": "govuk-!-width-one-quarter"},
-            {"text": "", "classes": "govuk-!-width-one-quarter"}
+            {"text": "Name", "classes": "govuk-!-width-one-third"},
+            {"text": "Lot"},
+            {"text": ""}
           ] %}
 
           {% for draft in drafts|sort(attribute="serviceName") %}
@@ -101,9 +101,9 @@
         {% else %}
 
           {% set head = [
-            {"text": "Lot", "classes": "govuk-!-width-one-quarter"},
-            {"text": "Name", "classes": "govuk-!-width-one-half"},
-            {"text": "", "classes": "govuk-!-width-one-quarter"}
+            {"text": "Lot", "classes": "govuk-!-width-one-third"},
+            {"text": "Name"},
+            {"text": ""}
           ] %}
 
           {% for draft in drafts|sort(attribute="lotName") %}
@@ -138,7 +138,7 @@
           {{ govukTable({
             "head": head,
             "rows": ns.drafts_rows,
-            "classes": "govuk-!-margin-bottom-6"
+            "classes": "dm-table govuk-!-margin-bottom-6"
           })}}
         {% else %}
           <h2 class="govuk-heading-m">Drafts</h2>
@@ -151,7 +151,8 @@
 
           {{ govukTable({
             "head": head,
-            "rows": ns.complete_drafts_rows
+            "rows": ns.complete_drafts_rows,
+            "classes": "dm-table"
           })}}
         {% else %}
           <h2 class="govuk-heading-m">Ready for submission</h2>

--- a/app/templates/frameworks/submission_lots.html
+++ b/app/templates/frameworks/submission_lots.html
@@ -187,6 +187,9 @@
           "rows": ns.lots
         })}}
       {% endif %}
+      <p class="govuk-body">
+        <a class="govuk-link" href="{{ url_for('.framework_dashboard', framework_slug=framework.slug) }}">Back to {{ framework.name }} application</a>
+      </p>
     </div>
   </div>
 

--- a/app/templates/frameworks/submission_lots.html
+++ b/app/templates/frameworks/submission_lots.html
@@ -34,7 +34,7 @@
   {% include "partials/service_warning.html" %}
 {% endif %}
 
-  <div class="govuk-grid-row">
+  <div class="govuk-grid-row govuk-!-margin-bottom-6">
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-l">Your {{ framework.name }} services</h1>
       {% if framework.family == 'g-cloud' %}
@@ -42,20 +42,151 @@
           {% if framework.status == 'pending' and not application_made %}
             <p class="govuk-body">The services below were not submitted.</p>
           {% else %}
-          <p class="govuk-body">The service information you provide here:</p>
+          <p class="govuk-body">The service information you provide in your application:</p>
           <ul class="govuk-list govuk-list--bullet">
-            <li>will be public</li>
-            <li>may be used as filters</li>
-            <li>will appear on your service description page </li>
-            <li>should help buyers review and compare services</li>
+            <li>will be on your public service description page</li>
+            <li>will help buyers review and compare services</li>
+            <li>may be used as filters in search</li>
           </ul>
           {% endif %}
         </div>
       {% endif %}
-      {{ govukButton({
-        "text": "Add a service",
-        "href": url_for('.choose_draft_service_lot', framework_slug=framework.slug)
-      })}}
+      {% if framework.status == 'open' %}
+        {{ govukButton({
+          "text": "Add a service",
+          "href": url_for('.choose_draft_service_lot', framework_slug=framework.slug)
+        })}}
+      {% endif %}
+    </div>
+  </div>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      {% if framework.status == 'open' %}
+        {% set ns = namespace(complete_drafts_rows = [], drafts_rows = [], head = []) %}
+
+        {% if framework.family == "g-cloud" %}
+
+          {% set head = [
+            {"text": "Name", "classes": "govuk-!-width-one-half"},
+            {"text": "Lot", "classes": "govuk-!-width-one-quarter"},
+            {"text": "", "classes": "govuk-!-width-one-quarter"}
+          ] %}
+
+          {% for draft in drafts|sort(attribute="serviceName") %}
+            {% set row = ns.drafts_rows.append(
+              [
+                {"text": draft["serviceName"]},
+                {"text": draft["lotName"]},
+                {
+                  "html": '<a href="' + url_for(".view_service_submission", framework_slug=framework.slug, lot_slug=draft.lot, service_id=draft["id"]) + '">Edit</a>',
+                  "classes": "dm-action-link"
+                }
+              ]
+            )%}
+          {% endfor %}
+          
+          {% for draft in complete_drafts|sort(attribute="serviceName") %}
+            {% set row = ns.complete_drafts_rows.append(
+              [
+                {"text": draft["serviceName"]},
+                {"text": draft["lotName"]},
+                {
+                  "html": '<a href="' + url_for(".view_service_submission", framework_slug=framework.slug, lot_slug=draft.lot, service_id=draft["id"]) + '">Edit</a>',
+                  "classes": "dm-action-link"
+                }
+              ]
+            )%}
+          {% endfor %}
+        {% else %}
+
+          {% set head = [
+            {"text": "Lot", "classes": "govuk-!-width-one-quarter"},
+            {"text": "Name", "classes": "govuk-!-width-one-half"},
+            {"text": "", "classes": "govuk-!-width-one-quarter"}
+          ] %}
+
+          {% for draft in drafts|sort(attribute="lotName") %}
+            {% set row = ns.drafts_rows.append(
+              [
+                {"text": draft["lotName"]},
+                {"text": draft["serviceName"] if draft["serviceName"] else ""},
+                {
+                  "html": '<a href="' + url_for(".view_service_submission", framework_slug=framework.slug, lot_slug=draft.lot, service_id=draft["id"]) + '">Edit</a>',
+                  "classes": "dm-action-link"
+                }
+              ]
+            )%}
+          {% endfor %}
+
+          {% for draft in complete_drafts|sort(attribute="lotName") %}
+              {% set row = ns.complete_drafts_rows.append(
+                [
+                  {"text": draft["lotName"]},
+                  {"text": draft["serviceName"] if draft["serviceName"] else ""},
+                  {
+                    "html": '<a href="' + url_for(".view_service_submission", framework_slug=framework.slug, lot_slug=draft.lot, service_id=draft["id"]) + '">Edit</a>',
+                    "classes": "dm-action-link"
+                  }
+                ]
+              )%}
+          {% endfor %}
+        {% endif %}
+
+        {% if drafts %}
+          <h2 class="govuk-heading-m">Drafts ({{drafts|length}})</h2>
+          {{ govukTable({
+            "head": head,
+            "rows": ns.drafts_rows,
+            "classes": "govuk-!-margin-bottom-6"
+          })}}
+        {% else %}
+          <h2 class="govuk-heading-m">Drafts</h2>
+          <p class="govuk-body">You haven’t added any draft services yet.</p>
+        {% endif %}
+
+        {% if complete_drafts %}
+          <h2 class="govuk-heading-m">Ready for submission{% if complete_drafts %} ({{complete_drafts|length}}) {% endif %}</h2>
+          <p class="govuk-body">These services will be submitted and can be edited before the deadline</p>
+
+          {{ govukTable({
+            "head": head,
+            "rows": ns.complete_drafts_rows
+          })}}
+        {% else %}
+          <h2 class="govuk-heading-m">Ready for submission</h2>
+          <p class="govuk-body">You haven’t marked any services as complete yet.</p>
+        {% endif %}
+      {% endif %}
+
+      {% if framework.status == 'standstill' or framework.status == 'pending' %}
+        {% set ns = namespace(lots = []) %}
+        {% for lot in lots %}
+          {% set row = ns.lots.append(
+          
+            {
+              "key": {
+                "text": lot.title, 
+              },
+              "value": {
+                "text": lot.statuses[0].title
+              },
+              "actions": {
+                "items": [
+                  {
+                    "href": url_for(".framework_submission_services", framework_slug=framework.slug, lot_slug=lot.slug),
+                    "text": "View",
+                    "visuallyHiddenText": "your submitted " + lot.title + " services"
+                  }
+                ]
+              }
+            }
+          )%}
+        {% endfor %}
+        {{ govukSummaryList({
+          "rows": ns.lots
+        })}}
+      {% endif %}
     </div>
   </div>
 

--- a/app/templates/services/choose_service_lot.html
+++ b/app/templates/services/choose_service_lot.html
@@ -36,6 +36,7 @@
       
       {{ govukRadios({
         "name": "lot_slug",
+        "classes": "dm-radios--description-hint",
         "errorMessage": {
           "text": errors['lot_slug'].errorMessage
         } if errors['lot_slug'],

--- a/app/templates/services/choose_service_lot.html
+++ b/app/templates/services/choose_service_lot.html
@@ -1,0 +1,62 @@
+{% extends "_base_page.html" %}
+
+{% block pageTitle %}
+  Your {{ framework.name }} services – Digital Marketplace
+{% endblock %}
+
+{% block breadcrumb %}
+  {{ govukBreadcrumbs({
+    "items": [
+      {
+        "text": "Digital Marketplace",
+        "href": "/"
+      },
+      {
+        "text": "Your account",
+        "href": url_for('.dashboard')
+      },
+      {
+        "text": ("Apply to " + framework.name) if framework.status == "open" else ("Your " + framework.name + " application"),
+        "href": url_for(".framework_dashboard", framework_slug=framework.slug)
+      },
+      {
+        "text": "Choose a service type"
+      }
+    ]
+  }) }}
+{% endblock %}
+
+{% block mainContent %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds"> 
+    <form method="post" enctype="multipart/form-data" action="{{ request.path }}" novalidate>
+      
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+      
+      {{ govukRadios({
+        "name": "lot_slug",
+        "errorMessage": {
+          "text": errors['lot_slug'].errorMessage
+        } if errors['lot_slug'],
+        "fieldset": {
+          "legend": {
+            "text": "What type of service do you want to add?",
+            "isPageHeading": true,
+            "classes": "govuk-fieldset__legend--l"
+          }
+        },
+        "items": lots
+      })}}
+      
+      {{ govukButton({
+        "text": "Save and continue"
+      })}}
+    </form>
+    <p class="govuk-body">
+      <a class="govuk-link" href="{{ url_for('.framework_dashboard', framework_slug=framework.slug) }}">Back to {{ framework.name }} application</a>
+    </p>
+  </div>
+</div>
+
+{% endblock %}

--- a/tests/app/main/helpers/test_frameworks.py
+++ b/tests/app/main/helpers/test_frameworks.py
@@ -758,6 +758,7 @@ class TestEnsureApplicationCompanyDetailsHaveBeenConfirmed(BaseApplicationTest):
             'main.previous_services',
             'main.copy_previous_service',
             'main.copy_all_previous_services',
+            'main.choose_draft_service_lot',
             'main.framework_submission_lots',
             'main.framework_submission_services',
             'main.framework_start_supplier_declaration',


### PR DESCRIPTION
https://trello.com/c/r8CxfKTO/820-5-replace-choose-a-lot-page-in-create-a-service-journey

This splits out the Choose a Lot page into two:

The first page has a list of existing draft and completed services, as well as an action button to add a service.
The second page allows the user to select a lot/service category for their new service.

This flow is ripe for user testing, there's a ticket here: https://trello.com/c/kxH01U71/7-test-new-add-a-service-page

Functional tests: https://github.com/alphagov/digitalmarketplace-functional-tests/pull/861

## Open before
![Screenshot 2021-03-08 at 14 03 32](https://user-images.githubusercontent.com/22524634/110331417-00be3280-8017-11eb-89d4-1d9f9fb48bc4.png)

## Open after
![Screenshot 2021-03-08 at 14 02 59](https://user-images.githubusercontent.com/22524634/110331371-f0a65300-8016-11eb-9578-05e90b59a28c.png)


## Standstill before
![Screenshot 2021-03-07 at 15 12 00](https://user-images.githubusercontent.com/22524634/110331071-8097cd00-8016-11eb-8abe-2c4ed268428d.png)

## Standstill after
![Screenshot 2021-03-07 at 15 36 10](https://user-images.githubusercontent.com/22524634/110331088-85f51780-8016-11eb-9e87-b19140d59643.png)

## Choose a service after
![Screenshot 2021-03-08 at 14 02 23](https://user-images.githubusercontent.com/22524634/110331317-dd938300-8016-11eb-9c50-752b287ad99b.png)

