### PR TITLE
Add govuk-table__caption--m override

### DIFF
--- a/app/assets/scss/overrides/_table.scss
+++ b/app/assets/scss/overrides/_table.scss
@@ -21,3 +21,14 @@
     }
  }
 
+/*
+ * GOV UK table caption modifiers are only available in govuk-frontend v3.12
+ * We use this modifier on our previous services table, so we can add our
+ * own override.
+ * @TODO: When we have updated to govuk-frontend v3.12, we should remove
+ * this.
+ */
+.govuk-table__caption--m {
+    @include govuk-font($size: 24, $weight: bold);
+    margin-bottom: govuk-spacing(3);
+}

--- a/app/templates/services/previous_services.html
+++ b/app/templates/services/previous_services.html
@@ -124,7 +124,7 @@
       {% endfor %}
       {{ govukTable({
         'caption': "Your services from {}".format(source_framework.name),
-        'captionClasses': "govuk-table__caption--l",
+        'captionClasses': "govuk-table__caption--m",
         'head': [
         {'text': "Service name"},
         {'html': '<span class="govuk-visually-hidden">Add to ' + framework.name + '</span>'}


### PR DESCRIPTION
These modifiers were only added in govuk-frontend 3.12, so we'll only have access to them once we've upgraded to that version in the future.

In the meantime, we can add an override for the specific class we need here.