### PR TITLE
Remove redundant checks and API requests

### DIFF
--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -27,7 +27,6 @@ from ..helpers.services import (
 from ..helpers.frameworks import (
     get_framework_and_lot_or_404,
     get_declaration_status,
-    get_supplier_framework_info,
     get_framework_or_404,
     get_framework_or_500,
     EnsureApplicationCompanyDetailsHaveBeenConfirmed,
@@ -315,10 +314,6 @@ def start_new_draft_service(framework_slug, lot_slug):
 
     framework, lot = get_framework_and_lot_or_404(data_api_client, framework_slug, lot_slug, allowed_statuses=['open'])
 
-    # Suppliers must have registered interest in a framework before they can create draft services
-    if not get_supplier_framework_info(data_api_client, framework_slug):
-        abort(404)
-
     content = content_loader.get_manifest(framework_slug, 'edit_submission').filter(
         {'lot': lot['slug']},
         inplace_allowed=True,
@@ -382,10 +377,6 @@ def start_new_draft_service(framework_slug, lot_slug):
 def copy_draft_service(framework_slug, lot_slug, service_id):
     framework, lot = get_framework_and_lot_or_404(data_api_client, framework_slug, lot_slug, allowed_statuses=['open'])
 
-    # Suppliers must have registered interest in a framework before they can edit draft services
-    if not get_supplier_framework_info(data_api_client, framework_slug):
-        abort(404)
-
     draft = data_api_client.get_draft_service(service_id).get('services')
 
     if draft['lotSlug'] != lot_slug or draft['frameworkSlug'] != framework_slug:
@@ -431,10 +422,6 @@ def copy_draft_service(framework_slug, lot_slug, service_id):
 def complete_draft_service(framework_slug, lot_slug, service_id):
     framework, lot = get_framework_and_lot_or_404(data_api_client, framework_slug, lot_slug, allowed_statuses=['open'])
 
-    # Suppliers must have registered interest in a framework before they can complete draft services
-    if not get_supplier_framework_info(data_api_client, framework_slug):
-        abort(404)
-
     draft = data_api_client.get_draft_service(service_id).get('services')
 
     if draft['lotSlug'] != lot_slug or draft['frameworkSlug'] != framework_slug:
@@ -465,10 +452,6 @@ def complete_draft_service(framework_slug, lot_slug, service_id):
 @return_404_if_applications_closed(lambda: data_api_client)
 def delete_draft_service(framework_slug, lot_slug, service_id):
     framework, lot = get_framework_and_lot_or_404(data_api_client, framework_slug, lot_slug, allowed_statuses=['open'])
-
-    # Suppliers must have registered interest in a framework before they can delete draft services
-    if not get_supplier_framework_info(data_api_client, framework_slug):
-        abort(404)
 
     draft = data_api_client.get_draft_service(service_id).get('services')
 
@@ -573,10 +556,6 @@ def edit_service_submission(framework_slug, lot_slug, service_id, section_id, qu
     """
     framework, lot = get_framework_and_lot_or_404(data_api_client, framework_slug, lot_slug, allowed_statuses=['open'])
 
-    # Suppliers must have registered interest in a framework before they can edit draft services
-    if not get_supplier_framework_info(data_api_client, framework_slug):
-        abort(404)
-
     force_return_to_summary = framework['framework'] == "digital-outcomes-and-specialists"
     force_continue_button = request.args.get('force_continue_button')
     next_question = None
@@ -676,10 +655,6 @@ def edit_service_submission(framework_slug, lot_slug, service_id, section_id, qu
 @EnsureApplicationCompanyDetailsHaveBeenConfirmed(data_api_client)
 @return_404_if_applications_closed(lambda: data_api_client)
 def remove_subsection(framework_slug, lot_slug, service_id, section_id, question_slug):
-    # Suppliers must have registered interest in a framework before they can edit draft services
-    if not get_supplier_framework_info(data_api_client, framework_slug):
-        abort(404)
-
     try:
         draft = data_api_client.get_draft_service(service_id)['services']
     except HTTPError as e:
@@ -851,10 +826,6 @@ def copy_all_previous_services(framework_slug, lot_slug):
     framework, lot = get_framework_and_lot_or_404(
         data_api_client, framework_slug, lot_slug, allowed_statuses=['open']
     )
-
-    # Suppliers must have registered interest in a framework before they can edit draft services
-    if not get_supplier_framework_info(data_api_client, framework_slug):
-        abort(404)
 
     questions_to_exclude = content_loader.get_metadata(framework['slug'], 'copy_services', 'questions_to_exclude')
     questions_to_copy = content_loader.get_metadata(framework['slug'], 'copy_services', 'questions_to_copy')

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -1356,12 +1356,6 @@ class TestCreateDraftService(BaseApplicationTest, MockEnsureApplicationCompanyDe
         res = self.client.get('/suppliers/frameworks/g-cloud-7/submissions/scs/create')
         assert res.status_code == 404
 
-    def test_can_not_get_create_draft_service_page_if_no_supplier_framework(self):
-        self.data_api_client.get_framework.return_value = self.framework(status='open')
-        self.data_api_client.get_supplier_framework_info.return_value = {'frameworkInterest': {}}
-        res = self.client.get('/suppliers/frameworks/g-cloud-7/submissions/scs/create')
-        assert res.status_code == 404
-
     def _test_post_create_draft_service(self, data, if_error_expected):
         self.data_api_client.get_framework.return_value = self.framework(status='open')
         self.data_api_client.create_new_draft_service.return_value = {"services": empty_g7_draft_service()}
@@ -1756,15 +1750,6 @@ class TestEditDraftService(BaseApplicationTest, MockEnsureApplicationCompanyDeta
         )
         assert res.status_code == 404
 
-    def test_edit_draft_section_with_no_supplier_framework_404(self, s3):
-        self.data_api_client.get_draft_service.return_value = self.empty_draft
-        self.data_api_client.get_supplier_framework_info.return_value = {'frameworkInterest': {}}
-
-        res = self.client.get(
-            '/suppliers/frameworks/g-cloud-7/submissions/scs/1/edit/service-definition'
-        )
-        assert res.status_code == 404
-
     def test_update_in_section_with_more_questions_redirects_to_next_question_in_section(self, s3):
         self.data_api_client.get_framework.return_value = self.framework(slug='g-cloud-9', status='open')
         self.data_api_client.get_draft_service.return_value = self.empty_g9_draft
@@ -2062,19 +2047,6 @@ class TestEditDraftService(BaseApplicationTest, MockEnsureApplicationCompanyDeta
 
         assert res.status_code == 404
         assert self.data_api_client.update_draft_service.called is False
-
-    def test_can_not_remove_subsection_if_no_supplier_framework(self, s3):
-        self.data_api_client.get_framework.return_value = self.framework(
-            status='open', slug='digital-outcomes-and-specialists'
-        )
-        self.data_api_client.get_draft_service.return_value = self.multiquestion_draft
-        self.data_api_client.get_supplier_framework_info.return_value = {'frameworkInterest': {}}
-
-        res = self.client.get(
-            '/suppliers/frameworks/digital-outcomes-and-specialists/submissions/' +
-            'digital-specialists/1/remove/individual-specialist-roles/agile-coach'
-        )
-        assert res.status_code == 404
 
     def test_fails_if_api_get_fails(self, s3):
         self.data_api_client.get_draft_service.side_effect = HTTPError(mock.Mock(status_code=504))
@@ -2930,15 +2902,6 @@ class TestCopyAllPreviousServices(CopyingPreviousServicesSetup,
     def test_returns_404_if_lot_not_found(self):
         res = self.client.post(
             '/suppliers/frameworks/g-cloud-10/submissions/sausage/copy-all-previous-framework-services'
-        )
-
-        assert res.status_code == 404
-
-    def test_returns_404_if_no_supplier_framework_interest(self):
-        self.data_api_client.get_supplier_framework_info.return_value = {'frameworkInterest': {}}
-
-        res = self.client.post(
-            '/suppliers/frameworks/g-cloud-10/submissions/cloud-hosting/copy-all-previous-framework-services'
         )
 
         assert res.status_code == 404


### PR DESCRIPTION
The `@EnsureApplicationCompanyDetailsHaveBeenConfirmed` annotation already ensures that suppliers have registered interest in a framework and returns a 404 status if not.

So the `if not get_supplier_framework_info(data_api_client, framework_slug):` checks are entirely redundant, since it is imossible for them ever to fail. So we can safely remove them all to remove some unnecessary API requests.

Add a test for this behaviour to the annotation tests. This means that we can safely remove the tests for this behaviour from the individual endpoints.

The history of this is that the annotation was added later (c29a4ee2597b81ce8062b385105479efb5379721). It looks as if they didn't notice that they'd made this check redundant at the time.

Discovered during https://github.com/alphagov/digitalmarketplace-supplier-frontend/pull/1428#discussion_r641648384