### PR TITLE
Replace radio in service reuse page

### DIFF
--- a/app/main/forms/frameworks.py
+++ b/app/main/forms/frameworks.py
@@ -3,7 +3,6 @@ from wtforms import HiddenField, RadioField
 from wtforms.validators import DataRequired, Length, InputRequired
 
 from dmutils.forms.fields import DMBooleanField, DMStripWhitespaceStringField, DMRadioField
-from dmutils.forms.widgets import DMSelectionButtonBase
 
 
 class AcceptAgreementVariationForm(FlaskForm):
@@ -30,21 +29,21 @@ class ReuseDeclarationForm(FlaskForm):
 
 
 class OneServiceLimitCopyServiceForm(FlaskForm):
-
-    copy_service = DMBooleanField(
-        "Do you want to reuse your previous {lot_name} service?",
-        false_values=("False", "false", ""),
-        widget=DMSelectionButtonBase(type="boolean"),
+    copy_service = RadioField(
+        id="input-copy_service-1",  # TODO: change to input-copy_service when on govuk-frontend~3
+        choices=[("yes", "Yes"), ("no", "No")],
+        validators=[InputRequired("Select yes if you want to reuse your previous service")],
     )
 
     def __init__(self, lot_name, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.copy_service.question = self.copy_service.question.format(lot_name=lot_name)
+        self.copy_service.label.text = f"Do you want to reuse your previous {lot_name} service?"
+
         if lot_name == 'digital specialists':
-            self.copy_service.question_advice = "You’ll need to review your previous answers. " \
-                                                "Roles won’t be copied if they have new questions."
+            self.copy_service.description = "You’ll need to review your previous answers. " \
+                                            "Roles won’t be copied if they have new questions."
         else:
-            self.copy_service.question_advice = "You still have to review your service and answer any new questions."
+            self.copy_service.description = "You still have to review your service and answer any new questions."
 
 
 class LegalAuthorityForm(FlaskForm):

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -729,7 +729,7 @@ def previous_services(framework_slug, lot_slug):
                     error_message=f"You already have a draft {lot['name'].lower()} service."
                 )
             if form.validate_on_submit():
-                if form.copy_service.data is True:
+                if form.copy_service.data == 'yes':
                     copy_service_from_previous_framework(
                         data_api_client,
                         content_loader,

--- a/app/templates/services/previous_services.html
+++ b/app/templates/services/previous_services.html
@@ -43,7 +43,7 @@
 
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-        <form method="POST" action="{{ url_for('.previous_services', framework_slug=framework.slug, lot_slug=lot.slug) }}">
+        <form method="POST" action="{{ url_for('.previous_services', framework_slug=framework.slug, lot_slug=lot.slug) }} novalidate">
           <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
 
           {{ govukRadios({

--- a/app/templates/services/previous_services.html
+++ b/app/templates/services/previous_services.html
@@ -43,25 +43,42 @@
 
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-        <div class="single-question-page">
-          <h1 class="govuk-heading-l">{{ form.copy_service.label }}</h1>
+        <form method="POST" action="{{ url_for('.previous_services', framework_slug=framework.slug, lot_slug=lot.slug) }}">
+          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
 
-          <form method="POST" action="{{ url_for('.previous_services', framework_slug=framework.slug, lot_slug=lot.slug) }}">
-            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+          {{ govukRadios({
+            "idPrefix": "input-" + form.copy_service.name,
+            "name": form.copy_service.name,
+            "hint": {
+              "text": form.copy_service.description,
+            },
+            "items": [
+              {"text": "Yes", "value": "yes"},
+              {"text": "No", "value": "no"},
+            ],
+            "fieldset": {
+              "legend": {
+                "text": form.copy_service.label.text,
+                "classes": "govuk-fieldset__legend--l",
+                "isPageHeading": true,
+              }
+            },
+            "errorMessage": {
+                "text": errors.get(form.copy_service.name, {}).get('message', None)
+              } if errors,
 
-            {{ form.copy_service }}
+          }) }}
 
-            {{ govukButton({
-              "text": "Save and continue",
-              "attributes": {
-                "data-analytics": "trackEvent",
-                "data-analytics-category": "Copy services",
-                "data-analytics-action": "Copy one lot service",
-                "data-analytics-label": lot.slug,
-              },
-            }) }}
-          </form>
-        </div>
+          {{ govukButton({
+            "text": "Save and continue",
+            "attributes": {
+              "data-analytics": "trackEvent",
+              "data-analytics-category": "Copy services",
+              "data-analytics-action": "Copy one lot service",
+              "data-analytics-label": lot.slug,
+            },
+          }) }}
+        </form>
       </div>
     </div>
   {% else %}


### PR DESCRIPTION
https://trello.com/c/JiuMuQNd/986-1-replace-radios-in-reuse-service-page

As part of moving to Design System 3, we need to replace our use of `toolkit/forms/selection-buttons.html` with `govukRadios` from the design system. This should make this page more accessible.

As part of this, we're also moving away from our customised DMRadioField to the standard wtforms equivalent.

I made a change in behaviour. Previously the page would default to 'no' if you didn't select a response. I couldn't work out how to keep this behaviour with govukradios, and couldn't see any other pages that did this. So it's now mandatory to provide a response on this page, in common with all other similar pages.

Old:

![image](https://user-images.githubusercontent.com/15256121/120642861-5450e880-c46d-11eb-8587-739ce9eb02de.png)

New:

![image](https://user-images.githubusercontent.com/15256121/120642888-5b77f680-c46d-11eb-830c-77498ddf8c8d.png)
