### PR TITLE
replace summary table on previous services page with govuk frontend v3 table

### DIFF
--- a/app/assets/scss/overrides/_table.scss
+++ b/app/assets/scss/overrides/_table.scss
@@ -21,3 +21,14 @@
     }
  }
 
+/*
+ * GOV UK table caption modifiers are only available in govuk-frontend v3.12
+ * We use this modifier on our previous services table, so we can add our
+ * own override.
+ * @TODO: When we have updated to govuk-frontend v3.12, we should remove
+ * this.
+ */
+.govuk-table__caption--m {
+    @include govuk-font($size: 24, $weight: bold);
+    margin-bottom: govuk-spacing(3);
+}

--- a/app/templates/services/previous_services.html
+++ b/app/templates/services/previous_services.html
@@ -84,7 +84,7 @@
 
 <h1 class="govuk-heading-l">Previous {{ lot.name|lower }} services</h1>
     {{ govukButton({
-    'text': 'Add all your services',
+    'text': 'Add all your {} services'.format(source_framework.name),
     'href': url_for('.confirm_copy_all_previous_services', framework_slug=framework.slug, lot_slug=lot.slug),
     "attributes": {
         "data-name": 'add-all-services'

--- a/app/templates/services/previous_services.html
+++ b/app/templates/services/previous_services.html
@@ -124,7 +124,7 @@
       {% endfor %}
       {{ govukTable({
         'caption': "Your services from {}".format(source_framework.name),
-        'captionClasses': "govuk-table__caption--l",
+        'captionClasses': "govuk-table__caption--m",
         'head': [
         {'text': "Service name"},
         {'html': '<span class="govuk-visually-hidden">Add to ' + framework.name + '</span>'}

--- a/app/templates/services/previous_services.html
+++ b/app/templates/services/previous_services.html
@@ -1,6 +1,4 @@
 {% extends "_base_page.html" %}
-{% import "toolkit/summary-table.html" as summary %}
-{% import "macros/submission.html" as submission %}
 
 {% block pageTitle %}
   Copy your {{ framework.name }} services – Digital Marketplace
@@ -84,41 +82,53 @@
   {% else %}
     {% include "partials/service_warning.html" %}
 
-    <h1 class="govuk-heading-l">Previous {{ lot.name|lower }} services</h1>
-
-    {{ summary.heading("Your services from {}".format(source_framework.name)) }}
-    {% if previous_services_still_to_copy|length > 1 %}
-      {{ summary.top_link("Add all your services", url_for('.confirm_copy_all_previous_services', framework_slug=framework.slug, lot_slug=lot.slug)) }}
+<h1 class="govuk-heading-l">Previous {{ lot.name|lower }} services</h1>
+    {{ govukButton({
+    'text': 'Add all your services',
+    'href': url_for('.confirm_copy_all_previous_services', framework_slug=framework.slug, lot_slug=lot.slug),
+    "attributes": {
+        "data-name": 'add-all-services'
+        }
+    }) }}
+<h2 class="govuk-heading-m" data-name="summary-item-heading">{{ "Your services from {}".format(source_framework.name) }}</h2>
+{% if previous_services_still_to_copy|length > 1 %}
     {% endif %}
-    {% call(service) summary.list_table(
-      previous_services_still_to_copy,
-      caption="Previous framework services",
-      field_headings=[
-          "Service name",
-          "Add to " + framework.name,
-      ],
-      field_headings_visible=False
-    ) %}
-      {% call summary.row() %}
-        {{ summary.service_link(service.serviceName,
-                                url_for(".edit_service", framework_slug=source_framework.slug, service_id=service.id)) }}
-        {% call summary.field(action=True) %}
-          <form method="post" action="{{ url_for('.copy_previous_service', framework_slug=framework.slug, lot_slug=service.lot, service_id=service.id) }}">
-            <input type="hidden" name="csrf_token" value="{{ csrf_token_value or csrf_token() }}" />
-            {{ govukButton({
-              "text": "Add",
-              "classes": "govuk-button--secondary govuk-!-margin-0",
-              "attributes": {
-                "data-analytics": "trackEvent",
-                "data-analytics-category": "Copy services",
-                "data-analytics-action": "Copy individual",
-                "data-analytics-label": "ID: {}".format(service.id),
-              },
-            }) }}
-          </form>
-        {% endcall %}
-      {% endcall %}
-    {% endcall %}
+      {% set ns = namespace(service_rows = []) %}
+      {% for service in previous_services_still_to_copy %}
+          {% set service_link %}
+            <a href="{{ url_for(".edit_service", framework_slug=source_framework.slug, service_id=service.id) }}">{{ service.serviceName }}</a>
+          {% endset %}
+          {% set add_button %}
+            <form method="post" action="{{ url_for('.copy_previous_service', framework_slug=framework.slug, lot_slug=service.lot, service_id=service.id) }}">
+                <input type="hidden" name="csrf_token" value="{{ csrf_token_value or csrf_token() }}" />
+                {{ govukButton({
+                          "text": "Add",
+                          "classes": "govuk-button--secondary govuk-!-margin-0",
+                          "attributes": {
+                            "data-analytics": "trackEvent",
+                            "data-analytics-category": "Copy services",
+                            "data-analytics-action": "Copy individual",
+                            "data-analytics-label": "ID: {}".format(service.id),
+                          },
+                        }) }}
+            </form>
+          {% endset %}
+
+          {% set row = ns.service_rows.append(
+          [
+          {'html': service_link},
+          {'html': add_button}
+          ]
+
+          ) %}
+      {% endfor %}
+      {{ govukTable({
+        'head': [
+        {'text': "Service name"},
+        {'html': '<span class="govuk-visually-hidden">Add to ' + framework.name + '</span>'}
+        ],
+        'rows': ns.service_rows,
+        }) }}
 
     <hr class="govuk-section-break govuk-section-break--m">
 

--- a/app/templates/services/previous_services.html
+++ b/app/templates/services/previous_services.html
@@ -102,7 +102,7 @@
             <form method="post" action="{{ url_for('.copy_previous_service', framework_slug=framework.slug, lot_slug=service.lot, service_id=service.id) }}">
                 <input type="hidden" name="csrf_token" value="{{ csrf_token_value or csrf_token() }}" />
                 {{ govukButton({
-                          "text": "Add",
+                          "html": 'Add<span class="govuk-visually-hidden"> {} to {}</span>'.format(service.serviceName, framework.name),
                           "classes": "govuk-button--secondary govuk-!-margin-0",
                           "attributes": {
                             "data-analytics": "trackEvent",

--- a/app/templates/services/previous_services.html
+++ b/app/templates/services/previous_services.html
@@ -84,7 +84,7 @@
 
 <h1 class="govuk-heading-l">Previous {{ lot.name|lower }} services</h1>
     {{ govukButton({
-    'text': 'Add all your {} services'.format(source_framework.name),
+    'text': 'Add all your services',
     'href': url_for('.confirm_copy_all_previous_services', framework_slug=framework.slug, lot_slug=lot.slug),
     "attributes": {
         "data-name": 'add-all-services'

--- a/app/templates/services/previous_services.html
+++ b/app/templates/services/previous_services.html
@@ -90,7 +90,7 @@
         "data-name": 'add-all-services'
         }
     }) }}
-<h2 class="govuk-heading-m" data-name="summary-item-heading">{{ "Your services from {}".format(source_framework.name) }}</h2>
+
 {% if previous_services_still_to_copy|length > 1 %}
     {% endif %}
       {% set ns = namespace(service_rows = []) %}
@@ -123,6 +123,8 @@
           ) %}
       {% endfor %}
       {{ govukTable({
+        'caption': "Your services from {}".format(source_framework.name),
+        'captionClasses': "govuk-table__caption--l",
         'head': [
         {'text': "Service name"},
         {'html': '<span class="govuk-visually-hidden">Add to ' + framework.name + '</span>'}

--- a/app/templates/services/previous_services.html
+++ b/app/templates/services/previous_services.html
@@ -1,7 +1,7 @@
 {% extends "_base_page.html" %}
 
 {% block pageTitle %}
-  Copy your {{ framework.name }} services – Digital Marketplace
+  Copy your {{ source_framework.name }} services – Digital Marketplace
 {% endblock %}
 
 {% block breadcrumb %}

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -2417,7 +2417,7 @@ class TestGetListPreviousServices(BaseApplicationTest, MockEnsureApplicationComp
         assert doc.xpath("//h1[normalize-space()='Previous cloud hosting services']")
         assert doc.xpath("//table/caption[normalize-space()='Your services from G-Cloud 9']")
 
-        add_all_link = doc.xpath("//a[@data-name='add-all-services']")[0]
+        add_all_link = doc.xpath("//a[@data-name='add-all-services'][normalize-space()='Add all your services']")[0]
         assert add_all_link.attrib['href'] == \
             '/suppliers/frameworks/g-cloud-10/submissions/cloud-hosting/copy-all-previous-framework-services'
 

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -2415,13 +2415,13 @@ class TestGetListPreviousServices(BaseApplicationTest, MockEnsureApplicationComp
         doc = html.fromstring(res.get_data(as_text=True))
 
         assert doc.xpath("//h1[normalize-space()='Previous cloud hosting services']")
-        assert doc.xpath("//h2[@class='summary-item-heading'][normalize-space()='Your services from G-Cloud 9']")
+        assert doc.xpath("//h2[@data-name='summary-item-heading'][normalize-space()='Your services from G-Cloud 9']")
 
-        add_all_link = doc.xpath("//a[@class='summary-change-link'][normalize-space()='Add all your services']")[0]
+        add_all_link = doc.xpath("//a[@data-name='add-all-services'][normalize-space()='Add all your services']")[0]
         assert add_all_link.attrib['href'] == \
             '/suppliers/frameworks/g-cloud-10/submissions/cloud-hosting/copy-all-previous-framework-services'
 
-        service_links = doc.xpath("//td[@class='summary-item-field-first-half']//a")
+        service_links = doc.xpath("//td//a")
         assert [service.text for service in service_links] == ['One', 'Two', 'Three']
 
         add_service_forms = doc.xpath(

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -2425,8 +2425,7 @@ class TestGetListPreviousServices(BaseApplicationTest, MockEnsureApplicationComp
         assert [service.text for service in service_links] == ['One', 'Two', 'Three']
 
         add_service_forms = doc.xpath(
-            "//form[@method='post'][.//button[normalize-space(string())=$t]][.//input[@name='csrf_token']]",
-            t="Add",
+            "//table//form[@method='post']"
         )
         assert len(add_service_forms) == 3
         assert all(

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -2415,7 +2415,7 @@ class TestGetListPreviousServices(BaseApplicationTest, MockEnsureApplicationComp
         doc = html.fromstring(res.get_data(as_text=True))
 
         assert doc.xpath("//h1[normalize-space()='Previous cloud hosting services']")
-        assert doc.xpath("//h2[@data-name='summary-item-heading'][normalize-space()='Your services from G-Cloud 9']")
+        assert doc.xpath("//table/caption[normalize-space()='Your services from G-Cloud 9']")
 
         add_all_link = doc.xpath("//a[@data-name='add-all-services'][normalize-space()='Add all your services']")[0]
         assert add_all_link.attrib['href'] == \

--- a/tests/app/main/test_services.py
+++ b/tests/app/main/test_services.py
@@ -2417,7 +2417,7 @@ class TestGetListPreviousServices(BaseApplicationTest, MockEnsureApplicationComp
         assert doc.xpath("//h1[normalize-space()='Previous cloud hosting services']")
         assert doc.xpath("//table/caption[normalize-space()='Your services from G-Cloud 9']")
 
-        add_all_link = doc.xpath("//a[@data-name='add-all-services'][normalize-space()='Add all your services']")[0]
+        add_all_link = doc.xpath("//a[@data-name='add-all-services']")[0]
         assert add_all_link.attrib['href'] == \
             '/suppliers/frameworks/g-cloud-10/submissions/cloud-hosting/copy-all-previous-framework-services'
 


### PR DESCRIPTION
https://trello.com/c/xcKuSRij/24-2-replace-summary-tables-of-services
We are replacing Digital Marketplace toolkit components with GOVUK frontend v3 (Design System) components as they have been accessibility tested.

## Before
![Screenshot 2021-06-21 at 12 14 07](https://user-images.githubusercontent.com/1764158/122772817-a84a3280-d29f-11eb-9bce-023a2dd71c3c.png)


## After
![Screenshot 2021-06-21 at 12 17 05](https://user-images.githubusercontent.com/1764158/122772728-936d9f00-d29f-11eb-9a03-52a790840b21.png)
