### PR TITLE
Replace declaration overview summary table with govukSummaryList

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "package-lock.json",
     "lines": null
   },
-  "generated_at": "2021-03-04T11:57:59Z",
+  "generated_at": "2021-03-12T10:20:51Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -79,35 +79,35 @@
         "hashed_secret": "6955d0539c7ae97361ab63d21bc2bb730edbce7a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3849,
+        "line_number": 3858,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "5b10c4aa69a96ad5a1a11ff1add1a37cdc71fb20",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3865,
+        "line_number": 3874,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "b818bf7ee968a5c29d4436a8243c223576f1d75a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3866,
+        "line_number": 3875,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "e5223482a22578724452e2315f44d0bc5fc457a3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4508,
+        "line_number": 4517,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "82cae5b1d77db4d964804f85ef2c818c6bec2614",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4533,
+        "line_number": 4542,
         "type": "Base64 High Entropy String"
       }
     ]

--- a/app/assets/scss/_action_links.scss
+++ b/app/assets/scss/_action_links.scss
@@ -1,0 +1,12 @@
+/*
+ * On some pages, we use a table with action links.
+ * We want to style all the action links to be right-aligned.
+ */
+
+.dm-action-link {
+    text-align: right;
+}
+
+.dm-section-action-link {
+    float: right;
+}

--- a/app/assets/scss/_action_links.scss
+++ b/app/assets/scss/_action_links.scss
@@ -4,9 +4,29 @@
  */
 
 .dm-action-link {
-    text-align: right;
+    @include govuk-media-query($from: tablet) {
+        text-align: right;
+    }
 }
 
 .dm-section-action-link {
-    float: right;
+    margin-bottom: govuk-spacing(3);
+    @include govuk-media-query($from: tablet) {
+
+        float: right;
+        width: auto;
+
+        a {
+            @include govuk-font($size: 24, $weight: bold);
+        }
+    }
 }
+
+/*
+ * We want headings next to action links to display inline
+ */
+ .dm-summary-list-heading {
+    @include govuk-media-query($from: tablet) {
+        display: inline-block;
+    }
+ }

--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -58,6 +58,7 @@ $govuk-global-styles: true;
 @import "node_modules/digitalmarketplace-govuk-frontend/digitalmarketplace/all";
 
 // App-specific styles
+@import "_action_links.scss";
 @import "_create_supplier.scss";
 @import "_framework-application.scss";
 @import "_service-status.scss";

--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -70,6 +70,7 @@ $govuk-global-styles: true;
 // Overrides
 @import "overrides/_list-entry";
 @import "overrides/_notifications_banner";
+@import "overrides/_summary-list";
 @import "overrides/_temporary-messages";
 @import "overrides/_task-list";
 @import "overrides/_tags";

--- a/app/assets/scss/overrides/_summary-list.scss
+++ b/app/assets/scss/overrides/_summary-list.scss
@@ -1,0 +1,46 @@
+/*
+ * On smaller screens, it's difficult to discern headings from summary
+ * list keys, so we size up the headings
+ */
+ .dm-summary-list-heading {
+    @include govuk-media-query($until: tablet) {
+        font-size: 22px;
+        margin-top: 10px;
+    }
+}
+
+/*
+ * A top border more clearly delineates the multiple data lists per page
+ * from their headings and other context.
+ */
+.dm-govuk-summary-list--top-border {
+    border-top: 1px solid $govuk-border-colour;
+
+    @include govuk-media-query($until: tablet) {
+        padding-top: govuk-spacing(3)
+    }
+}
+/*
+ * We de-bold the questions to avoid bombarding users with emphasised text
+ * and to help the headings stand out.
+ */
+.dm-govuk-summary-list .govuk-summary-list__key {
+    @include govuk-media-query($from: tablet) {
+        font-weight: $govuk-font-weight-regular;
+    }
+}
+
+/*
+ * When a summary list is empty, we display a paragraph styled to look like
+ * a row.
+ */
+.dm-no-summary-content {
+    color: $govuk-secondary-text-colour;
+    @include govuk-font(16);
+    margin-bottom: govuk-spacing(7);
+    border-top: 1px solid $govuk-border-colour;
+    border-bottom: 1px solid $govuk-border-colour;
+    padding-top: 10px;
+    padding-bottom: 10px;
+    max-width: 100%;
+  }

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -45,7 +45,7 @@ from ..helpers.frameworks import (
     get_statuses_for_lot,
     get_supplier_framework_info,
     get_supplier_on_framework_from_info,
-    get_supplier_registered_name_from_declaration,
+    get_supplier_registered_name_from_declaration, question_references,
     register_interest_in_framework,
     return_supplier_framework_info_if_on_framework_or_abort,
     returned_agreement_email_recipients,
@@ -548,6 +548,13 @@ def framework_supplier_declaration_overview(framework_slug):
                     ) if framework["status"] == "open" and sections_errors else None
                 )
             )
+
+        # We need to parse key text for question references. This isn't optimal, but references only apply to
+        # this app, so holding off on centralising this logic to the Content Loader.
+        def label_question_reference(row):
+            row["key"]["text"] = question_references(row.get("key", {}).get("text", ""), section.get_question)
+            return row
+        section.summary_list = list(map(label_question_reference, section.summary_list))
 
     return render_template(
         "frameworks/declaration_overview.html",

--- a/app/templates/frameworks/declaration_overview.html
+++ b/app/templates/frameworks/declaration_overview.html
@@ -72,56 +72,28 @@
   </div>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
-      {% import "toolkit/summary-table.html" as summary %}
+
       {% for section_slug, (section, section_errors) in sections_errors.items() %}
-        {{ summary.heading(section.name, id=section.slug) }}
-        {% if section.editable %}
-          {% if framework.status == 'open' %}
-            {{ summary.top_link("Edit", url_for(".framework_supplier_declaration_edit", framework_slug=framework.slug, section_id=section.id), hidden_text=section.name) }}
-          {% endif %}
-        {% endif %}
-        {% if section.summary_page_description %}
-          {{ summary.description(section.summary_page_description) }}
-        {% endif %}
-        {% call(question) summary.list_table(
-          section.questions,
-          caption=section.name,
-          field_headings=[
-            "Question",
-            "Answer",
-          ],
-          field_headings_visible=False
-        ) %}
-          {% call summary.row() %}
-            {{ summary.field_name(question.label|question_references(section.get_question)) }}
-            {% if section.editable %}
-              {% if framework.status == 'open' and section_errors %}
-                {% call summary.field() %}
-                  {# We don't want a question anchor on the first question of each section; it should take them
-                     to the top of the page so all content is visible #}
-                  {% if section.questions[0].id == question.id -%}
-                    <a class="govuk-link" href="{{ url_for(".framework_supplier_declaration_edit", framework_slug=framework.slug, section_id=section.id) }}">
-                  {% else -%}
-                    <a class="govuk-link" href="{{ url_for(".framework_supplier_declaration_edit", framework_slug=framework.slug, section_id=section.id, _anchor=question.id) }}">
-                  {%- endif -%}
-                  {% if supplier_framework.prefillDeclarationFromFrameworkSlug and section.prefill %}
-                    Review answer
-                  {% else %}
-                    Answer question
-                  {% endif %}
-                  </a>
-                {% endcall %}
-              {% elif not question.is_empty %}
-                {{ summary[question.type](question.value) }}
-              {% else %}
-                {# We need to call this (even if with nothing) to add the final column to the row, otherwise the row
-                   terminates early and the line separators between rows do not span the entire width of the table. #}
-                {% call summary.field(action=True) %}
-                {% endcall %}
-              {% endif %}
+        <h2 class="govuk-heading-m dm-summary-list-heading" id="{{ section.slug }}">
+          {{ section.name }}
+          {% if section.editable %}
+            {% if framework.status == 'open' %}
+              <span class="dm-section-action-link">
+                <a class="govuk-link" href="{{ url_for('.framework_supplier_declaration_edit', framework_slug=framework.slug, section_id=section.id)}}">
+                  Edit
+                  <span class="govuk-visually-hidden">{{ section.name }}</span>
+                </a>
+              </span>
             {% endif %}
-          {% endcall %}
-        {% endcall %}
+          {% endif %}
+        </h2>
+        {% if section.summary_page_description %}
+          <p class="govuk-body">{{ section.summary_page_description }}</p>
+        {% endif %}
+        {{ govukSummaryList({
+          "rows": section.summary_list,
+          "classes": "dm-govuk-summary-list dm-govuk-summary-list--top-border govuk-!-margin-bottom-9"
+        })}}
       {% endfor %}
 
       <hr class="govuk-section-break govuk-section-break--m">

--- a/app/templates/frameworks/declaration_overview.html
+++ b/app/templates/frameworks/declaration_overview.html
@@ -76,17 +76,17 @@
       {% for section_slug, (section, section_errors) in sections_errors.items() %}
         <h2 class="govuk-heading-m dm-summary-list-heading" id="{{ section.slug }}">
           {{ section.name }}
-          {% if section.editable %}
-            {% if framework.status == 'open' %}
-              <span class="dm-section-action-link">
-                <a class="govuk-link" href="{{ url_for('.framework_supplier_declaration_edit', framework_slug=framework.slug, section_id=section.id)}}">
-                  Edit
-                  <span class="govuk-visually-hidden">{{ section.name }}</span>
-                </a>
-              </span>
-            {% endif %}
-          {% endif %}
         </h2>
+        {% if section.editable %}
+          {% if framework.status == 'open' %}
+          <div class="dm-section-action-link">
+            <a class="govuk-link" href="{{ url_for('.framework_supplier_declaration_edit', framework_slug=framework.slug, section_id=section.id)}}">
+              Edit
+              <span class="govuk-visually-hidden">{{ section.name }}</span>
+            </a>
+          </div>
+          {% endif %}
+        {% endif %}
         {% if section.summary_page_description %}
           <p class="govuk-body">{{ section.summary_page_description }}</p>
         {% endif %}

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -2121,41 +2121,50 @@ class TestDeclarationOverview(BaseApplicationTest, MockEnsureApplicationCompanyD
             given a section (full text) name, returns that section's relevant information in a tuple (format described
             in comments)
         """
+
+        table_xpath = "//dl[preceding::h2[1][normalize-space(string())=$section_title]]"
+        edit_as_xpath = (
+            "//span[@class='dm-section-action-link'][preceding::h2[1][normalize-space(string())=$section_title]]"
+        )
+        caption_xpath = "normalize-space(string(./preceding::h2[1]))"
+        row_heading_xpath = "normalize-space(string(./dt))"
+        row_value_xpath = "normalize-space(string(./dd))"
+        row_a_element_xpath = "./dd//a"
+        row_a_href_xpath = "./dd//a/@href"
+        row_li_element_xpath = "./dd//li"
+        rows_xpath = ".//div[contains(@class,'govuk-summary-list__row')]"
+
         tables = doc.xpath(
-            "//table[preceding::h2[1][normalize-space(string())=$section_title]]",
+            table_xpath,
             section_title=section_title,
         )
         assert len(tables) == 1
         table = tables[0]
 
         edit_as = doc.xpath(
-            "//a[@class='summary-change-link'][preceding::h2[1][normalize-space(string())=$section_title]]",
+            edit_as_xpath,
             section_title=section_title,
         )
         assert ([a.xpath("normalize-space(string())") for a in edit_as] == ["Edit"]) is expect_edit_link
 
         return (
             # table caption text
-            table.xpath("normalize-space(string(./caption))"),
+            table.xpath(caption_xpath),
             # "Edit" link href
             edit_as[0].xpath("@href")[0] if expect_edit_link else None,
             tuple(
                 (
                     # contents of row heading
-                    row.xpath("normalize-space(string(./td[@class='summary-item-field-first']))"),
+                    row.xpath(row_heading_xpath),
                     # full text contents of row "value"
-                    row.xpath("normalize-space(string(./td[@class='summary-item-field']))"),
+                    row.xpath(row_value_xpath),
                     # full text contents of each a element in row value
-                    tuple(a.xpath("normalize-space(string())") for a in row.xpath(
-                        "./td[@class='summary-item-field']//a"
-                    )),
+                    tuple(a.xpath("normalize-space(string())") for a in row.xpath(row_a_element_xpath)),
                     # href of each a element in row value
-                    tuple(row.xpath("./td[@class='summary-item-field']//a/@href")),
+                    tuple(row.xpath(row_a_href_xpath)),
                     # full text contents of each li element in row value
-                    tuple(li.xpath("normalize-space(string())") for li in row.xpath(
-                        "./td[@class='summary-item-field']//li"
-                    )),
-                ) for row in table.xpath(".//tr[contains(@class,'summary-item-row')]")
+                    tuple(li.xpath("normalize-space(string())") for li in row.xpath(row_li_element_xpath)),
+                ) for row in table.xpath(rows_xpath)
             )
         )
 


### PR DESCRIPTION
https://trello.com/c/IzTERgai/857-2-replace-your-declaration-overview-summary-table-with-govuk-summary-list

## Changes:
* Summary table replaced with summary list
  * Each entry has an individual "Edit" link
  * Other behaviour stays the same

## Issues:
* All those Edit links look a bit busy.
* An existing issue: we use URI fragments to anchor to a specific question in the links from this summary list, but there's no other confirmation of where the page is focused - ideally the question we linked to would be highlighted on the next page.

### Old summary table
![Old summary table, showing some sections filled in, and the lack of "Edit" actions next to individual row items](https://user-images.githubusercontent.com/22524634/110927491-98749700-831d-11eb-940e-420ac663f9af.png)

### New summary list
![New summary list, showing some sections filled in, and "Edit" links for both the overall section, and individual entries within that section.](https://user-images.githubusercontent.com/22524634/110927490-97dc0080-831d-11eb-9d05-33d1c9f79eab.png)
