### PR TITLE
Improve the link to Companies House

### DIFF
--- a/app/templates/suppliers/edit_company_registration_number.html
+++ b/app/templates/suppliers/edit_company_registration_number.html
@@ -43,7 +43,7 @@
           "text": "Companies House number"
         },
         "hint": {
-          "html": "<a class='govuk-link' href='https://beta.companieshouse.gov.uk/search/companies'>Find your 8 digit Companies House number</a>"|safe,
+          "html": "<a target='_blank' rel='noopener noreferrer' class='govuk-link' href='https://beta.companieshouse.gov.uk/search/companies'>Find your 8 digit Companies House number</a>"|safe,
         },
         "value": form.companies_house_number.data if form.companies_house_number.data,
         "errorMessage": {

--- a/app/templates/suppliers/edit_company_registration_number.html
+++ b/app/templates/suppliers/edit_company_registration_number.html
@@ -43,7 +43,7 @@
           "text": "Companies House number"
         },
         "hint": {
-          "html": "<a target='_blank' rel='noopener noreferrer' class='govuk-link' href='https://find-and-update.company-information.service.gov.uk/search/companies'>Find your 8 digit Companies House number</a>"|safe,
+          "html": "<a target='_blank' rel='noopener noreferrer' class='govuk-link' href='https://find-and-update.company-information.service.gov.uk/search/companies'>Find your 8 digit Companies House number (opens in new tab)</a>"|safe,
         },
         "value": form.companies_house_number.data if form.companies_house_number.data,
         "errorMessage": {

--- a/app/templates/suppliers/edit_company_registration_number.html
+++ b/app/templates/suppliers/edit_company_registration_number.html
@@ -43,7 +43,7 @@
           "text": "Companies House number"
         },
         "hint": {
-          "html": "<a target='_blank' rel='noopener noreferrer' class='govuk-link' href='https://beta.companieshouse.gov.uk/search/companies'>Find your 8 digit Companies House number</a>"|safe,
+          "html": "<a target='_blank' rel='noopener noreferrer' class='govuk-link' href='https://find-and-update.company-information.service.gov.uk/search/companies'>Find your 8 digit Companies House number</a>"|safe,
         },
         "value": form.companies_house_number.data if form.companies_house_number.data,
         "errorMessage": {


### PR DESCRIPTION
Set it to open in a new tab, which should be more helpful for users. Also update the link to point to the current Companies House search page, which is what the old beta page redirected to.

Addresses https://github.com/alphagov/digitalmarketplace-supplier-frontend/pull/1403#discussion_r605038994