### PR TITLE
Return 200 response to GET /suppliers/mailing-list

### DIFF
--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -795,7 +795,7 @@ def join_open_framework_notification_mailing_list():
             # If no status code supplied, something has probably gone wrong
             status = mc_response.get('status_code', 503)
             # fall through to re-display form with error
-    else:
+    elif request.method == "POST":
         status = 400
         # fall through to re-display form with errors
 

--- a/tests/app/main/test_suppliers.py
+++ b/tests/app/main/test_suppliers.py
@@ -2222,7 +2222,7 @@ class TestJoinOpenFrameworkNotificationMailingList(BaseApplicationTest):
         response = self.client.get(
             "/suppliers/mailing-list",
         )
-        assert response.status_code == 400
+        assert response.status_code == 200
         doc = html.fromstring(response.get_data(as_text=True), base_url="/suppliers/mailing-list")
 
         assert not doc.xpath(


### PR DESCRIPTION
Currently, the status code for a GET request to /suppliers/mailing-list is always 400. Originally, it returned a 200. However, during refactoring (450bca893bb53401945c0401fd2c0e1bb5f343d6), it was changed to a 400. I can see no justification for the change, and suspect it was a mistake.

Change back to a 200 for GETs, since this seems more correct.