### PR TITLE
Fix issue where dependabot wasn't ignoring the dependancies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,9 +9,9 @@ updates:
   allow:
   - dependency-type: production
   ignore:
-  - dependency-name: govuk-frontend
+  - dependency-name: "govuk-frontend"
     update-types: ["version-update:semver-major"]
-  - dependency-name: digitalmarketplace-govuk-frontend
+  - dependency-name: "digitalmarketplace-govuk-frontend"
     update-types: ["version-update:semver-major"]
 - package-ecosystem: "npm"
   directory: "/"


### PR DESCRIPTION
Dependabot created PRs for these dependencies even though we want it to ignore them.
I think this could have been because the name of the packages were not in quotes.
https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates#specifying-dependencies-and-versions-to-ignore

I have corrected this