### PR TITLE
Replace content loader form macros in Make a Supplier Declaration journey

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "package-lock.json",
     "lines": null
   },
-  "generated_at": "2021-04-07T15:07:09Z",
+  "generated_at": "2021-04-01T16:33:21Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -84,14 +84,14 @@
         "hashed_secret": "e5223482a22578724452e2315f44d0bc5fc457a3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4644,
+        "line_number": 4653,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "82cae5b1d77db4d964804f85ef2c818c6bec2614",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4669,
+        "line_number": 4678,
         "type": "Base64 High Entropy String"
       }
     ]

--- a/app/assets/scss/_question.scss
+++ b/app/assets/scss/_question.scss
@@ -1,0 +1,88 @@
+/*
+ * Some of our questions display a notice (when there are no errors) informing the user when
+ * a question has been autofilled based on a previous declaration.
+ * To achieve this, we use the error message and apply some custom classes. 
+ *
+ * TODO: This is not ideal and we should review this to find a better solution.
+ */
+.dm-form-group--notice {
+    border-left: $govuk-border-width-form-group-error solid govuk-colour("blue");
+}
+
+.dm-error-message--notice {
+    color: govuk-colour("blue");
+}
+
+.dm-numbered-question {
+    /*
+     * For questions which aren't marked up, set the font size consistently
+     */
+    legend {
+        @include govuk-font($size: 19);
+    }
+
+    /* 
+     * Some questions are marked up, so paragraphs flow underneath the number. We want them to display
+     * next to it instead.
+     */
+    legend p:first-of-type {
+        display: inline;
+    }
+
+    /*
+     * Hack to get rid of spacing under lists in legends (ideally, these wouldn't be in the legend anyway)
+     */
+    legend ul {
+        margin-bottom: 0;
+    }
+
+    &__number {
+        @include govuk-font($size: 19, $weight: bold);
+        padding-right: govuk-spacing(1);
+
+        &:after {
+            content: "."
+        }
+
+        @include govuk-media-query($from: desktop) {
+            position: absolute;
+            left: govuk-spacing(6) * -1;
+            &:after {
+                content: ""
+            }
+        }
+    }
+
+    @include govuk-media-query($from: desktop) {
+        position: relative;
+        /*
+         * Rather than shifting the number left, outside of the content border, shift the rest of the content to
+         * the right.
+         */
+        margin-left: govuk-spacing(6);
+        /*
+         * Override for govuk-elements, which sets this to 100%, causing it to overflow
+         * TODO: Remove once govuk-elements is removed.
+         */
+        width: auto;
+    }
+}
+
+label.dm-numbered-question {
+    margin-bottom: govuk-spacing(2);
+
+    p:first-of-type {
+        display: inline;
+    }
+
+    /*
+     * The way we generate labels puts the field component immediately after the label.
+     * This is potentially a bit brittle.
+     */
+    & + div {
+        @include govuk-media-query($from: desktop) {
+            margin-left: govuk-spacing(6);
+            right: govuk-spacing(6);
+        }
+    }
+}

--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -61,6 +61,7 @@ $govuk-global-styles: true;
 @import "_action_links.scss";
 @import "_create_supplier.scss";
 @import "_framework-application.scss";
+@import "_question.scss";
 @import "_service-status.scss";
 @import "_service_submission.scss";
 @import "_single-summary-page.scss";

--- a/app/assets/scss/overrides/_radios.scss
+++ b/app/assets/scss/overrides/_radios.scss
@@ -10,3 +10,13 @@
 .dm-radios--description-hint .govuk-radios__hint .govuk-list {
     color: $govuk-secondary-text-colour;
 }
+
+/*
+ * We have multiple conditional questions on one option in the declaration journey.
+ * Because of the way content loader generates questions we end up with no spacing
+ * beneath the conditional fieldset. This fixes that, but might become unnecessary
+ * if we redesign the question.
+ */
+.govuk-radios__conditional fieldset {
+    margin-bottom: govuk-spacing(6);
+}

--- a/app/main/helpers/validation.py
+++ b/app/main/helpers/validation.py
@@ -44,6 +44,7 @@ class DeclarationValidator(object):
                 validation_message = self.get_error_message(question_id, raw_errors_map[question_id])
                 errors_map.append((question_id, {
                     'input_name': question_id,
+                    'href': self.content.get_question(question_id).get('href') or None,
                     'question': "Question {}".format(question_number)
                     if question_number else self.content.get_question(question_id).get('question'),
                     'message': validation_message,

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -792,7 +792,15 @@ def framework_supplier_declaration_edit(framework_slug, section_id):
     form_html = []
     for question in section.questions:
         h = govuk_frontend.from_question(question, all_answers, errors, is_page_heading=False)
-        label_or_legend = h["fieldset"]["legend"] if "fieldset" in h else h["label"]
+
+        # we want to use a class to style numbered questions
+        if "fieldset" in h:
+            label_or_legend = h["fieldset"]["legend"]
+            h["fieldset"]["classes"] = "dm-numbered-question {}".format(h['fieldset'].get('classes', ''))
+        else:
+            label_or_legend = h["label"]
+            h["label"]["classes"] = "dm-numbered-question {}".format(h['label'].get('classes', ''))
+
         params = h["params"]
 
         # we allow question references in the question label, hint, and error message

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -831,6 +831,7 @@ def framework_supplier_declaration_edit(framework_slug, section_id):
                 (question.id not in errors)
                 and name_of_framework_that_section_has_been_prefilled_from
                 and (question.id in all_answers)
+                and (question.id in declaration_to_reuse)
             ):
                 # this is a misuse of error message component but I can't think of a better way right now
                 params["formGroup"] = {"classes": "dm-form-group--notice"}

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -6,11 +6,12 @@ from dmutils.errors import render_error_page
 from itertools import chain
 
 from dmutils.forms.errors import govuk_errors
-from flask import request, abort, flash, redirect, url_for, current_app, session
+from flask import Markup, request, abort, flash, redirect, url_for, current_app, session
 from flask_login import current_user
 
 from dmapiclient import APIError, HTTPError
 from dmapiclient.audit import AuditTypes
+from dmcontent import govuk_frontend
 from dmcontent.questions import ContentQuestion
 from dmcontent.errors import ContentNotFoundError
 from dmcontent.html import to_summary_list_row
@@ -45,13 +46,14 @@ from ..helpers.frameworks import (
     get_statuses_for_lot,
     get_supplier_framework_info,
     get_supplier_on_framework_from_info,
-    get_supplier_registered_name_from_declaration, question_references,
+    get_supplier_registered_name_from_declaration,
     register_interest_in_framework,
     return_supplier_framework_info_if_on_framework_or_abort,
     returned_agreement_email_recipients,
     return_404_if_applications_closed,
     check_framework_supports_e_signature_or_404,
-    get_completed_lots, get_framework_contract_title
+    get_completed_lots, get_framework_contract_title,
+    question_references,
 )
 from ..helpers.services import (
     get_drafts,
@@ -786,6 +788,44 @@ def framework_supplier_declaration_edit(framework_slug, section_id):
 
         errors = updated_errors
 
+    # prepare the govuk-frontend macro calls for this page with some customizations
+    form_html = []
+    for question in section.questions:
+        h = govuk_frontend.from_question(question, all_answers, errors, is_page_heading=False)
+        label_or_legend = h["fieldset"]["legend"] if "fieldset" in h else h["label"]
+        params = h["params"]
+
+        # we allow question references in the question label, hint, and error message
+        label_or_legend["text"] = question_references(label_or_legend["text"], content.get_question)
+        if "hint" in params:
+            params["hint"]["text"] = question_references(params["hint"]["text"], content.get_question)
+        if "errorMessage" in params:
+            params["errorMessage"]["text"] = question_references(params["errorMessage"]["text"], content.get_question)
+
+        # we want question numbers in the label
+        label_or_legend["html"] = (
+            Markup(f'<span class="dm-numbered-question__number">{question.number}</span> ')
+            + label_or_legend["text"]
+        )
+        del label_or_legend["text"]
+
+        # we add a 'message' to each question which is prefilled
+        if (
+            (question.id not in errors)
+            and name_of_framework_that_section_has_been_prefilled_from
+            and (question.id in all_answers)
+        ):
+            # this is a misuse of error message component but I can't think of a better way right now
+            params["formGroup"] = {"classes": "dm-form-group--notice"}
+            params["errorMessage"] = {
+                "classes": "dm-error-message--notice",
+                "text": "This answer is from your {} declaration".format(
+                    name_of_framework_that_section_has_been_prefilled_from),
+                "visuallyHiddenText": "Notice",
+            }
+
+        form_html.append(h)
+
     session_timeout = displaytimeformat(datetime.utcnow() + timedelta(hours=1))
     return render_template(
         "frameworks/edit_declaration_section.html",
@@ -795,8 +835,10 @@ def framework_supplier_declaration_edit(framework_slug, section_id):
         name_of_framework_that_section_has_been_prefilled_from=name_of_framework_that_section_has_been_prefilled_from,
         declaration_answers=all_answers,
         get_question=content.get_question,
+        form_html=form_html,
+        render=govuk_frontend.render,
         errors=errors,
-        session_timeout=session_timeout
+        session_timeout=session_timeout,
     ), status_code
 
 

--- a/app/templates/_base_page.html
+++ b/app/templates/_base_page.html
@@ -7,10 +7,12 @@
 {% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/select/macro.njk" import govukSelect %}
+{% from "govuk/components/file-upload/macro.njk" import govukFileUpload %}
 {% from "govuk/components/character-count/macro.njk" import govukCharacterCount %}
 {% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 
 {# Import DM components #}

--- a/app/templates/frameworks/edit_declaration_section.html
+++ b/app/templates/frameworks/edit_declaration_section.html
@@ -1,5 +1,8 @@
 {% extends "_base_page.html" %}
-{% import "macros/toolkit_forms.html" as forms %}
+
+{% from "govuk/components/character-count/macro.njk" import govukCharacterCount %}
+{% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
+{% from "govuk/components/label/macro.njk" import govukLabel %}
 
 {% block pageTitle %}
   {{ framework.name }} supplier declaration – Digital Marketplace
@@ -51,24 +54,9 @@
                 {{ section.description|question_references(get_question) }}
               </div>
             {% endif %}
-            {% for question in section.questions %}
-                {{ forms[question.type](
-                    question,
-                    declaration_answers,
-                    errors if errors and (errors[question.id] or question.type == 'multiquestion') else {},
-                    question_number=question.number,
-                    get_question=get_question,
-                    message=(
-                            "This answer is from your {} declaration".format(name_of_framework_that_section_has_been_prefilled_from)
-                        if
-                            name_of_framework_that_section_has_been_prefilled_from and (declaration_answers.get(question.id) is not none or question.type == 'multiquestion')
-                        else
-                            None
-                            )
-                   )
-                }}
 
-            {% endfor %}
+
+            {{ render(form_html) }}
 
             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
 

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -2995,11 +2995,11 @@ class TestSupplierDeclaration(BaseApplicationTest, MockEnsureApplicationCompanyD
             "Answers on this page are from an earlier declaration and need review."
 
         # Blue information messages are shown next to each question
-        info_messages = doc.xpath('//div[@class="message-wrapper"]//span[@class="message-content"]')
+        info_messages = doc.xpath('//span[contains(@class, "dm-error-message--notice")]')
         assert len(info_messages) == 5
         for message in info_messages:
-            assert self.strip_all_whitespace(message.text) == self.strip_all_whitespace(
-                "This answer is from your Digital Stuff 2 declaration"
+            assert self.strip_all_whitespace(message.text_content()) == self.strip_all_whitespace(
+                "Notice: This answer is from your Digital Stuff 2 declaration"
             )
 
     def test_get_with_with_partially_prefilled_answers(self):
@@ -3062,11 +3062,11 @@ class TestSupplierDeclaration(BaseApplicationTest, MockEnsureApplicationCompanyD
             "Answers on this page are from an earlier declaration and need review."
 
         # Blue information messages are shown next to pre-filled questions only
-        info_messages = doc.xpath('//div[@class="message-wrapper"]//span[@class="message-content"]')
+        info_messages = doc.xpath('//span[contains(@class, "dm-error-message--notice")]')
         assert len(info_messages) == 3
         for message in info_messages:
-            assert self.strip_all_whitespace(message.text) == self.strip_all_whitespace(
-                "This answer is from your Digital Stuff 2 declaration"
+            assert self.strip_all_whitespace(message.text_content()) == self.strip_all_whitespace(
+                "Notice: This answer is from your Digital Stuff 2 declaration"
             )
 
     def test_answers_not_prefilled_if_section_has_already_been_saved(self):
@@ -3404,7 +3404,7 @@ class TestSupplierDeclaration(BaseApplicationTest, MockEnsureApplicationCompanyD
         assert res.status_code == 400
         doc = html.fromstring(res.get_data(as_text=True))
         assert len(doc.xpath(
-            "//*[contains(@class,'validation-message')][contains(normalize-space(string()), $text)]",
+            "//*[contains(@class,'govuk-error-message')][contains(normalize-space(string()), $text)]",
             text="Your document is not in an open format.",
         )) == 1
         assert self.data_api_client.set_supplier_declaration.called is False


### PR DESCRIPTION
https://trello.com/c/zXOnW11P/892-2-replace-content-loader-form-macros-in-make-a-supplier-declaration-journey

This PR relies on:

alphagov/digitalmarketplace-content-loader/pull/143
alphagov/digitalmarketplace-content-loader/pull/144

## Outstanding issues
- [x] Content loader PR #143 has outstanding comments
- [x] Functional tests need doing
- [ ] It's difficult to discern between the three subquestions on the modern slavery question (53).