### PR TITLE
Add support for localstack S3 subdomains

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "package-lock.json",
     "lines": null
   },
-  "generated_at": "2021-03-08T14:16:08Z",
+  "generated_at": "2021-04-07T15:07:09Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -58,22 +58,6 @@
     }
   ],
   "results": {
-    "config.py": [
-      {
-        "hashed_secret": "6ece33acdf8a843e90915a2b661ab55941348059",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 164,
-        "type": "Secret Keyword"
-      },
-      {
-        "hashed_secret": "e9dcc6d93c625c72f0c2e7197e80fe49760d5c75",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 168,
-        "type": "Secret Keyword"
-      }
-    ],
     "tests/app/main/test_frameworks.py": [
       {
         "hashed_secret": "6955d0539c7ae97361ab63d21bc2bb730edbce7a",

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -243,7 +243,7 @@ def update_section(framework_slug, service_id, section_id):
     errors = None
     # This utils method filters out any empty documents and validates against service document rules
     uploaded_documents, document_errors = upload_service_documents(
-        s3.S3(current_app.config['DM_DOCUMENTS_BUCKET']),
+        s3.S3(current_app.config['DM_DOCUMENTS_BUCKET'], endpoint_url=current_app.config.get("DM_S3_ENDPOINT_URL")),
         'documents',
         current_app.config['DM_ASSETS_URL'],
         service,

--- a/config.py
+++ b/config.py
@@ -139,7 +139,7 @@ class Development(Config):
     DM_API_AUTH_TOKEN = "myToken"
 
     DM_S3_ENDPOINT_URL = (  # use envvars to set this, defaults to using AWS
-        f"http://localhost:{os.environ['DM_S3_ENDPOINT_PORT']}"
+        f"http://s3.localhost.localstack.cloud:{os.environ['DM_S3_ENDPOINT_PORT']}"
         if os.getenv("DM_S3_ENDPOINT_PORT") else None
     )
 
@@ -148,8 +148,8 @@ class Development(Config):
     DM_AGREEMENTS_BUCKET = "digitalmarketplace-dev-uploads"
     DM_DOCUMENTS_BUCKET = "digitalmarketplace-dev-uploads"
     DM_ASSETS_URL = (
-        f"{DM_S3_ENDPOINT_URL}"
-        if DM_S3_ENDPOINT_URL else
+        f"http://{DM_SUBMISSIONS_BUCKET}.s3.localhost.localstack.cloud:{os.environ['DM_S3_ENDPOINT_PORT']}"
+        if os.getenv("DM_S3_ENDPOINT_PORT") else
         f"https://{DM_SUBMISSIONS_BUCKET}.s3-eu-west-1.amazonaws.com"
     )
 


### PR DESCRIPTION
Trello: https://trello.com/c/XoWXM8lC/85-run-dmrunner-without-credentials

This matches what we use for the real S3 - the old way of doing it in the path is deprecated.

By using localstack S3 subdomains, we now get file upload working correctly. This is because we no longer lose the bucket name when we add the document path, which was the previous behaviour.

This affects supplier-frontend only when run locally in developer mode. It depends on having a recent version of localstack - see https://github.com/alphagov/digitalmarketplace-runner/pull/194. This change means that the functional tests tagged as '@file-upload' now succeed when run locally.

Also, an unrelated small secret baseline update.