### PR TITLE
Ask for company registration number with govukRadios 

### DIFF
--- a/app/templates/suppliers/edit_company_registration_number.html
+++ b/app/templates/suppliers/edit_company_registration_number.html
@@ -31,42 +31,71 @@
 <div class="single-question-page">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-l">Are you registered with Companies House?</h1>
-
-      <form method="POST" action="{{ url_for('.edit_supplier_registration_number') }}">
+      <form method="POST" action="{{ url_for('.edit_supplier_registration_number') }}" novalidate>
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
 
-        {%
-          with
-          name = "has_companies_house_number",
-          type = "radio",
-          value = form.has_companies_house_number.data,
-          error = errors.get("has_companies_house_number", {}).get("message", None),
-          options = [
-          {
-              "label": "Yes",
-              "reveal": {
-                "name": "companies_house_number",
-                "question": "Companies House number",
-                "hint": "<a class='govuk-link' href='https://beta.companieshouse.gov.uk/search/companies'>Find your 8 digit Companies House number</a>"|safe,
-                "value": form.companies_house_number.data,
-                "error": errors.get("companies_house_number", {}).get("message", None),
-              }
+        {% set companiesHouseNumberHtml %}
+        {{ govukInput({
+          "id": form.companies_house_number.id,
+          "name": form.companies_house_number.name,
+          "label": {
+            "text": "Companies House number"
           },
-          {
-              "label": "No",
-              "reveal": {
-                "name": "other_company_registration_number",
-                "question": "Enter a number that can be used to identify your business and provide details of the organisation that issued it.",
-                "hint": "For example, ‘0123456789, Unique Taxpayer Reference, HMRC, UK’",
-                "value": form.other_company_registration_number.data,
-                "error": errors.get("other_company_registration_number", {}).get("message", None),
-              }
-          }
-        ]
-      %}
-        {% include "toolkit/forms/selection-buttons.html" %}
-      {% endwith %}
+          "hint": {
+            "html": "<a class='govuk-link' href='https://beta.companieshouse.gov.uk/search/companies'>Find your 8 digit Companies House number</a>"|safe,
+          },
+          "value": form.companies_house_number.data if form.companies_house_number.data,
+          "errorMessage": {
+            "text": errors.get(form.companies_house_number.name, {}).get('message', None)
+          } if errors and form.companies_house_number.name in errors,
+        }) }}
+        {% endset -%}
+
+        {% set otherCompanyRegistrationNumberHtml %}
+        {{ govukInput({
+          "id": form.other_company_registration_number.id,
+          "name": form.other_company_registration_number.name,
+          "label": {
+            "text": "Enter a number that can be used to identify your business and provide details of the organisation that issued it."
+          },
+          "hint": {
+            "text": "For example, ‘0123456789, Unique Taxpayer Reference, HMRC, UK’",
+          },
+          "value": form.other_company_registration_number.data if form.other_company_registration_number.data,
+          "errorMessage": {
+            "text": errors.get(form.other_company_registration_number.name, {}).get('message', None)
+          } if errors and form.other_company_registration_number.name in errors,
+        }) }}
+        {% endset -%}
+
+        {{ govukRadios({
+          "idPrefix": "input-" + form.has_companies_house_number.name,
+          "name": form.has_companies_house_number.name,
+          "fieldset": {
+            "legend": {
+              "text": form.has_companies_house_number.label.text,
+              "classes": "govuk-fieldset__legend--l",
+              "isPageHeading": true,
+            }
+          },
+          "errorMessage": {
+              "text": errors.get(form.has_companies_house_number.name, {}).get('message', None)
+            } if errors and form.has_companies_house_number.name in errors,
+          "items": [
+            {
+              "value": "Yes",
+              "text": "Yes",
+              "conditional": {"html": companiesHouseNumberHtml},
+              "checked": form.has_companies_house_number.data == "Yes",
+            },
+            {
+              "value": "No",
+              "text": "No",
+              "conditional": {"html": otherCompanyRegistrationNumberHtml},
+              "checked": form.has_companies_house_number.data == "No",
+            },
+          ]
+        }) }}
 
         {{ govukButton({
           "text": "Save and return",

--- a/app/templates/suppliers/edit_company_registration_number.html
+++ b/app/templates/suppliers/edit_company_registration_number.html
@@ -28,82 +28,80 @@
 
 {% block mainContent %}
 
-<div class="single-question-page">
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <form method="POST" action="{{ url_for('.edit_supplier_registration_number') }}" novalidate>
-        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <form method="POST" action="{{ url_for('.edit_supplier_registration_number') }}" novalidate>
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
 
-        {% set companiesHouseNumberHtml %}
-        {{ govukInput({
-          "id": form.companies_house_number.id,
-          "name": form.companies_house_number.name,
-          "label": {
-            "text": "Companies House number"
-          },
-          "hint": {
-            "html": "<a class='govuk-link' href='https://beta.companieshouse.gov.uk/search/companies'>Find your 8 digit Companies House number</a>"|safe,
-          },
-          "value": form.companies_house_number.data if form.companies_house_number.data,
-          "errorMessage": {
-            "text": errors.get(form.companies_house_number.name, {}).get('message', None)
-          } if errors and form.companies_house_number.name in errors,
-        }) }}
-        {% endset -%}
+      {% set companiesHouseNumberHtml %}
+      {{ govukInput({
+        "id": form.companies_house_number.id,
+        "name": form.companies_house_number.name,
+        "label": {
+          "text": "Companies House number"
+        },
+        "hint": {
+          "html": "<a class='govuk-link' href='https://beta.companieshouse.gov.uk/search/companies'>Find your 8 digit Companies House number</a>"|safe,
+        },
+        "value": form.companies_house_number.data if form.companies_house_number.data,
+        "errorMessage": {
+          "text": errors.get(form.companies_house_number.name, {}).get('message', None)
+        } if errors and form.companies_house_number.name in errors,
+      }) }}
+      {% endset -%}
 
-        {% set otherCompanyRegistrationNumberHtml %}
-        {{ govukInput({
-          "id": form.other_company_registration_number.id,
-          "name": form.other_company_registration_number.name,
-          "label": {
-            "text": "Enter a number that can be used to identify your business and provide details of the organisation that issued it."
-          },
-          "hint": {
-            "text": "For example, ‘0123456789, Unique Taxpayer Reference, HMRC, UK’",
-          },
-          "value": form.other_company_registration_number.data if form.other_company_registration_number.data,
-          "errorMessage": {
-            "text": errors.get(form.other_company_registration_number.name, {}).get('message', None)
-          } if errors and form.other_company_registration_number.name in errors,
-        }) }}
-        {% endset -%}
+      {% set otherCompanyRegistrationNumberHtml %}
+      {{ govukInput({
+        "id": form.other_company_registration_number.id,
+        "name": form.other_company_registration_number.name,
+        "label": {
+          "text": "Enter a number that can be used to identify your business and provide details of the organisation that issued it."
+        },
+        "hint": {
+          "text": "For example, ‘0123456789, Unique Taxpayer Reference, HMRC, UK’",
+        },
+        "value": form.other_company_registration_number.data if form.other_company_registration_number.data,
+        "errorMessage": {
+          "text": errors.get(form.other_company_registration_number.name, {}).get('message', None)
+        } if errors and form.other_company_registration_number.name in errors,
+      }) }}
+      {% endset -%}
 
-        {{ govukRadios({
-          "idPrefix": "input-" + form.has_companies_house_number.name,
-          "name": form.has_companies_house_number.name,
-          "fieldset": {
-            "legend": {
-              "text": form.has_companies_house_number.label.text,
-              "classes": "govuk-fieldset__legend--l",
-              "isPageHeading": true,
-            }
+      {{ govukRadios({
+        "idPrefix": "input-" + form.has_companies_house_number.name,
+        "name": form.has_companies_house_number.name,
+        "fieldset": {
+          "legend": {
+            "text": form.has_companies_house_number.label.text,
+            "classes": "govuk-fieldset__legend--l",
+            "isPageHeading": true,
+          }
+        },
+        "errorMessage": {
+            "text": errors.get(form.has_companies_house_number.name, {}).get('message', None)
+          } if errors and form.has_companies_house_number.name in errors,
+        "items": [
+          {
+            "value": "Yes",
+            "text": "Yes",
+            "conditional": {"html": companiesHouseNumberHtml},
+            "checked": form.has_companies_house_number.data == "Yes",
           },
-          "errorMessage": {
-              "text": errors.get(form.has_companies_house_number.name, {}).get('message', None)
-            } if errors and form.has_companies_house_number.name in errors,
-          "items": [
-            {
-              "value": "Yes",
-              "text": "Yes",
-              "conditional": {"html": companiesHouseNumberHtml},
-              "checked": form.has_companies_house_number.data == "Yes",
-            },
-            {
-              "value": "No",
-              "text": "No",
-              "conditional": {"html": otherCompanyRegistrationNumberHtml},
-              "checked": form.has_companies_house_number.data == "No",
-            },
-          ]
-        }) }}
+          {
+            "value": "No",
+            "text": "No",
+            "conditional": {"html": otherCompanyRegistrationNumberHtml},
+            "checked": form.has_companies_house_number.data == "No",
+          },
+        ]
+      }) }}
 
-        {{ govukButton({
-          "text": "Save and return",
-        }) }}
+      {{ govukButton({
+        "text": "Save and return",
+      }) }}
 
-        <p class="govuk-body"><a class="govuk-link" href="{{ url_for('.supplier_details') }}">Return to company details</a></p>
-      </form>
-    </div>
+      <p class="govuk-body"><a class="govuk-link" href="{{ url_for('.supplier_details') }}">Return to company details</a></p>
+    </form>
   </div>
 </div>
 

--- a/app/templates/suppliers/edit_company_registration_number.html
+++ b/app/templates/suppliers/edit_company_registration_number.html
@@ -1,7 +1,9 @@
 {% extends "_base_page.html" %}
 
+{% set page_name = "Company registration number" %}
+
 {% block pageTitle %}
-  Company registration number – Digital Marketplace
+  {% if errors %}Error: {% endif %}{{ page_name }} – Digital Marketplace
 {% endblock %}
 
 {% block breadcrumb %}
@@ -20,7 +22,7 @@
         "href": url_for('.supplier_details')
       },
       {
-        "text": "Company registration number"
+        "text": page_name,
       }
     ]
   }) }}


### PR DESCRIPTION
Trello: https://trello.com/c/aYM0E0zY/896-2-replace-radios-with-govuk-frontend-radios-component-in-confirm-company-details-journey

As part of moving to Design System 3, we need to replace our use of toolkit/forms/selection-buttons.html with govukRadios from the design system. This should make this page more accessible.

This question is quite complex, so the template is quite lengthy. However, quite a bit of that is just caused by the govukRadios being a bit more verbose and having more braces.

Similar to #1396 and #1401, though this question doesn't use `DMRadioField`, so this PR only needs to make template changes.

The overall diff is not very helpful - recommend reviewing commit by commit instead.

---

Old:
![image](https://user-images.githubusercontent.com/15256121/113152978-902dbe80-922e-11eb-89f7-d434717ca7e6.png)

New:
![image](https://user-images.githubusercontent.com/15256121/113153073-a63b7f00-922e-11eb-9dc0-dea775ea46e0.png)
