### PR TITLE
Fix list of live services for DOS

### DIFF
--- a/app/templates/services/list_services.html
+++ b/app/templates/services/list_services.html
@@ -33,7 +33,7 @@
     {% set ns = namespace(rows = []) %}
     {% for service in services %}
       {% set service_link %}
-        <a class="govuk-link" href="{{ url_for('.edit_service', framework_slug=service['frameworkSlug'], service_id=service['id']) }}">{{ service.serviceName }}</a>
+        <a class="govuk-link" href="{{ url_for('.edit_service', framework_slug=service['frameworkSlug'], service_id=service['id']) }}">{{ service.serviceName or service.lotName }}</a>
       {% endset %}
 
       {% set row = ns.rows.append(

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -170,6 +170,8 @@ class TestListServices(BaseApplicationTest):
                 "g-cloud-909": self.framework(status="live", slug="g-cloud-909"),
                 "g-cloud-890": self.framework(status="open", slug="g-cloud-890"),
                 "g-cloud-870": self.framework(status="expired", slug="g-cloud-870"),
+                "digital-outcomes-and-specialists-100":
+                    self.framework(status="live", slug="digital-outcomes-and-specialists-100"),
             }[framework_slug]
         except KeyError:
             raise HTTPError(mock.Mock(status_code=404))
@@ -250,6 +252,30 @@ class TestListServices(BaseApplicationTest):
         self.data_api_client.find_services.assert_called_once_with(
             supplier_id=1234,
             framework="g-cloud-909",
+        )
+
+    def test_shows_service_for_single_service_lot(self):
+        self.login()
+
+        self.data_api_client.get_framework.side_effect = self._mock_get_framework_side_effect
+        self.data_api_client.find_services.return_value = {
+            'services': [{
+                'status': 'published',
+                'id': '123',
+                'lotSlug': 'digital-outcomes',
+                'lotName': 'Digital Outcomes',
+                'frameworkName': "digital-outcomes-and-specialists-100",
+                'frameworkSlug': "digital-outcomes-and-specialists-100",
+            }]
+        }
+
+        res = self.client.get("/suppliers/frameworks/digital-outcomes-and-specialists-100/services")
+        assert res.status_code == 200
+
+        document = html.fromstring(res.get_data(as_text=True))
+        assert document.xpath(
+            "//td[contains(@class, 'govuk-table__cell')][normalize-space(string())=$t]//a",
+            t="Digital Outcomes",
         )
 
     def test_should_not_be_able_to_see_page_if_user_inactive(self):


### PR DESCRIPTION
In https://github.com/alphagov/digitalmarketplace-supplier-frontend/pull/1439, I accidentally removed some logic that is needed for the DOS version of this table to render correctly. This is because some DOS lots are limited to one service, so the service has no name.

Fix the logic to match the previous logic, and then add a test for this scenario

![image](https://user-images.githubusercontent.com/15256121/121178051-fe59b780-c855-11eb-9981-52f871081bdd.png)
