### PR TITLE
Replace text boxes on confirm company details journey

### DIFF
--- a/app/templates/_base_page.html
+++ b/app/templates/_base_page.html
@@ -6,6 +6,7 @@
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/select/macro.njk" import govukSelect %}
+{% from "govuk/components/character-count/macro.njk" import govukCharacterCount %}
 {% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}

--- a/app/templates/_base_page.html
+++ b/app/templates/_base_page.html
@@ -4,6 +4,7 @@
 {% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/select/macro.njk" import govukSelect %}
 {% from "govuk/components/character-count/macro.njk" import govukCharacterCount %}

--- a/app/templates/suppliers/edit_registered_name.html
+++ b/app/templates/suppliers/edit_registered_name.html
@@ -1,7 +1,7 @@
 {% extends "_base_page.html" %}
 
 {% block pageTitle %}
-  Registered company name – Digital Marketplace
+  {% if errors %}Error: {% endif %}Registered company name – Digital Marketplace
 {% endblock %}
 
 {% block breadcrumb %}
@@ -27,32 +27,34 @@
 {% endblock %}
 
 {% block mainContent %}
-<div class="single-question-page">
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-l">Registered company name</h1>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
 
-      <form method="POST" action="{{ url_for('.edit_supplier_registered_name') }}">
-        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+    <form method="POST" action="{{ url_for('.edit_supplier_registered_name') }}" novalidate>
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
 
-        {%
-          with
-          name = "registered_company_name",
-          question = "Registered company name",
-          value = form.registered_company_name.data,
-          error = errors.get("registered_company_name", {}).get("message", None),
-          question_advice = "This could be different to your trading name."
-        %}
-          {% include "toolkit/forms/textbox.html" %}
-        {% endwith %}
+      {{ govukInput({
+        "label": {
+          "text": form.registered_company_name.label.text,
+          "classes": "govuk-label--l",
+          "attributes": {"id": form.registered_company_name.name},
+          "isPageHeading": true
+        },
+        "hint": {
+          "text": "This could be different to your trading name."
+        },
+        "id": "input-" + form.registered_company_name.name,
+        "name": form.registered_company_name.name,
+        "errorMessage": errors.registered_company_name.errorMessage if errors.registered_company_name.errorMessage,
+        "value": form.registered_company_name.data if form.registered_company_name.data
+      })}}
 
-        {{ govukButton({
-          "text": "Save and return",
-        }) }}
+      {{ govukButton({
+        "text": "Save and return",
+      }) }}
 
-        <p class="govuk-body"><a class="govuk-link" href="{{ url_for('.supplier_details') }}">Return to company details</a></p>
-      </form>
-    </div>
+      <p class="govuk-body"><a class="govuk-link" href="{{ url_for('.supplier_details') }}">Return to company details</a></p>
+    </form>
   </div>
 </div>
 

--- a/app/templates/suppliers/edit_what_buyers_will_see.html
+++ b/app/templates/suppliers/edit_what_buyers_will_see.html
@@ -1,8 +1,7 @@
 {% extends "_base_page.html" %}
-{% import "toolkit/forms/macros/forms.html" as forms %}
 
 {% block pageTitle %}
-  What buyers will see – Digital Marketplace
+  {% if errors %} Error: {% endif %}What buyers will see – Digital Marketplace
 {% endblock %}
 
 {% block breadcrumb %}
@@ -32,35 +31,95 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
       <h1 class="govuk-heading-xl">What buyers will see</h1>
-
-      <div class="dmspeak">
-        <p class="govuk-body">This information will be visible on the Digital Marketplace.</p>
-        <p class="govuk-body">You can change it at any time.</p>
-      </div>
+      <p class="govuk-body">This information will be visible on the Digital Marketplace.</p>
+      <p class="govuk-body">You can change it at any time.</p>
     </div>
   </div>
-
-  <form action="{{ url_for('.edit_what_buyers_will_see') }}" method="post">
-
-  <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-      {{ form.contactName }}
-      {{ form.email }}
-      {{ form.phoneNumber }}
-      {{ form.description }}
+      <form action="{{ url_for('.edit_what_buyers_will_see') }}" method="post" novalidate>
+
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+
+        {{ govukInput({
+          "label": {
+            "text": form.contactName.label.text,
+            "classes": "govuk-label--m",
+            "attributes": {"id": form.contactName.name}
+          },
+          "hint": {
+            "text": form.contactName.hint
+          },
+          "id": "input-" + form.contactName.name,
+          "name": form.contactName.name,
+          "errorMessage": errors.contactName.errorMessage if errors.contactName.errorMessage,
+          "value": form.contactName.data if form.contactName.data
+        })}}
+
+        {{ govukInput({
+          "label": {
+            "text": form.email.label.text,
+            "classes": "govuk-label--m",
+            "attributes": {"id": form.email.name}
+          },
+          "hint": {
+            "text": form.email.hint
+          },
+          "autocomplete": "email",
+          "id": "input-" + form.email.name,
+          "name": form.email.name,
+          "type": "email",
+          "spellcheck": false,
+          "errorMessage": errors.email.errorMessage if errors.email.errorMessage,
+          "value": form.email.data if form.email.data
+        })}}
+
+        {{ govukInput({
+          "label": {
+            "text": form.phoneNumber.label.text,
+            "classes": "govuk-label--m",
+            "attributes": {"id": form.phoneNumber.name}
+          },
+          "hint": {
+            "text": form.phoneNumber.hint
+          },
+          "autocomplete": "tel",
+          "id": "input-" + form.phoneNumber.name,
+          "name": form.phoneNumber.name,
+          "type": "tel",
+          "errorMessage": errors.phoneNumber.errorMessage if errors.phoneNumber.errorMessage,
+          "value": form.phoneNumber.data if form.phoneNumber.data
+        })}}
+
+        {{ govukCharacterCount({
+          "label": {
+            "text": form.description.question,
+            "classes": "govuk-label--m",
+            "attributes": {"id": "description"}
+          },
+          "hint": {
+            "html": form.description.hint,
+            "classes": "dm-question-advice"
+          },
+          "errorMessage": errors.description.errorMessage,
+          "id": "input-" + form.description.name,
+          "name": form.description.name,
+          "value": form.description.data if form.description.data,
+          "maxwords": 50
+        }) }}
+
+        {{ govukButton({
+          "text": "Save and return",
+        }) }}
+        <p class="govuk-body">
+          <a class="govuk-link" href="{{ url_for('.supplier_details') }}">Return to company details</a>
+        </p>
+
+      </form>
 
     </div>
   </div>
-
-  {{ govukButton({
-    "text": "Save and return",
-  }) }}
-  <p class="govuk-body">
-    <a class="govuk-link" href="{{ url_for('.supplier_details') }}">Return to company details</a>
-  </p>
-  </form>
 
 {% endblock %}

--- a/app/templates/suppliers/registered_address.html
+++ b/app/templates/suppliers/registered_address.html
@@ -6,7 +6,7 @@
   {{ super() }}
 {% endblock %}
 {% block pageTitle %}
-  Registered address – Digital Marketplace
+  {% if errors %}Error: {% endif %}Registered address – Digital Marketplace
 {% endblock %}
 
 {% block breadcrumb %}
@@ -34,59 +34,110 @@
 
 {% block mainContent %}
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-full">
-      <h1 class="govuk-heading-l">What is your registered office address?</h1>
-    </div>
-  </div>
-
-  <form action="{{ url_for('.edit_registered_address') }}" method="post">
-
-  <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
-
-  <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-      {{ form.street }}
-      {{ form.city }}
-      {{ form.postcode }}
+      <form action="{{ url_for('.edit_registered_address') }}" method="post" novalidate>
 
-      {# TODO: make sure this is using the standard GOV.UK design system location autocomplete #}
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
 
-      {% set ns = namespace(countries = []) %}
-      {% if not form.country.data %}
-        {% set c = ns.countries.append({"value": "", "text": "", "selected": not form.country.data }) %}
-      {% endif %}
+        {% call govukFieldset({
+          "legend": {
+            "text": "What is your registered office address?",
+            "classes": "govuk-fieldset__legend--l",
+            "isPageHeading": true
+          }
+        }) %}
 
-      {% for country in countries %}
-        {% set c = ns.countries.append({"value": country[1], "text": country[0], "selected": form.country.data == country[1] }) %}
-      {% endfor %}
+          {{ govukInput({
+            "label": {
+              "text": form.street.label.text,
+              "classes": "govuk-label--m",
+              "attributes": {"id": form.street.name}
+            },
+            "hint": {
+              "text": form.street.hint
+            },
+            "id": "input-" + form.street.name,
+            "name": form.street.name,
+            "autocomplete": "street-address",
+            "errorMessage": errors.street.errorMessage if errors.street.errorMessage,
+            "value": form.street.data if form.street.data
+          })}}
 
-      {{ govukSelect({
-        "id": "input-" + form.country.name,
-        "name": form.country.name,
-        "classes": "location-autocomplete-fallback govuk-input--width-10",
-        "label": {
-          "text": "Country",
-          "classes": "govuk-label--m",
-        },
-        "hint": {
-          "text": form.country.hint
-        } if form.country.hint,
-        "items": ns.countries,
-        "errorMessage": errors.country.errorMessage if errors.country.errorMessage,
-        "value": form.country.data if form.country.data
-      })}}
+          {{ govukInput({
+            "label": {
+              "text": form.city.label.text,
+              "classes": "govuk-label--m",
+              "attributes": {"id": form.city.name}
+            },
+            "hint": {
+              "text": form.city.hint
+            },
+            "classes": "govuk-!-width-two-thirds",
+            "id": "input-" + form.city.name,
+            "name": form.city.name,
+            "autocomplete": "address-town",
+            "errorMessage": errors.city.errorMessage if errors.city.errorMessage,
+            "value": form.city.data if form.city.data
+          })}}
 
-      {{ govukButton({
-        "text": "Save and return",
-      }) }}
+          {{ govukInput({
+            "label": {
+              "text": form.postcode.label.text,
+              "classes": "govuk-label--m",
+              "attributes": {"id": form.postcode.name}
+            },
+            "hint": {
+              "text": form.postcode.hint
+            },
+            "classes": "govuk-input--width-10",
+            "id": "input-" + form.postcode.name,
+            "name": form.postcode.name,
+            "autocomplete": "address-town",
+            "errorMessage": errors.postcode.errorMessage if errors.postcode.errorMessage,
+            "value": form.postcode.data if form.postcode.data
+          })}}
+
+          {# TODO: make sure this is using the standard GOV.UK design system location autocomplete #}
+
+          {% set ns = namespace(countries = []) %}
+          {% if not form.country.data %}
+            {% set c = ns.countries.append({"value": "", "text": "", "selected": not form.country.data }) %}
+          {% endif %}
+
+          {% for country in countries %}
+            {% set c = ns.countries.append({"value": country[1], "text": country[0], "selected": form.country.data == country[1] }) %}
+          {% endfor %}
+
+          {{ govukSelect({
+            "id": "input-" + form.country.name,
+            "name": form.country.name,
+            "classes": "location-autocomplete-fallback govuk-input--width-10",
+            "label": {
+              "text": "Country",
+              "classes": "govuk-label--m",
+            },
+            "hint": {
+              "text": form.country.hint
+            } if form.country.hint,
+            "items": ns.countries,
+            "errorMessage": errors.country.errorMessage if errors.country.errorMessage,
+            "value": form.country.data if form.country.data
+          })}}
+
+        {% endcall %}
+
+        {{ govukButton({
+          "text": "Save and return",
+        }) }}
+        <p class="govuk-body">
+          <a class="govuk-link" href="{{ url_for('.supplier_details') }}">Return to company details</a>
+        </p>
+
+      </form>
 
     </div>
   </div>
-  <p class="govuk-body">
-    <a class="govuk-link" href="{{ url_for('.supplier_details') }}">Return to company details</a>
-  </p>
-</form>
 {% endblock %}
 
 {% block pageScripts %}

--- a/tests/app/helpers.py
+++ b/tests/app/helpers.py
@@ -550,15 +550,20 @@ class BaseApplicationTest:
         masthead_heading = doc.xpath('normalize-space(//h2[@class="govuk-error-summary__title"]/text())')
         masthead_link_text = doc.xpath(
             "normalize-space(//ul[contains(@class, 'govuk-error-summary__list')]/li/a/text())")
-        validation_text = doc.xpath('normalize-space(//span[@class="validation-message"]/text())')
+        error_message_span = doc.xpath('//span[@class="govuk-error-message"]')
+        # TODO: When all error messages are govuk-frontend, we can simplify this
+        if error_message_span:
+            error_message = error_message_span[0].text_content().strip()
+        else:
+            error_message = doc.xpath('normalize-space(//span[@class="validation-message"]/text())')
 
         assert res.status_code == 400
         assert masthead_heading and title == masthead_heading, \
             f"Expected '{title}' == '{masthead_heading}'"
         assert masthead_link_text and question_name == masthead_link_text, \
             f"Expected '{question_name}' == '{masthead_link_text}'"
-        assert validation_text and validation_message == validation_text, \
-            f"Expected '{validation_message}' == '{validation_text}'"
+        assert error_message and validation_message == error_message, \
+            f"Expected '{validation_message}' == '{error_message}'"
 
 
 class FakeMail(object):

--- a/tests/app/main/test_suppliers.py
+++ b/tests/app/main/test_suppliers.py
@@ -1347,10 +1347,7 @@ class TestSupplierUpdate(BaseApplicationTest):
         for xpath_selector, expected_content in [
             ("[contains(@class, 'govuk-error-summary__list')]/li/a", "Enter a contact name."),
             ("[contains(@class, 'govuk-error-summary__list')]/li/a", "Enter an email address."),
-            ("[contains(@class, 'govuk-error-summary__list')]/li/a", "Enter a phone number."),
-            ("[@class='validation-message']", "Enter a contact name."),
-            ("[@class='validation-message']", "Enter an email address."),
-            ("[@class='validation-message']", "Enter a phone number."),
+            ("[contains(@class, 'govuk-error-summary__list')]/li/a", "Enter a phone number.")
         ]:
             assert doc.xpath(
                 f"//*{xpath_selector}[normalize-space(string())='{expected_content}']"
@@ -1374,9 +1371,7 @@ class TestSupplierUpdate(BaseApplicationTest):
 
         for xpath_selector, expected_content in [
             ("[contains(@class, 'govuk-error-summary__list')]/li/a", "Enter a phone number under 20 characters."),
-            ("[contains(@class, 'govuk-error-summary__list')]/li/a", "Enter a contact name under 256 characters."),
-            ("[@class='validation-message']", "Enter a contact name under 256 characters."),
-            ("[@class='validation-message']", "Enter a phone number under 20 characters."),
+            ("[contains(@class, 'govuk-error-summary__list')]/li/a", "Enter a contact name under 256 characters.")
         ]:
             assert doc.xpath(
                 f"//*{xpath_selector}[normalize-space(string())='{expected_content}']"
@@ -1396,8 +1391,7 @@ class TestSupplierUpdate(BaseApplicationTest):
         doc = html.fromstring(response)
 
         for xpath_selector, expected_content in [
-            ("[contains(@class, 'govuk-error-summary__list')]/li/a", "Enter a valid email address."),
-            ("[@class='validation-message']", "Enter a valid email address."),
+            ("[contains(@class, 'govuk-error-summary__list')]/li/a", "Enter a valid email address.")
         ]:
             assert doc.xpath(
                 f"//*{xpath_selector}[normalize-space(string())='{expected_content}']"
@@ -2649,7 +2643,7 @@ class TestSupplierAddRegisteredCompanyName(BaseApplicationTest):
         self.assert_single_question_page_validation_errors(
             res,
             question_name="Enter your registered company name.",
-            validation_message="Enter your registered company name."
+            validation_message="Error: Enter your registered company name."
         )
         assert self.data_api_client.update_supplier.call_args_list == []
 
@@ -2683,7 +2677,7 @@ class TestSupplierAddRegisteredCompanyName(BaseApplicationTest):
         page_heading = doc.xpath('//h1')
 
         assert res.status_code == 200
-        assert page_heading[0].text.strip() == "Registered company name"
+        assert page_heading[0].text_content().strip() == "Registered company name"
         assert doc.xpath('//form[@action="/suppliers/registered-company-name/edit"]')
         assert self.data_api_client.update_supplier.call_args_list == []
 
@@ -2941,7 +2935,7 @@ class TestSupplierAddRegistrationNumber(BaseApplicationTest):
         page_heading = doc.xpath('//h1')
 
         assert res.status_code == 200
-        assert page_heading[0].text.strip() == "Are you registered with Companies House?"
+        assert page_heading[0].text_content().strip() == "Are you registered with Companies House?"
         assert doc.xpath('//form[@action="/suppliers/registration-number/edit"]')
         assert self.data_api_client.update_supplier.call_args_list == []
 


### PR DESCRIPTION
This replaces our Frontend Toolkit text fields with GOV.UK Design System equivalents for the Confirm Company Details journey.

https://trello.com/c/gQM1Rikz/895-2-replace-text-boxes-with-govuk-frontend-text-input-component-in-confirm-company-details-journey

https://trello.com/c/duej3OKP/894-1-replace-large-text-boxes-with-govuk-frontend-charactercount-component-in-confirm-company-details-journey