### PR TITLE
Load G-Cloud 13 content

### DIFF
--- a/app/main/__init__.py
+++ b/app/main/__init__.py
@@ -137,6 +137,12 @@ def _load_g_cloud(primary_cl):
     primary_cl.load_messages('g-cloud-12', ['urls', 'advice', 'e-signature'])
     primary_cl.load_metadata('g-cloud-12', ['copy_services', 'following_framework'])
 
+    primary_cl.load_manifest('g-cloud-13', 'services', 'edit_service')
+    primary_cl.load_manifest('g-cloud-13', 'services', 'edit_submission')
+    primary_cl.load_manifest('g-cloud-13', 'declaration', 'declaration')
+    primary_cl.load_messages('g-cloud-13', ['urls', 'advice', 'e-signature'])
+    primary_cl.load_metadata('g-cloud-13', ['copy_services', 'following_framework'])
+
 
 def _make_content_loader_factory():
     primary_cl = ContentLoader('app/content')


### PR DESCRIPTION
This allows us to open G-Cloud 13 applications on local environments so we can work on changes. I simply copied the manifests, metadata and messages loaded from G-Cloud 12 - G-Cloud 13 at the moment is almost a complete copy of G-Cloud 12.

Nothing in here is visible to our users until the API framework object is created, so this is safe to deploy.