### PR TITLE
Remove 'a person' pricing option for G-Cloud services

### DIFF
--- a/app/templates/macros/pricing-input/template.njk
+++ b/app/templates/macros/pricing-input/template.njk
@@ -44,11 +44,6 @@
         selected: True if "Unit" == priceInputUnit.value else False,
       },
       {
-        value: "Person",
-        text: "a person",
-        selected: True if "Person" == priceInputUnit.value else False,
-      },
-      {
         value: "Licence",
         text: "a licence",
         selected: True if "Licence" == priceInputUnit.value else False,


### PR DESCRIPTION
In G-Cloud 13 we will only allow unit pricing for lots 1, 2 and 3. There will be a separate lot 4 that handles cloud support billed on a per person basis. Lot 4 doesn't exist yet, so we can remove the option to select per person pricing from the existing lots 1, 2 and 3 and re-introduce it for lot 4 when that's created.

This only affects the list of pricing options that's shown to the user when creating a service, not what the API will accept or any existing services. This page is also only accessible when creating a service, so there will be no user-facing impact.

To see the difference in the list, make sure you have the latest version of the API checked out as well as this branch. Then create a new framework object for G-Cloud 13 and set the status to `open`:

```
data.create_framework(slug="g-cloud-13",
    name="G-Cloud 13",
    framework_family_slug="g-cloud",
    lots=["cloud-hosting", "cloud-software", "cloud-support"],
    has_direct_award=True,
    has_further_competition=False,
    status="coming")

data.update_framework("g-cloud-13", data={"status": "open"})
```

You can log in as a supplier and start your G-Cloud 13 application. 

<img width="890" alt="Screenshot 2021-07-22 at 14 42 36" src="https://user-images.githubusercontent.com/6362602/126649116-c0178282-5140-439c-b6b4-5b1e627c2d13.png">

https://trello.com/c/3SULJbtw/78-1-g-cloud-13-filter-a-person-from-lots-1-2-3-pricing-question