### PR TITLE
 update Company Details error messages to be more in line with Design System examples 

### DIFF
--- a/app/main/forms/suppliers.py
+++ b/app/main/forms/suppliers.py
@@ -102,7 +102,7 @@ class AddCompanyRegistrationNumberForm(FlaskForm):
         validators=[
             Optional(),
             Regexp(r'^([0-9]{2}|[A-Za-z]{2})[0-9]{6}$',
-                   message="Companies House number must be 8 characters"
+                   message="Your Companies House number must be 8 characters"
                    )
         ]
     )
@@ -165,7 +165,7 @@ class CompanyPublicContactInformationForm(FlaskForm):
 class DunsNumberForm(FlaskForm):
     duns_number = DMStripWhitespaceStringField('DUNS Number', validators=[
         InputRequired(message="Enter your 9 digit DUNS number"),
-        Regexp(r'^\d{9}$', message="DUNS number must be 9 digits"),
+        Regexp(r'^\d{9}$', message="Your DUNS number must be 9 digits"),
     ])
 
 

--- a/app/main/forms/suppliers.py
+++ b/app/main/forms/suppliers.py
@@ -27,21 +27,21 @@ class EditSupplierInformationForm(FlaskForm):
         "Contact name",
         hint="This can be the name of the person or team you want buyers to contact",
         validators=[
-            InputRequired(message="Enter a contact name."),
-            Length(max=255, message="Enter a contact name under 256 characters."),
+            InputRequired(message="Enter a contact name"),
+            Length(max=255, message="Contact name must be %(max)d characters or fewer"),
         ])
     email = DMEmailField(
         "Contact email address",
         hint="This is the email buyers will use to contact you",
         validators=[
-            InputRequired(message="Enter an email address."),
-            EmailValidator(message="Enter a valid email address."),
+            InputRequired(message="Enter an email address"),
+            EmailValidator(message="Enter an email address in the correct format, like name@example.com"),
         ])
     phoneNumber = DMStripWhitespaceStringField(
         "Contact phone number",
         validators=[
-            InputRequired(message="Enter a phone number."),
-            Length(max=20, message="Enter a phone number under 20 characters.")
+            InputRequired(message="Enter a phone number"),
+            Length(max=20, message="Phone number must be %(max)d characters or fewer")
         ])
     description = DMStripWhitespaceStringField(
         "Supplier summary",
@@ -54,20 +54,20 @@ class EditSupplierInformationForm(FlaskForm):
 
 class EditRegisteredAddressForm(FlaskForm):
     street = DMStripWhitespaceStringField("Building and street", validators=[
-        InputRequired(message="Enter a street address."),
-        Length(max=255, message="Enter a building and street name under 256 characters."),
+        InputRequired(message="Enter a street address"),
+        Length(max=255, message="Building and street name must be %(max)d characters or fewer"),
     ])
     city = DMStripWhitespaceStringField("Town or city", validators=[
-        InputRequired(message="Enter a town or city."),
-        Length(max=255, message="Enter a town or city name under 256 characters."),
+        InputRequired(message="Enter a town or city"),
+        Length(max=255, message="Town or city name must be %(max)d characters or fewer"),
     ])
     postcode = DMStripWhitespaceStringField("Postcode", validators=[
-        InputRequired(message="Enter a postcode."),
-        Length(max=15, message="Enter a valid postcode under 15 characters."),
+        InputRequired(message="Enter a postcode"),
+        Length(max=15, message="Postcode must be %(max)d characters or fewer"),
     ])
     country = DMStripWhitespaceStringField("Country", validators=[
-        InputRequired(message="Enter a country."),
-        AnyOf(values=[country[1] for country in COUNTRY_TUPLE], message="Enter a valid country."),
+        InputRequired(message="Enter a country"),
+        AnyOf(values=[country[1] for country in COUNTRY_TUPLE], message="Enter a valid country"),
     ])
 
     def validate(self):
@@ -83,8 +83,8 @@ class EditRegisteredAddressForm(FlaskForm):
 # "Add" rather than "Edit" because this information can only be set once by a supplier
 class AddCompanyRegisteredNameForm(FlaskForm):
     registered_company_name = DMStripWhitespaceStringField('Registered company name', validators=[
-        InputRequired(message="Enter your registered company name."),
-        Length(max=255, message="Enter a registered company name under 256 characters.")
+        InputRequired(message="Enter your registered company name"),
+        Length(max=255, message="Registered company must be %(max)d characters or fewer")
     ])
 
 
@@ -92,7 +92,7 @@ class AddCompanyRegistrationNumberForm(FlaskForm):
     has_companies_house_number = RadioField(
         "Are you registered with Companies House?",
         id="input-has_companies_house_number-1",
-        validators=[InputRequired(message="You need to answer this question.")],
+        validators=[InputRequired(message="Select yes if you are registered with Companies House")],
         choices=[('Yes', 'Yes'), ('No', 'No')]
     )
     companies_house_number = DMStripWhitespaceStringField(
@@ -102,7 +102,7 @@ class AddCompanyRegistrationNumberForm(FlaskForm):
         validators=[
             Optional(),
             Regexp(r'^([0-9]{2}|[A-Za-z]{2})[0-9]{6}$',
-                   message="Enter your 8 digit Companies House number."
+                   message="Companies House number must be 8 characters"
                    )
         ]
     )
@@ -112,7 +112,7 @@ class AddCompanyRegistrationNumberForm(FlaskForm):
         default='',
         validators=[
             Optional(),
-            Length(max=255, message="Enter a registration number under 256 characters.")
+            Length(max=255, message="Registration number must be %(max)d characters or fewer")
         ]
     )
 
@@ -133,11 +133,11 @@ class AddCompanyRegistrationNumberForm(FlaskForm):
         if not super(AddCompanyRegistrationNumberForm, self).validate():
             valid = False
         if self.has_companies_house_number.data == "Yes" and not self.companies_house_number.data:
-            self.companies_house_number.errors.append('Enter a Companies House number.')
+            self.companies_house_number.errors.append('Enter a Companies House number')
             valid = False
 
         if self.has_companies_house_number.data == "No" and not self.other_company_registration_number.data:
-            self.other_company_registration_number.errors.append('Enter a company registration number.')
+            self.other_company_registration_number.errors.append('Enter a company registration number')
             valid = False
 
         return valid
@@ -145,27 +145,27 @@ class AddCompanyRegistrationNumberForm(FlaskForm):
 
 class CompanyPublicContactInformationForm(FlaskForm):
     company_name = DMStripWhitespaceStringField('Company name', validators=[
-        InputRequired(message="Enter your company name."),
-        Length(max=255, message="Enter a company name under 256 characters.")
+        InputRequired(message="Enter your company name"),
+        Length(max=255, message="Company name must be %(max)d characters or fewer")
     ])
     contact_name = DMStripWhitespaceStringField('Contact name', validators=[
-        InputRequired(message="Enter a contact name."),
-        Length(max=255, message="Enter a contact name under 256 characters.")
+        InputRequired(message="Enter a contact name"),
+        Length(max=255, message="Contact name must be %(max)d characters or fewer")
     ])
     email_address = DMStripWhitespaceStringField('Contact email address', validators=[
-        InputRequired(message="Enter an email address."),
-        EmailValidator(message="Enter a valid email address."),
+        InputRequired(message="Enter an email address"),
+        EmailValidator(message="Enter an email address in the correct format, like name@example.com"),
     ])
     phone_number = DMStripWhitespaceStringField('Contact phone number', validators=[
-        InputRequired(message="Enter a phone number."),
-        Length(max=20, message="Enter a phone number under 20 characters.")
+        InputRequired(message="Enter a phone number"),
+        Length(max=20, message="Phone number must be %(max)d characters or fewer")
     ])
 
 
 class DunsNumberForm(FlaskForm):
     duns_number = DMStripWhitespaceStringField('DUNS Number', validators=[
-        InputRequired(message="Enter your 9 digit DUNS number."),
-        Regexp(r'^\d{9}$', message="Enter your 9 digit DUNS number."),
+        InputRequired(message="Enter your 9 digit DUNS number"),
+        Regexp(r'^\d{9}$', message="DUNS number must be 9 digits"),
     ])
 
 
@@ -173,14 +173,14 @@ class ConfirmCompanyForm(FlaskForm):
     confirmed = DMBooleanField(
         'Is this the company you want to create an account for?',
         false_values=("False", "false", ""),
-        validators=[InputRequired(message="Choose 'Yes' or 'No'.")]
+        validators=[InputRequired(message="Select yes if this is the company you want to create an account for")]
     )
 
 
 class EmailAddressForm(FlaskForm):
     email_address = DMStripWhitespaceStringField('Email address', validators=[
-        InputRequired(message="Enter an email address."),
-        EmailValidator(message="Enter a valid email address."),
+        InputRequired(message="Enter an email address"),
+        EmailValidator(message="Enter an email address in the correct format, like name@example.com"),
     ])
 
 
@@ -214,7 +214,7 @@ class CompanyOrganisationSizeForm(FlaskForm):
 
     organisation_size = RadioField(
         "What size is your organisation?",
-        validators=[InputRequired(message="You must choose an organisation size.")],
+        validators=[InputRequired(message="Select an organisation size")],
         choices=[(option["value"], option["label"]) for option in OPTIONS],
         id="input-organisation_size-1"  # TODO: change to input-organisation_size when on govuk-frontend~3
     )
@@ -254,7 +254,7 @@ class CompanyTradingStatusForm(FlaskForm):
 
     trading_status = RadioField(
         "What’s your trading status?",
-        validators=[InputRequired(message="You must choose a trading status.")],
+        validators=[InputRequired(message="Select a trading status")],
         choices=[(option["value"], option["label"]) for option in OPTIONS],
         id="input-trading_status-1"  # TODO: change to input-trading_status when on govuk-frontend~3
     )

--- a/tests/app/helpers.py
+++ b/tests/app/helpers.py
@@ -543,7 +543,6 @@ class BaseApplicationTest:
     def assert_single_question_page_validation_errors(self,
                                                       res,
                                                       title="There is a problem",
-                                                      question_name="",
                                                       validation_message=""
                                                       ):
         doc = html.fromstring(res.get_data(as_text=True))
@@ -560,8 +559,8 @@ class BaseApplicationTest:
         assert res.status_code == 400
         assert masthead_heading and title == masthead_heading, \
             f"Expected '{title}' == '{masthead_heading}'"
-        assert masthead_link_text and question_name == masthead_link_text, \
-            f"Expected '{question_name}' == '{masthead_link_text}'"
+        assert masthead_link_text and validation_message == masthead_link_text, \
+            f"Expected '{validation_message}' == '{masthead_link_text}'"
         assert error_message and validation_message in error_message, \
             f"Expected '{validation_message}' in '{error_message}'"
 

--- a/tests/app/main/test_suppliers.py
+++ b/tests/app/main/test_suppliers.py
@@ -1345,10 +1345,11 @@ class TestSupplierUpdate(BaseApplicationTest):
         doc = html.fromstring(response)
 
         for xpath_selector, expected_content in [
-            ("[contains(@class, 'govuk-error-summary__list')]/li/a", "Enter a contact name."),
-            ("[contains(@class, 'govuk-error-summary__list')]/li/a", "Enter an email address."),
-            ("[contains(@class, 'govuk-error-summary__list')]/li/a", "Enter a phone number.")
+            ("[contains(@class, 'govuk-error-summary__list')]/li/a", "Enter a contact name"),
+            ("[contains(@class, 'govuk-error-summary__list')]/li/a", "Enter an email address"),
+            ("[contains(@class, 'govuk-error-summary__list')]/li/a", "Enter a phone number")
         ]:
+
             assert doc.xpath(
                 f"//*{xpath_selector}[normalize-space(string())='{expected_content}']"
             )
@@ -1370,8 +1371,8 @@ class TestSupplierUpdate(BaseApplicationTest):
         doc = html.fromstring(response)
 
         for xpath_selector, expected_content in [
-            ("[contains(@class, 'govuk-error-summary__list')]/li/a", "Enter a phone number under 20 characters."),
-            ("[contains(@class, 'govuk-error-summary__list')]/li/a", "Enter a contact name under 256 characters.")
+            ("[contains(@class, 'govuk-error-summary__list')]/li/a", "Phone number must be 20 characters or fewer"),
+            ("[contains(@class, 'govuk-error-summary__list')]/li/a", "Contact name must be 255 characters or fewer")
         ]:
             assert doc.xpath(
                 f"//*{xpath_selector}[normalize-space(string())='{expected_content}']"
@@ -1391,7 +1392,8 @@ class TestSupplierUpdate(BaseApplicationTest):
         doc = html.fromstring(response)
 
         for xpath_selector, expected_content in [
-            ("[contains(@class, 'govuk-error-summary__list')]/li/a", "Enter a valid email address.")
+            ("[contains(@class, 'govuk-error-summary__list')]/li/a",
+             "Enter an email address in the correct format, like name@example.com")
         ]:
             assert doc.xpath(
                 f"//*{xpath_selector}[normalize-space(string())='{expected_content}']"
@@ -1563,8 +1565,8 @@ class TestEditSupplierRegisteredAddress(BaseApplicationTest):
         })
 
         assert status == 400
-        assert "Enter a town or city." in response
-        assert "Enter a country." in response
+        assert "Enter a town or city" in response
+        assert "Enter a country" in response
 
         assert self.data_api_client.update_supplier.called is False
         assert self.data_api_client.update_contact_information.called is False
@@ -1592,9 +1594,9 @@ class TestEditSupplierRegisteredAddress(BaseApplicationTest):
         assert status == status_code
 
         validation_messages = [
-            "Enter a building and street name under 256 characters.",
-            "Enter a town or city name under 256 characters.",
-            "Enter a valid postcode under 15 characters.",
+            "Building and street name must be 255 characters or fewer",
+            "Town or city name must be 255 characters or fewer",
+            "Postcode must be 15 characters or fewer",
         ]
         for message in validation_messages:
             assert (message in response) == validation_error_returned
@@ -1621,7 +1623,7 @@ class TestEditSupplierRegisteredAddress(BaseApplicationTest):
         })
 
         assert status == 400
-        assert "Enter a country." in response
+        assert "Enter a country" in response
 
         assert self.data_api_client.update_supplier.called is False
         assert self.data_api_client.update_contact_information.called is False
@@ -1685,8 +1687,15 @@ class TestCreateSupplier(BaseApplicationTest):
         res = self.client.get("/suppliers/create/company-details")
         assert res.status_code == 200
 
-    @pytest.mark.parametrize('duns_number', [None, 'invalid', '12345678', '1234567890'])
-    def test_should_be_an_error_if_missing_or_invalid_duns_number(self, duns_number):
+    @pytest.mark.parametrize(
+        "duns_number,expected_message",
+        [(None, 'Enter your 9 digit DUNS number'),
+         ('invalid', 'DUNS number must be 9 digits'),
+         ('12345678', 'DUNS number must be 9 digits'),
+         ('1234567890', 'DUNS number must be 9 digits'),
+         ],
+    )
+    def test_should_be_an_error_if_missing_or_invalid_duns_number(self, duns_number, expected_message):
         """Ensures that validation on duns number prevents submission of:
         1) No value
         2) Non-numerics
@@ -1698,8 +1707,8 @@ class TestCreateSupplier(BaseApplicationTest):
 
         self.assert_single_question_page_validation_errors(
             res,
-            question_name="Enter your 9 digit DUNS number.",
-            validation_message="Enter your 9 digit DUNS number."
+            question_name=expected_message,
+            validation_message=expected_message
         )
 
     def test_should_be_an_error_if_duns_number_in_use(self, get_organization_by_duns_number):
@@ -1837,7 +1846,7 @@ class TestCreateSupplier(BaseApplicationTest):
             }
         )
         assert res.status_code == 400
-        assert "Enter your company name." in res.get_data(as_text=True)
+        assert "Enter your company name" in res.get_data(as_text=True)
 
     def test_should_not_allow_contact_details_with_too_long_company_name(self):
         twofiftysix = "a" * 256
@@ -1851,7 +1860,7 @@ class TestCreateSupplier(BaseApplicationTest):
             }
         )
         assert res.status_code == 400
-        assert "Enter a company name under 256 characters." in res.get_data(as_text=True)
+        assert "Company name must be 255 characters or fewer" in res.get_data(as_text=True)
 
     def test_should_not_allow_contact_details_without_contact_name(self):
         res = self.client.post(
@@ -1863,7 +1872,7 @@ class TestCreateSupplier(BaseApplicationTest):
             }
         )
         assert res.status_code == 400
-        assert "Enter a contact name." in res.get_data(as_text=True)
+        assert "Enter a contact name" in res.get_data(as_text=True)
 
     def test_should_not_allow_contact_details_with_too_long_contact_name(self):
         twofiftysix = "a" * 256
@@ -1877,7 +1886,7 @@ class TestCreateSupplier(BaseApplicationTest):
             }
         )
         assert res.status_code == 400
-        assert "Enter a contact name under 256 characters." in res.get_data(as_text=True)
+        assert "Contact name must be 255 characters or fewer" in res.get_data(as_text=True)
 
     def test_should_not_allow_contact_details_without_email(self):
         res = self.client.post(
@@ -1889,7 +1898,7 @@ class TestCreateSupplier(BaseApplicationTest):
             }
         )
         assert res.status_code == 400
-        assert "Enter an email address." in res.get_data(as_text=True)
+        assert "Enter an email address" in res.get_data(as_text=True)
 
     def test_should_not_allow_contact_details_with_invalid_email(self):
         res = self.client.post(
@@ -1902,7 +1911,7 @@ class TestCreateSupplier(BaseApplicationTest):
             }
         )
         assert res.status_code == 400
-        assert "Enter a valid email address." in res.get_data(as_text=True)
+        assert "Enter an email address in the correct format, like name@example.com" in res.get_data(as_text=True)
 
     def test_should_not_allow_contact_details_without_phone_number(self):
         res = self.client.post(
@@ -1914,7 +1923,7 @@ class TestCreateSupplier(BaseApplicationTest):
             }
         )
         assert res.status_code == 400
-        assert "Enter a phone number." in res.get_data(as_text=True)
+        assert "Enter a phone number" in res.get_data(as_text=True)
 
     def test_should_not_allow_contact_details_with_too_long_phone_number(self):
         twentyone = "a" * 21
@@ -1928,7 +1937,7 @@ class TestCreateSupplier(BaseApplicationTest):
             }
         )
         assert res.status_code == 400
-        assert "Enter a phone number under 20 characters." in res.get_data(as_text=True)
+        assert "Phone number must be 20 characters or fewer" in res.get_data(as_text=True)
 
     def test_should_show_multiple_errors(self):
         res = self.client.post(
@@ -1937,10 +1946,10 @@ class TestCreateSupplier(BaseApplicationTest):
         )
 
         assert res.status_code == 400
-        assert "Enter your company name." in res.get_data(as_text=True)
-        assert "Enter a phone number." in res.get_data(as_text=True)
-        assert "Enter an email address." in res.get_data(as_text=True)
-        assert "Enter a contact name." in res.get_data(as_text=True)
+        assert "Enter your company name" in res.get_data(as_text=True)
+        assert "Enter a phone number" in res.get_data(as_text=True)
+        assert "Enter an email address" in res.get_data(as_text=True)
+        assert "Enter a contact name" in res.get_data(as_text=True)
 
     def test_should_populate_duns_from_session(self):
         with self.client.session_transaction() as sess:
@@ -2076,7 +2085,7 @@ class TestCreateSupplier(BaseApplicationTest):
             data={}
         )
         assert res.status_code == 400
-        assert "Enter an email address." in res.get_data(as_text=True)
+        assert "Enter an email address" in res.get_data(as_text=True)
 
     def test_should_not_allow_incorrect_email_address(self):
         with self.client.session_transaction() as sess:
@@ -2089,7 +2098,7 @@ class TestCreateSupplier(BaseApplicationTest):
             }
         )
         assert res.status_code == 400
-        assert "Enter a valid email address." in res.get_data(as_text=True)
+        assert "Enter an email address in the correct format, like name@example.com" in res.get_data(as_text=True)
 
     @mock.patch("app.main.suppliers.send_user_account_email")
     def test_should_allow_correct_email_address(self, send_user_account_email):
@@ -2237,8 +2246,8 @@ class TestJoinOpenFrameworkNotificationMailingList(BaseApplicationTest):
         self.assert_no_flashes()
 
     @pytest.mark.parametrize("email_address_value,expected_validation_message", (
-        ("pint@twopence", "Enter a valid email address.",),
-        ("", "Enter an email address.",),
+        ("pint@twopence", "Enter an email address in the correct format, like name@example.com",),
+        ("", "Enter an email address",),
     ))
     @mock.patch("app.main.views.suppliers.DMMailChimpClient")
     def test_post_invalid_email(
@@ -2562,7 +2571,7 @@ class TestSupplierEditOrganisationSize(BaseApplicationTest):
 
     @pytest.mark.parametrize('organisation_size, expected_error',
                              (
-                                 (None, "You must choose an organisation size."),
+                                 (None, "Select an organisation size"),
                                  ('blah', "Not a valid choice")
                              ))
     def test_missing_or_invalid_choice_shows_validation(self, organisation_size, expected_error):
@@ -2643,8 +2652,8 @@ class TestSupplierAddRegisteredCompanyName(BaseApplicationTest):
 
         self.assert_single_question_page_validation_errors(
             res,
-            question_name="Enter your registered company name.",
-            validation_message="Error: Enter your registered company name."
+            question_name="Enter your registered company name",
+            validation_message="Error: Enter your registered company name"
         )
         assert self.data_api_client.update_supplier.call_args_list == []
 
@@ -2724,7 +2733,7 @@ class TestSupplierEditTradingStatus(BaseApplicationTest):
 
     @pytest.mark.parametrize('trading_status, expected_error',
                              (
-                                 (None, "You must choose a trading status."),
+                                 (None, "Select a trading status"),
                                  ('blah', "Not a valid choice")
                              ))
     def test_missing_or_invalid_choice_shows_validation(self, trading_status, expected_error):
@@ -2816,32 +2825,32 @@ class TestSupplierAddRegistrationNumber(BaseApplicationTest):
                  'companies_house_number': '',
                  'other_company_registration_number': ''
                  },
-                'You need to answer this question.',
-                'You need to answer this question.'
+                'Select yes if you are registered with Companies House',
+                'Select yes if you are registered with Companies House'
             ),
             (
                 {'has_companies_house_number': 'Yes',
                  'companies_house_number': '',
                  'other_company_registration_number': ''
                  },
-                'Enter a Companies House number.',
-                'Enter a Companies House number.'
+                'Enter a Companies House number',
+                'Enter a Companies House number'
             ),
             (
                 {'has_companies_house_number': 'Yes',
                  'companies_house_number': '123456789',
                  'other_company_registration_number': ''
                  },
-                'Enter your 8 digit Companies House number.',
-                'Enter your 8 digit Companies House number.'
+                "Companies House number must be 8 characters",
+                "Companies House number must be 8 characters"
             ),
             (
                 {'has_companies_house_number': 'No',
                  'companies_house_number': '',
                  'other_company_registration_number': 'a' * 256
                  },
-                'Enter a registration number under 256 characters.',
-                'Enter a registration number under 256 characters.'
+                'Registration number must be 255 characters or fewer',
+                'Registration number must be 255 characters or fewer'
             )
         )
     )

--- a/tests/app/main/test_suppliers.py
+++ b/tests/app/main/test_suppliers.py
@@ -1690,9 +1690,9 @@ class TestCreateSupplier(BaseApplicationTest):
     @pytest.mark.parametrize(
         "duns_number,expected_message",
         [(None, 'Enter your 9 digit DUNS number'),
-         ('invalid', 'DUNS number must be 9 digits'),
-         ('12345678', 'DUNS number must be 9 digits'),
-         ('1234567890', 'DUNS number must be 9 digits'),
+         ('invalid', 'Your DUNS number must be 9 digits'),
+         ('12345678', 'Your DUNS number must be 9 digits'),
+         ('1234567890', 'Your DUNS number must be 9 digits'),
          ],
     )
     def test_should_be_an_error_if_missing_or_invalid_duns_number(self, duns_number, expected_message):
@@ -2827,8 +2827,8 @@ class TestSupplierAddRegistrationNumber(BaseApplicationTest):
                  'companies_house_number': '123456789',
                  'other_company_registration_number': ''
                  },
-                "Companies House number must be 8 characters",
-                "Companies House number must be 8 characters"
+                "Your Companies House number must be 8 characters",
+                "Your Companies House number must be 8 characters"
             ),
             (
                 {'has_companies_house_number': 'No',

--- a/tests/app/main/test_suppliers.py
+++ b/tests/app/main/test_suppliers.py
@@ -1705,11 +1705,7 @@ class TestCreateSupplier(BaseApplicationTest):
             data={'duns_number': duns_number} if duns_number else {}
         )
 
-        self.assert_single_question_page_validation_errors(
-            res,
-            question_name=expected_message,
-            validation_message=expected_message
-        )
+        self.assert_single_question_page_validation_errors(res, validation_message=expected_message)
 
     def test_should_be_an_error_if_duns_number_in_use(self, get_organization_by_duns_number):
         self.data_api_client.find_suppliers.return_value = {"suppliers": ["one supplier", "two suppliers"]}
@@ -2587,11 +2583,7 @@ class TestSupplierEditOrganisationSize(BaseApplicationTest):
         assert error[0].text_content().strip() == f"Error: {expected_error}", \
             'The validation message is not as anticipated.'
 
-        self.assert_single_question_page_validation_errors(
-            res,
-            question_name=expected_error,
-            validation_message=expected_error
-        )
+        self.assert_single_question_page_validation_errors(res, validation_message=expected_error)
 
     @pytest.mark.parametrize('size', (None, 'micro', 'small', 'medium', 'large'))
     def test_post_choice_triggers_api_supplier_update_and_redirect(self, size):
@@ -2650,11 +2642,7 @@ class TestSupplierAddRegisteredCompanyName(BaseApplicationTest):
 
         res = self.client.post("/suppliers/registered-company-name/edit")
 
-        self.assert_single_question_page_validation_errors(
-            res,
-            question_name="Enter your registered company name",
-            validation_message="Error: Enter your registered company name"
-        )
+        self.assert_single_question_page_validation_errors(res, validation_message="Enter your registered company name")
         assert self.data_api_client.update_supplier.call_args_list == []
 
     def test_post_input_triggers_api_supplier_update_and_redirect(self):
@@ -2749,9 +2737,7 @@ class TestSupplierEditTradingStatus(BaseApplicationTest):
         assert error[0].text_content().strip() == f"Error: {expected_error}", \
             'The validation message is not as anticipated.'
 
-        self.assert_single_question_page_validation_errors(res,
-                                                           question_name=expected_error,
-                                                           validation_message=expected_error)
+        self.assert_single_question_page_validation_errors(res, validation_message=expected_error)
 
     @pytest.mark.parametrize('trading_status', (None, 'limited company (LTD)', 'other'))
     def test_post_choice_triggers_api_supplier_update_and_redirect(self, trading_status):
@@ -2865,11 +2851,7 @@ class TestSupplierAddRegistrationNumber(BaseApplicationTest):
 
         res = self.client.post("/suppliers/registration-number/edit", data=incomplete_data)
 
-        self.assert_single_question_page_validation_errors(
-            res,
-            question_name=question_mentioned,
-            validation_message=validation_message
-        )
+        self.assert_single_question_page_validation_errors(res, validation_message=validation_message)
         assert self.data_api_client.update_supplier.call_args_list == []
 
         # Assert the links in the error summary point to elements on the page


### PR DESCRIPTION
https://trello.com/c/AnpNWBC7/893-2-update-error-messages-for-confirm-company-details-journey
Re-word error messages to be closer to those used in Design System examples from https://design-system.service.gov.uk/components/error-message/

@NoraGDS please may you review the wording changes in `app/main/forms/suppliers.py`?