### PR TITLE
Fix previous services form attributes typo

### DIFF
--- a/app/templates/services/previous_services.html
+++ b/app/templates/services/previous_services.html
@@ -43,7 +43,7 @@
 
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-        <form method="POST" action="{{ url_for('.previous_services', framework_slug=framework.slug, lot_slug=lot.slug) }} novalidate">
+        <form method="POST" action="{{ url_for('.previous_services', framework_slug=framework.slug, lot_slug=lot.slug) }}" novalidate>
           <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
 
           {{ govukRadios({


### PR DESCRIPTION
Spotted a typo in #1437 where the `novalidate` attribute was enclosed in the `action` string - this fixes it.