### PR TITLE
don't show table if no completed services

### DIFF
--- a/app/templates/frameworks/services.html
+++ b/app/templates/frameworks/services.html
@@ -138,7 +138,7 @@
 
   {% if not complete_drafts %}
   {{ "You haven’t marked any services as complete yet." if framework.status == 'open' else "You didn’t mark any services as complete."  }}
-  {% endif %}
+  {% else %}
   {% set ns = namespace(completed_rows = []) %}
    {% if framework.status == 'open' %}
     {% for complete_draft in complete_drafts %}
@@ -182,6 +182,7 @@
         {% endfor %}
       </ul>
     {% endif %}
+{% endif %}
 
 
         <hr class="govuk-section-break govuk-section-break--m">


### PR DESCRIPTION
https://trello.com/c/xcKuSRij/24-2-replace-summary-tables-of-services
Bugfix after https://github.com/alphagov/digitalmarketplace-supplier-frontend/pull/1451
Previously we were erroneously showing an empty table before a supplier had completed a service.

## Before
![Screenshot 2021-06-21 at 10 47 12](https://user-images.githubusercontent.com/1764158/122743295-c7849800-d27e-11eb-80c7-7dcc277ad5d2.png)

## After
![Screenshot 2021-06-21 at 10 47 37](https://user-images.githubusercontent.com/1764158/122743382-d9fed180-d27e-11eb-9afe-8e071cb5562a.png)

