### PR TITLE
Replace banners in create a service journey

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "package-lock.json",
     "lines": null
   },
-  "generated_at": "2021-04-01T16:33:21Z",
+  "generated_at": "2021-05-24T16:29:49Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -84,14 +84,14 @@
         "hashed_secret": "e5223482a22578724452e2315f44d0bc5fc457a3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4653,
+        "line_number": 4660,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "82cae5b1d77db4d964804f85ef2c818c6bec2614",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4678,
+        "line_number": 4685,
         "type": "Base64 High Entropy String"
       }
     ]

--- a/app/templates/partials/service_warning.html
+++ b/app/templates/partials/service_warning.html
@@ -1,16 +1,11 @@
 {% if declaration_status != 'complete' %}
+  {% set declaration_url = url_for('.framework_start_supplier_declaration' if declaration_status == 'unstarted' else '.framework_supplier_declaration_overview', framework_slug=framework.slug) %}
   {% set banner_content %}
-  You still need to <a class="govuk-link" href="{% if declaration_status == 'unstarted' %}{{ url_for('.framework_start_supplier_declaration', framework_slug=framework.slug) }}{% else %}{{ url_for('.framework_supplier_declaration_overview', framework_slug=framework.slug) }}{% endif %}">make your supplier declaration</a>.
+    You still need to <a class="govuk-link" href="{{ declaration_url }}">make your supplier declaration</a>.
   {% endset %}
 
-  {% with declaration_url = url_for('.framework_start_supplier_declaration' if declaration_status == 'unstarted' else '.framework_supplier_declaration_overview', framework_slug=framework.slug) %}
-    {%
-      with
-      heading = "Your application is not complete",
-      banner_content = banner_content|safe,
-      type = 'information'
-    %}
-      {% include 'toolkit/notification-banner.html' %}
-    {% endwith %}
-  {% endwith %}
+  {{ dmBanner({
+    "title": "Your application is not complete",
+    "html": banner_content
+  })}}
 {% endif %}

--- a/app/templates/services/service_submission.html
+++ b/app/templates/services/service_submission.html
@@ -43,7 +43,7 @@
 
   {% if service_data.status == 'submitted' and declaration_status != 'complete' and framework.status == 'open' %}
     {% set declaration_warning_content %}
-      You need to <a class="govuk-link" href="{{ url_for('.framework_supplier_declaration_overview', framework_slug=framework.slug) }}">make the supplier&nbsp;declaration</a> before {{ service_data.get('serviceName', service_data['lotName'])|lower }} can be submitted
+      You need to <a class="govuk-link" href="{{ url_for('.framework_supplier_declaration_overview', framework_slug=framework.slug) }}">make the supplier&nbsp;declaration</a> before {{ service_data.get('serviceName', service_data['lotName'])|lower }} can be submitted.
     {% endset %}  
 
     {{ dmBanner({
@@ -53,25 +53,18 @@
   {% endif %}
 
   {% if framework.status == 'pending' %}
-    <div class="wrapper">
-      <aside role="complementary" class="temporary-message" aria-labelledby="temporary-message-heading">
-        {% if service_data.status == 'submitted' %}
-          <h2 class="temporary-message-heading" id="temporary-message-heading">
-            This service was submitted
-          </h2>
-          <p class="temporary-message-message">
-            If your application is successful, it will be available on the Digital Marketplace when {{ framework.name }} goes live.
-          </p>
-        {% else %}
-          <h2 class="temporary-message-heading" id="temporary-message-heading">
-            This service was not submitted
-          </h2>
-          <p class="temporary-message-message">
-            It wasn't marked as complete at the deadline.
-          </p>
-        {% endif %}
-      </aside>
-    </div>
+    {% if service_data.status == 'submitted' %}
+      {% set service_status_banner_title = "This service was submitted" %}
+      {% set service_status_banner_content = "If your application is successful, it will be available on the Digital Marketplace when " + framework.name + " goes live." %}
+    {% else %}
+      {% set service_status_banner_title = "This service was not submitted" %}
+      {% set service_status_banner_content = "It wasn't marked as complete at the deadline." %}
+    {% endif %} 
+
+    {{ dmBanner({
+      "title": service_status_banner_title,
+      "html": service_status_banner_content
+    })}}
   {% endif %}
 {% endblock %}
 

--- a/app/templates/services/service_submission.html
+++ b/app/templates/services/service_submission.html
@@ -42,15 +42,14 @@
   {% endwith %}
 
   {% if service_data.status == 'submitted' and declaration_status != 'complete' and framework.status == 'open' %}
-    <div class="wrapper">
-      {%
-        with
-        message = 'You need to <a class="govuk-link" href="'|safe + url_for('.framework_supplier_declaration_overview', framework_slug=framework.slug) + '">make the supplier&nbsp;declaration</a> before '|safe + service_data.get('serviceName', service_data['lotName'])|lower + ' can be submitted',
-        type = 'warning'
-      %}
-        {% include 'toolkit/notification-banner.html' %}
-      {% endwith %}
-    </div>
+    {% set declaration_warning_content %}
+      You need to <a class="govuk-link" href="{{ url_for('.framework_supplier_declaration_overview', framework_slug=framework.slug) }}">make the supplier&nbsp;declaration</a> before {{ service_data.get('serviceName', service_data['lotName'])|lower }} can be submitted
+    {% endset %}  
+
+    {{ dmBanner({
+      "title": "Your application is not complete",
+      "html": declaration_warning_content
+    })}}
   {% endif %}
 
   {% if framework.status == 'pending' %}

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -2212,14 +2212,14 @@ class TestShowDraftService(BaseApplicationTest, MockEnsureApplicationCompanyDeta
         res = self.client.get('/suppliers/frameworks/g-cloud-7/submissions/scs/1')
 
         doc = html.fromstring(res.get_data(as_text=True))
-        message = doc.xpath('//aside[@class="temporary-message"]')
+        message = doc.xpath('//section[@class="dm-banner"]')
 
         assert len(message) > 0
         assert u"This service was not submitted" in message[0].xpath(
-            'h2[@class="temporary-message-heading"]/text()'
+            'h2[contains(@class, "dm-banner__title")]/text()'
         )[0]
         assert u"It wasn't marked as complete at the deadline." in message[0].xpath(
-            'p[@class="temporary-message-message"]/text()'
+            'div[@class="dm-banner__body"]/text()'
         )[0]
 
     @mock.patch('app.main.views.services.count_unanswered_questions')
@@ -2230,12 +2230,12 @@ class TestShowDraftService(BaseApplicationTest, MockEnsureApplicationCompanyDeta
         res = self.client.get('/suppliers/frameworks/g-cloud-7/submissions/scs/2')
 
         doc = html.fromstring(res.get_data(as_text=True))
-        message = doc.xpath('//aside[@class="temporary-message"]')
+        message = doc.xpath('//section[@class="dm-banner"]')
 
         assert len(message) > 0
-        assert u"This service was submitted" in message[0].xpath('h2[@class="temporary-message-heading"]/text()')[0]
+        assert u"This service was submitted" in message[0].xpath('h2[contains(@class, "dm-banner__title")]/text()')[0]
         assert u"If your application is successful, it will be available on the Digital Marketplace when " \
-            u"G-Cloud 7 goes live." in message[0].xpath('p[@class="temporary-message-message"]/text()')[0]
+            u"G-Cloud 7 goes live." in message[0].xpath('div[@class="dm-banner__body"]/text()')[0]
 
 
 class TestDeleteDraftService(BaseApplicationTest, MockEnsureApplicationCompanyDetailsHaveBeenConfirmedMixin):
@@ -2575,10 +2575,10 @@ class TestGetListPreviousServices(BaseApplicationTest, MockEnsureApplicationComp
         doc = html.fromstring(res.get_data(as_text=True))
 
         banner = doc.xpath(
-            "//div[@class='banner-information-without-action']/h2[normalize-space()='Your application is not complete']"
+            "//section[@class='dm-banner']/h2[normalize-space()='Your application is not complete']"
         )
         declaration = doc.xpath(
-            "//div[@class='banner-information-without-action']//a[normalize-space()='make your supplier declaration']"
+            "//section[@class='dm-banner']//a[normalize-space()='make your supplier declaration']"
         )
 
         if banner_present:


### PR DESCRIPTION
We want to replace our [Digital Marketplace Frontend Toolkit](https://github.com/alphagov/digitalmarketplace-frontend-toolkit) banners with [Digital Marketplace govuk-frontend](https://github.com/alphagov/digitalmarketplace-govuk-frontend/tree/master/src/digitalmarketplace/components/banner) banners.

Mostly straightforward, but see https://github.com/alphagov/digitalmarketplace-supplier-frontend/commit/ff2c7b6028cef63a3f25c99220f0cda32dceae56 for a potentially iffy like-for-like replacement.

We can now also use the [Design System Notification Banner](https://design-system.service.gov.uk/components/notification-banner/) once we've updated to [govuk-frontend version 3.10+](https://github.com/alphagov/govuk-frontend/releases/tag/v3.10.0).

https://trello.com/c/kFrLeDrP/972-1-replace-banners-in-create-a-service-journey