### PR TITLE
Update DUNS number validation for digitalmarketplace-utils 57.0.0

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -8,5 +8,5 @@ itsdangerous==1.1.0
 
 digitalmarketplace-apiclient
 digitalmarketplace-content-loader
-digitalmarketplace-utils
+digitalmarketplace-utils>=57.0.0
 git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.2-alpha#egg=govuk-frontend-jinja==0.5.2-alpha

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,7 @@ digitalmarketplace-apiclient==21.13.0
     # via -r requirements.in
 digitalmarketplace-content-loader==7.31.0
     # via -r requirements.in
-digitalmarketplace-utils==56.1.2
+digitalmarketplace-utils==57.0.0
     # via
     #   -r requirements.in
     #   digitalmarketplace-content-loader


### PR DESCRIPTION
Closes https://trello.com/c/52Xz6MJM/2184-users-are-able-to-create-supplier-accounts-with-invalid-duns-numbers

This PR updates the supplier frontend to use digitalmarketplace-utils 57.0.0 with changes in alphagov/digitalmarketplace-utils#603.

This will hopefully fix our smoulder tests so that invalid DUNS numbers cannot be used to create a supplier account.