### PR TITLE
Fix tests for updates table

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "package-lock.json",
     "lines": null
   },
-  "generated_at": "2021-05-24T16:29:49Z",
+  "generated_at": "2021-05-27T14:21:25Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -63,35 +63,35 @@
         "hashed_secret": "6955d0539c7ae97361ab63d21bc2bb730edbce7a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3858,
+        "line_number": 3823,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "5b10c4aa69a96ad5a1a11ff1add1a37cdc71fb20",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3874,
+        "line_number": 3839,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "b818bf7ee968a5c29d4436a8243c223576f1d75a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3875,
+        "line_number": 3840,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "e5223482a22578724452e2315f44d0bc5fc457a3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4660,
+        "line_number": 4625,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "82cae5b1d77db4d964804f85ef2c818c6bec2614",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4685,
+        "line_number": 4650,
         "type": "Base64 High Entropy String"
       }
     ]

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "package-lock.json",
     "lines": null
   },
-  "generated_at": "2021-05-27T14:21:25Z",
+  "generated_at": "2021-05-27T16:02:26Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"

--- a/app/assets/scss/_updates.scss
+++ b/app/assets/scss/_updates.scss
@@ -1,18 +1,3 @@
 #input-clarification_question {
   height: 20.75em;
 }
-
-.updates-document-tables {
-
-  table.summary-item-body tbody td {
-    vertical-align: middle;
-  }
-
-  .document-link-with-icon {
-    width: auto;
-    @include core-16;
-    padding-top: 0;
-    padding-bottom: 0;
-  }
-
-}

--- a/app/templates/frameworks/updates.html
+++ b/app/templates/frameworks/updates.html
@@ -53,7 +53,7 @@
           <h2 class="govuk-heading-m">{{ section.heading }}</h2>
           <p class="govuk-body">{{ section.empty_message }}</p>
         {% else %}
-        <table class="govuk-table">
+        <table class="govuk-table" data-name="updates-documents">
           <caption class="govuk-table__caption govuk-heading-m">
             <span>{{ section.heading }}</span>
             {% if section.files %}

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -3572,10 +3572,10 @@ class TestFrameworkUpdatesPage(BaseApplicationTest):
         doc = html.fromstring(response.get_data(as_text=True))
         self._assert_page_title_and_table_headings(doc)
 
-        [communications_table, clarifications_table] = doc.xpath('//table[contains(@class, "govuk-table")]')
+        [communications_table, clarifications_table] = doc.xpath('//table[@data-name="updates-documents"]')
 
         def assert_updates_table_contains_files(table, files):
-            item_rows = table.findall('.//tr[@class="govuk-table__row"]')
+            item_rows = table.findall('.//tr')
             assert len(item_rows) == len(files)
 
             # test that the file names and urls are right


### PR DESCRIPTION
Trello: https://trello.com/c/tnbrDQrf/960-1-investigate-broken-tests-in-supplier-frontend-1-day

Previously, this test was broken in two ways:
1. The CSS styles used in the xpaths were no longer in use due to https://github.com/alphagov/digitalmarketplace-supplier-frontend/pull/1286/
2. The test didn't fail when the xpath search found no matching tables.

So I needed to fix this by updating the xpaths to match the current naming. I then updated the tests to fail if it ever fails to find the two tables - for clarifications and communications.

The two affected tests seemed very similar, so I consolidated them into one.