### PR TITLE
Change URL stored for declaration documents

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "package-lock.json",
     "lines": null
   },
-  "generated_at": "2021-05-27T16:02:26Z",
+  "generated_at": "2021-06-09T14:39:47Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -63,35 +63,35 @@
         "hashed_secret": "6955d0539c7ae97361ab63d21bc2bb730edbce7a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3823,
+        "line_number": 3824,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "5b10c4aa69a96ad5a1a11ff1add1a37cdc71fb20",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3839,
+        "line_number": 3840,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "b818bf7ee968a5c29d4436a8243c223576f1d75a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3840,
+        "line_number": 3841,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "e5223482a22578724452e2315f44d0bc5fc457a3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4625,
+        "line_number": 4626,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "82cae5b1d77db4d964804f85ef2c818c6bec2614",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4650,
+        "line_number": 4651,
         "type": "Base64 High Entropy String"
       }
     ]

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -713,12 +713,11 @@ def framework_supplier_declaration_edit(framework_slug, section_id):
 
         # File fields won't be returned by `section.get_data` so handle these separately
         if request.files:
-            documents_url = url_for('.dashboard', _external=True) + '/assets/'
             # This utils method filters out any empty documents and validates against service document rules
             uploaded_documents, document_errors = upload_declaration_documents(
                 s3.S3(current_app.config['DM_DOCUMENTS_BUCKET']),
                 'documents',
-                documents_url,
+                current_app.config['DM_ASSETS_URL'],
                 request.files,
                 section,
                 framework_slug,
@@ -897,6 +896,9 @@ def download_agreement_file(framework_slug, document_name):
 def download_declaration_document(framework_slug, supplier_id, document_name):
     """
     Equivalent to services.service_submission_document for retrieving declaration files uploaded to S3
+
+    The document bucket's contents are already public. So from G13/DOS6, we no longer use this endpoint. Retained for
+    back-compatibility.
     """
     if current_user.supplier_id != supplier_id:
         abort(404)

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -3255,7 +3255,8 @@ class TestSupplierDeclaration(BaseApplicationTest, MockEnsureApplicationCompanyD
                     'modernSlaveryReportingRequirements': None,
                     'mitigatingFactors3': None,
                     'modernSlaveryStatement': None,
-                    'modernSlaveryStatementOptional': 'http://localhost/suppliers/assets/g-cloud-11/documents/1234/modern-slavery-statement-2017-11-12-1314.pdf'  # noqa
+                    'modernSlaveryStatementOptional':
+                        'http://asset-host/g-cloud-11/documents/1234/modern-slavery-statement-2017-11-12-1314.pdf'
                 },
                 "email@email.com"
             )


### PR DESCRIPTION
https://trello.com/c/5E22SHaQ/27-ccs-sourcing-admins-cant-view-suppliers-modern-slavery-statements

Declaration documents are stored in the documents bucket, the contents of which are already public. So we don't need to go via supplier frontend to access the files. As far as I can tell, this functionality was added as a bug fix. It copied existing code for viewing files in non-public buckets, seemingly without realising that this was unnecessary (https://github.com/alphagov/digitalmarketplace-supplier-frontend/pull/1023).

Instead, use the assets URL to construct the URL we save in the declaration in the database. This will mean that other apps can now show these files to non-supplier users without having to do hacky URL-rewriting.

This also has the added benefit that declaration files uploaded in non-prod environments will now be viewable in buyer-frontend. This is because the current hacky rewriting that this PR makes redundant only works for production.

This won't have an effect on existing files. However, it should take effect for all future frameworks.