### PR TITLE
Replace radio on supplier trading status page

### DIFF
--- a/app/main/forms/suppliers.py
+++ b/app/main/forms/suppliers.py
@@ -252,8 +252,16 @@ class CompanyTradingStatusForm(FlaskForm):
         },
     ]
 
-    trading_status = DMRadioField(
+    trading_status = RadioField(
         "What’s your trading status?",
-        hint="This information will be used to find out about the types of companies on frameworks.",
         validators=[InputRequired(message="You must choose a trading status.")],
-        options=OPTIONS)
+        choices=[(option["value"], option["label"]) for option in OPTIONS],
+        id="input-trading_status-1"  # TODO: change to input-reuse when on govuk-frontend~3
+    )
+
+    def get_items(self):
+        return [
+            {'value': value, 'text': text, 'checked': checked}
+            for (value, text, checked)
+            in self.trading_status.iter_choices()
+        ]

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -428,7 +428,6 @@ def edit_supplier_organisation_size():
 @main.route('/trading-status/edit', methods=['GET', 'POST'])
 @login_required
 def edit_supplier_trading_status():
-
     prefill_data = {}
     if request.method == "GET":
         supplier = data_api_client.get_supplier(current_user.supplier_id)['suppliers']

--- a/app/templates/suppliers/edit_supplier_trading_status.html
+++ b/app/templates/suppliers/edit_supplier_trading_status.html
@@ -1,7 +1,9 @@
 {% extends "_base_page.html" %}
 
+{% set page_name = "Trading status" %}
+
 {% block pageTitle %}
-  Trading status – Digital Marketplace
+  {% if errors %}Error: {% endif %}{{ page_name }} – Digital Marketplace
 {% endblock %}
 
 {% block breadcrumb %}
@@ -20,7 +22,7 @@
         "href": url_for('.supplier_details')
       },
       {
-        "text": "Trading status"
+        "text": page_name
       }
     ]
   }) }}
@@ -31,12 +33,27 @@
 <div class="single-question-page">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-l">What&rsquo;s your trading status?</h1>
-
       <form method="POST" action="{{ url_for('.edit_supplier_trading_status') }}">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
 
-        {{ form.trading_status }}
+        {{ govukRadios({
+          "idPrefix": "input-" + form.trading_status.name,
+          "name": form.trading_status.name,
+          "hint": {
+            "text": "This information will be used to find out about the types of companies on frameworks.",
+          },
+          "fieldset": {
+            "legend": {
+              "text": form.trading_status.label.text,
+              "classes": "govuk-fieldset__legend--l",
+              "isPageHeading": true,
+            }
+          },
+          "errorMessage": {
+              "text": errors.get(form.trading_status.name, {}).get('message', None)
+            } if errors,
+          "items": form.get_items()
+        }) }}
 
         {{ govukButton({
           "text": "Save and return",

--- a/app/templates/suppliers/edit_supplier_trading_status.html
+++ b/app/templates/suppliers/edit_supplier_trading_status.html
@@ -33,7 +33,7 @@
 <div class="single-question-page">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <form method="POST" action="{{ url_for('.edit_supplier_trading_status') }}">
+      <form method="POST" action="{{ url_for('.edit_supplier_trading_status') }}" novalidate>
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
 
         {{ govukRadios({

--- a/app/templates/suppliers/edit_supplier_trading_status.html
+++ b/app/templates/suppliers/edit_supplier_trading_status.html
@@ -30,38 +30,36 @@
 
 {% block mainContent %}
 
-<div class="single-question-page">
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <form method="POST" action="{{ url_for('.edit_supplier_trading_status') }}" novalidate>
-        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <form method="POST" action="{{ url_for('.edit_supplier_trading_status') }}" novalidate>
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
 
-        {{ govukRadios({
-          "idPrefix": "input-" + form.trading_status.name,
-          "name": form.trading_status.name,
-          "hint": {
-            "text": "This information will be used to find out about the types of companies on frameworks.",
-          },
-          "fieldset": {
-            "legend": {
-              "text": form.trading_status.label.text,
-              "classes": "govuk-fieldset__legend--l",
-              "isPageHeading": true,
-            }
-          },
-          "errorMessage": {
-              "text": errors.get(form.trading_status.name, {}).get('message', None)
-            } if errors,
-          "items": form.get_items()
-        }) }}
+      {{ govukRadios({
+        "idPrefix": "input-" + form.trading_status.name,
+        "name": form.trading_status.name,
+        "hint": {
+          "text": "This information will be used to find out about the types of companies on frameworks.",
+        },
+        "fieldset": {
+          "legend": {
+            "text": form.trading_status.label.text,
+            "classes": "govuk-fieldset__legend--l",
+            "isPageHeading": true,
+          }
+        },
+        "errorMessage": {
+            "text": errors.get(form.trading_status.name, {}).get('message', None)
+          } if errors,
+        "items": form.get_items()
+      }) }}
 
-        {{ govukButton({
-          "text": "Save and return",
-        }) }}
+      {{ govukButton({
+        "text": "Save and return",
+      }) }}
 
-        <p class="govuk-body"><a class="govuk-link" href="{{ url_for('.supplier_details') }}">Return to company details</a></p>
-      </form>
-    </div>
+      <p class="govuk-body"><a class="govuk-link" href="{{ url_for('.supplier_details') }}">Return to company details</a></p>
+    </form>
   </div>
 </div>
 

--- a/tests/app/helpers.py
+++ b/tests/app/helpers.py
@@ -562,8 +562,8 @@ class BaseApplicationTest:
             f"Expected '{title}' == '{masthead_heading}'"
         assert masthead_link_text and question_name == masthead_link_text, \
             f"Expected '{question_name}' == '{masthead_link_text}'"
-        assert error_message and validation_message == error_message, \
-            f"Expected '{validation_message}' == '{error_message}'"
+        assert error_message and validation_message in error_message, \
+            f"Expected '{validation_message}' in '{error_message}'"
 
 
 class FakeMail(object):

--- a/tests/app/main/test_suppliers.py
+++ b/tests/app/main/test_suppliers.py
@@ -2732,11 +2732,12 @@ class TestSupplierEditTradingStatus(BaseApplicationTest):
         res = self.client.post("/suppliers/trading-status/edit",
                                data={'trading_status': trading_status} if trading_status else {})
         doc = html.fromstring(res.get_data(as_text=True))
-        error = doc.xpath('//span[@id="error-trading_status"]')
+        error = doc.xpath('//span[@id="input-trading_status-error"]')
 
         assert len(error) == 1, 'Only one validation message should be shown.'
 
-        assert error[0].text.strip() == expected_error, 'The validation message is not as anticipated.'
+        assert error[0].text_content().strip() == f"Error: {expected_error}", \
+            'The validation message is not as anticipated.'
 
         self.assert_single_question_page_validation_errors(res,
                                                            question_name=expected_error,


### PR DESCRIPTION
Trello: https://trello.com/c/aYM0E0zY/896-2-replace-radios-with-govuk-frontend-radios-component-in-confirm-company-details-journey

As part of moving to Design System 3, we need to replace our use of `toolkit/forms/selection-buttons.html` with `govukRadios` from the design system. This should make this page more accessible.

As part of this, we're also moving away from our customised DMRadioField to the standard wtforms equivalent.

We've added a helper method in `CompanyTradingStatusForm` to get the items in the right format for `govukRadios`. We're not sure this is the right way to do this - we'll refactor as necessary when we come to replace the other radios in the supplier details journey.