### PR TITLE
Remove pip-tools from requirements

### DIFF
--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -1,7 +1,5 @@
 -c requirements.txt
 
-pip-tools>=5.4.0
-
 cssselect
 flake8
 freezegun

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -18,10 +18,6 @@ charset-normalizer==2.0.6
     # via
     #   -c requirements.txt
     #   requests
-click==7.0
-    # via
-    #   -c requirements.txt
-    #   pip-tools
 cssselect==1.0.3
     # via -r requirements-dev.in
 digitalmarketplace-test-utils==2.8.2
@@ -54,8 +50,6 @@ packaging==20.1
     # via pytest
 pathtools==0.1.2
     # via watchdog
-pip-tools==5.5.0
-    # via -r requirements-dev.in
 pluggy==0.13.1
     # via pytest
 py==1.10.0
@@ -107,6 +101,3 @@ wcwidth==0.1.8
     # via pytest
 zipp==3.0.0
     # via importlib-metadata
-
-# The following packages are considered to be unsafe in a requirements file:
-# pip


### PR DESCRIPTION
https://trello.com/c/2dP0Dfmr/2357-fix-pip-tools-catch-22

As instructed, I have removed `pip-tools` and then updated the requirements files