### PR TITLE
Replace radio on organisation size page 

### DIFF
--- a/app/main/forms/suppliers.py
+++ b/app/main/forms/suppliers.py
@@ -1,5 +1,3 @@
-from itertools import zip_longest
-
 from flask_wtf import FlaskForm
 from wtforms import RadioField
 from wtforms.validators import AnyOf, InputRequired, Length, Optional, Regexp, ValidationError
@@ -221,14 +219,6 @@ class CompanyOrganisationSizeForm(FlaskForm):
         id="input-organisation_size-1"  # TODO: change to input-organisation_size when on govuk-frontend~3
     )
 
-    def get_items(self):
-        # Will throw an exception if the two input iterators are of different length, but that should never happen.
-        return [
-            {'value': value, 'text': text, 'checked': checked, 'hint': {'text': option['description']}}
-            for ((value, text, checked), option)
-            in zip_longest(self.organisation_size.iter_choices(), self.OPTIONS)
-        ]
-
 
 class CompanyTradingStatusForm(FlaskForm):
     OPTIONS = [
@@ -268,10 +258,3 @@ class CompanyTradingStatusForm(FlaskForm):
         choices=[(option["value"], option["label"]) for option in OPTIONS],
         id="input-trading_status-1"  # TODO: change to input-trading_status when on govuk-frontend~3
     )
-
-    def get_items(self):
-        return [
-            {'value': value, 'text': text, 'checked': checked}
-            for (value, text, checked)
-            in self.trading_status.iter_choices()
-        ]

--- a/app/main/forms/suppliers.py
+++ b/app/main/forms/suppliers.py
@@ -1,8 +1,10 @@
+from itertools import zip_longest
+
 from flask_wtf import FlaskForm
 from wtforms import RadioField
 from wtforms.validators import AnyOf, InputRequired, Length, Optional, Regexp, ValidationError
 
-from dmutils.forms.fields import DMBooleanField, DMStripWhitespaceStringField, DMEmailField, DMRadioField
+from dmutils.forms.fields import DMBooleanField, DMStripWhitespaceStringField, DMEmailField
 from dmutils.forms.validators import EmailValidator
 from dmutils.forms.widgets import DMTextArea
 from ..helpers.suppliers import COUNTRY_TUPLE
@@ -212,12 +214,20 @@ class CompanyOrganisationSizeForm(FlaskForm):
         },
     ]
 
-    organisation_size = DMRadioField(
+    organisation_size = RadioField(
         "What size is your organisation?",
-        hint="This information will be used to report on the number of contracts that go"
-        " to small and medium sized enterprises (SMEs).",
         validators=[InputRequired(message="You must choose an organisation size.")],
-        options=OPTIONS)
+        choices=[(option["value"], option["label"]) for option in OPTIONS],
+        id="input-organisation_size-1"  # TODO: change to input-organisation_size when on govuk-frontend~3
+    )
+
+    def get_items(self):
+        # Will throw an exception if the two input iterators are of different length, but that should never happen.
+        return [
+            {'value': value, 'text': text, 'checked': checked, 'hint': {'text': option['description']}}
+            for ((value, text, checked), option)
+            in zip_longest(self.organisation_size.iter_choices(), self.OPTIONS)
+        ]
 
 
 class CompanyTradingStatusForm(FlaskForm):
@@ -256,7 +266,7 @@ class CompanyTradingStatusForm(FlaskForm):
         "What’s your trading status?",
         validators=[InputRequired(message="You must choose a trading status.")],
         choices=[(option["value"], option["label"]) for option in OPTIONS],
-        id="input-trading_status-1"  # TODO: change to input-reuse when on govuk-frontend~3
+        id="input-trading_status-1"  # TODO: change to input-trading_status when on govuk-frontend~3
     )
 
     def get_items(self):

--- a/app/templates/suppliers/edit_supplier_organisation_size.html
+++ b/app/templates/suppliers/edit_supplier_organisation_size.html
@@ -50,7 +50,7 @@
         "errorMessage": {
             "text": errors.get(form.organisation_size.name, {}).get('message', None)
           } if errors,
-        "items": form.get_items()
+        "items": form.organisation_size.govuk_options,
       }) }}
 
       {{ govukButton({

--- a/app/templates/suppliers/edit_supplier_organisation_size.html
+++ b/app/templates/suppliers/edit_supplier_organisation_size.html
@@ -1,7 +1,9 @@
 {% extends "_base_page.html" %}
 
+{% set page_name = "Organisation size" %}
+
 {% block pageTitle %}
-  Organisation size – Digital Marketplace
+  {% if errors %}Error: {% endif %}{{ page_name }} – Digital Marketplace
 {% endblock %}
 
 {% block breadcrumb %}
@@ -20,7 +22,7 @@
         "href": url_for('.supplier_details')
       },
       {
-        "text": "Organisation size"
+        "text": page_name
       }
     ]
   }) }}

--- a/app/templates/suppliers/edit_supplier_organisation_size.html
+++ b/app/templates/suppliers/edit_supplier_organisation_size.html
@@ -29,23 +29,36 @@
 {% endblock %}
 
 {% block mainContent %}
-<div class="single-question-page">
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-l">What size is your organisation?</h1>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <form method="POST" action="{{ url_for('.edit_supplier_organisation_size') }}" novalidate>
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
 
-      <form method="POST" action="{{ url_for('.edit_supplier_organisation_size') }}">
-        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+      {{ govukRadios({
+        "idPrefix": "input-" + form.organisation_size.name,
+        "name": form.organisation_size.name,
+        "hint": {
+          "text": "This information will be used to report on the number of contracts that go to small and medium sized enterprises (SMEs).",
+        },
+        "fieldset": {
+          "legend": {
+            "text": form.organisation_size.label.text,
+            "classes": "govuk-fieldset__legend--l",
+            "isPageHeading": true,
+          }
+        },
+        "errorMessage": {
+            "text": errors.get(form.organisation_size.name, {}).get('message', None)
+          } if errors,
+        "items": form.get_items()
+      }) }}
 
-        {{ form.organisation_size }}
+      {{ govukButton({
+        "text": "Save and return",
+      }) }}
 
-        {{ govukButton({
-          "text": "Save and return",
-        }) }}
-
-        <p class="govuk-body"><a class="govuk-link" href="{{ url_for('.supplier_details') }}">Return to company details</a></p>
-      </form>
-    </div>
+      <p class="govuk-body"><a class="govuk-link" href="{{ url_for('.supplier_details') }}">Return to company details</a></p>
+    </form>
   </div>
 </div>
 

--- a/app/templates/suppliers/edit_supplier_trading_status.html
+++ b/app/templates/suppliers/edit_supplier_trading_status.html
@@ -51,7 +51,7 @@
         "errorMessage": {
             "text": errors.get(form.trading_status.name, {}).get('message', None)
           } if errors,
-        "items": form.get_items()
+        "items": form.trading_status.govuk_options,
       }) }}
 
       {{ govukButton({

--- a/tests/app/main/test_suppliers.py
+++ b/tests/app/main/test_suppliers.py
@@ -2571,11 +2571,12 @@ class TestSupplierEditOrganisationSize(BaseApplicationTest):
         res = self.client.post("/suppliers/organisation-size/edit",
                                data={'organisation_size': organisation_size} if organisation_size else {})
         doc = html.fromstring(res.get_data(as_text=True))
-        error = doc.xpath('//span[@id="error-organisation_size"]')
+        error = doc.xpath('//span[@id="input-organisation_size-error"]')
 
         assert len(error) == 1, 'Only one validation message should be shown.'
 
-        assert error[0].text.strip() == expected_error, 'The validation message is not as anticipated.'
+        assert error[0].text_content().strip() == f"Error: {expected_error}", \
+            'The validation message is not as anticipated.'
 
         self.assert_single_question_page_validation_errors(
             res,


### PR DESCRIPTION
Trello: https://trello.com/c/aYM0E0zY/896-2-replace-radios-with-govuk-frontend-radios-component-in-confirm-company-details-journey

As part of moving to Design System 3, we need to replace our use of `toolkit/forms/selection-buttons.html` with `govukRadios` from the design system. This should make this page more accessible.

As part of this, we're also moving away from our customised DMRadioField to the standard wtforms equivalent.

Follows the example of #1396

---
Old:

![image](https://user-images.githubusercontent.com/15256121/113024846-21455c80-917f-11eb-9ea7-7f89ebd8b5ac.png)


New:

![image](https://user-images.githubusercontent.com/15256121/113024792-0ffc5000-917f-11eb-84d3-605c350650ba.png)
