### PR TITLE
Replace get_section_as_question

### DIFF
--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -325,7 +325,7 @@ def start_new_draft_service(framework_slug, lot_slug):
         if section is None:
             abort(404)
 
-        section = section.get_question_as_section(section.get_next_question_slug())
+        section = section.get_question_as_section_containing_itself(section.get_next_question_slug())
 
     session_timeout = displaytimeformat(datetime.utcnow() + timedelta(hours=1))
 
@@ -576,7 +576,7 @@ def edit_service_submission(framework_slug, lot_slug, service_id, section_id, qu
     section = content.get_section(section_id)
     if section and (question_slug is not None):
         next_question = section.get_question_by_slug(section.get_next_question_slug(question_slug))
-        section = section.get_question_as_section(question_slug)
+        section = section.get_question_as_section_containing_itself(question_slug)
 
     if section is None or not section.editable:
         abort(404)
@@ -670,7 +670,7 @@ def confirm_subsection_remove(framework_slug, lot_slug, service_id, section_id, 
     section = content.get_section(section_id)
     containing_section = section
     if section and (question_slug is not None):
-        section = section.get_question_as_section(question_slug)
+        section = section.get_question_as_section_containing_itself(question_slug)
     if section is None or not section.editable:
         abort(404)
 
@@ -719,7 +719,7 @@ def remove_subsection(framework_slug, lot_slug, service_id, section_id, question
     section = content.get_section(section_id)
     containing_section = section
     if section and (question_slug is not None):
-        section = section.get_question_as_section(question_slug)
+        section = section.get_question_as_section_containing_itself(question_slug)
     if section is None or not section.editable:
         abort(404)
 

--- a/requirements.in
+++ b/requirements.in
@@ -7,6 +7,6 @@ Flask-WTF==0.15.1
 itsdangerous
 
 digitalmarketplace-apiclient
-digitalmarketplace-content-loader
+digitalmarketplace-content-loader>=8.2.0
 digitalmarketplace-utils>=57.0.0
 git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.8-alpha#egg=govuk-frontend-jinja==0.5.8-alpha

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ defusedxml==0.6.0
     # via odfpy
 digitalmarketplace-apiclient==22.0.0
     # via -r requirements.in
-digitalmarketplace-content-loader==8.1.1
+digitalmarketplace-content-loader==8.2.0
     # via -r requirements.in
 digitalmarketplace-utils==59.1.0
     # via


### PR DESCRIPTION
In some cases, we need to access the information about a question itself. The previous method removes certain fields (like type).

We can use this new method to retain the question information and use it.